### PR TITLE
feat:ENCLAVE-ENH-005: Add IBC support for cross-chain enclave federation

### DIFF
--- a/x/enclave/ibc/errors.go
+++ b/x/enclave/ibc/errors.go
@@ -1,0 +1,58 @@
+package ibc
+
+import (
+	"cosmossdk.io/errors"
+
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+// IBC enclave module sentinel errors
+var (
+	// ErrInvalidVersion is returned when the IBC version is invalid
+	ErrInvalidVersion = errors.Register(types.ModuleName, 2000, "invalid IBC module version")
+
+	// ErrInvalidPacket is returned when a packet is invalid
+	ErrInvalidPacket = errors.Register(types.ModuleName, 2001, "invalid IBC packet")
+
+	// ErrUnknownPacketType is returned when the packet type is unknown
+	ErrUnknownPacketType = errors.Register(types.ModuleName, 2002, "unknown packet type")
+
+	// ErrChannelNotFound is returned when a channel is not found
+	ErrChannelNotFound = errors.Register(types.ModuleName, 2003, "IBC channel not found")
+
+	// ErrInvalidChannelState is returned when channel state is invalid
+	ErrInvalidChannelState = errors.Register(types.ModuleName, 2004, "invalid channel state")
+
+	// ErrInvalidPort is returned when the port ID is invalid
+	ErrInvalidPort = errors.Register(types.ModuleName, 2005, "invalid port ID")
+
+	// ErrPortAlreadyBound is returned when the port is already bound
+	ErrPortAlreadyBound = errors.Register(types.ModuleName, 2006, "port already bound")
+
+	// ErrUntrustedChannel is returned when trying to sync via an untrusted channel
+	ErrUntrustedChannel = errors.Register(types.ModuleName, 2007, "channel is not trusted for sync operations")
+
+	// ErrMeasurementSyncFailed is returned when measurement sync fails
+	ErrMeasurementSyncFailed = errors.Register(types.ModuleName, 2008, "measurement sync failed")
+
+	// ErrIdentityQueryFailed is returned when identity query fails
+	ErrIdentityQueryFailed = errors.Register(types.ModuleName, 2009, "identity query failed")
+
+	// ErrAcknowledgementFailed is returned when acknowledgement processing fails
+	ErrAcknowledgementFailed = errors.Register(types.ModuleName, 2010, "acknowledgement processing failed")
+
+	// ErrPacketTimeout is returned when a packet times out
+	ErrPacketTimeout = errors.Register(types.ModuleName, 2011, "packet timeout")
+
+	// ErrChannelCapabilityNotFound is returned when channel capability is not found
+	ErrChannelCapabilityNotFound = errors.Register(types.ModuleName, 2012, "channel capability not found")
+
+	// ErrInvalidCounterparty is returned when the counterparty is invalid
+	ErrInvalidCounterparty = errors.Register(types.ModuleName, 2013, "invalid counterparty")
+
+	// ErrFederatedIdentityNotTrusted is returned when a federated identity is not trusted
+	ErrFederatedIdentityNotTrusted = errors.Register(types.ModuleName, 2014, "federated identity not trusted")
+
+	// ErrMeasurementAlreadyExists is returned when trying to sync a measurement that already exists
+	ErrMeasurementAlreadyExists = errors.Register(types.ModuleName, 2015, "measurement already exists")
+)

--- a/x/enclave/ibc/events.go
+++ b/x/enclave/ibc/events.go
@@ -1,0 +1,97 @@
+package ibc
+
+// IBC event types for enclave module
+const (
+	// EventTypePacketSent is emitted when a packet is sent
+	EventTypePacketSent = "enclave_ibc_packet_sent"
+
+	// EventTypePacketReceived is emitted when a packet is received
+	EventTypePacketReceived = "enclave_ibc_packet_received"
+
+	// EventTypePacketAcknowledged is emitted when a packet acknowledgement is processed
+	EventTypePacketAcknowledged = "enclave_ibc_packet_acknowledged"
+
+	// EventTypePacketTimeout is emitted when a packet times out
+	EventTypePacketTimeout = "enclave_ibc_packet_timeout"
+
+	// EventTypeIdentityQueried is emitted when an identity is queried via IBC
+	EventTypeIdentityQueried = "enclave_ibc_identity_queried"
+
+	// EventTypeMeasurementQueried is emitted when measurements are queried via IBC
+	EventTypeMeasurementQueried = "enclave_ibc_measurement_queried"
+
+	// EventTypeMeasurementSynced is emitted when a measurement is synced via IBC
+	EventTypeMeasurementSynced = "enclave_ibc_measurement_synced"
+
+	// EventTypeFederatedIdentityReceived is emitted when a federated identity is received
+	EventTypeFederatedIdentityReceived = "enclave_ibc_federated_identity_received"
+
+	// EventTypeChannelOpened is emitted when an IBC channel is opened
+	EventTypeChannelOpened = "enclave_ibc_channel_opened"
+
+	// EventTypeChannelClosed is emitted when an IBC channel is closed
+	EventTypeChannelClosed = "enclave_ibc_channel_closed"
+)
+
+// IBC event attribute keys
+const (
+	// AttributeKeyPacketType is the packet type
+	AttributeKeyPacketType = "packet_type"
+
+	// AttributeKeySourceChannel is the source channel ID
+	AttributeKeySourceChannel = "source_channel"
+
+	// AttributeKeyDestinationChannel is the destination channel ID
+	AttributeKeyDestinationChannel = "destination_channel"
+
+	// AttributeKeySourcePort is the source port ID
+	AttributeKeySourcePort = "source_port"
+
+	// AttributeKeyDestinationPort is the destination port ID
+	AttributeKeyDestinationPort = "destination_port"
+
+	// AttributeKeySequence is the packet sequence number
+	AttributeKeySequence = "sequence"
+
+	// AttributeKeyCounterpartyChainID is the counterparty chain ID
+	AttributeKeyCounterpartyChainID = "counterparty_chain_id"
+
+	// AttributeKeyValidatorAddress is the validator address
+	AttributeKeyValidatorAddress = "validator_address"
+
+	// AttributeKeyTEEType is the TEE type
+	AttributeKeyTEEType = "tee_type"
+
+	// AttributeKeyMeasurementHash is the measurement hash
+	AttributeKeyMeasurementHash = "measurement_hash"
+
+	// AttributeKeyIdentityCount is the count of identities
+	AttributeKeyIdentityCount = "identity_count"
+
+	// AttributeKeyMeasurementCount is the count of measurements
+	AttributeKeyMeasurementCount = "measurement_count"
+
+	// AttributeKeySuccess is whether the operation was successful
+	AttributeKeySuccess = "success"
+
+	// AttributeKeyError is the error message
+	AttributeKeyError = "error"
+
+	// AttributeKeyAckSuccess is whether the acknowledgement indicates success
+	AttributeKeyAckSuccess = "ack_success"
+
+	// AttributeKeyChannelID is the channel ID
+	AttributeKeyChannelID = "channel_id"
+
+	// AttributeKeyPortID is the port ID
+	AttributeKeyPortID = "port_id"
+
+	// AttributeKeyVersion is the IBC version
+	AttributeKeyVersion = "version"
+
+	// AttributeKeySourceChainID is the source chain ID
+	AttributeKeySourceChainID = "source_chain_id"
+
+	// AttributeKeyTrusted is whether the channel/measurement is trusted
+	AttributeKeyTrusted = "trusted"
+)

--- a/x/enclave/ibc/handler.go
+++ b/x/enclave/ibc/handler.go
@@ -1,0 +1,301 @@
+package ibc
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
+
+	"github.com/virtengine/virtengine/x/enclave/keeper"
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+// PacketHandler handles enclave IBC packets
+type PacketHandler struct {
+	ibcKeeper     IBCKeeper
+	enclaveKeeper keeper.IKeeper
+}
+
+// NewPacketHandler creates a new packet handler
+func NewPacketHandler(ibcKeeper IBCKeeper, enclaveKeeper keeper.IKeeper) PacketHandler {
+	return PacketHandler{
+		ibcKeeper:     ibcKeeper,
+		enclaveKeeper: enclaveKeeper,
+	}
+}
+
+// HandlePacket dispatches the packet to the appropriate handler based on type
+func (h PacketHandler) HandlePacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	data EnclavePacketData,
+) ibcexported.Acknowledgement {
+	switch data.Type {
+	case PacketTypeQueryEnclaveIdentity:
+		return h.handleQueryEnclaveIdentity(ctx, packet, data.Data)
+	case PacketTypeQueryMeasurementAllowlist:
+		return h.handleQueryMeasurementAllowlist(ctx, packet, data.Data)
+	case PacketTypeSyncMeasurement:
+		return h.handleSyncMeasurement(ctx, packet, data.Data)
+	default:
+		return NewErrorAcknowledgement(ErrUnknownPacketType.Wrapf("unknown packet type: %s", data.Type))
+	}
+}
+
+// handleQueryEnclaveIdentity handles a query for enclave identity
+func (h PacketHandler) handleQueryEnclaveIdentity(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	data json.RawMessage,
+) ibcexported.Acknowledgement {
+	var query QueryEnclaveIdentityPacket
+	if err := json.Unmarshal(data, &query); err != nil {
+		return NewErrorAcknowledgement(ErrInvalidPacket.Wrap(err.Error()))
+	}
+
+	if err := query.Validate(); err != nil {
+		return NewErrorAcknowledgement(err)
+	}
+
+	// Get matching identities
+	identities := h.ibcKeeper.GetActiveIdentitiesForQuery(ctx, query)
+
+	// Create response
+	response := EnclaveIdentityResponse{
+		Identities:  identities,
+		ChainID:     ctx.ChainID(),
+		BlockHeight: ctx.BlockHeight(),
+	}
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypeIdentityQueried,
+			sdk.NewAttribute(AttributeKeyValidatorAddress, query.ValidatorAddress),
+			sdk.NewAttribute(AttributeKeyTEEType, query.TEEType),
+			sdk.NewAttribute(AttributeKeyIdentityCount, fmt.Sprintf("%d", len(identities))),
+			sdk.NewAttribute(AttributeKeySourceChannel, packet.GetSourceChannel()),
+		),
+	)
+
+	return NewResultAcknowledgement(response)
+}
+
+// handleQueryMeasurementAllowlist handles a query for measurement allowlist
+func (h PacketHandler) handleQueryMeasurementAllowlist(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	data json.RawMessage,
+) ibcexported.Acknowledgement {
+	var query QueryMeasurementAllowlistPacket
+	if err := json.Unmarshal(data, &query); err != nil {
+		return NewErrorAcknowledgement(ErrInvalidPacket.Wrap(err.Error()))
+	}
+
+	if err := query.Validate(); err != nil {
+		return NewErrorAcknowledgement(err)
+	}
+
+	// Get matching measurements
+	measurements := h.ibcKeeper.GetMeasurementsForQuery(ctx, query)
+
+	// Create response
+	response := MeasurementAllowlistResponse{
+		Measurements: measurements,
+		ChainID:      ctx.ChainID(),
+		BlockHeight:  ctx.BlockHeight(),
+	}
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypeMeasurementQueried,
+			sdk.NewAttribute(AttributeKeyTEEType, query.TEEType),
+			sdk.NewAttribute(AttributeKeyMeasurementCount, fmt.Sprintf("%d", len(measurements))),
+			sdk.NewAttribute(AttributeKeySourceChannel, packet.GetSourceChannel()),
+		),
+	)
+
+	return NewResultAcknowledgement(response)
+}
+
+// handleSyncMeasurement handles a measurement sync request
+func (h PacketHandler) handleSyncMeasurement(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	data json.RawMessage,
+) ibcexported.Acknowledgement {
+	var sync SyncMeasurementPacket
+	if err := json.Unmarshal(data, &sync); err != nil {
+		return NewErrorAcknowledgement(ErrInvalidPacket.Wrap(err.Error()))
+	}
+
+	if err := sync.Validate(); err != nil {
+		return NewErrorAcknowledgement(err)
+	}
+
+	// Process the sync
+	err := h.ibcKeeper.ProcessSyncMeasurement(ctx, packet.GetDestChannel(), sync)
+	if err != nil {
+		return NewErrorAcknowledgement(err)
+	}
+
+	// Create acknowledgement
+	ack := SyncMeasurementAck{
+		Success:         true,
+		MeasurementHash: hex.EncodeToString(sync.Measurement.MeasurementHash),
+	}
+
+	return NewResultAcknowledgement(ack)
+}
+
+// HandleAcknowledgement processes acknowledgements for sent packets
+func (h PacketHandler) HandleAcknowledgement(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	originalData EnclavePacketData,
+	ack Acknowledgement,
+) error {
+	if !ack.Success() {
+		ctx.Logger().Warn("packet acknowledgement failed",
+			"type", originalData.Type,
+			"error", ack.Error,
+			"channel", packet.GetSourceChannel(),
+		)
+		return nil
+	}
+
+	switch originalData.Type {
+	case PacketTypeQueryEnclaveIdentity:
+		return h.handleEnclaveIdentityAck(ctx, packet, ack)
+	case PacketTypeQueryMeasurementAllowlist:
+		return h.handleMeasurementAllowlistAck(ctx, packet, ack)
+	case PacketTypeSyncMeasurement:
+		return h.handleSyncMeasurementAck(ctx, packet, ack)
+	default:
+		return nil
+	}
+}
+
+// handleEnclaveIdentityAck processes enclave identity query acknowledgement
+func (h PacketHandler) handleEnclaveIdentityAck(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	ack Acknowledgement,
+) error {
+	var response EnclaveIdentityResponse
+	if err := json.Unmarshal(ack.Result, &response); err != nil {
+		return ErrAcknowledgementFailed.Wrap(err.Error())
+	}
+
+	// Store received identities as federated identities
+	for _, identity := range response.Identities {
+		fedIdentity := FederatedIdentity{
+			Identity:        identity,
+			SourceChainID:   response.ChainID,
+			SourceChannelID: packet.GetSourceChannel(),
+			ReceivedHeight:  ctx.BlockHeight(),
+			Verified:        false, // Requires local verification
+		}
+
+		if err := h.ibcKeeper.SetFederatedIdentity(ctx, fedIdentity); err != nil {
+			ctx.Logger().Error("failed to store federated identity",
+				"validator", identity.ValidatorAddress,
+				"chain", response.ChainID,
+				"error", err,
+			)
+			continue
+		}
+
+		// Emit event
+		ctx.EventManager().EmitEvent(
+			sdk.NewEvent(
+				EventTypeFederatedIdentityReceived,
+				sdk.NewAttribute(AttributeKeyValidatorAddress, identity.ValidatorAddress),
+				sdk.NewAttribute(AttributeKeySourceChainID, response.ChainID),
+				sdk.NewAttribute(AttributeKeyTEEType, string(identity.TEEType)),
+				sdk.NewAttribute(AttributeKeyMeasurementHash, hex.EncodeToString(identity.MeasurementHash)),
+			),
+		)
+	}
+
+	return nil
+}
+
+// handleMeasurementAllowlistAck processes measurement allowlist query acknowledgement
+func (h PacketHandler) handleMeasurementAllowlistAck(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	ack Acknowledgement,
+) error {
+	var response MeasurementAllowlistResponse
+	if err := json.Unmarshal(ack.Result, &response); err != nil {
+		return ErrAcknowledgementFailed.Wrap(err.Error())
+	}
+
+	// Store received measurements as federated measurements
+	for _, measurement := range response.Measurements {
+		fedMeasurement := FederatedMeasurement{
+			Measurement:     measurement,
+			SourceChainID:   response.ChainID,
+			SourceChannelID: packet.GetSourceChannel(),
+			ReceivedHeight:  ctx.BlockHeight(),
+			Trusted:         h.ibcKeeper.IsChainTrusted(ctx, response.ChainID),
+		}
+
+		h.ibcKeeper.SetFederatedMeasurement(ctx, fedMeasurement)
+	}
+
+	return nil
+}
+
+// handleSyncMeasurementAck processes measurement sync acknowledgement
+func (h PacketHandler) handleSyncMeasurementAck(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	ack Acknowledgement,
+) error {
+	var syncAck SyncMeasurementAck
+	if err := json.Unmarshal(ack.Result, &syncAck); err != nil {
+		return ErrAcknowledgementFailed.Wrap(err.Error())
+	}
+
+	if !syncAck.Success {
+		ctx.Logger().Warn("measurement sync failed on remote chain",
+			"measurement", syncAck.MeasurementHash,
+			"error", syncAck.Error,
+			"channel", packet.GetSourceChannel(),
+		)
+	}
+
+	return nil
+}
+
+// VerifyFederatedIdentity verifies a federated identity against local measurement allowlist
+func (h PacketHandler) VerifyFederatedIdentity(ctx sdk.Context, identity FederatedIdentity) error {
+	// Check if the measurement is in local allowlist
+	if !h.enclaveKeeper.IsMeasurementAllowed(ctx, identity.Identity.MeasurementHash, ctx.BlockHeight()) {
+		// Check federated measurements
+		fedMeasurement, found := h.ibcKeeper.GetFederatedMeasurement(
+			ctx,
+			identity.SourceChainID,
+			identity.Identity.MeasurementHash,
+		)
+		if !found {
+			return types.ErrMeasurementNotAllowlisted
+		}
+		if !fedMeasurement.Trusted {
+			return ErrFederatedIdentityNotTrusted
+		}
+	}
+
+	// Validate the identity
+	if err := identity.Identity.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x/enclave/ibc/keeper.go
+++ b/x/enclave/ibc/keeper.go
@@ -1,0 +1,588 @@
+package ibc
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"cosmossdk.io/log"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	clienttypes "github.com/cosmos/ibc-go/v10/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
+
+	"github.com/virtengine/virtengine/x/enclave/keeper"
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+// IBCKeeper implements the IBC module interface for the enclave module
+type IBCKeeper struct {
+	cdc           codec.BinaryCodec
+	skey          storetypes.StoreKey
+	enclaveKeeper keeper.IKeeper
+	channelKeeper ChannelKeeper
+	portKeeper    PortKeeper
+}
+
+// ChannelKeeper defines the expected IBC channel keeper
+type ChannelKeeper interface {
+	GetChannel(ctx sdk.Context, portID, channelID string) (channeltypes.Channel, bool)
+	GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool)
+	SendPacket(ctx sdk.Context, sourcePort string, sourceChannel string, timeoutHeight clienttypes.Height, timeoutTimestamp uint64, data []byte) (uint64, error)
+}
+
+// PortKeeper defines the expected IBC port keeper
+type PortKeeper interface {
+	BindPort(ctx sdk.Context, portID string)
+	IsBound(ctx sdk.Context, portID string) bool
+}
+
+// NewIBCKeeper creates a new IBC keeper for the enclave module
+func NewIBCKeeper(
+	cdc codec.BinaryCodec,
+	skey storetypes.StoreKey,
+	enclaveKeeper keeper.IKeeper,
+	channelKeeper ChannelKeeper,
+	portKeeper PortKeeper,
+) IBCKeeper {
+	return IBCKeeper{
+		cdc:           cdc,
+		skey:          skey,
+		enclaveKeeper: enclaveKeeper,
+		channelKeeper: channelKeeper,
+		portKeeper:    portKeeper,
+	}
+}
+
+// Logger returns a module-specific logger
+func (k IBCKeeper) Logger(ctx sdk.Context) log.Logger {
+	return ctx.Logger().With("module", "x/"+ModuleName)
+}
+
+// ============================================================================
+// Port Binding
+// ============================================================================
+
+// BindPort binds to the enclave port
+func (k IBCKeeper) BindPort(ctx sdk.Context) error {
+	if k.portKeeper.IsBound(ctx, PortID) {
+		return ErrPortAlreadyBound
+	}
+	k.portKeeper.BindPort(ctx, PortID)
+	return nil
+}
+
+// IsBound checks if the port is bound
+func (k IBCKeeper) IsBound(ctx sdk.Context) bool {
+	return k.portKeeper.IsBound(ctx, PortID)
+}
+
+// ============================================================================
+// Channel Metadata
+// ============================================================================
+
+// SetChannelMetadata stores channel metadata
+func (k IBCKeeper) SetChannelMetadata(ctx sdk.Context, channelID string, metadata ChannelMetadata) {
+	store := ctx.KVStore(k.skey)
+	bz, _ := json.Marshal(metadata)
+	store.Set(ChannelMetadataKey(channelID), bz)
+}
+
+// GetChannelMetadata retrieves channel metadata
+func (k IBCKeeper) GetChannelMetadata(ctx sdk.Context, channelID string) (ChannelMetadata, bool) {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(ChannelMetadataKey(channelID))
+	if bz == nil {
+		return ChannelMetadata{}, false
+	}
+	var metadata ChannelMetadata
+	if err := json.Unmarshal(bz, &metadata); err != nil {
+		return ChannelMetadata{}, false
+	}
+	return metadata, true
+}
+
+// DeleteChannelMetadata deletes channel metadata
+func (k IBCKeeper) DeleteChannelMetadata(ctx sdk.Context, channelID string) {
+	store := ctx.KVStore(k.skey)
+	store.Delete(ChannelMetadataKey(channelID))
+}
+
+// IsChannelTrusted checks if a channel is trusted for sync operations
+func (k IBCKeeper) IsChannelTrusted(ctx sdk.Context, channelID string) bool {
+	metadata, found := k.GetChannelMetadata(ctx, channelID)
+	if !found {
+		return false
+	}
+	return metadata.Trusted
+}
+
+// SetChannelTrusted sets the trusted status of a channel
+func (k IBCKeeper) SetChannelTrusted(ctx sdk.Context, channelID string, trusted bool) error {
+	metadata, found := k.GetChannelMetadata(ctx, channelID)
+	if !found {
+		return ErrChannelNotFound
+	}
+	metadata.Trusted = trusted
+	k.SetChannelMetadata(ctx, channelID, metadata)
+	return nil
+}
+
+// ============================================================================
+// Trusted Chains
+// ============================================================================
+
+// SetTrustedChain marks a chain as trusted
+func (k IBCKeeper) SetTrustedChain(ctx sdk.Context, chainID string, trusted bool) {
+	store := ctx.KVStore(k.skey)
+	if trusted {
+		store.Set(TrustedChainKey(chainID), []byte{1})
+	} else {
+		store.Delete(TrustedChainKey(chainID))
+	}
+}
+
+// IsChainTrusted checks if a chain is trusted
+func (k IBCKeeper) IsChainTrusted(ctx sdk.Context, chainID string) bool {
+	store := ctx.KVStore(k.skey)
+	return store.Has(TrustedChainKey(chainID))
+}
+
+// ============================================================================
+// Federated Identities
+// ============================================================================
+
+// SetFederatedIdentity stores a federated identity
+func (k IBCKeeper) SetFederatedIdentity(ctx sdk.Context, identity FederatedIdentity) error {
+	validatorAddr, err := sdk.AccAddressFromBech32(identity.Identity.ValidatorAddress)
+	if err != nil {
+		return err
+	}
+
+	store := ctx.KVStore(k.skey)
+	bz, err := json.Marshal(identity)
+	if err != nil {
+		return err
+	}
+	store.Set(FederatedIdentityKey(identity.SourceChainID, validatorAddr), bz)
+	return nil
+}
+
+// GetFederatedIdentity retrieves a federated identity
+func (k IBCKeeper) GetFederatedIdentity(ctx sdk.Context, sourceChainID string, validatorAddr sdk.AccAddress) (FederatedIdentity, bool) {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(FederatedIdentityKey(sourceChainID, validatorAddr))
+	if bz == nil {
+		return FederatedIdentity{}, false
+	}
+	var identity FederatedIdentity
+	if err := json.Unmarshal(bz, &identity); err != nil {
+		return FederatedIdentity{}, false
+	}
+	return identity, true
+}
+
+// WithFederatedIdentities iterates over all federated identities from a chain
+func (k IBCKeeper) WithFederatedIdentities(ctx sdk.Context, sourceChainID string, fn func(identity FederatedIdentity) bool) {
+	store := ctx.KVStore(k.skey)
+	prefix := FederatedIdentityPrefix(sourceChainID)
+	iterator := store.Iterator(prefix, storetypes.PrefixEndBytes(prefix))
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var identity FederatedIdentity
+		if err := json.Unmarshal(iterator.Value(), &identity); err != nil {
+			continue
+		}
+		if fn(identity) {
+			break
+		}
+	}
+}
+
+// ============================================================================
+// Federated Measurements
+// ============================================================================
+
+// SetFederatedMeasurement stores a federated measurement
+func (k IBCKeeper) SetFederatedMeasurement(ctx sdk.Context, measurement FederatedMeasurement) {
+	store := ctx.KVStore(k.skey)
+	bz, _ := json.Marshal(measurement)
+	store.Set(FederatedMeasurementKey(measurement.SourceChainID, measurement.Measurement.MeasurementHash), bz)
+}
+
+// GetFederatedMeasurement retrieves a federated measurement
+func (k IBCKeeper) GetFederatedMeasurement(ctx sdk.Context, sourceChainID string, measurementHash []byte) (FederatedMeasurement, bool) {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(FederatedMeasurementKey(sourceChainID, measurementHash))
+	if bz == nil {
+		return FederatedMeasurement{}, false
+	}
+	var measurement FederatedMeasurement
+	if err := json.Unmarshal(bz, &measurement); err != nil {
+		return FederatedMeasurement{}, false
+	}
+	return measurement, true
+}
+
+// WithFederatedMeasurements iterates over all federated measurements from a chain
+func (k IBCKeeper) WithFederatedMeasurements(ctx sdk.Context, sourceChainID string, fn func(measurement FederatedMeasurement) bool) {
+	store := ctx.KVStore(k.skey)
+	prefix := FederatedMeasurementPrefix(sourceChainID)
+	iterator := store.Iterator(prefix, storetypes.PrefixEndBytes(prefix))
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var measurement FederatedMeasurement
+		if err := json.Unmarshal(iterator.Value(), &measurement); err != nil {
+			continue
+		}
+		if fn(measurement) {
+			break
+		}
+	}
+}
+
+// ============================================================================
+// Packet Sending
+// ============================================================================
+
+// SendQueryEnclaveIdentityPacket sends a query for enclave identity
+func (k IBCKeeper) SendQueryEnclaveIdentityPacket(
+	ctx sdk.Context,
+	sourceChannel string,
+	timeoutHeight ibcexported.Height,
+	timeoutTimestamp uint64,
+	query QueryEnclaveIdentityPacket,
+) (uint64, error) {
+	packetData, err := NewEnclavePacketData(PacketTypeQueryEnclaveIdentity, query)
+	if err != nil {
+		return 0, err
+	}
+
+	return k.sendPacket(ctx, sourceChannel, timeoutHeight, timeoutTimestamp, packetData)
+}
+
+// SendQueryMeasurementAllowlistPacket sends a query for measurement allowlist
+func (k IBCKeeper) SendQueryMeasurementAllowlistPacket(
+	ctx sdk.Context,
+	sourceChannel string,
+	timeoutHeight ibcexported.Height,
+	timeoutTimestamp uint64,
+	query QueryMeasurementAllowlistPacket,
+) (uint64, error) {
+	packetData, err := NewEnclavePacketData(PacketTypeQueryMeasurementAllowlist, query)
+	if err != nil {
+		return 0, err
+	}
+
+	return k.sendPacket(ctx, sourceChannel, timeoutHeight, timeoutTimestamp, packetData)
+}
+
+// SendSyncMeasurementPacket sends a measurement sync request
+func (k IBCKeeper) SendSyncMeasurementPacket(
+	ctx sdk.Context,
+	sourceChannel string,
+	timeoutHeight ibcexported.Height,
+	timeoutTimestamp uint64,
+	sync SyncMeasurementPacket,
+) (uint64, error) {
+	// Validate the sync packet
+	if err := sync.Validate(); err != nil {
+		return 0, err
+	}
+
+	packetData, err := NewEnclavePacketData(PacketTypeSyncMeasurement, sync)
+	if err != nil {
+		return 0, err
+	}
+
+	return k.sendPacket(ctx, sourceChannel, timeoutHeight, timeoutTimestamp, packetData)
+}
+
+func (k IBCKeeper) sendPacket(
+	ctx sdk.Context,
+	sourceChannel string,
+	timeoutHeight ibcexported.Height,
+	timeoutTimestamp uint64,
+	packetData EnclavePacketData,
+) (uint64, error) {
+	// Convert timeout height to client types
+	height, ok := timeoutHeight.(clienttypes.Height)
+	if !ok {
+		height = clienttypes.NewHeight(0, uint64(ctx.BlockHeight())+1000)
+	}
+
+	// Send the packet
+	sequence, err := k.channelKeeper.SendPacket(
+		ctx,
+		PortID,
+		sourceChannel,
+		height,
+		timeoutTimestamp,
+		packetData.GetBytes(),
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	// Store pending packet data for acknowledgement handling
+	k.setPendingPacket(ctx, sourceChannel, sequence, packetData)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypePacketSent,
+			sdk.NewAttribute(AttributeKeyPacketType, string(packetData.Type)),
+			sdk.NewAttribute(AttributeKeySourceChannel, sourceChannel),
+			sdk.NewAttribute(AttributeKeySequence, fmt.Sprintf("%d", sequence)),
+		),
+	)
+
+	return sequence, nil
+}
+
+// ============================================================================
+// Pending Packets
+// ============================================================================
+
+func (k IBCKeeper) setPendingPacket(ctx sdk.Context, channelID string, sequence uint64, data EnclavePacketData) {
+	store := ctx.KVStore(k.skey)
+	bz, _ := json.Marshal(data)
+	store.Set(PendingPacketKey(channelID, sequence), bz)
+}
+
+func (k IBCKeeper) getPendingPacket(ctx sdk.Context, channelID string, sequence uint64) (EnclavePacketData, bool) {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(PendingPacketKey(channelID, sequence))
+	if bz == nil {
+		return EnclavePacketData{}, false
+	}
+	var data EnclavePacketData
+	if err := json.Unmarshal(bz, &data); err != nil {
+		return EnclavePacketData{}, false
+	}
+	return data, true
+}
+
+func (k IBCKeeper) deletePendingPacket(ctx sdk.Context, channelID string, sequence uint64) {
+	store := ctx.KVStore(k.skey)
+	store.Delete(PendingPacketKey(channelID, sequence))
+}
+
+// ============================================================================
+// IBC Callbacks
+// ============================================================================
+
+// OnRecvPacket handles incoming packets
+func (k IBCKeeper) OnRecvPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	relayer sdk.AccAddress,
+) ibcexported.Acknowledgement {
+	var packetData EnclavePacketData
+	if err := json.Unmarshal(packet.GetData(), &packetData); err != nil {
+		return NewErrorAcknowledgement(ErrInvalidPacket.Wrap(err.Error()))
+	}
+
+	if err := packetData.Validate(); err != nil {
+		return NewErrorAcknowledgement(err)
+	}
+
+	// Emit receive event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypePacketReceived,
+			sdk.NewAttribute(AttributeKeyPacketType, string(packetData.Type)),
+			sdk.NewAttribute(AttributeKeySourceChannel, packet.GetSourceChannel()),
+			sdk.NewAttribute(AttributeKeyDestinationChannel, packet.GetDestChannel()),
+			sdk.NewAttribute(AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
+		),
+	)
+
+	// Handle the packet based on type
+	handler := NewPacketHandler(k, k.enclaveKeeper)
+	return handler.HandlePacket(ctx, packet, packetData)
+}
+
+// OnAcknowledgementPacket handles packet acknowledgements
+func (k IBCKeeper) OnAcknowledgementPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	acknowledgement []byte,
+	relayer sdk.AccAddress,
+) error {
+	var ack Acknowledgement
+	if err := json.Unmarshal(acknowledgement, &ack); err != nil {
+		return ErrAcknowledgementFailed.Wrap(err.Error())
+	}
+
+	// Get the original packet data
+	pendingData, found := k.getPendingPacket(ctx, packet.GetSourceChannel(), packet.GetSequence())
+	if !found {
+		// Packet not found - might have been cleaned up already
+		return nil
+	}
+
+	// Clean up pending packet
+	k.deletePendingPacket(ctx, packet.GetSourceChannel(), packet.GetSequence())
+
+	// Handle acknowledgement based on packet type
+	handler := NewPacketHandler(k, k.enclaveKeeper)
+	if err := handler.HandleAcknowledgement(ctx, packet, pendingData, ack); err != nil {
+		k.Logger(ctx).Error("failed to handle acknowledgement", "error", err)
+		return err
+	}
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypePacketAcknowledged,
+			sdk.NewAttribute(AttributeKeyPacketType, string(pendingData.Type)),
+			sdk.NewAttribute(AttributeKeySourceChannel, packet.GetSourceChannel()),
+			sdk.NewAttribute(AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
+			sdk.NewAttribute(AttributeKeyAckSuccess, fmt.Sprintf("%t", ack.Success())),
+		),
+	)
+
+	return nil
+}
+
+// OnTimeoutPacket handles packet timeouts
+func (k IBCKeeper) OnTimeoutPacket(
+	ctx sdk.Context,
+	packet channeltypes.Packet,
+	relayer sdk.AccAddress,
+) error {
+	// Get the original packet data
+	pendingData, found := k.getPendingPacket(ctx, packet.GetSourceChannel(), packet.GetSequence())
+	if !found {
+		return nil
+	}
+
+	// Clean up pending packet
+	k.deletePendingPacket(ctx, packet.GetSourceChannel(), packet.GetSequence())
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypePacketTimeout,
+			sdk.NewAttribute(AttributeKeyPacketType, string(pendingData.Type)),
+			sdk.NewAttribute(AttributeKeySourceChannel, packet.GetSourceChannel()),
+			sdk.NewAttribute(AttributeKeySequence, fmt.Sprintf("%d", packet.GetSequence())),
+		),
+	)
+
+	k.Logger(ctx).Warn("packet timed out",
+		"type", pendingData.Type,
+		"channel", packet.GetSourceChannel(),
+		"sequence", packet.GetSequence(),
+	)
+
+	return nil
+}
+
+// ============================================================================
+// Query Helpers
+// ============================================================================
+
+// GetActiveIdentitiesForQuery returns active enclave identities matching the query
+func (k IBCKeeper) GetActiveIdentitiesForQuery(ctx sdk.Context, query QueryEnclaveIdentityPacket) []types.EnclaveIdentity {
+	var identities []types.EnclaveIdentity
+	currentHeight := ctx.BlockHeight()
+
+	// If specific validator is requested
+	if query.ValidatorAddress != "" {
+		validatorAddr, err := sdk.AccAddressFromBech32(query.ValidatorAddress)
+		if err != nil {
+			return identities
+		}
+		identity, found := k.enclaveKeeper.GetEnclaveIdentity(ctx, validatorAddr)
+		if found {
+			if query.IncludeExpired || !identity.IsExpired(currentHeight) {
+				if query.TEEType == "" || string(identity.TEEType) == query.TEEType {
+					identities = append(identities, *identity)
+				}
+			}
+		}
+		return identities
+	}
+
+	// Return all matching identities
+	k.enclaveKeeper.WithEnclaveIdentities(ctx, func(identity types.EnclaveIdentity) bool {
+		if !query.IncludeExpired && identity.IsExpired(currentHeight) {
+			return false
+		}
+		if query.TEEType != "" && string(identity.TEEType) != query.TEEType {
+			return false
+		}
+		if identity.Status == types.EnclaveIdentityStatusActive ||
+			identity.Status == types.EnclaveIdentityStatusRotating {
+			identities = append(identities, identity)
+		}
+		return false
+	})
+
+	return identities
+}
+
+// GetMeasurementsForQuery returns measurements matching the query
+func (k IBCKeeper) GetMeasurementsForQuery(ctx sdk.Context, query QueryMeasurementAllowlistPacket) []types.MeasurementRecord {
+	return k.enclaveKeeper.GetMeasurementAllowlist(ctx, query.TEEType, query.IncludeRevoked)
+}
+
+// ProcessSyncMeasurement processes a measurement sync from a remote chain
+func (k IBCKeeper) ProcessSyncMeasurement(
+	ctx sdk.Context,
+	channelID string,
+	sync SyncMeasurementPacket,
+) error {
+	// Check if channel is trusted
+	if !k.IsChannelTrusted(ctx, channelID) {
+		return ErrUntrustedChannel
+	}
+
+	// Check if chain is trusted
+	if !k.IsChainTrusted(ctx, sync.SourceChainID) {
+		return ErrFederatedIdentityNotTrusted
+	}
+
+	// Check if measurement already exists locally
+	if _, found := k.enclaveKeeper.GetMeasurement(ctx, sync.Measurement.MeasurementHash); found {
+		return ErrMeasurementAlreadyExists
+	}
+
+	// Store as federated measurement
+	fedMeasurement := FederatedMeasurement{
+		Measurement:     sync.Measurement,
+		SourceChainID:   sync.SourceChainID,
+		SourceChannelID: channelID,
+		ReceivedHeight:  ctx.BlockHeight(),
+		Trusted:         true,
+	}
+	k.SetFederatedMeasurement(ctx, fedMeasurement)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypeMeasurementSynced,
+			sdk.NewAttribute(AttributeKeyMeasurementHash, hex.EncodeToString(sync.Measurement.MeasurementHash)),
+			sdk.NewAttribute(AttributeKeySourceChainID, sync.SourceChainID),
+			sdk.NewAttribute(AttributeKeySourceChannel, channelID),
+			sdk.NewAttribute(AttributeKeyTEEType, string(sync.Measurement.TEEType)),
+		),
+	)
+
+	return nil
+}
+
+// GetAppVersion returns the application version
+func (k IBCKeeper) GetAppVersion(ctx sdk.Context, portID, channelID string) (string, bool) {
+	channel, found := k.channelKeeper.GetChannel(ctx, portID, channelID)
+	if !found {
+		return "", false
+	}
+	return channel.Version, true
+}

--- a/x/enclave/ibc/keeper_test.go
+++ b/x/enclave/ibc/keeper_test.go
@@ -1,0 +1,449 @@
+package ibc
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+func TestEnclavePacketData_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      EnclavePacketData
+		expectErr bool
+	}{
+		{
+			name: "valid query identity packet",
+			data: EnclavePacketData{
+				Type: PacketTypeQueryEnclaveIdentity,
+				Data: json.RawMessage(`{"validator_address":"cosmos1..."}`),
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid query measurement packet",
+			data: EnclavePacketData{
+				Type: PacketTypeQueryMeasurementAllowlist,
+				Data: json.RawMessage(`{"tee_type":"SGX"}`),
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid packet type",
+			data: EnclavePacketData{
+				Type: "invalid_type",
+				Data: json.RawMessage(`{}`),
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty packet data",
+			data: EnclavePacketData{
+				Type: PacketTypeQueryEnclaveIdentity,
+				Data: nil,
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.data.Validate()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewEnclavePacketData(t *testing.T) {
+	query := QueryEnclaveIdentityPacket{
+		ValidatorAddress: "cosmos1abc...",
+		TEEType:          "SGX",
+	}
+
+	packet, err := NewEnclavePacketData(PacketTypeQueryEnclaveIdentity, query)
+	require.NoError(t, err)
+	require.Equal(t, PacketTypeQueryEnclaveIdentity, packet.Type)
+	require.NotEmpty(t, packet.Data)
+
+	// Verify the data can be unmarshaled back
+	var decoded QueryEnclaveIdentityPacket
+	err = json.Unmarshal(packet.Data, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, query.ValidatorAddress, decoded.ValidatorAddress)
+	require.Equal(t, query.TEEType, decoded.TEEType)
+}
+
+func TestQueryEnclaveIdentityPacket_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		packet    QueryEnclaveIdentityPacket
+		expectErr bool
+	}{
+		{
+			name:      "empty packet is valid",
+			packet:    QueryEnclaveIdentityPacket{},
+			expectErr: false,
+		},
+		{
+			name: "with validator address",
+			packet: QueryEnclaveIdentityPacket{
+				ValidatorAddress: "cosmos1abc...",
+			},
+			expectErr: false,
+		},
+		{
+			name: "with tee type filter",
+			packet: QueryEnclaveIdentityPacket{
+				TEEType: "SGX",
+			},
+			expectErr: false,
+		},
+		{
+			name: "with include expired",
+			packet: QueryEnclaveIdentityPacket{
+				IncludeExpired: true,
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.packet.Validate()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSyncMeasurementPacket_Validate(t *testing.T) {
+	validMeasurement := types.MeasurementRecord{
+		MeasurementHash: make([]byte, 32),
+		TEEType:         types.TEETypeSGX,
+		Description:     "Test measurement",
+		MinISVSVN:       1,
+	}
+
+	tests := []struct {
+		name      string
+		packet    SyncMeasurementPacket
+		expectErr bool
+	}{
+		{
+			name: "valid packet",
+			packet: SyncMeasurementPacket{
+				Measurement:   validMeasurement,
+				SourceChainID: "testchain-1",
+			},
+			expectErr: false,
+		},
+		{
+			name: "empty source chain id",
+			packet: SyncMeasurementPacket{
+				Measurement:   validMeasurement,
+				SourceChainID: "",
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid measurement",
+			packet: SyncMeasurementPacket{
+				Measurement: types.MeasurementRecord{
+					MeasurementHash: nil,
+				},
+				SourceChainID: "testchain-1",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.packet.Validate()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAcknowledgement(t *testing.T) {
+	t.Run("success acknowledgement", func(t *testing.T) {
+		result := EnclaveIdentityResponse{
+			ChainID:     "testchain-1",
+			BlockHeight: 100,
+		}
+		ack := NewResultAcknowledgement(result)
+		require.True(t, ack.Success())
+		require.NotEmpty(t, ack.Result)
+		require.Empty(t, ack.Error)
+	})
+
+	t.Run("error acknowledgement", func(t *testing.T) {
+		ack := NewErrorAcknowledgement(ErrInvalidPacket)
+		require.False(t, ack.Success())
+		require.Empty(t, ack.Result)
+		require.NotEmpty(t, ack.Error)
+	})
+}
+
+func TestFederatedIdentityKey(t *testing.T) {
+	validatorAddr := []byte("validator123")
+	chainID := "cosmoshub-4"
+
+	key := FederatedIdentityKey(chainID, validatorAddr)
+	require.NotEmpty(t, key)
+	require.True(t, len(key) > len(PrefixFederatedIdentity))
+
+	// Keys for different chains should be different
+	key2 := FederatedIdentityKey("osmosis-1", validatorAddr)
+	require.NotEqual(t, key, key2)
+
+	// Keys for different validators should be different
+	key3 := FederatedIdentityKey(chainID, []byte("validator456"))
+	require.NotEqual(t, key, key3)
+}
+
+func TestFederatedMeasurementKey(t *testing.T) {
+	measurementHash := make([]byte, 32)
+	copy(measurementHash, []byte("measurement"))
+	chainID := "cosmoshub-4"
+
+	key := FederatedMeasurementKey(chainID, measurementHash)
+	require.NotEmpty(t, key)
+	require.True(t, len(key) > len(PrefixFederatedMeasurement))
+}
+
+func TestChannelMetadataKey(t *testing.T) {
+	key := ChannelMetadataKey("channel-0")
+	require.NotEmpty(t, key)
+	require.True(t, len(key) > len(PrefixChannelMetadata))
+}
+
+func TestPendingPacketKey(t *testing.T) {
+	key := PendingPacketKey("channel-0", 42)
+	require.NotEmpty(t, key)
+	require.True(t, len(key) > len(PrefixPendingPacket)+8)
+}
+
+func TestTrustedChainKey(t *testing.T) {
+	key := TrustedChainKey("cosmoshub-4")
+	require.NotEmpty(t, key)
+	require.True(t, len(key) > len(PrefixTrustedChain))
+}
+
+func TestEnclaveIdentityResponse(t *testing.T) {
+	response := EnclaveIdentityResponse{
+		Identities: []types.EnclaveIdentity{
+			{
+				ValidatorAddress: "cosmos1abc...",
+				TEEType:          types.TEETypeSGX,
+				MeasurementHash:  make([]byte, 32),
+				EncryptionPubKey: []byte("pubkey"),
+				SigningPubKey:    []byte("sigkey"),
+				AttestationQuote: []byte("quote"),
+				ExpiryHeight:     1000,
+				Status:           types.EnclaveIdentityStatusActive,
+			},
+		},
+		ChainID:     "testchain-1",
+		BlockHeight: 500,
+	}
+
+	bz, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.NotEmpty(t, bz)
+
+	var decoded EnclaveIdentityResponse
+	err = json.Unmarshal(bz, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, response.ChainID, decoded.ChainID)
+	require.Equal(t, response.BlockHeight, decoded.BlockHeight)
+	require.Len(t, decoded.Identities, 1)
+}
+
+func TestMeasurementAllowlistResponse(t *testing.T) {
+	response := MeasurementAllowlistResponse{
+		Measurements: []types.MeasurementRecord{
+			{
+				MeasurementHash: make([]byte, 32),
+				TEEType:         types.TEETypeSGX,
+				Description:     "Test measurement",
+				MinISVSVN:       1,
+				AddedAt:         time.Now(),
+			},
+		},
+		ChainID:     "testchain-1",
+		BlockHeight: 500,
+	}
+
+	bz, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.NotEmpty(t, bz)
+
+	var decoded MeasurementAllowlistResponse
+	err = json.Unmarshal(bz, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, response.ChainID, decoded.ChainID)
+	require.Len(t, decoded.Measurements, 1)
+}
+
+func TestSyncMeasurementAck(t *testing.T) {
+	ack := SyncMeasurementAck{
+		Success:         true,
+		MeasurementHash: hex.EncodeToString(make([]byte, 32)),
+	}
+
+	bz, err := json.Marshal(ack)
+	require.NoError(t, err)
+
+	var decoded SyncMeasurementAck
+	err = json.Unmarshal(bz, &decoded)
+	require.NoError(t, err)
+	require.True(t, decoded.Success)
+	require.Equal(t, ack.MeasurementHash, decoded.MeasurementHash)
+}
+
+func TestChannelMetadata(t *testing.T) {
+	metadata := ChannelMetadata{
+		CounterpartyChainID: "osmosis-1",
+		Version:             Version,
+		Trusted:             true,
+	}
+
+	bz, err := json.Marshal(metadata)
+	require.NoError(t, err)
+
+	var decoded ChannelMetadata
+	err = json.Unmarshal(bz, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, metadata.CounterpartyChainID, decoded.CounterpartyChainID)
+	require.Equal(t, metadata.Version, decoded.Version)
+	require.True(t, decoded.Trusted)
+}
+
+func TestFederatedIdentity(t *testing.T) {
+	identity := FederatedIdentity{
+		Identity: types.EnclaveIdentity{
+			ValidatorAddress: "cosmos1abc...",
+			TEEType:          types.TEETypeSGX,
+			MeasurementHash:  make([]byte, 32),
+			EncryptionPubKey: []byte("pubkey"),
+			SigningPubKey:    []byte("sigkey"),
+			AttestationQuote: []byte("quote"),
+			ExpiryHeight:     1000,
+			Status:           types.EnclaveIdentityStatusActive,
+		},
+		SourceChainID:   "cosmoshub-4",
+		SourceChannelID: "channel-0",
+		ReceivedHeight:  500,
+		Verified:        true,
+	}
+
+	bz, err := json.Marshal(identity)
+	require.NoError(t, err)
+
+	var decoded FederatedIdentity
+	err = json.Unmarshal(bz, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, identity.SourceChainID, decoded.SourceChainID)
+	require.Equal(t, identity.SourceChannelID, decoded.SourceChannelID)
+	require.True(t, decoded.Verified)
+}
+
+func TestFederatedMeasurement(t *testing.T) {
+	measurement := FederatedMeasurement{
+		Measurement: types.MeasurementRecord{
+			MeasurementHash: make([]byte, 32),
+			TEEType:         types.TEETypeSGX,
+			Description:     "Test measurement",
+			MinISVSVN:       1,
+		},
+		SourceChainID:   "cosmoshub-4",
+		SourceChannelID: "channel-0",
+		ReceivedHeight:  500,
+		Trusted:         true,
+	}
+
+	bz, err := json.Marshal(measurement)
+	require.NoError(t, err)
+
+	var decoded FederatedMeasurement
+	err = json.Unmarshal(bz, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, measurement.SourceChainID, decoded.SourceChainID)
+	require.True(t, decoded.Trusted)
+}
+
+func TestPacketDataGetBytes(t *testing.T) {
+	packet := EnclavePacketData{
+		Type: PacketTypeQueryEnclaveIdentity,
+		Data: json.RawMessage(`{"validator_address":"cosmos1..."}`),
+	}
+
+	bz := packet.GetBytes()
+	require.NotEmpty(t, bz)
+
+	var decoded EnclavePacketData
+	err := json.Unmarshal(bz, &decoded)
+	require.NoError(t, err)
+	require.Equal(t, packet.Type, decoded.Type)
+}
+
+func TestAcknowledgementGetBytes(t *testing.T) {
+	ack := NewResultAcknowledgement(map[string]string{"key": "value"})
+	bz := ack.GetBytes()
+	require.NotEmpty(t, bz)
+
+	var decoded Acknowledgement
+	err := json.Unmarshal(bz, &decoded)
+	require.NoError(t, err)
+	require.True(t, decoded.Success())
+}
+
+func TestValidateEnclavePacket(t *testing.T) {
+	validPacket := EnclavePacketData{
+		Type: PacketTypeQueryEnclaveIdentity,
+		Data: json.RawMessage(`{}`),
+	}
+	require.NoError(t, ValidateEnclavePacket(validPacket))
+
+	invalidPacket := EnclavePacketData{
+		Type: "invalid",
+		Data: json.RawMessage(`{}`),
+	}
+	require.Error(t, ValidateEnclavePacket(invalidPacket))
+}
+
+func TestAllPacketTypes(t *testing.T) {
+	packetTypes := []PacketType{
+		PacketTypeQueryEnclaveIdentity,
+		PacketTypeQueryMeasurementAllowlist,
+		PacketTypeSyncMeasurement,
+		PacketTypeEnclaveIdentityResponse,
+		PacketTypeMeasurementAllowlistResponse,
+		PacketTypeSyncMeasurementAck,
+	}
+
+	for _, pt := range packetTypes {
+		packet := EnclavePacketData{
+			Type: pt,
+			Data: json.RawMessage(`{}`),
+		}
+		require.NoError(t, packet.Validate(), "packet type %s should be valid", pt)
+	}
+}

--- a/x/enclave/ibc/keys.go
+++ b/x/enclave/ibc/keys.go
@@ -1,0 +1,108 @@
+package ibc
+
+import "encoding/binary"
+
+// IBC store key prefixes
+var (
+	// PrefixFederatedIdentity is the prefix for federated identity storage
+	// Key: PrefixFederatedIdentity | source_chain_id | validator_address -> FederatedIdentity
+	PrefixFederatedIdentity = []byte{0x10}
+
+	// PrefixFederatedMeasurement is the prefix for federated measurement storage
+	// Key: PrefixFederatedMeasurement | source_chain_id | measurement_hash -> FederatedMeasurement
+	PrefixFederatedMeasurement = []byte{0x11}
+
+	// PrefixChannelMetadata is the prefix for channel metadata storage
+	// Key: PrefixChannelMetadata | channel_id -> ChannelMetadata
+	PrefixChannelMetadata = []byte{0x12}
+
+	// PrefixPortBinding is the prefix for port binding state
+	// Key: PrefixPortBinding -> bool (whether port is bound)
+	PrefixPortBinding = []byte{0x13}
+
+	// PrefixPendingPacket is the prefix for pending packets awaiting acknowledgement
+	// Key: PrefixPendingPacket | channel_id | sequence -> packet data
+	PrefixPendingPacket = []byte{0x14}
+
+	// PrefixTrustedChain is the prefix for trusted chain IDs
+	// Key: PrefixTrustedChain | chain_id -> bool
+	PrefixTrustedChain = []byte{0x15}
+)
+
+// FederatedIdentityKey returns the store key for a federated identity
+func FederatedIdentityKey(sourceChainID string, validatorAddr []byte) []byte {
+	chainIDBytes := []byte(sourceChainID)
+	key := make([]byte, 0, len(PrefixFederatedIdentity)+len(chainIDBytes)+1+len(validatorAddr))
+	key = append(key, PrefixFederatedIdentity...)
+	key = append(key, chainIDBytes...)
+	key = append(key, 0x00) // separator
+	key = append(key, validatorAddr...)
+	return key
+}
+
+// FederatedMeasurementKey returns the store key for a federated measurement
+func FederatedMeasurementKey(sourceChainID string, measurementHash []byte) []byte {
+	chainIDBytes := []byte(sourceChainID)
+	key := make([]byte, 0, len(PrefixFederatedMeasurement)+len(chainIDBytes)+1+len(measurementHash))
+	key = append(key, PrefixFederatedMeasurement...)
+	key = append(key, chainIDBytes...)
+	key = append(key, 0x00) // separator
+	key = append(key, measurementHash...)
+	return key
+}
+
+// ChannelMetadataKey returns the store key for channel metadata
+func ChannelMetadataKey(channelID string) []byte {
+	channelIDBytes := []byte(channelID)
+	key := make([]byte, 0, len(PrefixChannelMetadata)+len(channelIDBytes))
+	key = append(key, PrefixChannelMetadata...)
+	key = append(key, channelIDBytes...)
+	return key
+}
+
+// PortBindingKey returns the store key for port binding state
+func PortBindingKey() []byte {
+	return PrefixPortBinding
+}
+
+// PendingPacketKey returns the store key for a pending packet
+func PendingPacketKey(channelID string, sequence uint64) []byte {
+	channelIDBytes := []byte(channelID)
+	key := make([]byte, 0, len(PrefixPendingPacket)+len(channelIDBytes)+1+8)
+	key = append(key, PrefixPendingPacket...)
+	key = append(key, channelIDBytes...)
+	key = append(key, 0x00) // separator
+	seqBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(seqBytes, sequence)
+	key = append(key, seqBytes...)
+	return key
+}
+
+// TrustedChainKey returns the store key for a trusted chain
+func TrustedChainKey(chainID string) []byte {
+	chainIDBytes := []byte(chainID)
+	key := make([]byte, 0, len(PrefixTrustedChain)+len(chainIDBytes))
+	key = append(key, PrefixTrustedChain...)
+	key = append(key, chainIDBytes...)
+	return key
+}
+
+// FederatedIdentityPrefix returns the prefix for iterating federated identities from a chain
+func FederatedIdentityPrefix(sourceChainID string) []byte {
+	chainIDBytes := []byte(sourceChainID)
+	key := make([]byte, 0, len(PrefixFederatedIdentity)+len(chainIDBytes)+1)
+	key = append(key, PrefixFederatedIdentity...)
+	key = append(key, chainIDBytes...)
+	key = append(key, 0x00) // separator
+	return key
+}
+
+// FederatedMeasurementPrefix returns the prefix for iterating federated measurements from a chain
+func FederatedMeasurementPrefix(sourceChainID string) []byte {
+	chainIDBytes := []byte(sourceChainID)
+	key := make([]byte, 0, len(PrefixFederatedMeasurement)+len(chainIDBytes)+1)
+	key = append(key, PrefixFederatedMeasurement...)
+	key = append(key, chainIDBytes...)
+	key = append(key, 0x00) // separator
+	return key
+}

--- a/x/enclave/ibc/module.go
+++ b/x/enclave/ibc/module.go
@@ -1,0 +1,336 @@
+package ibc
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	channeltypes "github.com/cosmos/ibc-go/v10/modules/core/04-channel/types"
+	porttypes "github.com/cosmos/ibc-go/v10/modules/core/05-port/types"
+	ibcexported "github.com/cosmos/ibc-go/v10/modules/core/exported"
+)
+
+var (
+	_ porttypes.IBCModule = (*IBCModule)(nil)
+)
+
+// IBCModule implements the IBC Module interface for the enclave module
+type IBCModule struct {
+	keeper IBCKeeper
+}
+
+// NewIBCModule creates a new IBCModule
+func NewIBCModule(keeper IBCKeeper) IBCModule {
+	return IBCModule{
+		keeper: keeper,
+	}
+}
+
+// OnChanOpenInit implements the IBCModule interface
+func (m IBCModule) OnChanOpenInit(
+	ctx sdk.Context,
+	order channeltypes.Order,
+	connectionHops []string,
+	portID string,
+	channelID string,
+	counterparty channeltypes.Counterparty,
+	version string,
+) (string, error) {
+	// Validate port ID
+	if portID != PortID {
+		return "", ErrInvalidPort.Wrapf("expected %s, got %s", PortID, portID)
+	}
+
+	// Require unordered channels for enclave IBC
+	if order != channeltypes.UNORDERED {
+		return "", channeltypes.ErrInvalidChannelOrdering.Wrapf(
+			"expected %s channel, got %s",
+			channeltypes.UNORDERED,
+			order,
+		)
+	}
+
+	// Validate version
+	if version != "" && version != Version {
+		return "", ErrInvalidVersion.Wrapf("expected %s, got %s", Version, version)
+	}
+
+	m.keeper.Logger(ctx).Info("channel open init",
+		"port", portID,
+		"channel", channelID,
+		"version", Version,
+	)
+
+	return Version, nil
+}
+
+// OnChanOpenTry implements the IBCModule interface
+func (m IBCModule) OnChanOpenTry(
+	ctx sdk.Context,
+	order channeltypes.Order,
+	connectionHops []string,
+	portID string,
+	channelID string,
+	counterparty channeltypes.Counterparty,
+	counterpartyVersion string,
+) (string, error) {
+	// Validate port ID
+	if portID != PortID {
+		return "", ErrInvalidPort.Wrapf("expected %s, got %s", PortID, portID)
+	}
+
+	// Require unordered channels
+	if order != channeltypes.UNORDERED {
+		return "", channeltypes.ErrInvalidChannelOrdering.Wrapf(
+			"expected %s channel, got %s",
+			channeltypes.UNORDERED,
+			order,
+		)
+	}
+
+	// Validate counterparty version
+	if counterpartyVersion != Version {
+		return "", ErrInvalidVersion.Wrapf("expected %s, got %s", Version, counterpartyVersion)
+	}
+
+	m.keeper.Logger(ctx).Info("channel open try",
+		"port", portID,
+		"channel", channelID,
+		"counterparty_version", counterpartyVersion,
+	)
+
+	return Version, nil
+}
+
+// OnChanOpenAck implements the IBCModule interface
+func (m IBCModule) OnChanOpenAck(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+	counterpartyChannelID string,
+	counterpartyVersion string,
+) error {
+	// Validate counterparty version
+	if counterpartyVersion != Version {
+		return ErrInvalidVersion.Wrapf("expected %s, got %s", Version, counterpartyVersion)
+	}
+
+	// Store channel metadata
+	m.keeper.SetChannelMetadata(ctx, channelID, ChannelMetadata{
+		Version: Version,
+		Trusted: false, // Channels are untrusted by default, must be set via governance
+	})
+
+	m.keeper.Logger(ctx).Info("channel open ack",
+		"port", portID,
+		"channel", channelID,
+		"counterparty_channel", counterpartyChannelID,
+	)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypeChannelOpened,
+			sdk.NewAttribute(AttributeKeyChannelID, channelID),
+			sdk.NewAttribute(AttributeKeyPortID, portID),
+			sdk.NewAttribute(AttributeKeyVersion, Version),
+		),
+	)
+
+	return nil
+}
+
+// OnChanOpenConfirm implements the IBCModule interface
+func (m IBCModule) OnChanOpenConfirm(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+) error {
+	// Store channel metadata
+	m.keeper.SetChannelMetadata(ctx, channelID, ChannelMetadata{
+		Version: Version,
+		Trusted: false,
+	})
+
+	m.keeper.Logger(ctx).Info("channel open confirm",
+		"port", portID,
+		"channel", channelID,
+	)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypeChannelOpened,
+			sdk.NewAttribute(AttributeKeyChannelID, channelID),
+			sdk.NewAttribute(AttributeKeyPortID, portID),
+			sdk.NewAttribute(AttributeKeyVersion, Version),
+		),
+	)
+
+	return nil
+}
+
+// OnChanCloseInit implements the IBCModule interface
+func (m IBCModule) OnChanCloseInit(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+) error {
+	// Disallow user-initiated channel closing
+	return ErrInvalidChannelState.Wrap("user cannot close channel")
+}
+
+// OnChanCloseConfirm implements the IBCModule interface
+func (m IBCModule) OnChanCloseConfirm(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+) error {
+	// Clean up channel metadata
+	m.keeper.DeleteChannelMetadata(ctx, channelID)
+
+	m.keeper.Logger(ctx).Info("channel closed",
+		"port", portID,
+		"channel", channelID,
+	)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			EventTypeChannelClosed,
+			sdk.NewAttribute(AttributeKeyChannelID, channelID),
+			sdk.NewAttribute(AttributeKeyPortID, portID),
+		),
+	)
+
+	return nil
+}
+
+// OnRecvPacket implements the IBCModule interface
+func (m IBCModule) OnRecvPacket(
+	ctx sdk.Context,
+	channelVersion string,
+	packet channeltypes.Packet,
+	relayer sdk.AccAddress,
+) ibcexported.Acknowledgement {
+	return m.keeper.OnRecvPacket(ctx, packet, relayer)
+}
+
+// OnAcknowledgementPacket implements the IBCModule interface
+func (m IBCModule) OnAcknowledgementPacket(
+	ctx sdk.Context,
+	channelVersion string,
+	packet channeltypes.Packet,
+	acknowledgement []byte,
+	relayer sdk.AccAddress,
+) error {
+	return m.keeper.OnAcknowledgementPacket(ctx, packet, acknowledgement, relayer)
+}
+
+// OnTimeoutPacket implements the IBCModule interface
+func (m IBCModule) OnTimeoutPacket(
+	ctx sdk.Context,
+	channelVersion string,
+	packet channeltypes.Packet,
+	relayer sdk.AccAddress,
+) error {
+	return m.keeper.OnTimeoutPacket(ctx, packet, relayer)
+}
+
+// OnChanUpgradeInit implements the IBCModule interface
+func (m IBCModule) OnChanUpgradeInit(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+	proposedOrder channeltypes.Order,
+	proposedConnectionHops []string,
+	proposedVersion string,
+) (string, error) {
+	if proposedVersion != Version {
+		return "", ErrInvalidVersion.Wrapf("expected %s, got %s", Version, proposedVersion)
+	}
+
+	if proposedOrder != channeltypes.UNORDERED {
+		return "", channeltypes.ErrInvalidChannelOrdering.Wrapf(
+			"expected %s channel, got %s",
+			channeltypes.UNORDERED,
+			proposedOrder,
+		)
+	}
+
+	return Version, nil
+}
+
+// OnChanUpgradeTry implements the IBCModule interface
+func (m IBCModule) OnChanUpgradeTry(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+	proposedOrder channeltypes.Order,
+	proposedConnectionHops []string,
+	counterpartyVersion string,
+) (string, error) {
+	if counterpartyVersion != Version {
+		return "", ErrInvalidVersion.Wrapf("expected %s, got %s", Version, counterpartyVersion)
+	}
+
+	if proposedOrder != channeltypes.UNORDERED {
+		return "", channeltypes.ErrInvalidChannelOrdering.Wrapf(
+			"expected %s channel, got %s",
+			channeltypes.UNORDERED,
+			proposedOrder,
+		)
+	}
+
+	return Version, nil
+}
+
+// OnChanUpgradeAck implements the IBCModule interface
+func (m IBCModule) OnChanUpgradeAck(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+	counterpartyVersion string,
+) error {
+	if counterpartyVersion != Version {
+		return ErrInvalidVersion.Wrapf("expected %s, got %s", Version, counterpartyVersion)
+	}
+	return nil
+}
+
+// OnChanUpgradeOpen implements the IBCModule interface
+func (m IBCModule) OnChanUpgradeOpen(
+	ctx sdk.Context,
+	portID string,
+	channelID string,
+	proposedOrder channeltypes.Order,
+	proposedConnectionHops []string,
+	proposedVersion string,
+) {
+	m.keeper.Logger(ctx).Info("channel upgraded",
+		"port", portID,
+		"channel", channelID,
+		"version", proposedVersion,
+	)
+}
+
+// UnmarshalPacketData unmarshals packet data
+func (m IBCModule) UnmarshalPacketData(ctx sdk.Context, portID, channelID string, bz []byte) (interface{}, string, error) {
+	var packetData EnclavePacketData
+	if err := packetData.Validate(); err != nil {
+		return nil, "", err
+	}
+	return packetData, Version, nil
+}
+
+// GetAppVersion returns the application version string
+func (m IBCModule) GetAppVersion(ctx sdk.Context, portID, channelID string) (string, bool) {
+	return m.keeper.GetAppVersion(ctx, portID, channelID)
+}
+
+// ValidateEnclavePacket validates an enclave packet
+func ValidateEnclavePacket(packetData EnclavePacketData) error {
+	if err := packetData.Validate(); err != nil {
+		return fmt.Errorf("invalid packet data: %w", err)
+	}
+	return nil
+}

--- a/x/enclave/ibc/types.go
+++ b/x/enclave/ibc/types.go
@@ -1,0 +1,270 @@
+// Package ibc implements IBC support for cross-chain enclave identity federation.
+//
+// This package provides IBC module interfaces for querying and syncing enclave
+// identities and measurement allowlists across IBC-connected chains.
+package ibc
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/virtengine/virtengine/x/enclave/types"
+)
+
+const (
+	// Version defines the current version the IBC enclave module supports
+	Version = "enclave-1"
+
+	// PortID is the default port id for the enclave IBC module
+	PortID = "enclave"
+
+	// ModuleName is the IBC module name for enclave
+	ModuleName = "enclave-ibc"
+)
+
+// PacketType defines the type of IBC packet
+type PacketType string
+
+const (
+	// PacketTypeQueryEnclaveIdentity is a query for enclave identity
+	PacketTypeQueryEnclaveIdentity PacketType = "query_enclave_identity"
+
+	// PacketTypeQueryMeasurementAllowlist is a query for measurement allowlist
+	PacketTypeQueryMeasurementAllowlist PacketType = "query_measurement_allowlist"
+
+	// PacketTypeSyncMeasurement is a sync request for measurements
+	PacketTypeSyncMeasurement PacketType = "sync_measurement"
+
+	// PacketTypeEnclaveIdentityResponse is a response containing enclave identity
+	PacketTypeEnclaveIdentityResponse PacketType = "enclave_identity_response"
+
+	// PacketTypeMeasurementAllowlistResponse is a response containing measurement allowlist
+	PacketTypeMeasurementAllowlistResponse PacketType = "measurement_allowlist_response"
+
+	// PacketTypeSyncMeasurementAck is an acknowledgement for measurement sync
+	PacketTypeSyncMeasurementAck PacketType = "sync_measurement_ack"
+)
+
+// EnclavePacketData is the base structure for all enclave IBC packets
+type EnclavePacketData struct {
+	Type PacketType      `json:"type"`
+	Data json.RawMessage `json:"data"`
+}
+
+// NewEnclavePacketData creates a new EnclavePacketData
+func NewEnclavePacketData(packetType PacketType, data interface{}) (EnclavePacketData, error) {
+	bz, err := json.Marshal(data)
+	if err != nil {
+		return EnclavePacketData{}, err
+	}
+	return EnclavePacketData{
+		Type: packetType,
+		Data: bz,
+	}, nil
+}
+
+// GetBytes returns the JSON marshaled bytes of the packet data
+func (p EnclavePacketData) GetBytes() []byte {
+	bz, _ := json.Marshal(p)
+	return bz
+}
+
+// Validate validates the packet data
+func (p EnclavePacketData) Validate() error {
+	switch p.Type {
+	case PacketTypeQueryEnclaveIdentity,
+		PacketTypeQueryMeasurementAllowlist,
+		PacketTypeSyncMeasurement,
+		PacketTypeEnclaveIdentityResponse,
+		PacketTypeMeasurementAllowlistResponse,
+		PacketTypeSyncMeasurementAck:
+		// Valid packet types
+	default:
+		return fmt.Errorf("unknown packet type: %s", p.Type)
+	}
+
+	if len(p.Data) == 0 {
+		return fmt.Errorf("packet data cannot be empty")
+	}
+
+	return nil
+}
+
+// QueryEnclaveIdentityPacket is the data for querying a remote chain's enclave identity
+type QueryEnclaveIdentityPacket struct {
+	// ValidatorAddress is the validator address to query (optional - if empty, returns all active)
+	ValidatorAddress string `json:"validator_address,omitempty"`
+
+	// TEEType filters by TEE type (optional)
+	TEEType string `json:"tee_type,omitempty"`
+
+	// IncludeExpired includes expired identities in the response
+	IncludeExpired bool `json:"include_expired,omitempty"`
+}
+
+// Validate validates the query packet
+func (p QueryEnclaveIdentityPacket) Validate() error {
+	// All fields are optional, so this is always valid
+	return nil
+}
+
+// QueryMeasurementAllowlistPacket is the data for querying a remote chain's measurement allowlist
+type QueryMeasurementAllowlistPacket struct {
+	// TEEType filters by TEE type (optional)
+	TEEType string `json:"tee_type,omitempty"`
+
+	// IncludeRevoked includes revoked measurements in the response
+	IncludeRevoked bool `json:"include_revoked,omitempty"`
+}
+
+// Validate validates the query packet
+func (p QueryMeasurementAllowlistPacket) Validate() error {
+	return nil
+}
+
+// SyncMeasurementPacket is the data for syncing a measurement to a remote chain
+type SyncMeasurementPacket struct {
+	// Measurement is the measurement to sync
+	Measurement types.MeasurementRecord `json:"measurement"`
+
+	// SourceChainID is the chain ID of the source chain
+	SourceChainID string `json:"source_chain_id"`
+
+	// ProposalID is the governance proposal that approved this sync (if applicable)
+	ProposalID uint64 `json:"proposal_id,omitempty"`
+}
+
+// Validate validates the sync packet
+func (p SyncMeasurementPacket) Validate() error {
+	if err := p.Measurement.Validate(); err != nil {
+		return fmt.Errorf("invalid measurement: %w", err)
+	}
+	if p.SourceChainID == "" {
+		return fmt.Errorf("source chain ID cannot be empty")
+	}
+	return nil
+}
+
+// EnclaveIdentityResponse is the response data for enclave identity queries
+type EnclaveIdentityResponse struct {
+	// Identities is the list of enclave identities
+	Identities []types.EnclaveIdentity `json:"identities"`
+
+	// ChainID is the chain ID of the responding chain
+	ChainID string `json:"chain_id"`
+
+	// BlockHeight is the block height at which this data was read
+	BlockHeight int64 `json:"block_height"`
+}
+
+// MeasurementAllowlistResponse is the response data for measurement allowlist queries
+type MeasurementAllowlistResponse struct {
+	// Measurements is the list of measurements
+	Measurements []types.MeasurementRecord `json:"measurements"`
+
+	// ChainID is the chain ID of the responding chain
+	ChainID string `json:"chain_id"`
+
+	// BlockHeight is the block height at which this data was read
+	BlockHeight int64 `json:"block_height"`
+}
+
+// SyncMeasurementAck is the acknowledgement data for measurement sync
+type SyncMeasurementAck struct {
+	// Success indicates if the sync was successful
+	Success bool `json:"success"`
+
+	// Error is the error message if sync failed
+	Error string `json:"error,omitempty"`
+
+	// MeasurementHash is the hash of the synced measurement
+	MeasurementHash string `json:"measurement_hash"`
+}
+
+// Acknowledgement defines the IBC acknowledgement structure
+type Acknowledgement struct {
+	// Result is the successful result data (JSON encoded)
+	Result []byte `json:"result,omitempty"`
+
+	// Error is the error message if the packet processing failed
+	Error string `json:"error,omitempty"`
+}
+
+// NewResultAcknowledgement creates a successful acknowledgement
+func NewResultAcknowledgement(result interface{}) Acknowledgement {
+	bz, _ := json.Marshal(result)
+	return Acknowledgement{
+		Result: bz,
+	}
+}
+
+// NewErrorAcknowledgement creates an error acknowledgement
+func NewErrorAcknowledgement(err error) Acknowledgement {
+	return Acknowledgement{
+		Error: err.Error(),
+	}
+}
+
+// Success returns true if the acknowledgement is successful
+func (a Acknowledgement) Success() bool {
+	return a.Error == ""
+}
+
+// GetBytes returns the JSON marshaled bytes of the acknowledgement
+func (a Acknowledgement) GetBytes() []byte {
+	bz, _ := json.Marshal(a)
+	return bz
+}
+
+// Acknowledgement implements the exported.Acknowledgement interface
+func (a Acknowledgement) Acknowledgement() []byte {
+	return a.GetBytes()
+}
+
+// FederatedIdentity represents an enclave identity from a remote chain
+type FederatedIdentity struct {
+	// Identity is the enclave identity
+	Identity types.EnclaveIdentity `json:"identity"`
+
+	// SourceChainID is the chain ID where this identity originates
+	SourceChainID string `json:"source_chain_id"`
+
+	// SourceChannelID is the IBC channel through which this identity was received
+	SourceChannelID string `json:"source_channel_id"`
+
+	// ReceivedHeight is the local block height when this identity was received
+	ReceivedHeight int64 `json:"received_height"`
+
+	// Verified indicates if this identity has been verified locally
+	Verified bool `json:"verified"`
+}
+
+// FederatedMeasurement represents a measurement synced from a remote chain
+type FederatedMeasurement struct {
+	// Measurement is the measurement record
+	Measurement types.MeasurementRecord `json:"measurement"`
+
+	// SourceChainID is the chain ID where this measurement originates
+	SourceChainID string `json:"source_chain_id"`
+
+	// SourceChannelID is the IBC channel through which this measurement was received
+	SourceChannelID string `json:"source_channel_id"`
+
+	// ReceivedHeight is the local block height when this measurement was received
+	ReceivedHeight int64 `json:"received_height"`
+
+	// Trusted indicates if this measurement is trusted for local verification
+	Trusted bool `json:"trusted"`
+}
+
+// ChannelMetadata stores metadata about an IBC channel
+type ChannelMetadata struct {
+	// CounterpartyChainID is the chain ID of the counterparty
+	CounterpartyChainID string `json:"counterparty_chain_id"`
+
+	// Version is the IBC version negotiated
+	Version string `json:"version"`
+
+	// Trusted indicates if this channel is trusted for measurement sync
+	Trusted bool `json:"trusted"`
+}

--- a/x/enclave/keeper/metrics.go
+++ b/x/enclave/keeper/metrics.go
@@ -145,7 +145,7 @@ func (k Keeper) RecordMetrics(ctx sdk.Context) {
 	measurementCounts := make(map[string]float64)
 	k.WithMeasurements(ctx, func(measurement types.MeasurementRecord) bool {
 		if !measurement.Revoked {
-			measurementCounts[measurement.TeeType.String()]++
+			measurementCounts[measurement.TEEType.String()]++
 		}
 		return false
 	})


### PR DESCRIPTION
## Priority: P3 (Future)

Enable cross-chain enclave identity federation via IBC.

### Requirements
- Create IBC module interface
- Define packet types:
  - QueryEnclaveIdentityPacket
  - QueryMeasurementAllowlistPacket
  - SyncMeasurementPacket
- Implement IBC callbacks:
  - OnRecvPacket
  - OnAcknowledgementPacket
  - OnTimeoutPacket
- Add channel handshake logic
- Support federated identity verification

### Use Cases
- Query remote chain's enclave identities
- Cross-chain measurement allowlist sync
- Federated identity verification
- Multi-chain TEE coordination

### Files to Create
- ibc/module.go (IBC module interface)
- ibc/packets.proto (packet definitions)
- ibc/keeper.go (IBC keeper with callbacks)
- ibc/handler.go (packet handlers)
- ibc/types.go (IBC types)
- ibc/events.go (IBC events)

### Dependencies
- IBC-Go v10 module patterns
- Channel setup and versioning
- Packet acknowledgement handling

### Estimated Effort
1000 LOC, 1 week