### PR TITLE
Add Istio service mesh baseline for VirtEngine services

### DIFF
--- a/deploy/istio/README.md
+++ b/deploy/istio/README.md
@@ -1,0 +1,44 @@
+# VirtEngine Service Mesh (Istio)
+
+This directory provides a baseline Istio service mesh setup for VirtEngine microservices, including mTLS, traffic management, circuit breaking, retries, tracing, and service-to-service authorization.
+
+## What is included
+
+- Istio install manifest (Operator) with access logging and OpenTelemetry tracing.
+- Namespace onboarding with sidecar injection.
+- Strict mTLS policy for in-namespace workloads.
+- Service-to-service AuthorizationPolicy (mesh identities only).
+- Traffic policies (retries, timeouts) and circuit breakers (outlier detection).
+- OpenTelemetry Collector deployment for trace ingestion.
+
+## Install Istio
+
+1) Install the Istio operator or use istioctl (preferred). Example:
+
+```
+istioctl operator init
+kubectl apply -f deploy/istio/install/istio-operator.yaml
+```
+
+2) Wait for Istio control plane to be ready in `istio-system`.
+
+## Apply mesh policies and observability
+
+```
+kubectl apply -k deploy/istio
+```
+
+## Customize for your cluster
+
+- Service names: update the `host` fields in `deploy/istio/traffic/*` to match your Kubernetes Services.
+- AuthorizationPolicy: if your ingress gateway runs outside `istio-system`, add its namespace to `deploy/istio/base/authorizationpolicy.yaml`.
+- Tracing backend: `deploy/istio/observability/otel-collector.yaml` exports to logging only; wire exporters to Tempo/Jaeger/OTLP as needed.
+- mTLS exceptions: if any non-mesh workloads must talk to these services, add explicit policies or create an exception PeerAuthentication.
+
+## Best practices baked in
+
+- Enforced mTLS with mesh identity checks.
+- Explicit traffic policies to bound retries and timeouts.
+- Outlier detection for circuit breaking to reduce cascading failures.
+- Centralized tracing via OpenTelemetry collector.
+- Access logs enabled at the mesh level (see IstioOperator meshConfig).

--- a/deploy/istio/base/authorizationpolicy.yaml
+++ b/deploy/istio/base/authorizationpolicy.yaml
@@ -1,0 +1,13 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-mesh-s2s
+  namespace: virtengine
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            namespaces:
+              - virtengine
+              - istio-system

--- a/deploy/istio/base/namespace.yaml
+++ b/deploy/istio/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: virtengine
+  labels:
+    istio-injection: enabled

--- a/deploy/istio/base/peer-authentication.yaml
+++ b/deploy/istio/base/peer-authentication.yaml
@@ -1,0 +1,8 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: virtengine
+spec:
+  mtls:
+    mode: STRICT

--- a/deploy/istio/base/telemetry.yaml
+++ b/deploy/istio/base/telemetry.yaml
@@ -1,0 +1,10 @@
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: virtengine-default
+  namespace: virtengine
+spec:
+  tracing:
+    - providers:
+        - name: otel
+      randomSamplingPercentage: 100

--- a/deploy/istio/install/istio-operator.yaml
+++ b/deploy/istio/install/istio-operator.yaml
@@ -1,0 +1,18 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: virtengine-istio
+  namespace: istio-system
+spec:
+  profile: default
+  meshConfig:
+    accessLogFile: /dev/stdout
+    enableTracing: true
+    extensionProviders:
+      - name: otel
+        opentelemetry:
+          service: otel-collector.virtengine-observability.svc.cluster.local
+          port: 4317
+  values:
+    pilot:
+      traceSampling: 100.0

--- a/deploy/istio/kustomization.yaml
+++ b/deploy/istio/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base/namespace.yaml
+  - base/peer-authentication.yaml
+  - base/authorizationpolicy.yaml
+  - base/telemetry.yaml
+  - observability/namespace.yaml
+  - observability/otel-collector.yaml
+  - traffic/destinationrule-virtengine-node.yaml
+  - traffic/destinationrule-waldur.yaml
+  - traffic/destinationrule-portal.yaml
+  - traffic/destinationrule-provider-daemon.yaml
+  - traffic/virtualservice-virtengine-node.yaml
+  - traffic/virtualservice-waldur.yaml
+  - traffic/virtualservice-portal.yaml
+  - traffic/virtualservice-provider-daemon.yaml

--- a/deploy/istio/observability/namespace.yaml
+++ b/deploy/istio/observability/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: virtengine-observability

--- a/deploy/istio/observability/otel-collector.yaml
+++ b/deploy/istio/observability/otel-collector.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: virtengine-observability
+data:
+  otel-collector-config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    exporters:
+      logging:
+        loglevel: info
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [logging]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: virtengine-observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector:0.95.0
+          args:
+            - "--config=/conf/otel-collector-config.yaml"
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+          volumeMounts:
+            - name: otel-collector-config
+              mountPath: /conf
+      volumes:
+        - name: otel-collector-config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: virtengine-observability
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http

--- a/deploy/istio/traffic/destinationrule-portal.yaml
+++ b/deploy/istio/traffic/destinationrule-portal.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: portal
+  namespace: virtengine
+spec:
+  host: portal.virtengine.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http1MaxPendingRequests: 100
+        maxRequestsPerConnection: 100
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 5s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50

--- a/deploy/istio/traffic/destinationrule-provider-daemon.yaml
+++ b/deploy/istio/traffic/destinationrule-provider-daemon.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: provider-daemon
+  namespace: virtengine
+spec:
+  host: provider-daemon.virtengine.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http1MaxPendingRequests: 100
+        maxRequestsPerConnection: 100
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 5s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50

--- a/deploy/istio/traffic/destinationrule-virtengine-node.yaml
+++ b/deploy/istio/traffic/destinationrule-virtengine-node.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: virtengine-node
+  namespace: virtengine
+spec:
+  host: virtengine-node.virtengine.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http1MaxPendingRequests: 100
+        maxRequestsPerConnection: 100
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 5s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50

--- a/deploy/istio/traffic/destinationrule-waldur.yaml
+++ b/deploy/istio/traffic/destinationrule-waldur.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: waldur
+  namespace: virtengine
+spec:
+  host: waldur.virtengine.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http1MaxPendingRequests: 100
+        maxRequestsPerConnection: 100
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 5s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50

--- a/deploy/istio/traffic/virtualservice-portal.yaml
+++ b/deploy/istio/traffic/virtualservice-portal.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: portal
+  namespace: virtengine
+spec:
+  hosts:
+    - portal.virtengine.svc.cluster.local
+  http:
+    - timeout: 15s
+      retries:
+        attempts: 3
+        perTryTimeout: 3s
+        retryOn: gateway-error,connect-failure,refused-stream,reset,5xx
+      route:
+        - destination:
+            host: portal.virtengine.svc.cluster.local

--- a/deploy/istio/traffic/virtualservice-provider-daemon.yaml
+++ b/deploy/istio/traffic/virtualservice-provider-daemon.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: provider-daemon
+  namespace: virtengine
+spec:
+  hosts:
+    - provider-daemon.virtengine.svc.cluster.local
+  http:
+    - timeout: 10s
+      retries:
+        attempts: 3
+        perTryTimeout: 2s
+        retryOn: gateway-error,connect-failure,refused-stream,reset,5xx
+      route:
+        - destination:
+            host: provider-daemon.virtengine.svc.cluster.local

--- a/deploy/istio/traffic/virtualservice-virtengine-node.yaml
+++ b/deploy/istio/traffic/virtualservice-virtengine-node.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: virtengine-node
+  namespace: virtengine
+spec:
+  hosts:
+    - virtengine-node.virtengine.svc.cluster.local
+  http:
+    - timeout: 10s
+      retries:
+        attempts: 3
+        perTryTimeout: 2s
+        retryOn: gateway-error,connect-failure,refused-stream,reset,5xx
+      route:
+        - destination:
+            host: virtengine-node.virtengine.svc.cluster.local

--- a/deploy/istio/traffic/virtualservice-waldur.yaml
+++ b/deploy/istio/traffic/virtualservice-waldur.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: waldur
+  namespace: virtengine
+spec:
+  hosts:
+    - waldur.virtengine.svc.cluster.local
+  http:
+    - timeout: 10s
+      retries:
+        attempts: 3
+        perTryTimeout: 2s
+        retryOn: gateway-error,connect-failure,refused-stream,reset,5xx
+      route:
+        - destination:
+            host: waldur.virtengine.svc.cluster.local


### PR DESCRIPTION
## Summary\n\nThis PR introduces a baseline Istio service mesh deployment for VirtEngine, including install configuration, mTLS, service-to-service authorization, traffic management (retries/timeouts), circuit breaking, and distributed tracing via OpenTelemetry.\n\n## What changed\n\n- Added Istio Operator install manifest to configure mesh access logging and OTLP tracing.\n- Added namespace onboarding with automatic sidecar injection.\n- Enforced strict mTLS and mesh-only service-to-service authorization in the irtengine namespace.\n- Added DestinationRules (circuit breaking/outlier detection) and VirtualServices (timeouts/retries) for core services.\n- Added an OpenTelemetry Collector deployment for trace ingestion.\n- Added a kustomization and README documenting install/apply steps and customization guidance.\n\n## Why\n\nThe INFRA-006 task requires a comprehensive service mesh with mTLS, traffic management, retries/circuit breaking, authentication, tracing, and observability improvements. These manifests establish that baseline and provide a consistent operational starting point.\n\n## Implementation notes\n\n- The traffic policies assume service names irtengine-node, waldur, portal, and provider-daemon in the irtengine namespace. Update hostnames if your services differ.\n- AuthorizationPolicy allows traffic from irtengine and istio-system; add namespaces as needed for gateways or external mesh workloads.\n- OTel Collector exports to logging by default; wire exporters to Tempo/Jaeger/OTLP as needed.\n\nThis PR was written using [Vibe Kanban](https://vibekanban.com)