### PR TITLE
feat: MFA-CORE-002: Implement Authorization Session Management

### DIFF
--- a/x/mfa/keeper/keeper.go
+++ b/x/mfa/keeper/keeper.go
@@ -42,6 +42,18 @@ type IKeeper interface {
 	DeleteAuthorizationSession(ctx sdk.Context, sessionID string) error
 	GetAccountSessions(ctx sdk.Context, address sdk.AccAddress) []types.AuthorizationSession
 
+	// Authorization session management (MFA-CORE-002)
+	HasValidAuthSession(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType) bool
+	HasValidAuthSessionWithDevice(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType, deviceFingerprint string) bool
+	ConsumeAuthSession(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType) error
+	ConsumeAuthSessionWithDevice(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType, deviceFingerprint string) error
+	CreateAuthSessionForAction(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType, verifiedFactors []types.FactorType, deviceFingerprint string) (*types.AuthorizationSession, error)
+	GetValidSessionsForAccount(ctx sdk.Context, address sdk.AccAddress) []types.AuthorizationSession
+	CleanupExpiredSessions(ctx sdk.Context, address sdk.AccAddress) int
+	ValidateSessionForTransaction(ctx sdk.Context, sessionID string, address sdk.AccAddress, action types.SensitiveTransactionType, deviceFingerprint string) error
+	GetSessionDurationForAction(ctx sdk.Context, action types.SensitiveTransactionType) int64
+	IsActionSingleUse(ctx sdk.Context, action types.SensitiveTransactionType) bool
+
 	// Trusted devices
 	AddTrustedDevice(ctx sdk.Context, address sdk.AccAddress, device *types.DeviceInfo) error
 	RemoveTrustedDevice(ctx sdk.Context, address sdk.AccAddress, fingerprint string) error

--- a/x/mfa/keeper/sessions.go
+++ b/x/mfa/keeper/sessions.go
@@ -1,0 +1,281 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/virtengine/virtengine/x/mfa/types"
+)
+
+// ============================================================================
+// Authorization Session Management
+//
+// Implements session duration per action type as defined in MFA-CORE-002:
+// - Critical (AccountRecovery, KeyRotation, AccountDeletion, TwoFactorDisable): Single use
+// - High (ProviderReg, LargeWithdrawal, ValidatorReg, RoleAssignment): 15 minutes
+// - Medium (HighValueOrder, GovernanceProposal, GovernanceVote): 30 minutes
+// - Low (MediumWithdrawal, TransferToNewAddress, APIKeyGeneration): 60 minutes
+// ============================================================================
+
+// HasValidAuthSession checks if an account has a valid authorization session for the given action.
+// Returns true if:
+// - A valid (non-expired) session exists for the account and action
+// - For single-use sessions, it has not been used yet
+// - Device fingerprint matches if session is device-bound
+func (k Keeper) HasValidAuthSession(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType) bool {
+	return k.hasValidAuthSessionWithDevice(ctx, address, action, "")
+}
+
+// HasValidAuthSessionWithDevice checks if an account has a valid authorization session
+// for the given action, optionally validating the device fingerprint.
+func (k Keeper) HasValidAuthSessionWithDevice(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType, deviceFingerprint string) bool {
+	return k.hasValidAuthSessionWithDevice(ctx, address, action, deviceFingerprint)
+}
+
+// hasValidAuthSessionWithDevice is the internal implementation for session validation.
+func (k Keeper) hasValidAuthSessionWithDevice(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType, deviceFingerprint string) bool {
+	sessions := k.GetAccountSessions(ctx, address)
+	now := ctx.BlockTime()
+
+	for _, session := range sessions {
+		// Check if session is for the correct action type
+		if session.TransactionType != action {
+			continue
+		}
+
+		// Check if session is valid (not expired, not used if single-use)
+		if !session.IsValid(now) {
+			continue
+		}
+
+		// If device fingerprint validation is requested and session is device-bound
+		if deviceFingerprint != "" && session.DeviceFingerprint != "" {
+			if session.DeviceFingerprint != deviceFingerprint {
+				continue
+			}
+		}
+
+		return true
+	}
+
+	return false
+}
+
+// ConsumeAuthSession consumes a single-use authorization session for the given action.
+// For single-use sessions (Critical tier), this marks the session as used.
+// For multi-use sessions, this is a no-op (session remains valid until expiry).
+// Returns an error if no valid session exists.
+func (k Keeper) ConsumeAuthSession(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType) error {
+	return k.consumeAuthSessionWithDevice(ctx, address, action, "")
+}
+
+// ConsumeAuthSessionWithDevice consumes a session with device validation.
+func (k Keeper) ConsumeAuthSessionWithDevice(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType, deviceFingerprint string) error {
+	return k.consumeAuthSessionWithDevice(ctx, address, action, deviceFingerprint)
+}
+
+// consumeAuthSessionWithDevice is the internal implementation for session consumption.
+func (k Keeper) consumeAuthSessionWithDevice(ctx sdk.Context, address sdk.AccAddress, action types.SensitiveTransactionType, deviceFingerprint string) error {
+	sessions := k.GetAccountSessions(ctx, address)
+	now := ctx.BlockTime()
+
+	for _, session := range sessions {
+		// Check if session is for the correct action type
+		if session.TransactionType != action {
+			continue
+		}
+
+		// Check if session is valid
+		if !session.IsValid(now) {
+			continue
+		}
+
+		// Validate device fingerprint if provided
+		if deviceFingerprint != "" && session.DeviceFingerprint != "" {
+			if session.DeviceFingerprint != deviceFingerprint {
+				return types.ErrDeviceMismatch.Wrap("device fingerprint does not match session")
+			}
+		}
+
+		// For single-use sessions, mark as used
+		if session.IsSingleUse {
+			return k.UseAuthorizationSession(ctx, session.SessionID)
+		}
+
+		// For multi-use sessions, just emit event (session remains valid)
+		ctx.EventManager().EmitEvent(
+			sdk.NewEvent(
+				types.EventTypeSessionUsed,
+				sdk.NewAttribute(types.AttributeKeySessionID, session.SessionID),
+				sdk.NewAttribute(types.AttributeKeyAccountAddress, address.String()),
+				sdk.NewAttribute(types.AttributeKeyTransactionType, action.String()),
+			),
+		)
+
+		return nil
+	}
+
+	return types.ErrSessionNotFound.Wrapf("no valid authorization session found for action %s", action.String())
+}
+
+// CreateAuthSessionForAction creates an authorization session for the given action type
+// using the default duration and single-use settings based on the action's risk level.
+func (k Keeper) CreateAuthSessionForAction(
+	ctx sdk.Context,
+	address sdk.AccAddress,
+	action types.SensitiveTransactionType,
+	verifiedFactors []types.FactorType,
+	deviceFingerprint string,
+) (*types.AuthorizationSession, error) {
+	now := ctx.BlockTime().Unix()
+
+	// Get session duration from sensitive tx config if available, otherwise use defaults
+	duration := action.GetDefaultSessionDuration()
+	isSingleUse := action.IsSingleUse()
+
+	// Check if there's a custom config for this action
+	if config, found := k.GetSensitiveTxConfig(ctx, action); found {
+		duration = config.SessionDuration
+		isSingleUse = config.IsSingleUse
+	}
+
+	// Calculate expiry time
+	var expiresAt int64
+	if isSingleUse {
+		// Single-use sessions get a short window (5 minutes) to complete the transaction
+		expiresAt = now + 5*60
+	} else if duration > 0 {
+		expiresAt = now + duration
+	} else {
+		// Default to 15 minutes if no duration configured
+		expiresAt = now + 15*60
+	}
+
+	session := &types.AuthorizationSession{
+		AccountAddress:    address.String(),
+		TransactionType:   action,
+		VerifiedFactors:   verifiedFactors,
+		CreatedAt:         now,
+		ExpiresAt:         expiresAt,
+		IsSingleUse:       isSingleUse,
+		DeviceFingerprint: deviceFingerprint,
+	}
+
+	if err := k.CreateAuthorizationSession(ctx, session); err != nil {
+		return nil, err
+	}
+
+	return session, nil
+}
+
+// GetValidSessionsForAccount returns all valid (non-expired, non-consumed) sessions for an account.
+func (k Keeper) GetValidSessionsForAccount(ctx sdk.Context, address sdk.AccAddress) []types.AuthorizationSession {
+	sessions := k.GetAccountSessions(ctx, address)
+	now := ctx.BlockTime()
+
+	var validSessions []types.AuthorizationSession
+	for _, session := range sessions {
+		if session.IsValid(now) {
+			validSessions = append(validSessions, session)
+		}
+	}
+
+	return validSessions
+}
+
+// CleanupExpiredSessions removes expired sessions for an account.
+// This is called during EndBlock or can be triggered manually.
+func (k Keeper) CleanupExpiredSessions(ctx sdk.Context, address sdk.AccAddress) int {
+	sessions := k.GetAccountSessions(ctx, address)
+	now := ctx.BlockTime()
+	deleted := 0
+
+	for _, session := range sessions {
+		if !session.IsValid(now) {
+			// Emit expiry event for sessions that expired (not just used single-use sessions)
+			if now.Unix() > session.ExpiresAt && session.UsedAt == 0 {
+				ctx.EventManager().EmitEvent(
+					sdk.NewEvent(
+						types.EventTypeSessionExpired,
+						sdk.NewAttribute(types.AttributeKeySessionID, session.SessionID),
+						sdk.NewAttribute(types.AttributeKeyAccountAddress, address.String()),
+					),
+				)
+			}
+
+			k.DeleteAuthorizationSession(ctx, session.SessionID)
+			deleted++
+		}
+	}
+
+	return deleted
+}
+
+// ValidateSessionForTransaction validates that a session is appropriate for the given transaction.
+// This performs comprehensive checks including:
+// - Session exists and is valid
+// - Session is for the correct action type
+// - Device fingerprint matches (if session is device-bound)
+// - Session has not been consumed (for single-use)
+func (k Keeper) ValidateSessionForTransaction(
+	ctx sdk.Context,
+	sessionID string,
+	address sdk.AccAddress,
+	action types.SensitiveTransactionType,
+	deviceFingerprint string,
+) error {
+	session, found := k.GetAuthorizationSession(ctx, sessionID)
+	if !found {
+		return types.ErrSessionNotFound.Wrapf("session %s not found", sessionID)
+	}
+
+	// Verify the session belongs to this account
+	if session.AccountAddress != address.String() {
+		return types.ErrUnauthorized.Wrap("session does not belong to this account")
+	}
+
+	// Verify the session is for this action type
+	if session.TransactionType != action {
+		return types.ErrUnauthorized.Wrapf("session is for action %s, not %s",
+			session.TransactionType.String(), action.String())
+	}
+
+	// Check if session is valid
+	now := ctx.BlockTime()
+	if !session.IsValid(now) {
+		if session.IsSingleUse && session.UsedAt > 0 {
+			return types.ErrSessionAlreadyUsed.Wrap("single-use session has already been consumed")
+		}
+		return types.ErrSessionExpired.Wrap("session has expired")
+	}
+
+	// Validate device fingerprint if session is device-bound
+	if session.DeviceFingerprint != "" && deviceFingerprint != "" {
+		if session.DeviceFingerprint != deviceFingerprint {
+			return types.ErrDeviceMismatch.Wrap("device fingerprint does not match session")
+		}
+	}
+
+	return nil
+}
+
+// GetSessionDurationForAction returns the session duration in seconds for a given action type.
+func (k Keeper) GetSessionDurationForAction(ctx sdk.Context, action types.SensitiveTransactionType) int64 {
+	// Check for custom config first
+	if config, found := k.GetSensitiveTxConfig(ctx, action); found {
+		return config.SessionDuration
+	}
+
+	// Fall back to defaults based on risk level
+	return action.GetDefaultSessionDuration()
+}
+
+// IsActionSingleUse returns whether an action type requires single-use authorization.
+func (k Keeper) IsActionSingleUse(ctx sdk.Context, action types.SensitiveTransactionType) bool {
+	// Check for custom config first
+	if config, found := k.GetSensitiveTxConfig(ctx, action); found {
+		return config.IsSingleUse
+	}
+
+	// Fall back to type defaults
+	return action.IsSingleUse()
+}

--- a/x/mfa/keeper/sessions_test.go
+++ b/x/mfa/keeper/sessions_test.go
@@ -1,0 +1,544 @@
+package keeper
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdktestutil "github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/virtengine/virtengine/x/mfa/types"
+)
+
+// mockVEIDKeeper implements VEIDKeeper for testing
+type mockVEIDKeeper struct {
+	scores map[string]uint32
+}
+
+func newMockVEIDKeeper() *mockVEIDKeeper {
+	return &mockVEIDKeeper{scores: make(map[string]uint32)}
+}
+
+func (m *mockVEIDKeeper) GetVEIDScore(ctx sdk.Context, address sdk.AccAddress) (uint32, bool) {
+	score, ok := m.scores[address.String()]
+	return score, ok
+}
+
+// mockRolesKeeper implements RolesKeeper for testing
+type mockRolesKeeper struct {
+	operational map[string]bool
+}
+
+func newMockRolesKeeper() *mockRolesKeeper {
+	return &mockRolesKeeper{operational: make(map[string]bool)}
+}
+
+func (m *mockRolesKeeper) IsAccountOperational(ctx sdk.Context, address sdk.AccAddress) bool {
+	op, ok := m.operational[address.String()]
+	return ok && op
+}
+
+func setupTestKeeper(t *testing.T) (sdk.Context, Keeper) {
+	key := storetypes.NewKVStoreKey(types.StoreKey)
+	testCtx := sdktestutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+	ctx := testCtx.Ctx.WithBlockTime(time.Now())
+
+	cdc := codec.NewLegacyAmino()
+	keeper := NewKeeper(cdc, key, "authority", newMockVEIDKeeper(), newMockRolesKeeper())
+
+	return ctx, keeper
+}
+
+func TestHasValidAuthSession(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+
+	// Test: No session exists
+	hasSession := keeper.HasValidAuthSession(ctx, addr, types.SensitiveTxProviderRegistration)
+	require.False(t, hasSession, "should return false when no session exists")
+
+	// Create a session
+	now := ctx.BlockTime().Unix()
+	session := &types.AuthorizationSession{
+		SessionID:       "test-session-1",
+		AccountAddress:  addr.String(),
+		TransactionType: types.SensitiveTxProviderRegistration,
+		VerifiedFactors: []types.FactorType{types.FactorTypeFIDO2},
+		CreatedAt:       now,
+		ExpiresAt:       now + 15*60, // 15 minutes
+		IsSingleUse:     false,
+	}
+	err := keeper.CreateAuthorizationSession(ctx, session)
+	require.NoError(t, err)
+
+	// Test: Valid session exists
+	hasSession = keeper.HasValidAuthSession(ctx, addr, types.SensitiveTxProviderRegistration)
+	require.True(t, hasSession, "should return true when valid session exists")
+
+	// Test: Wrong action type
+	hasSession = keeper.HasValidAuthSession(ctx, addr, types.SensitiveTxKeyRotation)
+	require.False(t, hasSession, "should return false for different action type")
+}
+
+func TestHasValidAuthSessionWithDevice(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+
+	now := ctx.BlockTime().Unix()
+	session := &types.AuthorizationSession{
+		SessionID:         "test-session-device",
+		AccountAddress:    addr.String(),
+		TransactionType:   types.SensitiveTxLargeWithdrawal,
+		VerifiedFactors:   []types.FactorType{types.FactorTypeFIDO2, types.FactorTypeVEID},
+		CreatedAt:         now,
+		ExpiresAt:         now + 15*60,
+		IsSingleUse:       false,
+		DeviceFingerprint: "device-fingerprint-abc123",
+	}
+	err := keeper.CreateAuthorizationSession(ctx, session)
+	require.NoError(t, err)
+
+	// Test: Correct device fingerprint
+	hasSession := keeper.HasValidAuthSessionWithDevice(ctx, addr, types.SensitiveTxLargeWithdrawal, "device-fingerprint-abc123")
+	require.True(t, hasSession, "should return true for matching device fingerprint")
+
+	// Test: Wrong device fingerprint
+	hasSession = keeper.HasValidAuthSessionWithDevice(ctx, addr, types.SensitiveTxLargeWithdrawal, "wrong-device")
+	require.False(t, hasSession, "should return false for non-matching device fingerprint")
+
+	// Test: Empty device fingerprint (should match any)
+	hasSession = keeper.HasValidAuthSession(ctx, addr, types.SensitiveTxLargeWithdrawal)
+	require.True(t, hasSession, "should return true when not checking device fingerprint")
+}
+
+func TestConsumeAuthSession_SingleUse(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+
+	now := ctx.BlockTime().Unix()
+	session := &types.AuthorizationSession{
+		SessionID:       "test-single-use",
+		AccountAddress:  addr.String(),
+		TransactionType: types.SensitiveTxAccountRecovery,
+		VerifiedFactors: []types.FactorType{types.FactorTypeVEID, types.FactorTypeFIDO2, types.FactorTypeSMS},
+		CreatedAt:       now,
+		ExpiresAt:       now + 5*60, // 5 minutes for single-use
+		IsSingleUse:     true,
+	}
+	err := keeper.CreateAuthorizationSession(ctx, session)
+	require.NoError(t, err)
+
+	// Verify session exists
+	hasSession := keeper.HasValidAuthSession(ctx, addr, types.SensitiveTxAccountRecovery)
+	require.True(t, hasSession)
+
+	// Consume the session
+	err = keeper.ConsumeAuthSession(ctx, addr, types.SensitiveTxAccountRecovery)
+	require.NoError(t, err)
+
+	// Session should no longer be valid (consumed)
+	hasSession = keeper.HasValidAuthSession(ctx, addr, types.SensitiveTxAccountRecovery)
+	require.False(t, hasSession, "single-use session should be consumed after use")
+
+	// Trying to consume again should fail
+	err = keeper.ConsumeAuthSession(ctx, addr, types.SensitiveTxAccountRecovery)
+	require.Error(t, err)
+}
+
+func TestConsumeAuthSession_MultiUse(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+
+	now := ctx.BlockTime().Unix()
+	session := &types.AuthorizationSession{
+		SessionID:       "test-multi-use",
+		AccountAddress:  addr.String(),
+		TransactionType: types.SensitiveTxHighValueOrder,
+		VerifiedFactors: []types.FactorType{types.FactorTypeVEID, types.FactorTypeFIDO2},
+		CreatedAt:       now,
+		ExpiresAt:       now + 30*60, // 30 minutes
+		IsSingleUse:     false,
+	}
+	err := keeper.CreateAuthorizationSession(ctx, session)
+	require.NoError(t, err)
+
+	// Consume the session
+	err = keeper.ConsumeAuthSession(ctx, addr, types.SensitiveTxHighValueOrder)
+	require.NoError(t, err)
+
+	// Session should still be valid (multi-use)
+	hasSession := keeper.HasValidAuthSession(ctx, addr, types.SensitiveTxHighValueOrder)
+	require.True(t, hasSession, "multi-use session should remain valid after use")
+
+	// Should be able to consume again
+	err = keeper.ConsumeAuthSession(ctx, addr, types.SensitiveTxHighValueOrder)
+	require.NoError(t, err)
+}
+
+func TestConsumeAuthSession_DeviceMismatch(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+
+	now := ctx.BlockTime().Unix()
+	session := &types.AuthorizationSession{
+		SessionID:         "test-device-bound",
+		AccountAddress:    addr.String(),
+		TransactionType:   types.SensitiveTxProviderRegistration,
+		VerifiedFactors:   []types.FactorType{types.FactorTypeVEID, types.FactorTypeFIDO2},
+		CreatedAt:         now,
+		ExpiresAt:         now + 15*60,
+		IsSingleUse:       false,
+		DeviceFingerprint: "original-device",
+	}
+	err := keeper.CreateAuthorizationSession(ctx, session)
+	require.NoError(t, err)
+
+	// Try to consume with wrong device
+	err = keeper.ConsumeAuthSessionWithDevice(ctx, addr, types.SensitiveTxProviderRegistration, "different-device")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "device fingerprint")
+
+	// Consume with correct device should work
+	err = keeper.ConsumeAuthSessionWithDevice(ctx, addr, types.SensitiveTxProviderRegistration, "original-device")
+	require.NoError(t, err)
+}
+
+func TestCreateAuthSessionForAction(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+
+	testCases := []struct {
+		name          string
+		action        types.SensitiveTransactionType
+		expectSingle  bool
+		minDuration   int64
+		maxDuration   int64
+	}{
+		{
+			name:          "Critical - AccountRecovery (single-use)",
+			action:        types.SensitiveTxAccountRecovery,
+			expectSingle:  true,
+			minDuration:   0,
+			maxDuration:   5 * 60, // 5 minute window for single-use
+		},
+		{
+			name:          "Critical - KeyRotation (single-use)",
+			action:        types.SensitiveTxKeyRotation,
+			expectSingle:  true,
+			minDuration:   0,
+			maxDuration:   5 * 60,
+		},
+		{
+			name:          "High - ProviderRegistration (15 min)",
+			action:        types.SensitiveTxProviderRegistration,
+			expectSingle:  false,
+			minDuration:   14 * 60,
+			maxDuration:   16 * 60,
+		},
+		{
+			name:          "High - LargeWithdrawal (15 min)",
+			action:        types.SensitiveTxLargeWithdrawal,
+			expectSingle:  false,
+			minDuration:   14 * 60,
+			maxDuration:   16 * 60,
+		},
+		{
+			name:          "Medium - HighValueOrder (30 min)",
+			action:        types.SensitiveTxHighValueOrder,
+			expectSingle:  false,
+			minDuration:   29 * 60,
+			maxDuration:   31 * 60,
+		},
+		{
+			name:          "Low - MediumWithdrawal (60 min)",
+			action:        types.SensitiveTxMediumWithdrawal,
+			expectSingle:  false,
+			minDuration:   59 * 60,
+			maxDuration:   61 * 60,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			session, err := keeper.CreateAuthSessionForAction(
+				ctx,
+				addr,
+				tc.action,
+				[]types.FactorType{types.FactorTypeFIDO2},
+				"test-device",
+			)
+			require.NoError(t, err)
+			require.NotNil(t, session)
+
+			require.Equal(t, tc.expectSingle, session.IsSingleUse, "single-use mismatch")
+
+			duration := session.ExpiresAt - session.CreatedAt
+			require.GreaterOrEqual(t, duration, tc.minDuration, "duration too short")
+			require.LessOrEqual(t, duration, tc.maxDuration, "duration too long")
+
+			// Cleanup
+			keeper.DeleteAuthorizationSession(ctx, session.SessionID)
+		})
+	}
+}
+
+func TestGetValidSessionsForAccount(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+
+	now := ctx.BlockTime().Unix()
+
+	// Create mix of valid and expired/used sessions
+	validSession := &types.AuthorizationSession{
+		SessionID:       "valid-session",
+		AccountAddress:  addr.String(),
+		TransactionType: types.SensitiveTxProviderRegistration,
+		VerifiedFactors: []types.FactorType{types.FactorTypeFIDO2},
+		CreatedAt:       now,
+		ExpiresAt:       now + 15*60,
+		IsSingleUse:     false,
+	}
+	keeper.CreateAuthorizationSession(ctx, validSession)
+
+	expiredSession := &types.AuthorizationSession{
+		SessionID:       "expired-session",
+		AccountAddress:  addr.String(),
+		TransactionType: types.SensitiveTxHighValueOrder,
+		VerifiedFactors: []types.FactorType{types.FactorTypeTOTP},
+		CreatedAt:       now - 60*60,
+		ExpiresAt:       now - 30*60, // Expired 30 min ago
+		IsSingleUse:     false,
+	}
+	keeper.CreateAuthorizationSession(ctx, expiredSession)
+
+	usedSingleUseSession := &types.AuthorizationSession{
+		SessionID:       "used-single-use",
+		AccountAddress:  addr.String(),
+		TransactionType: types.SensitiveTxAccountRecovery,
+		VerifiedFactors: []types.FactorType{types.FactorTypeVEID, types.FactorTypeFIDO2},
+		CreatedAt:       now,
+		ExpiresAt:       now + 5*60,
+		IsSingleUse:     true,
+		UsedAt:          now - 60, // Used 1 minute ago
+	}
+	keeper.CreateAuthorizationSession(ctx, usedSingleUseSession)
+
+	// Get valid sessions
+	validSessions := keeper.GetValidSessionsForAccount(ctx, addr)
+	require.Len(t, validSessions, 1, "should only return 1 valid session")
+	require.Equal(t, "valid-session", validSessions[0].SessionID)
+}
+
+func TestCleanupExpiredSessions(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+
+	now := ctx.BlockTime().Unix()
+
+	// Create sessions
+	keeper.CreateAuthorizationSession(ctx, &types.AuthorizationSession{
+		SessionID:       "valid-session",
+		AccountAddress:  addr.String(),
+		TransactionType: types.SensitiveTxProviderRegistration,
+		CreatedAt:       now,
+		ExpiresAt:       now + 15*60,
+	})
+
+	keeper.CreateAuthorizationSession(ctx, &types.AuthorizationSession{
+		SessionID:       "expired-session-1",
+		AccountAddress:  addr.String(),
+		TransactionType: types.SensitiveTxHighValueOrder,
+		CreatedAt:       now - 60*60,
+		ExpiresAt:       now - 30*60,
+	})
+
+	keeper.CreateAuthorizationSession(ctx, &types.AuthorizationSession{
+		SessionID:       "expired-session-2",
+		AccountAddress:  addr.String(),
+		TransactionType: types.SensitiveTxMediumWithdrawal,
+		CreatedAt:       now - 120*60,
+		ExpiresAt:       now - 60*60,
+	})
+
+	// Verify initial state
+	allSessions := keeper.GetAccountSessions(ctx, addr)
+	require.Len(t, allSessions, 3)
+
+	// Cleanup expired sessions
+	deleted := keeper.CleanupExpiredSessions(ctx, addr)
+	require.Equal(t, 2, deleted, "should delete 2 expired sessions")
+
+	// Verify only valid session remains
+	remainingSessions := keeper.GetAccountSessions(ctx, addr)
+	require.Len(t, remainingSessions, 1)
+	require.Equal(t, "valid-session", remainingSessions[0].SessionID)
+}
+
+func TestValidateSessionForTransaction(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+	otherAddr := sdk.AccAddress([]byte("other_address_123456"))
+
+	now := ctx.BlockTime().Unix()
+	session := &types.AuthorizationSession{
+		SessionID:         "validate-test-session",
+		AccountAddress:    addr.String(),
+		TransactionType:   types.SensitiveTxProviderRegistration,
+		VerifiedFactors:   []types.FactorType{types.FactorTypeFIDO2},
+		CreatedAt:         now,
+		ExpiresAt:         now + 15*60,
+		IsSingleUse:       false,
+		DeviceFingerprint: "bound-device",
+	}
+	keeper.CreateAuthorizationSession(ctx, session)
+
+	// Test: Valid session
+	err := keeper.ValidateSessionForTransaction(ctx, "validate-test-session", addr, types.SensitiveTxProviderRegistration, "bound-device")
+	require.NoError(t, err)
+
+	// Test: Session not found
+	err = keeper.ValidateSessionForTransaction(ctx, "non-existent", addr, types.SensitiveTxProviderRegistration, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	// Test: Wrong account
+	err = keeper.ValidateSessionForTransaction(ctx, "validate-test-session", otherAddr, types.SensitiveTxProviderRegistration, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not belong")
+
+	// Test: Wrong action type
+	err = keeper.ValidateSessionForTransaction(ctx, "validate-test-session", addr, types.SensitiveTxKeyRotation, "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "action")
+
+	// Test: Device mismatch
+	err = keeper.ValidateSessionForTransaction(ctx, "validate-test-session", addr, types.SensitiveTxProviderRegistration, "wrong-device")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "device")
+}
+
+func TestGetSessionDurationForAction(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+
+	testCases := []struct {
+		action           types.SensitiveTransactionType
+		expectedDuration int64
+	}{
+		{types.SensitiveTxAccountRecovery, 0},             // Critical - single use
+		{types.SensitiveTxKeyRotation, 0},                 // Critical - single use
+		{types.SensitiveTxProviderRegistration, 15 * 60},  // High - 15 min
+		{types.SensitiveTxLargeWithdrawal, 15 * 60},       // High - 15 min
+		{types.SensitiveTxHighValueOrder, 30 * 60},        // Medium - 30 min
+		{types.SensitiveTxMediumWithdrawal, 60 * 60},      // Low - 60 min
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.action.String(), func(t *testing.T) {
+			duration := keeper.GetSessionDurationForAction(ctx, tc.action)
+			require.Equal(t, tc.expectedDuration, duration)
+		})
+	}
+}
+
+func TestIsActionSingleUse(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+
+	singleUseActions := []types.SensitiveTransactionType{
+		types.SensitiveTxAccountRecovery,
+		types.SensitiveTxKeyRotation,
+		types.SensitiveTxAccountDeletion,
+		types.SensitiveTxTwoFactorDisable,
+		types.SensitiveTxValidatorRegistration,
+		types.SensitiveTxRoleAssignment,
+	}
+
+	multiUseActions := []types.SensitiveTransactionType{
+		types.SensitiveTxProviderRegistration,
+		types.SensitiveTxLargeWithdrawal,
+		types.SensitiveTxHighValueOrder,
+		types.SensitiveTxMediumWithdrawal,
+		types.SensitiveTxGovernanceProposal,
+	}
+
+	for _, action := range singleUseActions {
+		t.Run(action.String()+"_single", func(t *testing.T) {
+			isSingle := keeper.IsActionSingleUse(ctx, action)
+			require.True(t, isSingle, "%s should be single-use", action.String())
+		})
+	}
+
+	for _, action := range multiUseActions {
+		t.Run(action.String()+"_multi", func(t *testing.T) {
+			isSingle := keeper.IsActionSingleUse(ctx, action)
+			require.False(t, isSingle, "%s should be multi-use", action.String())
+		})
+	}
+}
+
+func TestCustomSensitiveTxConfig(t *testing.T) {
+	ctx, keeper := setupTestKeeper(t)
+	addr := sdk.AccAddress([]byte("test_address_1234567"))
+
+	// Set custom config for HighValueOrder with different duration
+	customConfig := &types.SensitiveTxConfig{
+		TransactionType: types.SensitiveTxHighValueOrder,
+		Enabled:         true,
+		MinVEIDScore:    80,
+		SessionDuration: 10 * 60, // 10 minutes instead of default 30
+		IsSingleUse:     true,    // Override to single-use
+		Description:     "Custom high-value order config",
+	}
+	err := keeper.SetSensitiveTxConfig(ctx, customConfig)
+	require.NoError(t, err)
+
+	// Create session should use custom config
+	session, err := keeper.CreateAuthSessionForAction(
+		ctx,
+		addr,
+		types.SensitiveTxHighValueOrder,
+		[]types.FactorType{types.FactorTypeFIDO2},
+		"",
+	)
+	require.NoError(t, err)
+
+	// Should be single-use (overridden)
+	require.True(t, session.IsSingleUse)
+
+	// Duration check helpers
+	duration := keeper.GetSessionDurationForAction(ctx, types.SensitiveTxHighValueOrder)
+	require.Equal(t, int64(10*60), duration)
+
+	isSingle := keeper.IsActionSingleUse(ctx, types.SensitiveTxHighValueOrder)
+	require.True(t, isSingle)
+}
+
+// Verify sessionStore JSON serialization works correctly
+func TestSessionStoreSerialization(t *testing.T) {
+	ss := sessionStore{
+		SessionID:         "test-id",
+		AccountAddress:    "cosmos1abc123",
+		TransactionType:   types.SensitiveTxProviderRegistration,
+		VerifiedFactors:   []types.FactorType{types.FactorTypeFIDO2, types.FactorTypeVEID},
+		CreatedAt:         1700000000,
+		ExpiresAt:         1700000900,
+		UsedAt:            0,
+		IsSingleUse:       false,
+		DeviceFingerprint: "device-123",
+	}
+
+	bz, err := json.Marshal(&ss)
+	require.NoError(t, err)
+
+	var decoded sessionStore
+	err = json.Unmarshal(bz, &decoded)
+	require.NoError(t, err)
+
+	require.Equal(t, ss.SessionID, decoded.SessionID)
+	require.Equal(t, ss.TransactionType, decoded.TransactionType)
+	require.Equal(t, ss.VerifiedFactors, decoded.VerifiedFactors)
+	require.Equal(t, ss.DeviceFingerprint, decoded.DeviceFingerprint)
+}


### PR DESCRIPTION
**Priority:** HIGH
**Spec Reference:** veid-flow-spec.md - Authorization Sessions
**Current State:** Session types defined, lifecycle incomplete

**Implementation Path:**
1. File: `x/mfa/keeper/sessions.go`
2. Implement session durations per action type:
   - Critical (AccountRecovery, KeyRotation): Single use
   - High (ProviderReg, LargeWithdrawal): 15 minutes
   - Medium (HighValueOrder): 30 minutes
3. Implement `HasValidAuthSession(ctx, addr, action) bool`
4. Implement `ConsumeAuthSession(ctx, addr, action) error` for single-use

**Acceptance Criteria:**
- Session expires after configured duration
- Single-use sessions consumed after first use
- Sessions bound to device/context hash