### PR TITLE
feat:ENCLAVE-ENH-007: CLI Commands Implementation

### DIFF
--- a/sdk/go/cli/enclave_query.go
+++ b/sdk/go/cli/enclave_query.go
@@ -1,0 +1,633 @@
+package cli
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/spf13/cobra"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+
+	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	enclavetypes "github.com/virtengine/virtengine/sdk/go/node/enclave/v1"
+)
+
+const (
+	FlagValidatorAddress = "validator"
+	FlagIncludeRevoked   = "include-revoked"
+	FlagForBlockHeight   = "for-height"
+	FlagCommitteeEpoch   = "epoch"
+	FlagScopeID          = "scope-id"
+	FlagBlockHeight      = "block-height"
+)
+
+// GetQueryEnclaveCmd returns the query commands for enclave module
+func GetQueryEnclaveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        enclavetypes.ModuleName,
+		Short:                      "Enclave query commands",
+		Long:                       "Query commands for the enclave module, including identity lookup, key queries, and measurement allowlist.",
+		SuggestionsMinimumDistance: 2,
+		RunE:                       sdkclient.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		GetQueryEnclaveIdentityCmd(),
+		GetQueryEnclaveKeysCmd(),
+		GetQueryEnclaveMeasurementsCmd(),
+		GetQueryEnclaveMeasurementCmd(),
+		GetQueryEnclaveRotationCmd(),
+		GetQueryEnclaveParamsCmd(),
+		GetQueryEnclaveValidKeySetCmd(),
+		GetQueryEnclaveAttestedResultCmd(),
+	)
+
+	return cmd
+}
+
+// GetQueryEnclaveIdentityCmd returns the command to query an enclave identity
+func GetQueryEnclaveIdentityCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "identity [validator-address]",
+		Short: "Query a validator's enclave identity",
+		Long: `Query the enclave identity for a specific validator.
+
+Returns the enclave identity including TEE type, measurement hash, encryption keys,
+attestation data, and status.
+
+Example:
+  $ virtengine query enclave identity virtengine1...
+  $ virtengine query enclave identity --validator=virtengine1...`,
+		Args:              cobra.MaximumNArgs(1),
+		PersistentPreRunE: QueryPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			cl := MustQueryClientFromContext(ctx)
+
+			var validatorAddr string
+			if len(args) > 0 {
+				validatorAddr = args[0]
+			} else {
+				var err error
+				validatorAddr, err = cmd.Flags().GetString(FlagValidatorAddress)
+				if err != nil {
+					return err
+				}
+			}
+
+			if validatorAddr == "" {
+				return fmt.Errorf("validator address is required")
+			}
+
+			req := &enclavetypes.QueryEnclaveIdentityRequest{
+				ValidatorAddress: validatorAddr,
+			}
+
+			res, err := queryEnclaveIdentity(ctx, cl, req)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(cmd, res)
+		},
+	}
+
+	cflags.AddQueryFlagsToCmd(cmd)
+	cmd.Flags().String(FlagValidatorAddress, "", "Validator address to query")
+
+	return cmd
+}
+
+// GetQueryEnclaveKeysCmd returns the command to query active validator enclave keys
+func GetQueryEnclaveKeysCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "keys",
+		Short: "Query active validator enclave keys",
+		Long: `Query all active validator enclave keys.
+
+Returns a list of all validators with active enclave identities, including
+their encryption public keys and measurement hashes.
+
+Example:
+  $ virtengine query enclave keys`,
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: QueryPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustQueryClientFromContext(ctx)
+
+			req := &enclavetypes.QueryActiveValidatorEnclaveKeysRequest{}
+
+			res, err := queryActiveValidatorEnclaveKeys(ctx, cl, req)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(cmd, res)
+		},
+	}
+
+	cflags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetQueryEnclaveMeasurementsCmd returns the command to query the measurement allowlist
+func GetQueryEnclaveMeasurementsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "measurements",
+		Short: "Query allowlisted enclave measurements",
+		Long: `Query the enclave measurement allowlist.
+
+Returns all measurements that are approved for enclave registration.
+Use --tee-type to filter by TEE type, and --include-revoked to include
+revoked measurements.
+
+Example:
+  $ virtengine query enclave measurements
+  $ virtengine query enclave measurements --tee-type=SGX
+  $ virtengine query enclave measurements --include-revoked`,
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: QueryPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustQueryClientFromContext(ctx)
+
+			teeType, _ := cmd.Flags().GetString(FlagTEEType)
+			includeRevoked, _ := cmd.Flags().GetBool(FlagIncludeRevoked)
+
+			req := &enclavetypes.QueryMeasurementAllowlistRequest{
+				TEEType:        teeType,
+				IncludeRevoked: includeRevoked,
+			}
+
+			res, err := queryMeasurementAllowlist(ctx, cl, req)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(cmd, res)
+		},
+	}
+
+	cflags.AddQueryFlagsToCmd(cmd)
+	cmd.Flags().String(FlagTEEType, "", "Filter by TEE type (SGX, SEV-SNP, NITRO, TRUSTZONE)")
+	cmd.Flags().Bool(FlagIncludeRevoked, false, "Include revoked measurements")
+
+	return cmd
+}
+
+// GetQueryEnclaveMeasurementCmd returns the command to query a specific measurement
+func GetQueryEnclaveMeasurementCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "measurement [measurement-hash]",
+		Short: "Query a specific enclave measurement",
+		Long: `Query a specific enclave measurement from the allowlist.
+
+Returns the measurement details including TEE type, description, minimum ISVSVN,
+and whether it is currently allowed.
+
+Example:
+  $ virtengine query enclave measurement 0123456789abcdef...
+  $ virtengine query enclave measurement --measurement-hash=0123456789abcdef...`,
+		Args:              cobra.MaximumNArgs(1),
+		PersistentPreRunE: QueryPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			cl := MustQueryClientFromContext(ctx)
+
+			var measurementHashHex string
+			if len(args) > 0 {
+				measurementHashHex = args[0]
+			} else {
+				var err error
+				measurementHashHex, err = cmd.Flags().GetString(FlagMeasurementHash)
+				if err != nil {
+					return err
+				}
+			}
+
+			if measurementHashHex == "" {
+				return fmt.Errorf("measurement hash is required")
+			}
+
+			measurementHash, err := hex.DecodeString(measurementHashHex)
+			if err != nil {
+				return fmt.Errorf("invalid measurement hash hex: %w", err)
+			}
+
+			req := &enclavetypes.QueryMeasurementRequest{
+				MeasurementHash: measurementHash,
+			}
+
+			res, err := queryMeasurement(ctx, cl, req)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(cmd, res)
+		},
+	}
+
+	cflags.AddQueryFlagsToCmd(cmd)
+	cmd.Flags().String(FlagMeasurementHash, "", "Measurement hash to query (hex-encoded)")
+
+	return cmd
+}
+
+// GetQueryEnclaveRotationCmd returns the command to query key rotation status
+func GetQueryEnclaveRotationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rotation [validator-address]",
+		Short: "Query key rotation status for a validator",
+		Long: `Query the key rotation status for a validator.
+
+Returns information about any active key rotation, including the overlap period
+and new key fingerprint.
+
+Example:
+  $ virtengine query enclave rotation virtengine1...
+  $ virtengine query enclave rotation --validator=virtengine1...`,
+		Args:              cobra.MaximumNArgs(1),
+		PersistentPreRunE: QueryPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			cl := MustQueryClientFromContext(ctx)
+
+			var validatorAddr string
+			if len(args) > 0 {
+				validatorAddr = args[0]
+			} else {
+				var err error
+				validatorAddr, err = cmd.Flags().GetString(FlagValidatorAddress)
+				if err != nil {
+					return err
+				}
+			}
+
+			if validatorAddr == "" {
+				return fmt.Errorf("validator address is required")
+			}
+
+			req := &enclavetypes.QueryKeyRotationRequest{
+				ValidatorAddress: validatorAddr,
+			}
+
+			res, err := queryKeyRotation(ctx, cl, req)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(cmd, res)
+		},
+	}
+
+	cflags.AddQueryFlagsToCmd(cmd)
+	cmd.Flags().String(FlagValidatorAddress, "", "Validator address to query")
+
+	return cmd
+}
+
+// GetQueryEnclaveParamsCmd returns the command to query module parameters
+func GetQueryEnclaveParamsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "Query enclave module parameters",
+		Long: `Query the current enclave module parameters.
+
+Returns parameters including allowed TEE types, expiry settings, rate limits,
+and attestation requirements.
+
+Example:
+  $ virtengine query enclave params`,
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: QueryPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustQueryClientFromContext(ctx)
+
+			req := &enclavetypes.QueryParamsRequest{}
+
+			res, err := queryEnclaveParams(ctx, cl, req)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(cmd, res)
+		},
+	}
+
+	cflags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetQueryEnclaveValidKeySetCmd returns the command to query valid key set
+func GetQueryEnclaveValidKeySetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "valid-keys",
+		Short: "Query the current valid key set",
+		Long: `Query the set of valid enclave keys for a given block height.
+
+Returns all validator keys that are valid at the specified block height,
+including keys in rotation overlap periods.
+
+Example:
+  $ virtengine query enclave valid-keys
+  $ virtengine query enclave valid-keys --for-height=12345`,
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: QueryPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustQueryClientFromContext(ctx)
+
+			forHeight, _ := cmd.Flags().GetInt64(FlagForBlockHeight)
+
+			req := &enclavetypes.QueryValidKeySetRequest{
+				ForBlockHeight: forHeight,
+			}
+
+			res, err := queryValidKeySet(ctx, cl, req)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(cmd, res)
+		},
+	}
+
+	cflags.AddQueryFlagsToCmd(cmd)
+	cmd.Flags().Int64(FlagForBlockHeight, 0, "Block height to check validity for (0 for current)")
+
+	return cmd
+}
+
+// GetQueryEnclaveAttestedResultCmd returns the command to query an attested result
+func GetQueryEnclaveAttestedResultCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "attested-result",
+		Short: "Query an attested scoring result",
+		Long: `Query an attested scoring result by block height and scope ID.
+
+Returns the scoring result including the score, enclave measurement, and
+validator attestation.
+
+Example:
+  $ virtengine query enclave attested-result --block-height=12345 --scope-id=abc123`,
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: QueryPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustQueryClientFromContext(ctx)
+
+			blockHeight, err := cmd.Flags().GetInt64(FlagBlockHeight)
+			if err != nil {
+				return err
+			}
+			if blockHeight <= 0 {
+				return fmt.Errorf("block height is required and must be positive")
+			}
+
+			scopeID, err := cmd.Flags().GetString(FlagScopeID)
+			if err != nil {
+				return err
+			}
+			if scopeID == "" {
+				return fmt.Errorf("scope ID is required")
+			}
+
+			req := &enclavetypes.QueryAttestedResultRequest{
+				BlockHeight: blockHeight,
+				ScopeID:     scopeID,
+			}
+
+			res, err := queryAttestedResult(ctx, cl, req)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(cmd, res)
+		},
+	}
+
+	cflags.AddQueryFlagsToCmd(cmd)
+	cmd.Flags().Int64(FlagBlockHeight, 0, "Block height of the result")
+	cmd.Flags().String(FlagScopeID, "", "Scope ID of the result")
+
+	_ = cmd.MarkFlagRequired(FlagBlockHeight)
+	_ = cmd.MarkFlagRequired(FlagScopeID)
+
+	return cmd
+}
+
+// Query helper functions - these make gRPC calls to the enclave module
+// In production, these would use the actual gRPC client
+
+// MustQueryClientFromContext is an alias for MustLightClientFromContext
+// that provides enclave query functionality
+func MustQueryClientFromContext(ctx context.Context) LightClient {
+	return MustLightClientFromContext(ctx)
+}
+
+// queryEnclaveIdentity queries an enclave identity
+func queryEnclaveIdentity(ctx context.Context, cl LightClient, req *enclavetypes.QueryEnclaveIdentityRequest) (*enclavetypes.QueryEnclaveIdentityResponse, error) {
+	// This uses the standard REST/gRPC query path
+	// The actual implementation would use cl.Query().Enclave().EnclaveIdentity(ctx, req)
+	// For now, we simulate via the ABCIQuery interface
+
+	queryPath := fmt.Sprintf("/virtengine.enclave.v1.Query/EnclaveIdentity")
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resBytes, err := abciQuery(ctx, cl, queryPath, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var res enclavetypes.QueryEnclaveIdentityResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// queryActiveValidatorEnclaveKeys queries all active validator enclave keys
+func queryActiveValidatorEnclaveKeys(ctx context.Context, cl LightClient, req *enclavetypes.QueryActiveValidatorEnclaveKeysRequest) (*enclavetypes.QueryActiveValidatorEnclaveKeysResponse, error) {
+	queryPath := fmt.Sprintf("/virtengine.enclave.v1.Query/ActiveValidatorEnclaveKeys")
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resBytes, err := abciQuery(ctx, cl, queryPath, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var res enclavetypes.QueryActiveValidatorEnclaveKeysResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// queryMeasurementAllowlist queries the measurement allowlist
+func queryMeasurementAllowlist(ctx context.Context, cl LightClient, req *enclavetypes.QueryMeasurementAllowlistRequest) (*enclavetypes.QueryMeasurementAllowlistResponse, error) {
+	queryPath := fmt.Sprintf("/virtengine.enclave.v1.Query/MeasurementAllowlist")
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resBytes, err := abciQuery(ctx, cl, queryPath, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var res enclavetypes.QueryMeasurementAllowlistResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// queryMeasurement queries a specific measurement
+func queryMeasurement(ctx context.Context, cl LightClient, req *enclavetypes.QueryMeasurementRequest) (*enclavetypes.QueryMeasurementResponse, error) {
+	queryPath := fmt.Sprintf("/virtengine.enclave.v1.Query/Measurement")
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resBytes, err := abciQuery(ctx, cl, queryPath, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var res enclavetypes.QueryMeasurementResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// queryKeyRotation queries key rotation status
+func queryKeyRotation(ctx context.Context, cl LightClient, req *enclavetypes.QueryKeyRotationRequest) (*enclavetypes.QueryKeyRotationResponse, error) {
+	queryPath := fmt.Sprintf("/virtengine.enclave.v1.Query/KeyRotation")
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resBytes, err := abciQuery(ctx, cl, queryPath, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var res enclavetypes.QueryKeyRotationResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// queryEnclaveParams queries module parameters
+func queryEnclaveParams(ctx context.Context, cl LightClient, req *enclavetypes.QueryParamsRequest) (*enclavetypes.QueryParamsResponse, error) {
+	queryPath := fmt.Sprintf("/virtengine.enclave.v1.Query/Params")
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resBytes, err := abciQuery(ctx, cl, queryPath, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var res enclavetypes.QueryParamsResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// queryValidKeySet queries the valid key set
+func queryValidKeySet(ctx context.Context, cl LightClient, req *enclavetypes.QueryValidKeySetRequest) (*enclavetypes.QueryValidKeySetResponse, error) {
+	queryPath := fmt.Sprintf("/virtengine.enclave.v1.Query/ValidKeySet")
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resBytes, err := abciQuery(ctx, cl, queryPath, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var res enclavetypes.QueryValidKeySetResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// queryAttestedResult queries an attested result
+func queryAttestedResult(ctx context.Context, cl LightClient, req *enclavetypes.QueryAttestedResultRequest) (*enclavetypes.QueryAttestedResultResponse, error) {
+	queryPath := fmt.Sprintf("/virtengine.enclave.v1.Query/AttestedResult")
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resBytes, err := abciQuery(ctx, cl, queryPath, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var res enclavetypes.QueryAttestedResultResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+// abciQuery performs an ABCI query using the client context
+func abciQuery(_ context.Context, cl LightClient, path string, data []byte) ([]byte, error) {
+	cctx := cl.ClientContext()
+	resp, err := cctx.QueryABCI(abci.RequestQuery{
+		Path: path,
+		Data: data,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("query failed with code %d: %s", resp.Code, resp.Log)
+	}
+
+	return resp.Value, nil
+}
+
+// printJSON prints a response as JSON
+func printJSON(cmd *cobra.Command, v interface{}) error {
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	cmd.Println(string(out))
+	return nil
+}

--- a/sdk/go/cli/enclave_tx.go
+++ b/sdk/go/cli/enclave_tx.go
@@ -1,0 +1,531 @@
+package cli
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	enclavetypes "github.com/virtengine/virtengine/sdk/go/node/enclave/v1"
+)
+
+const (
+	FlagTEEType            = "tee-type"
+	FlagMeasurementHash    = "measurement-hash"
+	FlagSignerHash         = "signer-hash"
+	FlagEncryptionPubKey   = "encryption-pubkey"
+	FlagSigningPubKey      = "signing-pubkey"
+	FlagAttestationQuote   = "attestation-quote"
+	FlagISVProdID          = "isv-prod-id"
+	FlagISVSVN             = "isv-svn"
+	FlagQuoteVersion       = "quote-version"
+	FlagOverlapBlocks      = "overlap-blocks"
+	FlagDescription        = "description"
+	FlagMinISVSVN          = "min-isv-svn"
+	FlagExpiryBlocks       = "expiry-blocks"
+	FlagReason             = "reason"
+	FlagNewMeasurementHash = "new-measurement-hash"
+)
+
+// GetTxEnclaveCmd returns the transaction commands for enclave module
+func GetTxEnclaveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        enclavetypes.ModuleName,
+		Short:                      "Enclave transaction subcommands",
+		Long:                       "Transaction commands for the enclave module, including identity registration, key rotation, and measurement management.",
+		SuggestionsMinimumDistance: 2,
+		RunE:                       sdkclient.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		GetTxEnclaveRegisterCmd(),
+		GetTxEnclaveRotateCmd(),
+		GetTxEnclaveProposeMeasurementCmd(),
+		GetTxEnclaveRevokeMeasurementCmd(),
+	)
+
+	return cmd
+}
+
+// GetTxEnclaveRegisterCmd returns the command to register a new enclave identity
+func GetTxEnclaveRegisterCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a new enclave identity for a validator",
+		Long: `Register a new enclave identity for a validator.
+
+The enclave identity binds a validator to a verified TEE (Trusted Execution Environment)
+with cryptographic attestation. This enables the validator to participate in secure
+identity verification scoring.
+
+Required flags:
+  --tee-type:           TEE type (SGX, SEV-SNP, NITRO, TRUSTZONE)
+  --measurement-hash:   Enclave measurement hash (32 bytes, hex-encoded)
+  --encryption-pubkey:  Enclave encryption public key (hex-encoded)
+  --signing-pubkey:     Enclave signing public key (hex-encoded)
+  --attestation-quote:  Raw attestation quote from TEE (hex-encoded)
+
+Example:
+  $ virtengine tx enclave register \
+      --tee-type=SGX \
+      --measurement-hash=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+      --encryption-pubkey=<hex-encoded-key> \
+      --signing-pubkey=<hex-encoded-key> \
+      --attestation-quote=<hex-encoded-quote> \
+      --from mykey`,
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: TxPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustClientFromContext(ctx)
+			cctx := cl.ClientContext()
+
+			// Get TEE type
+			teeTypeStr, err := cmd.Flags().GetString(FlagTEEType)
+			if err != nil {
+				return err
+			}
+			teeType := enclavetypes.TEEType(teeTypeStr)
+			if !enclavetypes.IsValidTEEType(teeType) {
+				return fmt.Errorf("invalid TEE type: %s (valid: SGX, SEV-SNP, NITRO, TRUSTZONE)", teeTypeStr)
+			}
+
+			// Get measurement hash
+			measurementHashHex, err := cmd.Flags().GetString(FlagMeasurementHash)
+			if err != nil {
+				return err
+			}
+			measurementHash, err := hex.DecodeString(measurementHashHex)
+			if err != nil {
+				return fmt.Errorf("invalid measurement hash hex: %w", err)
+			}
+			if len(measurementHash) != 32 {
+				return fmt.Errorf("measurement hash must be 32 bytes, got %d", len(measurementHash))
+			}
+
+			// Get optional signer hash
+			var signerHash []byte
+			signerHashHex, _ := cmd.Flags().GetString(FlagSignerHash)
+			if signerHashHex != "" {
+				signerHash, err = hex.DecodeString(signerHashHex)
+				if err != nil {
+					return fmt.Errorf("invalid signer hash hex: %w", err)
+				}
+			}
+
+			// Get encryption public key
+			encryptionPubKeyHex, err := cmd.Flags().GetString(FlagEncryptionPubKey)
+			if err != nil {
+				return err
+			}
+			encryptionPubKey, err := hex.DecodeString(encryptionPubKeyHex)
+			if err != nil {
+				return fmt.Errorf("invalid encryption public key hex: %w", err)
+			}
+
+			// Get signing public key
+			signingPubKeyHex, err := cmd.Flags().GetString(FlagSigningPubKey)
+			if err != nil {
+				return err
+			}
+			signingPubKey, err := hex.DecodeString(signingPubKeyHex)
+			if err != nil {
+				return fmt.Errorf("invalid signing public key hex: %w", err)
+			}
+
+			// Get attestation quote (from file or hex string)
+			attestationQuoteArg, err := cmd.Flags().GetString(FlagAttestationQuote)
+			if err != nil {
+				return err
+			}
+			var attestationQuote []byte
+			if _, err := os.Stat(attestationQuoteArg); err == nil {
+				// It's a file path
+				attestationQuote, err = os.ReadFile(attestationQuoteArg)
+				if err != nil {
+					return fmt.Errorf("failed to read attestation quote file: %w", err)
+				}
+			} else {
+				// It's a hex string
+				attestationQuote, err = hex.DecodeString(attestationQuoteArg)
+				if err != nil {
+					return fmt.Errorf("invalid attestation quote hex: %w", err)
+				}
+			}
+
+			// Get optional ISV Product ID
+			isvProdID, _ := cmd.Flags().GetUint16(FlagISVProdID)
+
+			// Get optional ISV SVN
+			isvSVN, _ := cmd.Flags().GetUint16(FlagISVSVN)
+
+			// Get optional quote version
+			quoteVersion, _ := cmd.Flags().GetUint32(FlagQuoteVersion)
+
+			msg := &enclavetypes.MsgRegisterEnclaveIdentity{
+				ValidatorAddress: cctx.GetFromAddress().String(),
+				TEEType:          teeType,
+				MeasurementHash:  measurementHash,
+				SignerHash:       signerHash,
+				EncryptionPubKey: encryptionPubKey,
+				SigningPubKey:    signingPubKey,
+				AttestationQuote: attestationQuote,
+				ISVProdID:        isvProdID,
+				ISVSVN:           isvSVN,
+				QuoteVersion:     quoteVersion,
+			}
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			resp, err := cl.Tx().BroadcastMsgs(ctx, []sdk.Msg{msg})
+			if err != nil {
+				return err
+			}
+
+			return cl.PrintMessage(resp)
+		},
+	}
+
+	cflags.AddTxFlagsToCmd(cmd)
+
+	cmd.Flags().String(FlagTEEType, "", "TEE type (SGX, SEV-SNP, NITRO, TRUSTZONE)")
+	cmd.Flags().String(FlagMeasurementHash, "", "Enclave measurement hash (32 bytes, hex-encoded)")
+	cmd.Flags().String(FlagSignerHash, "", "Signer measurement hash (optional, hex-encoded)")
+	cmd.Flags().String(FlagEncryptionPubKey, "", "Enclave encryption public key (hex-encoded)")
+	cmd.Flags().String(FlagSigningPubKey, "", "Enclave signing public key (hex-encoded)")
+	cmd.Flags().String(FlagAttestationQuote, "", "Attestation quote (hex-encoded or file path)")
+	cmd.Flags().Uint16(FlagISVProdID, 0, "ISV Product ID")
+	cmd.Flags().Uint16(FlagISVSVN, 0, "ISV Security Version Number")
+	cmd.Flags().Uint32(FlagQuoteVersion, 3, "Quote format version")
+
+	_ = cmd.MarkFlagRequired(FlagTEEType)
+	_ = cmd.MarkFlagRequired(FlagMeasurementHash)
+	_ = cmd.MarkFlagRequired(FlagEncryptionPubKey)
+	_ = cmd.MarkFlagRequired(FlagSigningPubKey)
+	_ = cmd.MarkFlagRequired(FlagAttestationQuote)
+
+	return cmd
+}
+
+// GetTxEnclaveRotateCmd returns the command to rotate enclave keys
+func GetTxEnclaveRotateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rotate",
+		Short: "Rotate enclave keys for a validator",
+		Long: `Rotate the enclave keys for a validator.
+
+Key rotation allows a validator to update their enclave keys while maintaining
+identity continuity. During the overlap period, both old and new keys are valid,
+ensuring no service disruption.
+
+Required flags:
+  --encryption-pubkey:  New encryption public key (hex-encoded)
+  --signing-pubkey:     New signing public key (hex-encoded)
+  --attestation-quote:  New attestation quote (hex-encoded or file path)
+  --overlap-blocks:     Number of blocks for key overlap period
+
+Example:
+  $ virtengine tx enclave rotate \
+      --encryption-pubkey=<new-hex-encoded-key> \
+      --signing-pubkey=<new-hex-encoded-key> \
+      --attestation-quote=<new-hex-encoded-quote> \
+      --overlap-blocks=1000 \
+      --from mykey`,
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: TxPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustClientFromContext(ctx)
+			cctx := cl.ClientContext()
+
+			// Get new encryption public key
+			encryptionPubKeyHex, err := cmd.Flags().GetString(FlagEncryptionPubKey)
+			if err != nil {
+				return err
+			}
+			newEncryptionPubKey, err := hex.DecodeString(encryptionPubKeyHex)
+			if err != nil {
+				return fmt.Errorf("invalid encryption public key hex: %w", err)
+			}
+
+			// Get new signing public key
+			signingPubKeyHex, err := cmd.Flags().GetString(FlagSigningPubKey)
+			if err != nil {
+				return err
+			}
+			newSigningPubKey, err := hex.DecodeString(signingPubKeyHex)
+			if err != nil {
+				return fmt.Errorf("invalid signing public key hex: %w", err)
+			}
+
+			// Get new attestation quote
+			attestationQuoteArg, err := cmd.Flags().GetString(FlagAttestationQuote)
+			if err != nil {
+				return err
+			}
+			var newAttestationQuote []byte
+			if _, err := os.Stat(attestationQuoteArg); err == nil {
+				newAttestationQuote, err = os.ReadFile(attestationQuoteArg)
+				if err != nil {
+					return fmt.Errorf("failed to read attestation quote file: %w", err)
+				}
+			} else {
+				newAttestationQuote, err = hex.DecodeString(attestationQuoteArg)
+				if err != nil {
+					return fmt.Errorf("invalid attestation quote hex: %w", err)
+				}
+			}
+
+			// Get overlap blocks
+			overlapBlocks, err := cmd.Flags().GetInt64(FlagOverlapBlocks)
+			if err != nil {
+				return err
+			}
+			if overlapBlocks <= 0 {
+				return fmt.Errorf("overlap blocks must be positive")
+			}
+
+			// Get optional new measurement hash (for enclave upgrade)
+			var newMeasurementHash []byte
+			newMeasurementHashHex, _ := cmd.Flags().GetString(FlagNewMeasurementHash)
+			if newMeasurementHashHex != "" {
+				newMeasurementHash, err = hex.DecodeString(newMeasurementHashHex)
+				if err != nil {
+					return fmt.Errorf("invalid new measurement hash hex: %w", err)
+				}
+				if len(newMeasurementHash) != 32 {
+					return fmt.Errorf("new measurement hash must be 32 bytes, got %d", len(newMeasurementHash))
+				}
+			}
+
+			// Get new ISV SVN
+			newISVSVN, _ := cmd.Flags().GetUint16(FlagISVSVN)
+
+			msg := &enclavetypes.MsgRotateEnclaveIdentity{
+				ValidatorAddress:    cctx.GetFromAddress().String(),
+				NewEncryptionPubKey: newEncryptionPubKey,
+				NewSigningPubKey:    newSigningPubKey,
+				NewAttestationQuote: newAttestationQuote,
+				NewMeasurementHash:  newMeasurementHash,
+				NewISVSVN:           newISVSVN,
+				OverlapBlocks:       overlapBlocks,
+			}
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			resp, err := cl.Tx().BroadcastMsgs(ctx, []sdk.Msg{msg})
+			if err != nil {
+				return err
+			}
+
+			return cl.PrintMessage(resp)
+		},
+	}
+
+	cflags.AddTxFlagsToCmd(cmd)
+
+	cmd.Flags().String(FlagEncryptionPubKey, "", "New encryption public key (hex-encoded)")
+	cmd.Flags().String(FlagSigningPubKey, "", "New signing public key (hex-encoded)")
+	cmd.Flags().String(FlagAttestationQuote, "", "New attestation quote (hex-encoded or file path)")
+	cmd.Flags().Int64(FlagOverlapBlocks, 0, "Number of blocks for key overlap period")
+	cmd.Flags().String(FlagNewMeasurementHash, "", "New measurement hash if enclave was upgraded (hex-encoded)")
+	cmd.Flags().Uint16(FlagISVSVN, 0, "New ISV Security Version Number")
+
+	_ = cmd.MarkFlagRequired(FlagEncryptionPubKey)
+	_ = cmd.MarkFlagRequired(FlagSigningPubKey)
+	_ = cmd.MarkFlagRequired(FlagAttestationQuote)
+	_ = cmd.MarkFlagRequired(FlagOverlapBlocks)
+
+	return cmd
+}
+
+// GetTxEnclaveProposeMeasurementCmd returns the command to propose a new measurement
+func GetTxEnclaveProposeMeasurementCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "propose-measurement",
+		Short: "Propose a new enclave measurement for the allowlist (governance only)",
+		Long: `Propose adding a new enclave measurement to the allowlist.
+
+This command can only be executed by the governance module authority.
+Use this via a governance proposal to add new approved enclave measurements.
+
+Required flags:
+  --measurement-hash: Enclave measurement hash (32 bytes, hex-encoded)
+  --tee-type:         TEE type (SGX, SEV-SNP, NITRO, TRUSTZONE)
+  --description:      Human-readable description
+
+Example:
+  $ virtengine tx enclave propose-measurement \
+      --measurement-hash=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+      --tee-type=SGX \
+      --description="VirtEngine Identity Enclave v1.0.0" \
+      --min-isv-svn=1 \
+      --from governance`,
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: TxPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustClientFromContext(ctx)
+			cctx := cl.ClientContext()
+
+			// Get measurement hash
+			measurementHashHex, err := cmd.Flags().GetString(FlagMeasurementHash)
+			if err != nil {
+				return err
+			}
+			measurementHash, err := hex.DecodeString(measurementHashHex)
+			if err != nil {
+				return fmt.Errorf("invalid measurement hash hex: %w", err)
+			}
+			if len(measurementHash) != 32 {
+				return fmt.Errorf("measurement hash must be 32 bytes, got %d", len(measurementHash))
+			}
+
+			// Get TEE type
+			teeTypeStr, err := cmd.Flags().GetString(FlagTEEType)
+			if err != nil {
+				return err
+			}
+			teeType := enclavetypes.TEEType(teeTypeStr)
+			if !enclavetypes.IsValidTEEType(teeType) {
+				return fmt.Errorf("invalid TEE type: %s", teeTypeStr)
+			}
+
+			// Get description
+			description, err := cmd.Flags().GetString(FlagDescription)
+			if err != nil {
+				return err
+			}
+			if description == "" {
+				return fmt.Errorf("description is required")
+			}
+
+			// Get optional min ISV SVN
+			minISVSVN, _ := cmd.Flags().GetUint16(FlagMinISVSVN)
+
+			// Get optional expiry blocks
+			expiryBlocks, _ := cmd.Flags().GetInt64(FlagExpiryBlocks)
+
+			msg := &enclavetypes.MsgProposeMeasurement{
+				Authority:       cctx.GetFromAddress().String(),
+				MeasurementHash: measurementHash,
+				TEEType:         teeType,
+				Description:     description,
+				MinISVSVN:       minISVSVN,
+				ExpiryBlocks:    expiryBlocks,
+			}
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			resp, err := cl.Tx().BroadcastMsgs(ctx, []sdk.Msg{msg})
+			if err != nil {
+				return err
+			}
+
+			return cl.PrintMessage(resp)
+		},
+	}
+
+	cflags.AddTxFlagsToCmd(cmd)
+
+	cmd.Flags().String(FlagMeasurementHash, "", "Enclave measurement hash (32 bytes, hex-encoded)")
+	cmd.Flags().String(FlagTEEType, "", "TEE type (SGX, SEV-SNP, NITRO, TRUSTZONE)")
+	cmd.Flags().String(FlagDescription, "", "Human-readable description")
+	cmd.Flags().Uint16(FlagMinISVSVN, 0, "Minimum required ISV Security Version Number")
+	cmd.Flags().Int64(FlagExpiryBlocks, 0, "Number of blocks until measurement expires (0 for no expiry)")
+
+	_ = cmd.MarkFlagRequired(FlagMeasurementHash)
+	_ = cmd.MarkFlagRequired(FlagTEEType)
+	_ = cmd.MarkFlagRequired(FlagDescription)
+
+	return cmd
+}
+
+// GetTxEnclaveRevokeMeasurementCmd returns the command to revoke a measurement
+func GetTxEnclaveRevokeMeasurementCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revoke-measurement",
+		Short: "Revoke an enclave measurement from the allowlist (governance only)",
+		Long: `Revoke an enclave measurement from the allowlist.
+
+This command can only be executed by the governance module authority.
+Use this via a governance proposal to revoke compromised or deprecated measurements.
+
+Required flags:
+  --measurement-hash: Enclave measurement hash to revoke (hex-encoded)
+  --reason:           Reason for revocation
+
+Example:
+  $ virtengine tx enclave revoke-measurement \
+      --measurement-hash=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+      --reason="Security vulnerability discovered in enclave version 1.0.0" \
+      --from governance`,
+		Args:              cobra.ExactArgs(0),
+		PersistentPreRunE: TxPersistentPreRunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			cl := MustClientFromContext(ctx)
+			cctx := cl.ClientContext()
+
+			// Get measurement hash
+			measurementHashHex, err := cmd.Flags().GetString(FlagMeasurementHash)
+			if err != nil {
+				return err
+			}
+			measurementHash, err := hex.DecodeString(measurementHashHex)
+			if err != nil {
+				return fmt.Errorf("invalid measurement hash hex: %w", err)
+			}
+			if len(measurementHash) != 32 {
+				return fmt.Errorf("measurement hash must be 32 bytes, got %d", len(measurementHash))
+			}
+
+			// Get reason
+			reason, err := cmd.Flags().GetString(FlagReason)
+			if err != nil {
+				return err
+			}
+			if reason == "" {
+				return fmt.Errorf("reason is required")
+			}
+
+			msg := &enclavetypes.MsgRevokeMeasurement{
+				Authority:       cctx.GetFromAddress().String(),
+				MeasurementHash: measurementHash,
+				Reason:          reason,
+			}
+
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			resp, err := cl.Tx().BroadcastMsgs(ctx, []sdk.Msg{msg})
+			if err != nil {
+				return err
+			}
+
+			return cl.PrintMessage(resp)
+		},
+	}
+
+	cflags.AddTxFlagsToCmd(cmd)
+
+	cmd.Flags().String(FlagMeasurementHash, "", "Enclave measurement hash to revoke (hex-encoded)")
+	cmd.Flags().String(FlagReason, "", "Reason for revocation")
+
+	_ = cmd.MarkFlagRequired(FlagMeasurementHash)
+	_ = cmd.MarkFlagRequired(FlagReason)
+
+	return cmd
+}

--- a/sdk/go/cli/query.go
+++ b/sdk/go/cli/query.go
@@ -72,6 +72,7 @@ func QueryCmd() *cobra.Command {
 		GetQueryWasmCmd(),
 		GetQueryOracleCmd(),
 		GetQueryBMECmd(),
+		GetQueryEnclaveCmd(),
 		GetQueryModuleNameToAddressCmd(),
 	)
 

--- a/sdk/go/cli/tx.go
+++ b/sdk/go/cli/tx.go
@@ -90,6 +90,7 @@ func TxCmd() *cobra.Command {
 		GetTxWasmCmd(),
 		GetTxOracleCmd(),
 		GetTxBMECmd(),
+		GetTxEnclaveCmd(),
 	)
 
 	cmd.PersistentFlags().String(cflags.FlagChainID, "", "The network chain ID")

--- a/sdk/go/node/enclave/v1/errors.go
+++ b/sdk/go/node/enclave/v1/errors.go
@@ -1,0 +1,31 @@
+package v1
+
+import (
+	"cosmossdk.io/errors"
+)
+
+var (
+	// ErrInvalidEnclaveIdentity indicates an invalid enclave identity
+	ErrInvalidEnclaveIdentity = errors.Register(ModuleName, 1, "invalid enclave identity")
+
+	// ErrInvalidMeasurement indicates an invalid measurement
+	ErrInvalidMeasurement = errors.Register(ModuleName, 2, "invalid measurement")
+
+	// ErrEnclaveIdentityNotFound indicates the enclave identity was not found
+	ErrEnclaveIdentityNotFound = errors.Register(ModuleName, 3, "enclave identity not found")
+
+	// ErrEnclaveIdentityExists indicates the enclave identity already exists
+	ErrEnclaveIdentityExists = errors.Register(ModuleName, 4, "enclave identity already exists")
+
+	// ErrMeasurementNotAllowlisted indicates the measurement is not allowlisted
+	ErrMeasurementNotAllowlisted = errors.Register(ModuleName, 5, "measurement not allowlisted")
+
+	// ErrKeyRotationInProgress indicates a key rotation is already in progress
+	ErrKeyRotationInProgress = errors.Register(ModuleName, 6, "key rotation already in progress")
+
+	// ErrNoActiveRotation indicates no active key rotation was found
+	ErrNoActiveRotation = errors.Register(ModuleName, 7, "no active key rotation")
+
+	// ErrUnauthorized indicates an unauthorized action
+	ErrUnauthorized = errors.Register(ModuleName, 8, "unauthorized")
+)

--- a/sdk/go/node/enclave/v1/identity.go
+++ b/sdk/go/node/enclave/v1/identity.go
@@ -1,0 +1,180 @@
+package v1
+
+import (
+	"time"
+)
+
+// EnclaveIdentity represents a validator's enclave identity record
+type EnclaveIdentity struct {
+	// ValidatorAddress is the validator operator address
+	ValidatorAddress string `json:"validator_address" yaml:"validator_address"`
+
+	// TEEType is the type of TEE (SGX, SEV-SNP, NITRO)
+	TEEType TEEType `json:"tee_type" yaml:"tee_type"`
+
+	// MeasurementHash is the enclave measurement (MRENCLAVE for SGX)
+	MeasurementHash []byte `json:"measurement_hash" yaml:"measurement_hash"`
+
+	// SignerHash is the signer measurement (MRSIGNER for SGX)
+	SignerHash []byte `json:"signer_hash,omitempty" yaml:"signer_hash"`
+
+	// EncryptionPubKey is the enclave's public key for encryption
+	EncryptionPubKey []byte `json:"encryption_pub_key" yaml:"encryption_pub_key"`
+
+	// SigningPubKey is the enclave's public key for signing attestations
+	SigningPubKey []byte `json:"signing_pub_key" yaml:"signing_pub_key"`
+
+	// AttestationQuote is the raw attestation quote from the TEE
+	AttestationQuote []byte `json:"attestation_quote" yaml:"attestation_quote"`
+
+	// AttestationChain is the certificate chain for attestation verification
+	AttestationChain [][]byte `json:"attestation_chain,omitempty" yaml:"attestation_chain"`
+
+	// ISVProdID is the Independent Software Vendor Product ID
+	ISVProdID uint16 `json:"isv_prod_id" yaml:"isv_prod_id"`
+
+	// ISVSVN is the Independent Software Vendor Security Version Number
+	ISVSVN uint16 `json:"isv_svn" yaml:"isv_svn"`
+
+	// QuoteVersion is the attestation quote format version
+	QuoteVersion uint32 `json:"quote_version" yaml:"quote_version"`
+
+	// DebugMode indicates if the enclave is in debug mode
+	DebugMode bool `json:"debug_mode" yaml:"debug_mode"`
+
+	// Epoch is the registration epoch
+	Epoch uint64 `json:"epoch" yaml:"epoch"`
+
+	// ExpiryHeight is the block height when this identity expires
+	ExpiryHeight int64 `json:"expiry_height" yaml:"expiry_height"`
+
+	// RegisteredAt is the timestamp when this identity was registered
+	RegisteredAt time.Time `json:"registered_at" yaml:"registered_at"`
+
+	// UpdatedAt is the timestamp when this identity was last updated
+	UpdatedAt time.Time `json:"updated_at" yaml:"updated_at"`
+
+	// Status is the current status of the enclave identity
+	Status string `json:"status" yaml:"status"`
+}
+
+// MeasurementRecord represents an approved enclave measurement in the allowlist
+type MeasurementRecord struct {
+	// MeasurementHash is the enclave measurement hash
+	MeasurementHash []byte `json:"measurement_hash" yaml:"measurement_hash"`
+
+	// TEEType is the TEE type this measurement is for
+	TEEType TEEType `json:"tee_type" yaml:"tee_type"`
+
+	// Description is a human-readable description
+	Description string `json:"description" yaml:"description"`
+
+	// MinISVSVN is the minimum required security version
+	MinISVSVN uint16 `json:"min_isv_svn" yaml:"min_isv_svn"`
+
+	// AddedAt is when this measurement was added
+	AddedAt time.Time `json:"added_at" yaml:"added_at"`
+
+	// AddedByProposal is the governance proposal ID that added this measurement
+	AddedByProposal uint64 `json:"added_by_proposal" yaml:"added_by_proposal"`
+
+	// ExpiryHeight is when this measurement expires (0 for no expiry)
+	ExpiryHeight int64 `json:"expiry_height,omitempty" yaml:"expiry_height"`
+
+	// Revoked indicates if this measurement has been revoked
+	Revoked bool `json:"revoked" yaml:"revoked"`
+
+	// RevokedAt is when this measurement was revoked (if applicable)
+	RevokedAt *time.Time `json:"revoked_at,omitempty" yaml:"revoked_at"`
+
+	// RevokedByProposal is the governance proposal that revoked this (if applicable)
+	RevokedByProposal uint64 `json:"revoked_by_proposal,omitempty" yaml:"revoked_by_proposal"`
+}
+
+// KeyRotationRecord represents a key rotation event
+type KeyRotationRecord struct {
+	// ValidatorAddress is the validator operator address
+	ValidatorAddress string `json:"validator_address" yaml:"validator_address"`
+
+	// Epoch is the epoch when rotation was initiated
+	Epoch uint64 `json:"epoch" yaml:"epoch"`
+
+	// OldKeyFingerprint is the fingerprint of the old key
+	OldKeyFingerprint string `json:"old_key_fingerprint" yaml:"old_key_fingerprint"`
+
+	// NewKeyFingerprint is the fingerprint of the new key
+	NewKeyFingerprint string `json:"new_key_fingerprint" yaml:"new_key_fingerprint"`
+
+	// OverlapStartHeight is when both keys become valid
+	OverlapStartHeight int64 `json:"overlap_start_height" yaml:"overlap_start_height"`
+
+	// OverlapEndHeight is when the old key becomes invalid
+	OverlapEndHeight int64 `json:"overlap_end_height" yaml:"overlap_end_height"`
+
+	// InitiatedAt is when the rotation was initiated
+	InitiatedAt time.Time `json:"initiated_at" yaml:"initiated_at"`
+
+	// CompletedAt is when the rotation was completed (old key invalidated)
+	CompletedAt *time.Time `json:"completed_at,omitempty" yaml:"completed_at"`
+
+	// Status is the current status of the rotation
+	Status string `json:"status" yaml:"status"`
+}
+
+// ValidatorKeyInfo contains key information for a validator
+type ValidatorKeyInfo struct {
+	ValidatorAddress string `json:"validator_address" yaml:"validator_address"`
+	EncryptionKeyID  string `json:"encryption_key_id" yaml:"encryption_key_id"`
+	EncryptionPubKey []byte `json:"encryption_pub_key" yaml:"encryption_pub_key"`
+	MeasurementHash  []byte `json:"measurement_hash" yaml:"measurement_hash"`
+	ExpiryHeight     int64  `json:"expiry_height" yaml:"expiry_height"`
+	IsInRotation     bool   `json:"is_in_rotation" yaml:"is_in_rotation"`
+}
+
+// Params contains the module parameters
+type Params struct {
+	// AllowedTEETypes specifies which TEE types are allowed
+	AllowedTEETypes []string `json:"allowed_tee_types" yaml:"allowed_tee_types"`
+
+	// DefaultExpiryBlocks is the default expiry period in blocks
+	DefaultExpiryBlocks int64 `json:"default_expiry_blocks" yaml:"default_expiry_blocks"`
+
+	// MinOverlapBlocks is the minimum overlap period for key rotation
+	MinOverlapBlocks int64 `json:"min_overlap_blocks" yaml:"min_overlap_blocks"`
+
+	// MaxOverlapBlocks is the maximum overlap period for key rotation
+	MaxOverlapBlocks int64 `json:"max_overlap_blocks" yaml:"max_overlap_blocks"`
+
+	// MinQuoteVersion is the minimum attestation quote version
+	MinQuoteVersion uint32 `json:"min_quote_version" yaml:"min_quote_version"`
+
+	// RequireAttestationChain indicates if attestation chain is required
+	RequireAttestationChain bool `json:"require_attestation_chain" yaml:"require_attestation_chain"`
+}
+
+// AttestedScoringResult represents an attested VEID scoring result
+type AttestedScoringResult struct {
+	// ScopeID is the identity scope being scored
+	ScopeID string `json:"scope_id" yaml:"scope_id"`
+
+	// AccountAddress is the account that owns the scope
+	AccountAddress string `json:"account_address" yaml:"account_address"`
+
+	// Score is the computed identity score
+	Score uint32 `json:"score" yaml:"score"`
+
+	// Status is the scoring status
+	Status string `json:"status" yaml:"status"`
+
+	// BlockHeight is when the scoring was performed
+	BlockHeight int64 `json:"block_height" yaml:"block_height"`
+
+	// ValidatorAddress is the validator that performed the scoring
+	ValidatorAddress string `json:"validator_address" yaml:"validator_address"`
+
+	// EnclaveMeasurementHash is the measurement of the enclave that scored
+	EnclaveMeasurementHash []byte `json:"enclave_measurement_hash" yaml:"enclave_measurement_hash"`
+
+	// EnclaveSignature is the enclave's signature over the result
+	EnclaveSignature []byte `json:"enclave_signature" yaml:"enclave_signature"`
+}

--- a/sdk/go/node/enclave/v1/msgs.go
+++ b/sdk/go/node/enclave/v1/msgs.go
@@ -1,0 +1,245 @@
+package v1
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// MsgRegisterEnclaveIdentity registers a new enclave identity for a validator
+type MsgRegisterEnclaveIdentity struct {
+	// ValidatorAddress is the validator operator address
+	ValidatorAddress string `json:"validator_address" yaml:"validator_address"`
+
+	// TEEType is the type of TEE
+	TEEType TEEType `json:"tee_type" yaml:"tee_type"`
+
+	// MeasurementHash is the enclave measurement hash
+	MeasurementHash []byte `json:"measurement_hash" yaml:"measurement_hash"`
+
+	// SignerHash is the signer measurement (MRSIGNER)
+	SignerHash []byte `json:"signer_hash,omitempty" yaml:"signer_hash"`
+
+	// EncryptionPubKey is the enclave's public key for encryption
+	EncryptionPubKey []byte `json:"encryption_pub_key" yaml:"encryption_pub_key"`
+
+	// SigningPubKey is the enclave's public key for signing
+	SigningPubKey []byte `json:"signing_pub_key" yaml:"signing_pub_key"`
+
+	// AttestationQuote is the raw attestation quote
+	AttestationQuote []byte `json:"attestation_quote" yaml:"attestation_quote"`
+
+	// AttestationChain is the certificate chain
+	AttestationChain [][]byte `json:"attestation_chain,omitempty" yaml:"attestation_chain"`
+
+	// ISVProdID is the product ID
+	ISVProdID uint16 `json:"isv_prod_id" yaml:"isv_prod_id"`
+
+	// ISVSVN is the security version number
+	ISVSVN uint16 `json:"isv_svn" yaml:"isv_svn"`
+
+	// QuoteVersion is the quote format version
+	QuoteVersion uint32 `json:"quote_version" yaml:"quote_version"`
+}
+
+var _ sdk.Msg = &MsgRegisterEnclaveIdentity{}
+
+// ValidateBasic performs basic validation
+func (m MsgRegisterEnclaveIdentity) ValidateBasic() error {
+	if m.ValidatorAddress == "" {
+		return ErrInvalidEnclaveIdentity.Wrap("validator address cannot be empty")
+	}
+
+	if _, err := sdk.AccAddressFromBech32(m.ValidatorAddress); err != nil {
+		return ErrInvalidEnclaveIdentity.Wrapf("invalid validator address: %v", err)
+	}
+
+	if !IsValidTEEType(m.TEEType) {
+		return ErrInvalidEnclaveIdentity.Wrapf("invalid TEE type: %s", m.TEEType)
+	}
+
+	if len(m.MeasurementHash) != 32 {
+		return ErrInvalidEnclaveIdentity.Wrapf("measurement hash must be 32 bytes, got %d", len(m.MeasurementHash))
+	}
+
+	if len(m.EncryptionPubKey) == 0 {
+		return ErrInvalidEnclaveIdentity.Wrap("encryption public key cannot be empty")
+	}
+
+	if len(m.SigningPubKey) == 0 {
+		return ErrInvalidEnclaveIdentity.Wrap("signing public key cannot be empty")
+	}
+
+	if len(m.AttestationQuote) == 0 {
+		return ErrInvalidEnclaveIdentity.Wrap("attestation quote cannot be empty")
+	}
+
+	return nil
+}
+
+// GetSigners returns the signers
+func (m MsgRegisterEnclaveIdentity) GetSigners() []sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(m.ValidatorAddress)
+	if err != nil {
+		return nil
+	}
+	return []sdk.AccAddress{addr}
+}
+
+// MsgRotateEnclaveIdentity initiates a key rotation for a validator's enclave
+type MsgRotateEnclaveIdentity struct {
+	// ValidatorAddress is the validator operator address
+	ValidatorAddress string `json:"validator_address" yaml:"validator_address"`
+
+	// NewEncryptionPubKey is the new enclave encryption public key
+	NewEncryptionPubKey []byte `json:"new_encryption_pub_key" yaml:"new_encryption_pub_key"`
+
+	// NewSigningPubKey is the new enclave signing public key
+	NewSigningPubKey []byte `json:"new_signing_pub_key" yaml:"new_signing_pub_key"`
+
+	// NewAttestationQuote is the new attestation quote
+	NewAttestationQuote []byte `json:"new_attestation_quote" yaml:"new_attestation_quote"`
+
+	// NewAttestationChain is the new certificate chain
+	NewAttestationChain [][]byte `json:"new_attestation_chain,omitempty" yaml:"new_attestation_chain"`
+
+	// NewMeasurementHash is the new measurement hash (if enclave was upgraded)
+	NewMeasurementHash []byte `json:"new_measurement_hash,omitempty" yaml:"new_measurement_hash"`
+
+	// NewISVSVN is the new security version
+	NewISVSVN uint16 `json:"new_isv_svn" yaml:"new_isv_svn"`
+
+	// OverlapBlocks is the number of blocks for which both keys are valid
+	OverlapBlocks int64 `json:"overlap_blocks" yaml:"overlap_blocks"`
+}
+
+var _ sdk.Msg = &MsgRotateEnclaveIdentity{}
+
+// ValidateBasic performs basic validation
+func (m MsgRotateEnclaveIdentity) ValidateBasic() error {
+	if m.ValidatorAddress == "" {
+		return ErrInvalidEnclaveIdentity.Wrap("validator address cannot be empty")
+	}
+
+	if _, err := sdk.AccAddressFromBech32(m.ValidatorAddress); err != nil {
+		return ErrInvalidEnclaveIdentity.Wrapf("invalid validator address: %v", err)
+	}
+
+	if len(m.NewEncryptionPubKey) == 0 {
+		return ErrInvalidEnclaveIdentity.Wrap("new encryption public key cannot be empty")
+	}
+
+	if len(m.NewSigningPubKey) == 0 {
+		return ErrInvalidEnclaveIdentity.Wrap("new signing public key cannot be empty")
+	}
+
+	if len(m.NewAttestationQuote) == 0 {
+		return ErrInvalidEnclaveIdentity.Wrap("new attestation quote cannot be empty")
+	}
+
+	if m.OverlapBlocks <= 0 {
+		return ErrInvalidEnclaveIdentity.Wrap("overlap blocks must be positive")
+	}
+
+	return nil
+}
+
+// GetSigners returns the signers
+func (m MsgRotateEnclaveIdentity) GetSigners() []sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(m.ValidatorAddress)
+	if err != nil {
+		return nil
+	}
+	return []sdk.AccAddress{addr}
+}
+
+// MsgProposeMeasurement proposes a new enclave measurement for the allowlist
+type MsgProposeMeasurement struct {
+	// Authority is the governance authority address
+	Authority string `json:"authority" yaml:"authority"`
+
+	// MeasurementHash is the enclave measurement hash to add
+	MeasurementHash []byte `json:"measurement_hash" yaml:"measurement_hash"`
+
+	// TEEType is the TEE type this measurement is for
+	TEEType TEEType `json:"tee_type" yaml:"tee_type"`
+
+	// Description is a human-readable description
+	Description string `json:"description" yaml:"description"`
+
+	// MinISVSVN is the minimum required security version
+	MinISVSVN uint16 `json:"min_isv_svn" yaml:"min_isv_svn"`
+
+	// ExpiryBlocks is the number of blocks until expiry (0 for no expiry)
+	ExpiryBlocks int64 `json:"expiry_blocks,omitempty" yaml:"expiry_blocks"`
+}
+
+var _ sdk.Msg = &MsgProposeMeasurement{}
+
+// ValidateBasic performs basic validation
+func (m MsgProposeMeasurement) ValidateBasic() error {
+	if m.Authority == "" {
+		return ErrInvalidMeasurement.Wrap("authority cannot be empty")
+	}
+
+	if len(m.MeasurementHash) != 32 {
+		return ErrInvalidMeasurement.Wrapf("measurement hash must be 32 bytes, got %d", len(m.MeasurementHash))
+	}
+
+	if !IsValidTEEType(m.TEEType) {
+		return ErrInvalidMeasurement.Wrapf("invalid TEE type: %s", m.TEEType)
+	}
+
+	if m.Description == "" {
+		return ErrInvalidMeasurement.Wrap("description cannot be empty")
+	}
+
+	return nil
+}
+
+// GetSigners returns the signers
+func (m MsgProposeMeasurement) GetSigners() []sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(m.Authority)
+	if err != nil {
+		return nil
+	}
+	return []sdk.AccAddress{addr}
+}
+
+// MsgRevokeMeasurement revokes an enclave measurement from the allowlist
+type MsgRevokeMeasurement struct {
+	// Authority is the governance authority address
+	Authority string `json:"authority" yaml:"authority"`
+
+	// MeasurementHash is the enclave measurement hash to revoke
+	MeasurementHash []byte `json:"measurement_hash" yaml:"measurement_hash"`
+
+	// Reason is the reason for revocation
+	Reason string `json:"reason" yaml:"reason"`
+}
+
+var _ sdk.Msg = &MsgRevokeMeasurement{}
+
+// ValidateBasic performs basic validation
+func (m MsgRevokeMeasurement) ValidateBasic() error {
+	if m.Authority == "" {
+		return ErrInvalidMeasurement.Wrap("authority cannot be empty")
+	}
+
+	if len(m.MeasurementHash) != 32 {
+		return ErrInvalidMeasurement.Wrapf("measurement hash must be 32 bytes, got %d", len(m.MeasurementHash))
+	}
+
+	if m.Reason == "" {
+		return ErrInvalidMeasurement.Wrap("reason cannot be empty")
+	}
+
+	return nil
+}
+
+// GetSigners returns the signers
+func (m MsgRevokeMeasurement) GetSigners() []sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(m.Authority)
+	if err != nil {
+		return nil
+	}
+	return []sdk.AccAddress{addr}
+}

--- a/sdk/go/node/enclave/v1/query.go
+++ b/sdk/go/node/enclave/v1/query.go
@@ -1,0 +1,97 @@
+package v1
+
+// QueryEnclaveIdentityRequest is the request for querying an enclave identity
+type QueryEnclaveIdentityRequest struct {
+	ValidatorAddress string `json:"validator_address" yaml:"validator_address"`
+}
+
+// QueryEnclaveIdentityResponse is the response for querying an enclave identity
+type QueryEnclaveIdentityResponse struct {
+	Identity *EnclaveIdentity `json:"identity,omitempty" yaml:"identity"`
+}
+
+// QueryActiveValidatorEnclaveKeysRequest is the request for querying active validator enclave keys
+type QueryActiveValidatorEnclaveKeysRequest struct{}
+
+// QueryActiveValidatorEnclaveKeysResponse is the response for active validator enclave keys
+type QueryActiveValidatorEnclaveKeysResponse struct {
+	Identities []EnclaveIdentity `json:"identities" yaml:"identities"`
+}
+
+// QueryCommitteeEnclaveKeysRequest is the request for querying committee enclave keys
+type QueryCommitteeEnclaveKeysRequest struct {
+	// CommitteeEpoch is the epoch for which to get committee keys
+	CommitteeEpoch uint64 `json:"committee_epoch,omitempty" yaml:"committee_epoch"`
+}
+
+// QueryCommitteeEnclaveKeysResponse is the response for committee enclave keys
+type QueryCommitteeEnclaveKeysResponse struct {
+	Identities []EnclaveIdentity `json:"identities" yaml:"identities"`
+}
+
+// QueryMeasurementAllowlistRequest is the request for querying the measurement allowlist
+type QueryMeasurementAllowlistRequest struct {
+	// TEEType optionally filters by TEE type
+	TEEType string `json:"tee_type,omitempty" yaml:"tee_type"`
+
+	// IncludeRevoked optionally includes revoked measurements
+	IncludeRevoked bool `json:"include_revoked,omitempty" yaml:"include_revoked"`
+}
+
+// QueryMeasurementAllowlistResponse is the response for the measurement allowlist
+type QueryMeasurementAllowlistResponse struct {
+	Measurements []MeasurementRecord `json:"measurements" yaml:"measurements"`
+}
+
+// QueryMeasurementRequest is the request for querying a specific measurement
+type QueryMeasurementRequest struct {
+	MeasurementHash []byte `json:"measurement_hash" yaml:"measurement_hash"`
+}
+
+// QueryMeasurementResponse is the response for a specific measurement
+type QueryMeasurementResponse struct {
+	Measurement *MeasurementRecord `json:"measurement,omitempty" yaml:"measurement"`
+	IsAllowed   bool               `json:"is_allowed" yaml:"is_allowed"`
+}
+
+// QueryKeyRotationRequest is the request for querying key rotation status
+type QueryKeyRotationRequest struct {
+	ValidatorAddress string `json:"validator_address" yaml:"validator_address"`
+}
+
+// QueryKeyRotationResponse is the response for key rotation status
+type QueryKeyRotationResponse struct {
+	Rotation          *KeyRotationRecord `json:"rotation,omitempty" yaml:"rotation"`
+	HasActiveRotation bool               `json:"has_active_rotation" yaml:"has_active_rotation"`
+}
+
+// QueryValidKeySetRequest is the request for querying current valid key set
+type QueryValidKeySetRequest struct {
+	// ForBlockHeight is the block height to check validity for
+	ForBlockHeight int64 `json:"for_block_height,omitempty" yaml:"for_block_height"`
+}
+
+// QueryValidKeySetResponse is the response for current valid key set
+type QueryValidKeySetResponse struct {
+	ValidatorKeys []ValidatorKeyInfo `json:"validator_keys" yaml:"validator_keys"`
+	TotalCount    int                `json:"total_count" yaml:"total_count"`
+}
+
+// QueryParamsRequest is the request for querying module parameters
+type QueryParamsRequest struct{}
+
+// QueryParamsResponse is the response for module parameters
+type QueryParamsResponse struct {
+	Params Params `json:"params" yaml:"params"`
+}
+
+// QueryAttestedResultRequest is the request for querying an attested result
+type QueryAttestedResultRequest struct {
+	BlockHeight int64  `json:"block_height" yaml:"block_height"`
+	ScopeID     string `json:"scope_id" yaml:"scope_id"`
+}
+
+// QueryAttestedResultResponse is the response for an attested result
+type QueryAttestedResultResponse struct {
+	Result *AttestedScoringResult `json:"result,omitempty" yaml:"result"`
+}

--- a/sdk/go/node/enclave/v1/types.go
+++ b/sdk/go/node/enclave/v1/types.go
@@ -1,0 +1,40 @@
+// Package v1 contains the enclave module types for CLI usage.
+// These types mirror x/enclave/types for use in the SDK CLI.
+package v1
+
+const (
+	// ModuleName is the module name constant used in many places
+	ModuleName = "enclave"
+)
+
+// TEEType represents the type of Trusted Execution Environment
+type TEEType string
+
+const (
+	// TEETypeSGX is Intel SGX
+	TEETypeSGX TEEType = "SGX"
+
+	// TEETypeSEVSNP is AMD SEV-SNP
+	TEETypeSEVSNP TEEType = "SEV-SNP"
+
+	// TEETypeNitro is AWS Nitro Enclaves
+	TEETypeNitro TEEType = "NITRO"
+
+	// TEETypeTrustZone is ARM TrustZone
+	TEETypeTrustZone TEEType = "TRUSTZONE"
+)
+
+// AllTEETypes returns all valid TEE types
+func AllTEETypes() []TEEType {
+	return []TEEType{TEETypeSGX, TEETypeSEVSNP, TEETypeNitro, TEETypeTrustZone}
+}
+
+// IsValidTEEType checks if a TEE type is valid
+func IsValidTEEType(teeType TEEType) bool {
+	for _, t := range AllTEETypes() {
+		if t == teeType {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Overview
Implement CLI transaction and query commands for the enclave module.

## Scope
Create standalone CLI command files that interface with the enclave module's message and query handlers.

## Files to Create

### 1. x/enclave/client/cli/tx.go (~280 lines)
Transaction commands:
- `register` - Register new enclave identity
- `rotate` - Rotate enclave keys  
- `propose-measurement` - Add measurement to allowlist (gov only)
- `revoke-measurement` - Revoke measurement (gov only)

### 2. x/enclave/client/cli/query.go (~300 lines)
Query commands:
- `identity` - Query validator enclave identity
- `keys` - Query active validator keys
- `measurements` - Query allowlisted measurements
- `rotation` - Query key rotation status
- `params` - Query module parameters

### 3. Integration in cmd/virtengine/cmd/root.go
Wire up commands:
```go
import enclavecli "github.com/virtengine/virtengine/x/enclave/client/cli"
txCmd.AddCommand(enclavecli.GetTxCmd())
queryCmd.AddCommand(enclavecli.GetQueryCmd())
```

## Technical Details
- Follow VirtEngine CLI patterns (standalone files, not via module GetQueryCmd/GetTxCmd)
- Use cosmos-sdk/client for context and flags
- Commands should validate inputs before sending to chain
- Support all optional flags per message type

## Implementation Guide
Full code templates available in session checkpoint files.
See x/enclave/CLI_README.md for detailed specifications.

## Acceptance Criteria
- [ ] Transaction commands work: `virtengine tx enclave --help`
- [ ] Query commands work: `virtengine query enclave --help`
- [ ] All commands properly validate inputs
- [ ] Help text is clear and includes examples
- [ ] Commands integrate with existing flag handling

## Dependencies
- None (all keeper and type definitions already exist)

## Effort
~600 LOC, 4-6 hours

## Priority
Medium - Functionality works via direct messages, CLI is for convenience