### PR TITLE
feat:TEE-IMPL-003: Implement Enclave Registry On-Chain Module 

### DIFF
--- a/x/enclave/keeper/abci.go
+++ b/x/enclave/keeper/abci.go
@@ -1,0 +1,183 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+// BeginBlocker performs automatic maintenance tasks at the beginning of each block
+func (k Keeper) BeginBlocker(ctx sdk.Context) {
+	// Record metrics
+	k.RecordMetrics(ctx)
+
+	// Auto-complete expired key rotations
+	k.processExpiredKeyRotations(ctx)
+
+	// Update expired enclave identities
+	k.updateExpiredIdentities(ctx)
+
+	// Clean up old expired measurements (optional, configurable)
+	k.cleanupExpiredMeasurements(ctx)
+
+	// Clean up old rate limit tracking data (every 1000 blocks)
+	if ctx.BlockHeight()%1000 == 0 {
+		k.CleanupOldRegistrationCounts(ctx)
+	}
+}
+
+// processExpiredKeyRotations automatically completes key rotations that have
+// passed their overlap period end height
+func (k Keeper) processExpiredKeyRotations(ctx sdk.Context) {
+	currentHeight := ctx.BlockHeight()
+
+	k.WithEnclaveIdentities(ctx, func(identity types.EnclaveIdentity) bool {
+		if identity.Status != types.EnclaveIdentityStatusRotating {
+			return false
+		}
+
+		validatorAddr, err := sdk.AccAddressFromBech32(identity.ValidatorAddress)
+		if err != nil {
+			k.Logger(ctx).Error(
+				"invalid validator address during rotation check",
+				"address", identity.ValidatorAddress,
+				"error", err,
+			)
+			return false
+		}
+
+		rotation, exists := k.GetActiveKeyRotation(ctx, validatorAddr)
+		if !exists {
+			// Identity is in rotating status but no active rotation found
+			// Reset status to active
+			identity.Status = types.EnclaveIdentityStatusActive
+			if err := k.UpdateEnclaveIdentity(ctx, &identity); err != nil {
+				k.Logger(ctx).Error(
+					"failed to reset identity status",
+					"validator", identity.ValidatorAddress,
+					"error", err,
+				)
+			}
+			return false
+		}
+
+		// Check if overlap period has ended
+		if currentHeight >= rotation.OverlapEndHeight {
+			if err := k.CompleteKeyRotation(ctx, validatorAddr); err != nil {
+				k.Logger(ctx).Error(
+					"failed to auto-complete key rotation",
+					"validator", identity.ValidatorAddress,
+					"height", currentHeight,
+					"overlap_end", rotation.OverlapEndHeight,
+					"error", err,
+				)
+			} else {
+				k.Logger(ctx).Info(
+					"auto-completed key rotation",
+					"validator", identity.ValidatorAddress,
+					"height", currentHeight,
+					"new_key", rotation.NewKeyFingerprint,
+				)
+			}
+		}
+
+		return false
+	})
+}
+
+// updateExpiredIdentities automatically marks identities as expired when they
+// reach their expiry height
+func (k Keeper) updateExpiredIdentities(ctx sdk.Context) {
+	currentHeight := ctx.BlockHeight()
+
+	k.WithEnclaveIdentities(ctx, func(identity types.EnclaveIdentity) bool {
+		// Skip if already expired or revoked
+		if identity.Status == types.EnclaveIdentityStatusExpired ||
+			identity.Status == types.EnclaveIdentityStatusRevoked {
+			return false
+		}
+
+		// Check if identity has expired
+		if identity.IsExpired(currentHeight) {
+			identity.Status = types.EnclaveIdentityStatusExpired
+			if err := k.UpdateEnclaveIdentity(ctx, &identity); err != nil {
+				k.Logger(ctx).Error(
+					"failed to update expired identity",
+					"validator", identity.ValidatorAddress,
+					"expiry_height", identity.ExpiryHeight,
+					"error", err,
+				)
+			} else {
+				k.Logger(ctx).Info(
+					"marked identity as expired",
+					"validator", identity.ValidatorAddress,
+					"expiry_height", identity.ExpiryHeight,
+				)
+
+				// Emit expiry event
+				ctx.EventManager().EmitEvent(
+					sdk.NewEvent(
+						types.EventTypeEnclaveIdentityExpired,
+						sdk.NewAttribute(types.AttributeKeyValidator, identity.ValidatorAddress),
+						sdk.NewAttribute(types.AttributeKeyExpiryHeight, sdk.NewInt(identity.ExpiryHeight).String()),
+					),
+				)
+			}
+		}
+
+		return false
+	})
+}
+
+// cleanupExpiredMeasurements removes expired measurements from the store
+// This is optional and controlled by parameters
+func (k Keeper) cleanupExpiredMeasurements(ctx sdk.Context) {
+	params := k.GetParams(ctx)
+
+	// Only cleanup if enabled in parameters
+	if !params.EnableMeasurementCleanup {
+		return
+	}
+
+	currentHeight := ctx.BlockHeight()
+	cleanupCount := 0
+
+	k.WithMeasurements(ctx, func(measurement types.MeasurementRecord) bool {
+		// Skip if not expired
+		if measurement.ExpiryHeight == 0 || currentHeight < measurement.ExpiryHeight {
+			return false
+		}
+
+		// Skip if already revoked (keep revoked measurements for audit)
+		if measurement.Revoked {
+			return false
+		}
+
+		// Delete expired measurement
+		store := ctx.KVStore(k.skey)
+		store.Delete(types.MeasurementAllowlistKey(measurement.MeasurementHash))
+		cleanupCount++
+
+		k.Logger(ctx).Debug(
+			"cleaned up expired measurement",
+			"measurement", measurement.MeasurementHashHex(),
+			"expiry_height", measurement.ExpiryHeight,
+		)
+
+		return false
+	})
+
+	if cleanupCount > 0 {
+		k.Logger(ctx).Info(
+			"cleaned up expired measurements",
+			"count", cleanupCount,
+			"height", currentHeight,
+		)
+	}
+}
+
+// EndBlocker performs any necessary tasks at the end of each block
+func (k Keeper) EndBlocker(ctx sdk.Context) {
+	// Currently no end-block logic needed
+	// This is a placeholder for future functionality
+}

--- a/x/enclave/keeper/committee.go
+++ b/x/enclave/keeper/committee.go
@@ -1,0 +1,104 @@
+package keeper
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math/rand"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+// GetCommitteeEnclaveKeys returns enclave keys for the identity committee
+// This implements deterministic committee selection based on epoch
+func (k Keeper) GetCommitteeEnclaveKeys(ctx sdk.Context, epoch uint64) []types.EnclaveIdentity {
+	params := k.GetParams(ctx)
+	if !params.EnableCommitteeMode {
+		return k.GetActiveValidatorEnclaveKeys(ctx)
+	}
+
+	allKeys := k.GetActiveValidatorEnclaveKeys(ctx)
+	if uint32(len(allKeys)) <= params.CommitteeSize {
+		return allKeys
+	}
+
+	// Deterministic selection using epoch and block hash as seed
+	seed := k.computeCommitteeSeed(ctx, epoch)
+
+	// Fisher-Yates shuffle with deterministic RNG
+	rng := rand.New(rand.NewSource(int64(binary.BigEndian.Uint64(seed[:]))))
+	shuffled := make([]types.EnclaveIdentity, len(allKeys))
+	copy(shuffled, allKeys)
+
+	for i := len(shuffled) - 1; i > 0; i-- {
+		j := rng.Intn(i + 1)
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	}
+
+	return shuffled[:params.CommitteeSize]
+}
+
+// computeCommitteeSeed creates a deterministic seed for committee selection
+func (k Keeper) computeCommitteeSeed(ctx sdk.Context, epoch uint64) []byte {
+	h := sha256.New()
+
+	// Include chain ID for cross-chain uniqueness
+	h.Write([]byte(ctx.ChainID()))
+
+	// Include committee selection prefix
+	h.Write([]byte("enclave-committee-selection"))
+
+	// Include epoch
+	epochBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(epochBytes, epoch)
+	h.Write(epochBytes)
+
+	// Include block hash for additional entropy
+	// Note: We use the previous block hash to ensure determinism
+	// across all validators
+	if ctx.BlockHeight() > 0 {
+		prevBlockHash := ctx.BlockHeader().LastBlockId.Hash
+		h.Write(prevBlockHash)
+	}
+
+	return h.Sum(nil)
+}
+
+// GetCommitteeEpoch returns the current committee epoch based on block height
+func (k Keeper) GetCommitteeEpoch(ctx sdk.Context) uint64 {
+	params := k.GetParams(ctx)
+	if !params.EnableCommitteeMode {
+		return 0
+	}
+
+	// Each epoch lasts for CommitteeEpochBlocks blocks
+	// Default: 10000 blocks (~14 hours at 5s block time)
+	epochBlocks := int64(10000)
+	if params.CommitteeEpochBlocks > 0 {
+		epochBlocks = params.CommitteeEpochBlocks
+	}
+
+	return uint64(ctx.BlockHeight() / epochBlocks)
+}
+
+// IsValidatorInCommittee checks if a validator is in the current committee
+func (k Keeper) IsValidatorInCommittee(ctx sdk.Context, validatorAddr sdk.AccAddress) bool {
+	params := k.GetParams(ctx)
+	if !params.EnableCommitteeMode {
+		// If committee mode is disabled, all validators are "in committee"
+		return true
+	}
+
+	epoch := k.GetCommitteeEpoch(ctx)
+	committee := k.GetCommitteeEnclaveKeys(ctx, epoch)
+
+	validatorAddrStr := validatorAddr.String()
+	for _, member := range committee {
+		if member.ValidatorAddress == validatorAddrStr {
+			return true
+		}
+	}
+
+	return false
+}

--- a/x/enclave/keeper/metrics.go
+++ b/x/enclave/keeper/metrics.go
@@ -1,0 +1,231 @@
+package keeper
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// EnclaveIdentitiesTotal tracks total number of registered enclave identities
+	EnclaveIdentitiesTotal = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "identities_total",
+			Help:      "Total number of registered enclave identities",
+		},
+		[]string{"status"},
+	)
+
+	// EnclaveIdentityRegistrations tracks cumulative identity registrations
+	EnclaveIdentityRegistrations = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "identity_registrations_total",
+			Help:      "Total number of enclave identity registrations",
+		},
+	)
+
+	// EnclaveKeyRotations tracks active key rotations
+	EnclaveKeyRotationsActive = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "key_rotations_active",
+			Help:      "Number of active enclave key rotations",
+		},
+	)
+
+	// EnclaveKeyRotationsCompleted tracks completed key rotations
+	EnclaveKeyRotationsCompleted = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "key_rotations_completed_total",
+			Help:      "Total number of completed enclave key rotations",
+		},
+	)
+
+	// EnclaveMeasurementsAllowlisted tracks allowlisted measurements
+	EnclaveMeasurementsAllowlisted = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "measurements_allowlisted",
+			Help:      "Number of measurements in the allowlist",
+		},
+		[]string{"tee_type"},
+	)
+
+	// EnclaveMeasurementProposals tracks measurement proposals
+	EnclaveMeasurementProposals = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "measurement_proposals_total",
+			Help:      "Total number of measurement proposals",
+		},
+		[]string{"action"}, // "add" or "revoke"
+	)
+
+	// EnclaveAttestationVerifications tracks attestation verifications
+	EnclaveAttestationVerifications = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "attestation_verifications_total",
+			Help:      "Total number of attestation verifications",
+		},
+		[]string{"result"}, // "success" or "failure"
+	)
+
+	// EnclaveCommitteeSize tracks committee size
+	EnclaveCommitteeSize = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "committee_size",
+			Help:      "Current size of the enclave identity committee",
+		},
+	)
+
+	// EnclaveAttestationAge tracks age of attestations
+	EnclaveAttestationAge = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "attestation_age_blocks",
+			Help:      "Age of attestations in blocks at registration time",
+			Buckets:   prometheus.LinearBuckets(0, 1000, 20), // 0-20k blocks
+		},
+	)
+
+	// EnclaveIdentityExpiries tracks upcoming expiries
+	EnclaveIdentityExpiries = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "virtengine",
+			Subsystem: "enclave",
+			Name:      "identity_expiries_upcoming",
+			Help:      "Number of identities expiring in the next N blocks",
+		},
+		[]string{"time_range"}, // "1h", "24h", "7d"
+	)
+)
+
+// RecordMetrics updates all enclave module metrics
+// This should be called periodically (e.g., in BeginBlocker)
+func (k Keeper) RecordMetrics(ctx sdk.Context) {
+	// Count identities by status
+	statusCounts := make(map[string]float64)
+	k.WithEnclaveIdentities(ctx, func(identity types.EnclaveIdentity) bool {
+		statusCounts[identity.Status]++
+		return false
+	})
+
+	// Update identity count metrics
+	for status, count := range statusCounts {
+		EnclaveIdentitiesTotal.WithLabelValues(status).Set(count)
+	}
+
+	// Count active key rotations
+	activeRotations := 0
+	k.WithEnclaveIdentities(ctx, func(identity types.EnclaveIdentity) bool {
+		if identity.Status == types.EnclaveIdentityStatusRotating {
+			activeRotations++
+		}
+		return false
+	})
+	EnclaveKeyRotationsActive.Set(float64(activeRotations))
+
+	// Count measurements by TEE type
+	measurementCounts := make(map[string]float64)
+	k.WithMeasurements(ctx, func(measurement types.MeasurementRecord) bool {
+		if !measurement.Revoked {
+			measurementCounts[measurement.TeeType]++
+		}
+		return false
+	})
+
+	for teeType, count := range measurementCounts {
+		EnclaveMeasurementsAllowlisted.WithLabelValues(teeType).Set(count)
+	}
+
+	// Update committee size
+	params := k.GetParams(ctx)
+	if params.EnableCommitteeMode {
+		EnclaveCommitteeSize.Set(float64(params.CommitteeSize))
+	} else {
+		EnclaveCommitteeSize.Set(0)
+	}
+
+	// Track upcoming expiries
+	k.recordUpcomingExpiries(ctx)
+}
+
+// recordUpcomingExpiries tracks identities expiring soon
+func (k Keeper) recordUpcomingExpiries(ctx sdk.Context) {
+	currentHeight := ctx.BlockHeight()
+
+	// Define time ranges (assuming ~5s block time)
+	timeRanges := map[string]int64{
+		"1h":  720,   // 1 hour = 720 blocks
+		"24h": 17280, // 24 hours = 17,280 blocks
+		"7d":  120960, // 7 days = 120,960 blocks
+	}
+
+	expiryCounts := make(map[string]float64)
+
+	k.WithEnclaveIdentities(ctx, func(identity types.EnclaveIdentity) bool {
+		if identity.Status == types.EnclaveIdentityStatusExpired ||
+			identity.Status == types.EnclaveIdentityStatusRevoked {
+			return false
+		}
+
+		blocksUntilExpiry := identity.ExpiryHeight - currentHeight
+		if blocksUntilExpiry < 0 {
+			return false
+		}
+
+		for label, threshold := range timeRanges {
+			if blocksUntilExpiry <= threshold {
+				expiryCounts[label]++
+			}
+		}
+
+		return false
+	})
+
+	for label, count := range expiryCounts {
+		EnclaveIdentityExpiries.WithLabelValues(label).Set(count)
+	}
+}
+
+// RecordIdentityRegistration records a new identity registration
+func (k Keeper) RecordIdentityRegistration() {
+	EnclaveIdentityRegistrations.Inc()
+}
+
+// RecordKeyRotationCompleted records a completed key rotation
+func (k Keeper) RecordKeyRotationCompleted() {
+	EnclaveKeyRotationsCompleted.Inc()
+}
+
+// RecordMeasurementProposal records a measurement proposal
+func (k Keeper) RecordMeasurementProposal(action string) {
+	EnclaveMeasurementProposals.WithLabelValues(action).Inc()
+}
+
+// RecordAttestationVerification records an attestation verification result
+func (k Keeper) RecordAttestationVerification(success bool) {
+	result := "success"
+	if !success {
+		result = "failure"
+	}
+	EnclaveAttestationVerifications.WithLabelValues(result).Inc()
+}
+
+// RecordAttestationAge records the age of an attestation
+func (k Keeper) RecordAttestationAge(ageInBlocks int64) {
+	EnclaveAttestationAge.Observe(float64(ageInBlocks))
+}

--- a/x/enclave/keeper/msg_server.go
+++ b/x/enclave/keeper/msg_server.go
@@ -46,6 +46,9 @@ func (m msgServer) RegisterEnclaveIdentity(goCtx context.Context, msg *types.Msg
 		return nil, err
 	}
 
+	// Record metrics
+	m.keeper.RecordIdentityRegistration()
+
 	return &types.MsgRegisterEnclaveIdentityResponse{
 		KeyFingerprint: identity.KeyFingerprint(),
 		ExpiryHeight:   identity.ExpiryHeight,
@@ -147,6 +150,9 @@ func (m msgServer) ProposeMeasurement(goCtx context.Context, msg *types.MsgPropo
 		return nil, err
 	}
 
+	// Record metrics
+	m.keeper.RecordMeasurementProposal("add")
+
 	return &types.MsgProposeMeasurementResponse{
 		MeasurementHash: measurement.MeasurementHashHex(),
 	}, nil
@@ -165,6 +171,9 @@ func (m msgServer) RevokeMeasurement(goCtx context.Context, msg *types.MsgRevoke
 	if err := m.keeper.RevokeMeasurement(ctx, msg.MeasurementHash, msg.Reason, 0); err != nil {
 		return nil, err
 	}
+
+	// Record metrics
+	m.keeper.RecordMeasurementProposal("revoke")
 
 	return &types.MsgRevokeMeasurementResponse{}, nil
 }

--- a/x/enclave/keeper/rate_limit.go
+++ b/x/enclave/keeper/rate_limit.go
@@ -1,0 +1,202 @@
+package keeper
+
+import (
+	"encoding/binary"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+// Registration rate limiting store keys
+var (
+	// PrefixRegistrationCount stores per-block registration count
+	PrefixRegistrationCount = []byte{0x10}
+
+	// PrefixLastRegistration stores last registration height per validator
+	PrefixLastRegistration = []byte{0x11}
+)
+
+// registrationCountKey creates store key for block registration count
+func registrationCountKey(height int64) []byte {
+	bz := make([]byte, 8)
+	binary.BigEndian.PutUint64(bz, uint64(height))
+	return append(PrefixRegistrationCount, bz...)
+}
+
+// lastRegistrationKey creates store key for validator's last registration
+func lastRegistrationKey(validatorAddr sdk.AccAddress) []byte {
+	return append(PrefixLastRegistration, validatorAddr...)
+}
+
+// CheckRegistrationRateLimit checks if registration is allowed
+// Returns error if rate limit would be exceeded
+func (k Keeper) CheckRegistrationRateLimit(ctx sdk.Context, validatorAddr sdk.AccAddress) error {
+	params := k.GetParams(ctx)
+
+	// Check per-block registration limit
+	if params.MaxRegistrationsPerBlock > 0 {
+		if err := k.checkBlockRegistrationLimit(ctx, params.MaxRegistrationsPerBlock); err != nil {
+			return err
+		}
+	}
+
+	// Check validator cooldown period
+	if params.RegistrationCooldownBlocks > 0 {
+		if err := k.checkValidatorCooldown(ctx, validatorAddr, params.RegistrationCooldownBlocks); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkBlockRegistrationLimit verifies block registration limit
+func (k Keeper) checkBlockRegistrationLimit(ctx sdk.Context, maxPerBlock uint32) error {
+	currentHeight := ctx.BlockHeight()
+	store := ctx.KVStore(k.skey)
+
+	key := registrationCountKey(currentHeight)
+	bz := store.Get(key)
+
+	var count uint32
+	if bz != nil {
+		count = binary.BigEndian.Uint32(bz)
+	}
+
+	if count >= maxPerBlock {
+		return types.ErrTooManyRegistrations.Wrapf(
+			"block %d has %d registrations, max is %d",
+			currentHeight, count, maxPerBlock,
+		)
+	}
+
+	return nil
+}
+
+// checkValidatorCooldown verifies validator cooldown period
+func (k Keeper) checkValidatorCooldown(ctx sdk.Context, validatorAddr sdk.AccAddress, cooldownBlocks int64) error {
+	store := ctx.KVStore(k.skey)
+
+	key := lastRegistrationKey(validatorAddr)
+	bz := store.Get(key)
+
+	if bz != nil {
+		lastHeight := int64(binary.BigEndian.Uint64(bz))
+		currentHeight := ctx.BlockHeight()
+		blocksSinceLastReg := currentHeight - lastHeight
+
+		if blocksSinceLastReg < cooldownBlocks {
+			blocksRemaining := cooldownBlocks - blocksSinceLastReg
+			return types.ErrRegistrationCooldown.Wrapf(
+				"validator must wait %d more blocks (last registration at height %d)",
+				blocksRemaining, lastHeight,
+			)
+		}
+	}
+
+	return nil
+}
+
+// IncrementBlockRegistrationCount increments the registration count for current block
+func (k Keeper) IncrementBlockRegistrationCount(ctx sdk.Context) {
+	params := k.GetParams(ctx)
+	if params.MaxRegistrationsPerBlock == 0 {
+		// Rate limiting disabled
+		return
+	}
+
+	currentHeight := ctx.BlockHeight()
+	store := ctx.KVStore(k.skey)
+
+	key := registrationCountKey(currentHeight)
+	bz := store.Get(key)
+
+	var count uint32
+	if bz != nil {
+		count = binary.BigEndian.Uint32(bz)
+	}
+
+	count++
+
+	newBz := make([]byte, 4)
+	binary.BigEndian.PutUint32(newBz, count)
+	store.Set(key, newBz)
+}
+
+// RecordValidatorRegistration records validator's last registration height
+func (k Keeper) RecordValidatorRegistration(ctx sdk.Context, validatorAddr sdk.AccAddress) {
+	params := k.GetParams(ctx)
+	if params.RegistrationCooldownBlocks == 0 {
+		// Cooldown disabled
+		return
+	}
+
+	currentHeight := ctx.BlockHeight()
+	store := ctx.KVStore(k.skey)
+
+	key := lastRegistrationKey(validatorAddr)
+	bz := make([]byte, 8)
+	binary.BigEndian.PutUint64(bz, uint64(currentHeight))
+	store.Set(key, bz)
+}
+
+// CleanupOldRegistrationCounts removes old per-block registration counts
+// Should be called periodically to avoid unbounded store growth
+func (k Keeper) CleanupOldRegistrationCounts(ctx sdk.Context) {
+	currentHeight := ctx.BlockHeight()
+	store := ctx.KVStore(k.skey)
+
+	// Keep last 100,000 blocks of data (roughly 1 week at 5s blocks)
+	cutoffHeight := currentHeight - 100000
+	if cutoffHeight <= 0 {
+		return
+	}
+
+	// Iterate and delete old entries
+	iterator := store.Iterator(PrefixRegistrationCount, registrationCountKey(cutoffHeight))
+	defer iterator.Close()
+
+	keysToDelete := [][]byte{}
+	for ; iterator.Valid(); iterator.Next() {
+		keysToDelete = append(keysToDelete, iterator.Key())
+	}
+
+	for _, key := range keysToDelete {
+		store.Delete(key)
+	}
+
+	if len(keysToDelete) > 0 {
+		k.Logger(ctx).Debug(
+			"cleaned up old registration counts",
+			"count", len(keysToDelete),
+			"cutoff_height", cutoffHeight,
+		)
+	}
+}
+
+// GetBlockRegistrationCount returns current registration count for a block
+func (k Keeper) GetBlockRegistrationCount(ctx sdk.Context, height int64) uint32 {
+	store := ctx.KVStore(k.skey)
+	key := registrationCountKey(height)
+	bz := store.Get(key)
+
+	if bz == nil {
+		return 0
+	}
+
+	return binary.BigEndian.Uint32(bz)
+}
+
+// GetValidatorLastRegistrationHeight returns last registration height for a validator
+func (k Keeper) GetValidatorLastRegistrationHeight(ctx sdk.Context, validatorAddr sdk.AccAddress) (int64, bool) {
+	store := ctx.KVStore(k.skey)
+	key := lastRegistrationKey(validatorAddr)
+	bz := store.Get(key)
+
+	if bz == nil {
+		return 0, false
+	}
+
+	return int64(binary.BigEndian.Uint64(bz)), true
+}

--- a/x/enclave/module.go
+++ b/x/enclave/module.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	abci "github.com/cometbft/cometbft/abci/types"
 	"cosmossdk.io/core/appmodule"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -75,12 +76,19 @@ func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, _ client.TxEncodingCo
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the enclave module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	// Register gRPC gateway routes when query client is available
+	// REST API routes will be automatically generated and registered once proper
+	// protobuf definitions are generated (see ENCLAVE-ENH-001 task).
+	// The gRPC-Gateway will expose all query endpoints as REST endpoints:
+	// - GET /virtengine/enclave/v1/identity/{validator_address}
+	// - GET /virtengine/enclave/v1/keys/active
+	// - GET /virtengine/enclave/v1/measurements
+	// - etc.
 }
 
 // RegisterGRPCRoutes registers the gRPC Gateway routes for the enclave module.
 func (AppModuleBasic) RegisterGRPCRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	// Register gRPC routes when query client is available
+	// gRPC routes will be automatically registered once proper
+	// protobuf definitions and service registration is complete.
 }
 
 // GetQueryCmd returns the root query command of this module
@@ -137,6 +145,17 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 	gs := ExportGenesis(ctx, am.keeper)
 	// Use standard JSON encoding for stub types until proper protobuf generation
 	return cdc.MustMarshalJSON(gs)
+}
+
+// BeginBlock performs begin block logic for the enclave module
+func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
+	am.keeper.BeginBlocker(ctx)
+}
+
+// EndBlock performs end block logic for the enclave module
+func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.ValidatorUpdate {
+	am.keeper.EndBlocker(ctx)
+	return []abci.ValidatorUpdate{}
 }
 
 // GenerateGenesisState implements module.AppModuleSimulation

--- a/x/enclave/types/errors.go
+++ b/x/enclave/types/errors.go
@@ -62,4 +62,13 @@ var (
 
 	// ErrInvalidQuoteVersion is returned when the quote version is not supported
 	ErrInvalidQuoteVersion = errors.Register(ModuleName, 1918, "unsupported quote version")
+
+	// ErrRegistrationRateLimit is returned when registration rate limit is exceeded
+	ErrRegistrationRateLimit = errors.Register(ModuleName, 1919, "registration rate limit exceeded")
+
+	// ErrRegistrationCooldown is returned when validator is in cooldown period
+	ErrRegistrationCooldown = errors.Register(ModuleName, 1920, "validator in registration cooldown period")
+
+	// ErrTooManyRegistrations is returned when block registration limit is exceeded
+	ErrTooManyRegistrations = errors.Register(ModuleName, 1921, "too many registrations in block")
 )

--- a/x/enclave/types/events.go
+++ b/x/enclave/types/events.go
@@ -5,6 +5,7 @@ const (
 	EventTypeEnclaveIdentityRegistered = "enclave_identity_registered"
 	EventTypeEnclaveIdentityUpdated    = "enclave_identity_updated"
 	EventTypeEnclaveIdentityRevoked    = "enclave_identity_revoked"
+	EventTypeEnclaveIdentityExpired    = "enclave_identity_expired"
 	EventTypeEnclaveKeyRotated         = "enclave_key_rotated"
 	EventTypeKeyRotationCompleted      = "key_rotation_completed"
 	EventTypeMeasurementAdded          = "measurement_added"

--- a/x/enclave/types/genesis.go
+++ b/x/enclave/types/genesis.go
@@ -33,6 +33,18 @@ type Params struct {
 
 	// CommitteeSize is the size of the identity committee (if committee mode enabled)
 	CommitteeSize uint32 `json:"committee_size,omitempty"`
+
+	// CommitteeEpochBlocks is the number of blocks per committee epoch
+	CommitteeEpochBlocks int64 `json:"committee_epoch_blocks,omitempty"`
+
+	// EnableMeasurementCleanup enables automatic cleanup of expired measurements
+	EnableMeasurementCleanup bool `json:"enable_measurement_cleanup"`
+
+	// MaxRegistrationsPerBlock limits registrations per block (0 = unlimited)
+	MaxRegistrationsPerBlock uint32 `json:"max_registrations_per_block"`
+
+	// RegistrationCooldownBlocks enforces cooldown between re-registrations
+	RegistrationCooldownBlocks int64 `json:"registration_cooldown_blocks"`
 }
 
 // DefaultParams returns the default enclave parameters
@@ -48,6 +60,10 @@ func DefaultParams() Params {
 		MaxAttestationAge:          10000,                                    // ~14 hours
 		EnableCommitteeMode:        false,
 		CommitteeSize:              0,
+		CommitteeEpochBlocks:       10000,                                    // ~14 hours per epoch
+		EnableMeasurementCleanup:   false,                                    // Disabled by default
+		MaxRegistrationsPerBlock:   0,                                        // Unlimited by default
+		RegistrationCooldownBlocks: 0,                                        // No cooldown by default
 	}
 }
 


### PR DESCRIPTION
**Priority:** CRITICAL
**Spec Reference:** VE-229 - On-chain Enclave Registry
**Current State:** Not implemented

**Implementation Path:**
1. New module: `x/enclave/`
2. Store per-validator enclave identity:
   - enclave_measurement_hash
   - enclave_enc_pubkey
   - enclave_sign_pubkey
   - attestation_quote
3. Governance-controlled measurement allowlist
4. MsgRegisterEnclaveIdentity, MsgRotateEnclaveIdentity

**Acceptance Criteria:**
- Validators can register enclave identities
- Clients can query active validator enclave keys
- Rejected: expired attestations, non-allowlisted measurements