### PR TITLE
feat:ENCLAVE-ENH-002: Implement cryptographic attestation verification

### DIFF
--- a/x/enclave/keeper/attestation.go
+++ b/x/enclave/keeper/attestation.go
@@ -1,0 +1,185 @@
+package keeper
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	enclave "github.com/virtengine/virtengine/pkg/enclave_runtime"
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+const (
+	sgxQuoteVersionDCAP = 3
+)
+
+// verifyAttestation performs platform-specific cryptographic verification.
+func (k Keeper) verifyAttestation(ctx sdk.Context, identity *types.EnclaveIdentity, measurement *types.MeasurementRecord) error {
+	switch identity.TEEType {
+	case types.TEETypeSGX:
+		return k.verifySGXAttestation(ctx, identity, measurement)
+	case types.TEETypeSEVSNP:
+		return k.verifySEVSNPAttestation(ctx, identity, measurement)
+	case types.TEETypeNitro:
+		return k.verifyNitroAttestation(ctx, identity, measurement)
+	default:
+		return types.ErrAttestationInvalid.Wrapf("unsupported TEE type: %s", identity.TEEType)
+	}
+}
+
+type attestationChain struct {
+	certs []*x509.Certificate
+	crls  []*x509.RevocationList
+	json  [][]byte
+}
+
+func parseAttestationChain(chain [][]byte) (*attestationChain, error) {
+	parsed := &attestationChain{}
+
+	for _, entry := range chain {
+		if len(entry) == 0 {
+			continue
+		}
+
+		if bytes.HasPrefix(bytes.TrimSpace(entry), []byte("{")) {
+			parsed.json = append(parsed.json, entry)
+			continue
+		}
+
+		if parsePEMBlocks(entry, parsed); len(parsed.certs) > 0 || len(parsed.crls) > 0 {
+			continue
+		}
+
+		if cert, err := x509.ParseCertificate(entry); err == nil {
+			parsed.certs = append(parsed.certs, cert)
+			continue
+		}
+
+		if crl, err := x509.ParseRevocationList(entry); err == nil {
+			parsed.crls = append(parsed.crls, crl)
+		}
+	}
+
+	if len(parsed.certs) == 0 && len(parsed.json) == 0 {
+		return parsed, fmt.Errorf("attestation chain contains no usable entries")
+	}
+
+	return parsed, nil
+}
+
+func parsePEMBlocks(data []byte, out *attestationChain) int {
+	parsed := 0
+	for len(data) > 0 {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+		parsed++
+		switch block.Type {
+		case "CERTIFICATE":
+			if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+				out.certs = append(out.certs, cert)
+			}
+		case "X509 CRL", "CRL":
+			if crl, err := x509.ParseRevocationList(block.Bytes); err == nil {
+				out.crls = append(out.crls, crl)
+			}
+		default:
+			// ignore other PEM blocks
+		}
+	}
+	return parsed
+}
+
+func verifyChainWithRoots(ctx sdk.Context, leaf *x509.Certificate, chain []*x509.Certificate, rootsPEM [][]byte) error {
+	if leaf == nil {
+		return fmt.Errorf("missing leaf certificate")
+	}
+
+	verifier := enclave.NewCertificateChainVerifier()
+	verifier.CurrentTime = ctx.BlockTime()
+
+	for _, root := range rootsPEM {
+		if err := verifier.AddRootCA(root); err != nil {
+			return err
+		}
+	}
+	for _, cert := range chain {
+		if cert.Equal(leaf) {
+			continue
+		}
+		if err := verifier.AddIntermediateCA(cert.Raw); err != nil {
+			return err
+		}
+	}
+
+	return verifier.Verify([]*x509.Certificate{leaf})
+}
+
+func checkRevocations(ctx sdk.Context, leaf *x509.Certificate, issuerPool []*x509.Certificate, crls []*x509.RevocationList) error {
+	if len(crls) == 0 || leaf == nil {
+		return nil
+	}
+
+	verifyTime := ctx.BlockTime()
+	for _, crl := range crls {
+		if verifyTime.Before(crl.ThisUpdate) || (!crl.NextUpdate.IsZero() && verifyTime.After(crl.NextUpdate)) {
+			continue
+		}
+
+		for _, issuer := range issuerPool {
+			if err := crl.CheckSignatureFrom(issuer); err == nil {
+				for _, revoked := range crl.RevokedCertificateEntries {
+					if revoked.SerialNumber.Cmp(leaf.SerialNumber) == 0 {
+						return fmt.Errorf("certificate revoked by CRL issued by %s", issuer.Subject.CommonName)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func findJSONWithKey(entries [][]byte, key string) []byte {
+	for _, entry := range entries {
+		var payload map[string]json.RawMessage
+		if err := json.Unmarshal(entry, &payload); err != nil {
+			continue
+		}
+		if _, ok := payload[key]; ok {
+			return entry
+		}
+	}
+	return nil
+}
+
+func findCertificateBySubject(certs []*x509.Certificate, contains string) *x509.Certificate {
+	for _, cert := range certs {
+		if strings.Contains(strings.ToUpper(cert.Subject.CommonName), strings.ToUpper(contains)) {
+			return cert
+		}
+	}
+	if len(certs) > 0 {
+		return certs[0]
+	}
+	return nil
+}
+
+func selectLeafCertificate(certs []*x509.Certificate) *x509.Certificate {
+	for _, cert := range certs {
+		if !cert.IsCA {
+			return cert
+		}
+	}
+	if len(certs) > 0 {
+		return certs[0]
+	}
+	return nil
+}

--- a/x/enclave/keeper/attestation_nitro.go
+++ b/x/enclave/keeper/attestation_nitro.go
@@ -1,0 +1,59 @@
+package keeper
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	enclave "github.com/virtengine/virtengine/pkg/enclave_runtime"
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+func (k Keeper) verifyNitroAttestation(ctx sdk.Context, identity *types.EnclaveIdentity, measurement *types.MeasurementRecord) error {
+	nitroVerifier, err := enclave.NewNitroCryptoVerifier()
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("Nitro verifier init: %v", err)
+	}
+
+	// If measurement hash is a full PCR value, set it as expected PCR0.
+	if len(identity.MeasurementHash) == 48 {
+		nitroVerifier.SetExpectedPCR(0, identity.MeasurementHash)
+	}
+
+	result, err := nitroVerifier.Verify(identity.AttestationQuote)
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("Nitro verification error: %v", err)
+	}
+	if result == nil || !result.Valid || result.Document == nil {
+		return types.ErrAttestationInvalid.Wrap("Nitro verification failed")
+	}
+
+	pcr0, ok := enclave.GetPCR0(result.Document)
+	if !ok {
+		return types.ErrAttestationInvalid.Wrap("PCR0 missing in attestation document")
+	}
+
+	if err := verifyNitroMeasurement(identity, pcr0); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func verifyNitroMeasurement(identity *types.EnclaveIdentity, pcr0 []byte) error {
+	switch len(identity.MeasurementHash) {
+	case 32:
+		sum := sha256.Sum256(pcr0)
+		if !bytes.Equal(identity.MeasurementHash, sum[:]) {
+			return types.ErrAttestationInvalid.Wrap("measurement hash does not match PCR0")
+		}
+	case 48:
+		if !bytes.Equal(identity.MeasurementHash, pcr0) {
+			return types.ErrAttestationInvalid.Wrap("measurement hash does not match PCR0")
+		}
+	default:
+		return types.ErrAttestationInvalid.Wrap("unsupported measurement hash length for Nitro")
+	}
+	return nil
+}

--- a/x/enclave/keeper/attestation_sev.go
+++ b/x/enclave/keeper/attestation_sev.go
@@ -1,0 +1,84 @@
+package keeper
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	enclave "github.com/virtengine/virtengine/pkg/enclave_runtime"
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+func (k Keeper) verifySEVSNPAttestation(ctx sdk.Context, identity *types.EnclaveIdentity, measurement *types.MeasurementRecord) error {
+	report, err := types.ParseSEVSNPReport(identity.AttestationQuote)
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("parse SEV-SNP report: %v", err)
+	}
+
+	if report.Version != 1 && report.Version != 2 {
+		return types.ErrInvalidQuoteVersion.Wrapf("unsupported SEV-SNP report version: %d", report.Version)
+	}
+
+	if report.DebugEnabled() {
+		return types.ErrDebugModeEnabled
+	}
+
+	if err := verifySEVSNPMeasurement(identity, report.Measurement[:]); err != nil {
+		return err
+	}
+
+	if len(identity.SignerHash) > 0 && !bytes.Equal(identity.SignerHash, report.IDKeyDigest[:]) {
+		return types.ErrAttestationInvalid.Wrap("ID key digest does not match signer hash")
+	}
+
+	if len(identity.AttestationChain) == 0 {
+		return types.ErrAttestationInvalid.Wrap("attestation chain required for SEV-SNP verification")
+	}
+
+	chain, err := parseAttestationChain(identity.AttestationChain)
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("attestation chain parse: %v", err)
+	}
+
+	vcek := findCertificateBySubject(chain.certs, "VCEK")
+	if vcek == nil {
+		return types.ErrAttestationInvalid.Wrap("VCEK certificate not provided")
+	}
+
+	snpVerifier, err := enclave.NewSNPVerifier()
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("SNP verifier init: %v", err)
+	}
+
+	result, err := snpVerifier.VerifyWithCert(identity.AttestationQuote, vcek)
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("SNP verification error: %v", err)
+	}
+	if result == nil || !result.Valid {
+		return types.ErrAttestationInvalid.Wrap("SNP verification failed")
+	}
+
+	if err := checkRevocations(ctx, vcek, chain.certs, chain.crls); err != nil {
+		return types.ErrAttestationInvalid.Wrapf("SEV revocation: %v", err)
+	}
+
+	return nil
+}
+
+func verifySEVSNPMeasurement(identity *types.EnclaveIdentity, measurement []byte) error {
+	switch len(identity.MeasurementHash) {
+	case 32:
+		sum := sha256.Sum256(measurement)
+		if !bytes.Equal(identity.MeasurementHash, sum[:]) {
+			return types.ErrAttestationInvalid.Wrap("measurement hash does not match launch digest")
+		}
+	case 48:
+		if !bytes.Equal(identity.MeasurementHash, measurement) {
+			return types.ErrAttestationInvalid.Wrap("measurement hash does not match launch digest")
+		}
+	default:
+		return types.ErrAttestationInvalid.Wrap("unsupported measurement hash length for SEV-SNP")
+	}
+	return nil
+}

--- a/x/enclave/keeper/attestation_sgx.go
+++ b/x/enclave/keeper/attestation_sgx.go
@@ -1,0 +1,143 @@
+package keeper
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	enclave "github.com/virtengine/virtengine/pkg/enclave_runtime"
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+func (k Keeper) verifySGXAttestation(ctx sdk.Context, identity *types.EnclaveIdentity, measurement *types.MeasurementRecord) error {
+	quote, err := types.ParseSGXDCAPQuoteV3(identity.AttestationQuote)
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("parse SGX quote: %v", err)
+	}
+
+	if quote.Header.Version < sgxQuoteVersionDCAP {
+		return types.ErrInvalidQuoteVersion.Wrapf("quote version %d is below minimum %d", quote.Header.Version, sgxQuoteVersionDCAP)
+	}
+
+	if quote.Report.DebugEnabled() {
+		return types.ErrDebugModeEnabled
+	}
+
+	if !bytes.Equal(identity.MeasurementHash, quote.Report.MRENCLAVE[:]) {
+		return types.ErrAttestationInvalid.Wrap("MRENCLAVE does not match measurement hash")
+	}
+
+	if len(identity.SignerHash) > 0 && !bytes.Equal(identity.SignerHash, quote.Report.MRSIGNER[:]) {
+		return types.ErrAttestationInvalid.Wrap("MRSIGNER does not match signer hash")
+	}
+
+	if identity.ISVProdID != 0 && identity.ISVProdID != quote.Report.ISVProdID {
+		return types.ErrAttestationInvalid.Wrapf("ISVProdID mismatch: got %d expected %d", quote.Report.ISVProdID, identity.ISVProdID)
+	}
+
+	if identity.ISVSVN != 0 && identity.ISVSVN != quote.Report.ISVSVN {
+		return types.ErrAttestationInvalid.Wrapf("ISVSVN mismatch: got %d expected %d", quote.Report.ISVSVN, identity.ISVSVN)
+	}
+
+	if err := k.verifySGXCryptographic(ctx, identity, quote); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k Keeper) verifySGXCryptographic(ctx sdk.Context, identity *types.EnclaveIdentity, quote *types.SGXDCAPQuote) error {
+	dcapVerifier, err := enclave.NewDCAPVerifier()
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("DCAP verifier init: %v", err)
+	}
+
+	dcapResult, err := dcapVerifier.Verify(identity.AttestationQuote)
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("DCAP verification error: %v", err)
+	}
+	if dcapResult == nil || !dcapResult.Valid {
+		return types.ErrAttestationInvalid.Wrap("DCAP verification failed")
+	}
+
+	if len(identity.AttestationChain) == 0 {
+		return nil
+	}
+
+	chain, err := parseAttestationChain(identity.AttestationChain)
+	if err != nil {
+		return types.ErrAttestationInvalid.Wrapf("attestation chain parse: %v", err)
+	}
+
+	if len(chain.certs) > 0 {
+		leaf := selectLeafCertificate(chain.certs)
+		rootPEM := [][]byte{
+			[]byte(enclave.IntelSGXRootCAPEM),
+			[]byte(enclave.IntelSGXPCKProcessorCAPEM),
+		}
+		if err := verifyChainWithRoots(ctx, leaf, chain.certs, rootPEM); err != nil {
+			return types.ErrAttestationInvalid.Wrapf("SGX chain verify: %v", err)
+		}
+		if err := checkRevocations(ctx, leaf, chain.certs, chain.crls); err != nil {
+			return types.ErrAttestationInvalid.Wrapf("SGX revocation: %v", err)
+		}
+	}
+
+	if err := verifySGXCollateral(ctx, quote, chain); err != nil {
+		return types.ErrAttestationInvalid.Wrapf("SGX collateral: %v", err)
+	}
+
+	return nil
+}
+
+func verifySGXCollateral(ctx sdk.Context, quote *types.SGXDCAPQuote, chain *attestationChain) error {
+	if chain == nil || len(chain.json) == 0 {
+		return nil
+	}
+
+	// Optional TCB Info evaluation.
+	if tcbInfoJSON := findJSONWithKey(chain.json, "tcbInfo"); len(tcbInfoJSON) > 0 {
+		tcbVerifier := enclave.NewTCBInfoVerifier()
+		tcbInfo, err := tcbVerifier.ParseTCBInfo(tcbInfoJSON)
+		if err != nil {
+			return fmt.Errorf("parse TCB info: %w", err)
+		}
+		status, err := tcbVerifier.GetTCBStatus(tcbInfo, quote.Report.CPUSVN[:], quote.Header.PCESVN)
+		if err != nil {
+			return fmt.Errorf("TCB status lookup: %w", err)
+		}
+		if !enclave.IsTCBStatusAcceptable(status, false) {
+			return fmt.Errorf("TCB status %s is not acceptable", status)
+		}
+	}
+
+	// Optional QE Identity validation.
+	if qeIdentityJSON := findJSONWithKey(chain.json, "enclaveIdentity"); len(qeIdentityJSON) > 0 {
+		qeVerifier := enclave.NewQEIdentityVerifier()
+		qeIdentity, err := qeVerifier.ParseQEIdentity(qeIdentityJSON)
+		if err != nil {
+			return fmt.Errorf("parse QE identity: %w", err)
+		}
+		qeReport := convertSGXReport(quote.QEReport)
+		if err := qeVerifier.VerifyQEReport(&qeReport, qeIdentity); err != nil {
+			return fmt.Errorf("QE report verification failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func convertSGXReport(report types.SGXReportBody) enclave.SGXReportBody {
+	var body enclave.SGXReportBody
+	copy(body.CPUSVN[:], report.CPUSVN[:])
+	body.Attributes.Flags = binary.LittleEndian.Uint64(report.Attributes[0:8])
+	body.Attributes.Xfrm = binary.LittleEndian.Uint64(report.Attributes[8:16])
+	copy(body.MREnclave[:], report.MRENCLAVE[:])
+	copy(body.MRSigner[:], report.MRSIGNER[:])
+	body.ISVProdID = report.ISVProdID
+	body.ISVSVN = report.ISVSVN
+	copy(body.ReportData[:], report.ReportData[:])
+	return body
+}

--- a/x/enclave/keeper/attestation_test.go
+++ b/x/enclave/keeper/attestation_test.go
@@ -1,0 +1,51 @@
+package keeper
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"testing"
+
+	enclave "github.com/virtengine/virtengine/pkg/enclave_runtime"
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+func TestParseAttestationChainPEM(t *testing.T) {
+	chain, err := parseAttestationChain([][]byte{[]byte(enclave.IntelSGXRootCAPEM)})
+	if err != nil {
+		t.Fatalf("parseAttestationChain failed: %v", err)
+	}
+	if len(chain.certs) == 0 {
+		t.Fatalf("expected parsed certs, got none")
+	}
+}
+
+func TestParseAttestationChainJSON(t *testing.T) {
+	payload := []byte(`{"tcbInfo":{"id":"SGX","version":3,"tcbType":0,"tcbEvaluationDataNumber":1,"tcbLevels":[]}}`)
+	chain, err := parseAttestationChain([][]byte{payload})
+	if err != nil {
+		t.Fatalf("parseAttestationChain failed: %v", err)
+	}
+	if len(chain.json) == 0 {
+		t.Fatalf("expected json collateral entries")
+	}
+}
+
+func TestVerifySEVSNPMeasurement(t *testing.T) {
+	measurement := bytes.Repeat([]byte{0xAB}, 48)
+	sum := sha256.Sum256(measurement)
+	identity := &types.EnclaveIdentity{MeasurementHash: sum[:]}
+
+	if err := verifySEVSNPMeasurement(identity, measurement); err != nil {
+		t.Fatalf("verifySEVSNPMeasurement failed: %v", err)
+	}
+}
+
+func TestVerifyNitroMeasurement(t *testing.T) {
+	pcr := bytes.Repeat([]byte{0xCD}, 48)
+	sum := sha256.Sum256(pcr)
+	identity := &types.EnclaveIdentity{MeasurementHash: sum[:]}
+
+	if err := verifyNitroMeasurement(identity, pcr); err != nil {
+		t.Fatalf("verifyNitroMeasurement failed: %v", err)
+	}
+}

--- a/x/enclave/keeper/keeper.go
+++ b/x/enclave/keeper/keeper.go
@@ -704,8 +704,12 @@ func (k Keeper) ValidateAttestation(ctx sdk.Context, identity *types.EnclaveIden
 		)
 	}
 
-	// In production, this would verify the attestation quote cryptographically
-	// against the platform root of trust
+	if err := k.verifyAttestation(ctx, identity, measurement); err != nil {
+		k.RecordAttestationVerification(false)
+		return err
+	}
+
+	k.RecordAttestationVerification(true)
 	return nil
 }
 

--- a/x/enclave/types/attestation.go
+++ b/x/enclave/types/attestation.go
@@ -1,0 +1,170 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	sgxQuoteHeaderSize            = 48
+	sgxReportBodySize             = 384
+	sgxQuoteSigLenOffset          = sgxQuoteHeaderSize + sgxReportBodySize
+	sgxQuoteSigDataMinSize        = 64 + 64 + 384 + 64 + 2 + 2 + 4
+	sgxQuoteSigDataOffset         = sgxQuoteSigLenOffset + 4
+	sgxReportBodyOffset           = sgxQuoteHeaderSize
+	sgxReportAttributesOff        = 48
+	sgxReportMRENCLAVEOff         = 64
+	sgxReportMRSIGNEROff          = 128
+	sgxReportISVProdIDOff         = 256
+	sgxReportISVSVNOff            = 258
+	sgxReportReportDataOff        = 320
+	sgxAttrDebugFlag       uint64 = 0x02
+)
+
+const (
+	sevSnpMinReportSize            = 0x4A0 // 1184 bytes
+	sevSnpVersionOffset            = 0x000
+	sevSnpPolicyOffset             = 0x008
+	sevSnpReportDataOffset         = 0x050
+	sevSnpMeasurementOffset        = 0x090
+	sevSnpIDKeyDigestOffset        = 0x0E0
+	sevSnpAuthorKeyOffset          = 0x100
+	sevSnpCurrentTCBOffset         = 0x038
+	sevSnpReportedTCBOffset        = 0x160
+	sevSnpCommittedTCBOff          = 0x1A0
+	sevSnpDebugPolicy       uint64 = 1 << 19
+)
+
+// SGXQuoteHeader is the DCAP quote header (v3+).
+type SGXQuoteHeader struct {
+	Version            uint16
+	AttestationKeyType uint16
+	TEEType            uint32
+	QESVN              uint16
+	PCESVN             uint16
+	QEVendorID         [16]byte
+	UserData           [20]byte
+}
+
+// SGXReportBody captures the SGX report body fields we need for validation.
+type SGXReportBody struct {
+	CPUSVN     [16]byte
+	Attributes [16]byte
+	MRENCLAVE  [32]byte
+	MRSIGNER   [32]byte
+	ISVProdID  uint16
+	ISVSVN     uint16
+	ReportData [64]byte
+}
+
+// DebugEnabled returns true if the report attributes indicate a debug enclave.
+func (r SGXReportBody) DebugEnabled() bool {
+	flags := binary.LittleEndian.Uint64(r.Attributes[0:8])
+	return flags&sgxAttrDebugFlag != 0
+}
+
+// SGXDCAPQuote represents the parsed SGX DCAP quote.
+type SGXDCAPQuote struct {
+	Header   SGXQuoteHeader
+	Report   SGXReportBody
+	QEReport SGXReportBody
+}
+
+// ParseSGXDCAPQuoteV3 parses a DCAP v3 quote and extracts report data.
+func ParseSGXDCAPQuoteV3(quote []byte) (*SGXDCAPQuote, error) {
+	if len(quote) < sgxQuoteSigDataOffset+sgxQuoteSigDataMinSize {
+		return nil, fmt.Errorf("quote too small: got %d bytes, need at least %d", len(quote), sgxQuoteSigDataOffset+sgxQuoteSigDataMinSize)
+	}
+
+	header := SGXQuoteHeader{
+		Version:            binary.LittleEndian.Uint16(quote[0:2]),
+		AttestationKeyType: binary.LittleEndian.Uint16(quote[2:4]),
+		TEEType:            binary.LittleEndian.Uint32(quote[4:8]),
+		QESVN:              binary.LittleEndian.Uint16(quote[8:10]),
+		PCESVN:             binary.LittleEndian.Uint16(quote[10:12]),
+	}
+	copy(header.QEVendorID[:], quote[12:28])
+	copy(header.UserData[:], quote[28:48])
+
+	report, err := parseSGXReportBody(quote[sgxReportBodyOffset : sgxReportBodyOffset+sgxReportBodySize])
+	if err != nil {
+		return nil, fmt.Errorf("parse report body: %w", err)
+	}
+
+	// Signature data layout:
+	// [ISV Sig 64][AttKey 64][QE Report 384][QE Sig 64][AuthSize 2][AuthData ...][CertType 2][CertSize 4][CertData ...]
+	sigData := quote[sgxQuoteSigDataOffset:]
+	qeReportOffset := 64 + 64
+	qeReportBytes := sigData[qeReportOffset : qeReportOffset+sgxReportBodySize]
+	qeReport, err := parseSGXReportBody(qeReportBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse QE report body: %w", err)
+	}
+
+	return &SGXDCAPQuote{
+		Header:   header,
+		Report:   report,
+		QEReport: qeReport,
+	}, nil
+}
+
+func parseSGXReportBody(report []byte) (SGXReportBody, error) {
+	if len(report) < sgxReportBodySize {
+		return SGXReportBody{}, fmt.Errorf("report body too small: got %d bytes, need %d", len(report), sgxReportBodySize)
+	}
+
+	var body SGXReportBody
+	copy(body.CPUSVN[:], report[0:16])
+	copy(body.Attributes[:], report[sgxReportAttributesOff:sgxReportAttributesOff+16])
+	copy(body.MRENCLAVE[:], report[sgxReportMRENCLAVEOff:sgxReportMRENCLAVEOff+32])
+	copy(body.MRSIGNER[:], report[sgxReportMRSIGNEROff:sgxReportMRSIGNEROff+32])
+	body.ISVProdID = binary.LittleEndian.Uint16(report[sgxReportISVProdIDOff : sgxReportISVProdIDOff+2])
+	body.ISVSVN = binary.LittleEndian.Uint16(report[sgxReportISVSVNOff : sgxReportISVSVNOff+2])
+	copy(body.ReportData[:], report[sgxReportReportDataOff:sgxReportReportDataOff+64])
+	return body, nil
+}
+
+// SEVSNPReport represents a parsed SEV-SNP attestation report.
+type SEVSNPReport struct {
+	Version         uint32
+	Policy          uint64
+	ReportData      [64]byte
+	Measurement     [48]byte
+	IDKeyDigest     [32]byte
+	AuthorKeyDigest [32]byte
+	CurrentTCB      uint64
+	ReportedTCB     uint64
+	CommittedTCB    uint64
+}
+
+// DebugEnabled returns true when the SNP policy allows debug mode.
+func (r SEVSNPReport) DebugEnabled() bool {
+	return r.Policy&sevSnpDebugPolicy != 0
+}
+
+// ParseSEVSNPReport parses a SEV-SNP attestation report.
+func ParseSEVSNPReport(report []byte) (*SEVSNPReport, error) {
+	if len(report) < sevSnpMinReportSize {
+		return nil, fmt.Errorf("report too small: got %d bytes, need %d", len(report), sevSnpMinReportSize)
+	}
+
+	parsed := &SEVSNPReport{
+		Version:      binary.LittleEndian.Uint32(report[sevSnpVersionOffset : sevSnpVersionOffset+4]),
+		Policy:       binary.LittleEndian.Uint64(report[sevSnpPolicyOffset : sevSnpPolicyOffset+8]),
+		CurrentTCB:   binary.LittleEndian.Uint64(report[sevSnpCurrentTCBOffset : sevSnpCurrentTCBOffset+8]),
+		ReportedTCB:  binary.LittleEndian.Uint64(report[sevSnpReportedTCBOffset : sevSnpReportedTCBOffset+8]),
+		CommittedTCB: binary.LittleEndian.Uint64(report[sevSnpCommittedTCBOff : sevSnpCommittedTCBOff+8]),
+	}
+	copy(parsed.ReportData[:], report[sevSnpReportDataOffset:sevSnpReportDataOffset+64])
+	copy(parsed.Measurement[:], report[sevSnpMeasurementOffset:sevSnpMeasurementOffset+48])
+	copy(parsed.IDKeyDigest[:], report[sevSnpIDKeyDigestOffset:sevSnpIDKeyDigestOffset+32])
+	copy(parsed.AuthorKeyDigest[:], report[sevSnpAuthorKeyOffset:sevSnpAuthorKeyOffset+32])
+
+	return parsed, nil
+}
+
+// SEVSNPMeasurementHash computes a stable hash for a SEV-SNP measurement.
+func SEVSNPMeasurementHash(measurement []byte) [32]byte {
+	return sha256.Sum256(measurement)
+}


### PR DESCRIPTION
## Priority: P1 (Critical - Security)

Replace placeholder attestation validation with real cryptographic verification.

### Current Issue
Line 711-713 keeper.go: "In production, this would verify the attestation quote cryptographically"

### Requirements
- Implement SGX quote verification
  - Parse DCAP v3 quote format
  - Verify quote signature with Intel QE
  - Check MRENCLAVE/MRSIGNER
  - Verify TCB level
  - Check revocation lists
  - Verify cert chain to Intel root
- Implement SEV-SNP verification
  - AMD attestation report validation
  - Platform certificate chain
  - TCB version checking
- Implement Nitro Enclaves verification
  - AWS attestation document parsing
  - PCR validation
  - Certificate verification
- Add certificate chain validation (x509)

### Dependencies
- Intel SGX SDK / DCAP libraries
- AMD SEV-SNP verification library
- AWS Nitro Enclaves SDK
- Go crypto/x509 package

### Files to Create
- keeper/attestation.go (main logic)
- keeper/attestation_sgx.go
- keeper/attestation_sev.go
- keeper/attestation_nitro.go
- keeper/attestation_test.go
- types/attestation.go (quote parsing)

### Impact
**CRITICAL SECURITY FIX** - Current implementation accepts any attestation

### Estimated Effort
1500 LOC, 1-2 weeks