### PR TITLE
feat: VEID-CORE-001: Implement VEID Tier Transition Logic

### DIFF
--- a/x/veid/keeper/tier_transitions.go
+++ b/x/veid/keeper/tier_transitions.go
@@ -1,0 +1,354 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/virtengine/virtengine/x/veid/types"
+)
+
+// ============================================================================
+// VEID Tier Transition Logic
+// ============================================================================
+//
+// Implements the Account Tier System as defined in veid-flow-spec.md:
+// - Tier 0 (Unverified): Score 0-49 or non-verified status
+// - Tier 1 (Basic): Score 50-69
+// - Tier 2 (Standard): Score 70-84
+// - Tier 3 (Premium): Score 85-100
+//
+// Task Reference: VEID-CORE-001
+// ============================================================================
+
+// TierTransitionResult contains the result of a tier transition operation
+type TierTransitionResult struct {
+	// Address is the account address
+	Address string `json:"address"`
+
+	// OldTier is the tier before the transition
+	OldTier int `json:"old_tier"`
+
+	// NewTier is the tier after the transition
+	NewTier int `json:"new_tier"`
+
+	// CompositeScore is the calculated composite score
+	CompositeScore uint32 `json:"composite_score"`
+
+	// Changed indicates if the tier actually changed
+	Changed bool `json:"changed"`
+
+	// VerifiedScopeCount is the number of verified scopes
+	VerifiedScopeCount int `json:"verified_scope_count"`
+}
+
+// UpdateAccountTier fetches all verified scopes for an account, calculates
+// the composite score, maps it to a tier, stores the new tier, and emits
+// a VEIDTierChanged event if the tier changed.
+//
+// Tier mapping (per veid-flow-spec.md):
+// - Score 0-49: Tier 0 (Unverified)
+// - Score 50-69: Tier 1 (Basic)
+// - Score 70-84: Tier 2 (Standard)
+// - Score 85-100: Tier 3 (Premium)
+func (k Keeper) UpdateAccountTier(ctx sdk.Context, addr sdk.AccAddress) (*TierTransitionResult, error) {
+	// Get identity record
+	record, found := k.GetIdentityRecord(ctx, addr)
+	if !found {
+		return nil, types.ErrIdentityRecordNotFound.Wrapf("identity record not found for %s", addr.String())
+	}
+
+	// Store old tier for comparison
+	oldTier := k.computeTierInt(record.Tier)
+
+	// Calculate composite score from verified scopes
+	compositeScore, verifiedCount := k.calculateCompositeScore(ctx, addr)
+
+	// Determine new tier from composite score
+	newTier := k.determineTier(compositeScore, record)
+
+	// Create result
+	result := &TierTransitionResult{
+		Address:            addr.String(),
+		OldTier:            oldTier,
+		NewTier:            newTier,
+		CompositeScore:     compositeScore,
+		Changed:            oldTier != newTier,
+		VerifiedScopeCount: verifiedCount,
+	}
+
+	// Update record if score or tier changed
+	record.CurrentScore = compositeScore
+	record.Tier = k.tierIntToIdentityTier(newTier)
+	record.UpdatedAt = ctx.BlockTime()
+
+	if err := k.SetIdentityRecord(ctx, record); err != nil {
+		return nil, err
+	}
+
+	// Emit tier changed event if tier changed
+	if result.Changed {
+		if err := k.EmitTierChangedEvent(
+			ctx,
+			addr.String(),
+			types.TierToString(oldTier),
+			types.TierToString(newTier),
+			compositeScore,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+// calculateCompositeScore calculates the composite identity score from all
+// verified scopes for an account. Each scope type has a weight defined in
+// types.ScopeTypeWeight().
+//
+// Returns the composite score (capped at 100) and count of verified scopes.
+func (k Keeper) calculateCompositeScore(ctx sdk.Context, addr sdk.AccAddress) (uint32, int) {
+	var totalWeight uint32
+	var verifiedCount int
+
+	// Iterate through all scopes for the account
+	k.WithScopes(ctx, addr, func(scope types.IdentityScope) bool {
+		// Only count verified, non-revoked scopes
+		if scope.Status == types.VerificationStatusVerified && scope.IsActive() {
+			weight := types.ScopeTypeWeight(scope.ScopeType)
+			totalWeight += weight
+			verifiedCount++
+		}
+		return false // continue iteration
+	})
+
+	// Cap the score at MaxScore (100)
+	if totalWeight > types.MaxScore {
+		totalWeight = types.MaxScore
+	}
+
+	return totalWeight, verifiedCount
+}
+
+// determineTier maps a score to a tier based on the thresholds defined
+// in veid-flow-spec.md. Non-verified accounts are always Tier 0.
+func (k Keeper) determineTier(score uint32, record types.IdentityRecord) int {
+	// Locked accounts are Tier 0
+	if record.Locked {
+		return types.TierUnverified
+	}
+
+	// Apply tier thresholds per spec
+	switch {
+	case score >= types.ThresholdPremium: // 85-100
+		return types.TierPremium
+	case score >= types.ThresholdStandard: // 70-84
+		return types.TierStandard
+	case score >= types.ThresholdBasic: // 50-69
+		return types.TierBasic
+	default: // 0-49
+		return types.TierUnverified
+	}
+}
+
+// computeTierInt converts an IdentityTier string to its numeric tier value
+func (k Keeper) computeTierInt(tier types.IdentityTier) int {
+	switch tier {
+	case types.IdentityTierPremium, types.IdentityTierTrusted:
+		return types.TierPremium
+	case types.IdentityTierStandard, types.IdentityTierVerified:
+		return types.TierStandard
+	case types.IdentityTierBasic:
+		return types.TierBasic
+	default:
+		return types.TierUnverified
+	}
+}
+
+// tierIntToIdentityTier converts a numeric tier to IdentityTier
+func (k Keeper) tierIntToIdentityTier(tier int) types.IdentityTier {
+	switch tier {
+	case types.TierPremium:
+		return types.IdentityTierPremium
+	case types.TierStandard:
+		return types.IdentityTierStandard
+	case types.TierBasic:
+		return types.IdentityTierBasic
+	default:
+		return types.IdentityTierUnverified
+	}
+}
+
+// ============================================================================
+// Query Helpers
+// ============================================================================
+
+// GetAccountTierDetails returns detailed tier information for an account.
+// This extends the GetAccountTier method with additional context.
+type AccountTierDetails struct {
+	// Address is the account address
+	Address string `json:"address"`
+
+	// Tier is the current tier (0-3)
+	Tier int `json:"tier"`
+
+	// TierName is the human-readable tier name
+	TierName string `json:"tier_name"`
+
+	// Score is the current composite score
+	Score uint32 `json:"score"`
+
+	// Status is the account verification status
+	Status types.AccountStatus `json:"status"`
+
+	// NextTierThreshold is the score needed for the next tier (0 if at max)
+	NextTierThreshold uint32 `json:"next_tier_threshold"`
+
+	// PointsToNextTier is how many more points needed for next tier
+	PointsToNextTier uint32 `json:"points_to_next_tier"`
+
+	// VerifiedScopeCount is the number of verified scopes
+	VerifiedScopeCount int `json:"verified_scope_count"`
+
+	// Locked indicates if the account is locked
+	Locked bool `json:"locked"`
+}
+
+// GetAccountTierDetails returns detailed tier information for an account
+func (k Keeper) GetAccountTierDetails(ctx sdk.Context, addr sdk.AccAddress) (*AccountTierDetails, error) {
+	record, found := k.GetIdentityRecord(ctx, addr)
+	if !found {
+		return nil, types.ErrIdentityRecordNotFound.Wrapf("identity record not found for %s", addr.String())
+	}
+
+	// Get current score and status
+	score, status, _ := k.GetScore(ctx, addr.String())
+	if score == 0 {
+		score = record.CurrentScore
+		if !record.Locked && record.CurrentScore > 0 {
+			status = types.AccountStatusVerified
+		}
+	}
+
+	tier := types.ComputeTierFromScoreValue(score, status)
+
+	// Calculate next tier threshold
+	var nextThreshold uint32
+	var pointsNeeded uint32
+
+	switch tier {
+	case types.TierUnverified:
+		nextThreshold = types.ThresholdBasic
+		if score < nextThreshold {
+			pointsNeeded = nextThreshold - score
+		}
+	case types.TierBasic:
+		nextThreshold = types.ThresholdStandard
+		pointsNeeded = nextThreshold - score
+	case types.TierStandard:
+		nextThreshold = types.ThresholdPremium
+		pointsNeeded = nextThreshold - score
+	case types.TierPremium:
+		nextThreshold = 0 // Already at max
+		pointsNeeded = 0
+	}
+
+	// Count verified scopes
+	verifiedCount := record.CountVerifiedScopes()
+
+	return &AccountTierDetails{
+		Address:            addr.String(),
+		Tier:               tier,
+		TierName:           types.TierToString(tier),
+		Score:              score,
+		Status:             status,
+		NextTierThreshold:  nextThreshold,
+		PointsToNextTier:   pointsNeeded,
+		VerifiedScopeCount: verifiedCount,
+		Locked:             record.Locked,
+	}, nil
+}
+
+// ============================================================================
+// Threshold Helpers
+// ============================================================================
+
+// MeetsScoreThreshold checks if an account's score meets or exceeds the
+// specified threshold. Returns false if the account doesn't exist,
+// isn't verified, or is locked.
+func (k Keeper) MeetsScoreThreshold(ctx sdk.Context, addr sdk.AccAddress, threshold uint32) bool {
+	// Get identity record
+	record, found := k.GetIdentityRecord(ctx, addr)
+	if !found {
+		return false
+	}
+
+	// Locked accounts never meet thresholds
+	if record.Locked {
+		return false
+	}
+
+	// Get the current score and status
+	score, status, found := k.GetScore(ctx, addr.String())
+	if !found {
+		// Fall back to record's score
+		score = record.CurrentScore
+		if record.CurrentScore == 0 {
+			return false
+		}
+		status = types.AccountStatusVerified
+	}
+
+	// Must be verified to pass threshold checks
+	if status != types.AccountStatusVerified {
+		return false
+	}
+
+	return score >= threshold
+}
+
+// MeetsTierRequirement checks if an account meets the minimum tier requirement
+func (k Keeper) MeetsTierRequirement(ctx sdk.Context, addr sdk.AccAddress, requiredTier int) bool {
+	tier, err := k.GetAccountTier(ctx, addr.String())
+	if err != nil {
+		return false
+	}
+	return tier >= requiredTier
+}
+
+// GetTierThreshold returns the minimum score threshold for a tier
+func (k Keeper) GetTierThreshold(tier int) uint32 {
+	return types.GetMinimumScoreForTier(tier)
+}
+
+// ============================================================================
+// Batch Operations
+// ============================================================================
+
+// RecalculateAllAccountTiers recalculates tiers for all accounts.
+// This is useful after ML model updates or system-wide recalibration.
+// Returns the number of accounts processed and number of tier changes.
+func (k Keeper) RecalculateAllAccountTiers(ctx sdk.Context) (processed int, changed int) {
+	k.WithIdentityRecords(ctx, func(record types.IdentityRecord) bool {
+		addr, err := sdk.AccAddressFromBech32(record.AccountAddress)
+		if err != nil {
+			return false // continue
+		}
+
+		result, err := k.UpdateAccountTier(ctx, addr)
+		if err != nil {
+			k.Logger(ctx).Error("failed to recalculate tier",
+				"address", record.AccountAddress,
+				"error", err,
+			)
+			return false // continue
+		}
+
+		processed++
+		if result.Changed {
+			changed++
+		}
+
+		return false // continue
+	})
+
+	return processed, changed
+}

--- a/x/veid/keeper/tier_transitions_test.go
+++ b/x/veid/keeper/tier_transitions_test.go
@@ -1,0 +1,562 @@
+package keeper_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/store"
+	storemetrics "cosmossdk.io/store/metrics"
+	storetypes "cosmossdk.io/store/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	encryptiontypes "github.com/virtengine/virtengine/x/encryption/types"
+	"github.com/virtengine/virtengine/x/veid/keeper"
+	"github.com/virtengine/virtengine/x/veid/types"
+)
+
+// ============================================================================
+// Tier Transitions Tests
+// ============================================================================
+
+func TestUpdateAccountTier_NotFound(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("nonexistent"))
+
+	result, err := k.UpdateAccountTier(ctx, addr)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "identity record not found")
+}
+
+func TestUpdateAccountTier_Tier0_NoScopes(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000001"))
+
+	// Create identity record with no scopes
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	result, err := k.UpdateAccountTier(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, types.TierUnverified, result.NewTier)
+	require.Equal(t, uint32(0), result.CompositeScore)
+	require.Equal(t, 0, result.VerifiedScopeCount)
+}
+
+func TestUpdateAccountTier_Tier1_BasicAccess(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000002"))
+
+	// Create identity record
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Add scopes that total 50-69 points (Tier 1 Basic)
+	// ID Document = 30, Selfie = 20 = 50 points
+	addVerifiedScope(t, ctx, k, addr, "scope1", types.ScopeTypeIDDocument)
+	addVerifiedScope(t, ctx, k, addr, "scope2", types.ScopeTypeSelfie)
+
+	result, err := k.UpdateAccountTier(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, types.TierBasic, result.NewTier)
+	require.Equal(t, uint32(50), result.CompositeScore)
+	require.Equal(t, 2, result.VerifiedScopeCount)
+}
+
+func TestUpdateAccountTier_Tier2_StandardAccess(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000003"))
+
+	// Create identity record
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Add scopes that total 70-84 points (Tier 2 Standard)
+	// ID Document = 30, Selfie = 20, FaceVideo = 25 = 75 points
+	addVerifiedScope(t, ctx, k, addr, "scope1", types.ScopeTypeIDDocument)
+	addVerifiedScope(t, ctx, k, addr, "scope2", types.ScopeTypeSelfie)
+	addVerifiedScope(t, ctx, k, addr, "scope3", types.ScopeTypeFaceVideo)
+
+	result, err := k.UpdateAccountTier(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, types.TierStandard, result.NewTier)
+	require.Equal(t, uint32(75), result.CompositeScore)
+	require.Equal(t, 3, result.VerifiedScopeCount)
+}
+
+func TestUpdateAccountTier_Tier3_PremiumAccess(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000004"))
+
+	// Create identity record
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Add scopes that total 85+ points (Tier 3 Premium)
+	// ID Document = 30, Selfie = 20, FaceVideo = 25, DomainVerify = 15 = 90 points
+	addVerifiedScope(t, ctx, k, addr, "scope1", types.ScopeTypeIDDocument)
+	addVerifiedScope(t, ctx, k, addr, "scope2", types.ScopeTypeSelfie)
+	addVerifiedScope(t, ctx, k, addr, "scope3", types.ScopeTypeFaceVideo)
+	addVerifiedScope(t, ctx, k, addr, "scope4", types.ScopeTypeDomainVerify)
+
+	result, err := k.UpdateAccountTier(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, types.TierPremium, result.NewTier)
+	require.Equal(t, uint32(90), result.CompositeScore)
+	require.Equal(t, 4, result.VerifiedScopeCount)
+}
+
+func TestUpdateAccountTier_ScoreCappedAt100(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000005"))
+
+	// Create identity record
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Add all possible scopes (way more than 100 points)
+	addVerifiedScope(t, ctx, k, addr, "scope1", types.ScopeTypeIDDocument)   // 30
+	addVerifiedScope(t, ctx, k, addr, "scope2", types.ScopeTypeSelfie)        // 20
+	addVerifiedScope(t, ctx, k, addr, "scope3", types.ScopeTypeFaceVideo)     // 25
+	addVerifiedScope(t, ctx, k, addr, "scope4", types.ScopeTypeBiometric)     // 20
+	addVerifiedScope(t, ctx, k, addr, "scope5", types.ScopeTypeDomainVerify)  // 15
+	addVerifiedScope(t, ctx, k, addr, "scope6", types.ScopeTypeEmailProof)    // 10
+	addVerifiedScope(t, ctx, k, addr, "scope7", types.ScopeTypeSMSProof)      // 10
+	addVerifiedScope(t, ctx, k, addr, "scope8", types.ScopeTypeSSOMetadata)   // 5
+	addVerifiedScope(t, ctx, k, addr, "scope9", types.ScopeTypeADSSO)         // 12
+	// Total: 147 points, but should cap at 100
+
+	result, err := k.UpdateAccountTier(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, types.TierPremium, result.NewTier)
+	require.Equal(t, uint32(100), result.CompositeScore) // Capped at 100
+}
+
+func TestUpdateAccountTier_LockedAccount(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000006"))
+
+	// Create locked identity record
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	record.Locked = true
+	record.LockedReason = "fraud detected"
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Add high-value scopes
+	addVerifiedScope(t, ctx, k, addr, "scope1", types.ScopeTypeIDDocument)
+	addVerifiedScope(t, ctx, k, addr, "scope2", types.ScopeTypeSelfie)
+	addVerifiedScope(t, ctx, k, addr, "scope3", types.ScopeTypeFaceVideo)
+
+	result, err := k.UpdateAccountTier(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	// Even with high score, locked accounts are Tier 0
+	require.Equal(t, types.TierUnverified, result.NewTier)
+}
+
+func TestUpdateAccountTier_TierChange_EmitsEvent(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000007"))
+
+	// Create identity record at Tier 0
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	record.Tier = types.IdentityTierUnverified
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Add scopes to bring to Tier 1
+	addVerifiedScope(t, ctx, k, addr, "scope1", types.ScopeTypeIDDocument)
+	addVerifiedScope(t, ctx, k, addr, "scope2", types.ScopeTypeSelfie)
+
+	result, err := k.UpdateAccountTier(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Changed)
+	require.Equal(t, types.TierUnverified, result.OldTier)
+	require.Equal(t, types.TierBasic, result.NewTier)
+
+	// Check event was emitted
+	events := ctx.EventManager().Events()
+	found := false
+	for _, event := range events {
+		if event.Type == "virtengine.veid.v1.EventTierChanged" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "EventTierChanged should be emitted")
+}
+
+func TestUpdateAccountTier_NoChange_NoEvent(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000008"))
+
+	// Create identity record already at Tier 1
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	record.Tier = types.IdentityTierBasic
+	record.CurrentScore = 50
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Add scopes for exactly Tier 1
+	addVerifiedScope(t, ctx, k, addr, "scope1", types.ScopeTypeIDDocument) // 30
+	addVerifiedScope(t, ctx, k, addr, "scope2", types.ScopeTypeSelfie)     // 20 = 50
+
+	// Clear events
+	ctx = ctx.WithEventManager(sdk.NewEventManager())
+
+	result, err := k.UpdateAccountTier(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.Changed)
+	require.Equal(t, types.TierBasic, result.OldTier)
+	require.Equal(t, types.TierBasic, result.NewTier)
+
+	// Check no tier change event was emitted
+	events := ctx.EventManager().Events()
+	for _, event := range events {
+		require.NotEqual(t, "virtengine.veid.v1.EventTierChanged", event.Type)
+	}
+}
+
+// ============================================================================
+// MeetsScoreThreshold Tests
+// ============================================================================
+
+func TestMeetsScoreThreshold_Success(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000009"))
+
+	// Create verified identity record with score
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Set score with verified status
+	err = k.SetScore(ctx, addr.String(), 75, "v1.0")
+	require.NoError(t, err)
+
+	require.True(t, k.MeetsScoreThreshold(ctx, addr, 50))
+	require.True(t, k.MeetsScoreThreshold(ctx, addr, 70))
+	require.True(t, k.MeetsScoreThreshold(ctx, addr, 75))
+	require.False(t, k.MeetsScoreThreshold(ctx, addr, 76))
+	require.False(t, k.MeetsScoreThreshold(ctx, addr, 85))
+}
+
+func TestMeetsScoreThreshold_NotFound(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("nonexistent"))
+
+	require.False(t, k.MeetsScoreThreshold(ctx, addr, 50))
+}
+
+func TestMeetsScoreThreshold_LockedAccount(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000010"))
+
+	// Create locked identity record with high score
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	record.Locked = true
+	record.CurrentScore = 100
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Even with score 100, locked accounts don't meet thresholds
+	require.False(t, k.MeetsScoreThreshold(ctx, addr, 0))
+}
+
+// ============================================================================
+// MeetsTierRequirement Tests
+// ============================================================================
+
+func TestMeetsTierRequirement(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000011"))
+
+	// Create verified identity record
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Set score for Tier 2 (70-84)
+	err = k.SetScore(ctx, addr.String(), 75, "v1.0")
+	require.NoError(t, err)
+
+	require.True(t, k.MeetsTierRequirement(ctx, addr, types.TierUnverified))
+	require.True(t, k.MeetsTierRequirement(ctx, addr, types.TierBasic))
+	require.True(t, k.MeetsTierRequirement(ctx, addr, types.TierStandard))
+	require.False(t, k.MeetsTierRequirement(ctx, addr, types.TierPremium))
+}
+
+// ============================================================================
+// GetAccountTierDetails Tests
+// ============================================================================
+
+func TestGetAccountTierDetails_Success(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000012"))
+
+	// Create identity record
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Set score for Tier 2
+	err = k.SetScore(ctx, addr.String(), 75, "v1.0")
+	require.NoError(t, err)
+
+	details, err := k.GetAccountTierDetails(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+	require.Equal(t, addr.String(), details.Address)
+	require.Equal(t, types.TierStandard, details.Tier)
+	require.Equal(t, "standard", details.TierName)
+	require.Equal(t, uint32(75), details.Score)
+	require.Equal(t, types.ThresholdPremium, details.NextTierThreshold)
+	require.Equal(t, uint32(10), details.PointsToNextTier) // 85 - 75 = 10
+	require.False(t, details.Locked)
+}
+
+func TestGetAccountTierDetails_AtMaxTier(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("testaddr0000000013"))
+
+	// Create identity record
+	record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+	err := k.SetIdentityRecord(ctx, *record)
+	require.NoError(t, err)
+
+	// Set score for Tier 3 (Premium)
+	err = k.SetScore(ctx, addr.String(), 95, "v1.0")
+	require.NoError(t, err)
+
+	details, err := k.GetAccountTierDetails(ctx, addr)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+	require.Equal(t, types.TierPremium, details.Tier)
+	require.Equal(t, "premium", details.TierName)
+	require.Equal(t, uint32(0), details.NextTierThreshold)  // Already at max
+	require.Equal(t, uint32(0), details.PointsToNextTier)
+}
+
+func TestGetAccountTierDetails_NotFound(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+	addr := sdk.AccAddress([]byte("nonexistent"))
+
+	details, err := k.GetAccountTierDetails(ctx, addr)
+	require.Error(t, err)
+	require.Nil(t, details)
+	require.Contains(t, err.Error(), "identity record not found")
+}
+
+// ============================================================================
+// RecalculateAllAccountTiers Tests
+// ============================================================================
+
+func TestRecalculateAllAccountTiers(t *testing.T) {
+	ctx, k := setupTierTestKeeper(t)
+
+	// Create multiple accounts with different scores
+	for i := 0; i < 5; i++ {
+		addr := sdk.AccAddress([]byte{byte(i + 100), byte(i + 100), byte(i + 100), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, byte(i)})
+		record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+		err := k.SetIdentityRecord(ctx, *record)
+		require.NoError(t, err)
+
+		// Add varying scopes
+		if i >= 1 {
+			addVerifiedScope(t, ctx, k, addr, "scope1", types.ScopeTypeIDDocument)
+		}
+		if i >= 2 {
+			addVerifiedScope(t, ctx, k, addr, "scope2", types.ScopeTypeSelfie)
+		}
+		if i >= 3 {
+			addVerifiedScope(t, ctx, k, addr, "scope3", types.ScopeTypeFaceVideo)
+		}
+	}
+
+	processed, changed := k.RecalculateAllAccountTiers(ctx)
+	require.Equal(t, 5, processed)
+	require.GreaterOrEqual(t, changed, 0)
+}
+
+// ============================================================================
+// Tier Threshold Edge Cases
+// ============================================================================
+
+func TestTierThresholds_EdgeCases(t *testing.T) {
+	testCases := []struct {
+		name          string
+		score         uint32
+		expectedTier  int
+	}{
+		{"Score 0", 0, types.TierUnverified},
+		{"Score 49 (just below Basic)", 49, types.TierUnverified},
+		{"Score 50 (exactly Basic)", 50, types.TierBasic},
+		{"Score 51", 51, types.TierBasic},
+		{"Score 69 (top of Basic)", 69, types.TierBasic},
+		{"Score 70 (exactly Standard)", 70, types.TierStandard},
+		{"Score 84 (top of Standard)", 84, types.TierStandard},
+		{"Score 85 (exactly Premium)", 85, types.TierPremium},
+		{"Score 100 (max)", 100, types.TierPremium},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, k := setupTierTestKeeper(t)
+			addr := sdk.AccAddress([]byte("testaddr" + tc.name))
+
+			record := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+			err := k.SetIdentityRecord(ctx, *record)
+			require.NoError(t, err)
+
+			// Set score directly
+			err = k.SetScore(ctx, addr.String(), tc.score, "v1.0")
+			require.NoError(t, err)
+
+			tier, err := k.GetAccountTier(ctx, addr.String())
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedTier, tier, "Score %d should map to tier %d", tc.score, tc.expectedTier)
+		})
+	}
+}
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+func setupTierTestKeeper(t *testing.T) (sdk.Context, keeper.Keeper) {
+	t.Helper()
+
+	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+	interfaceRegistry := codectypes.NewInterfaceRegistry()
+	types.RegisterInterfaces(interfaceRegistry)
+	cdc := codec.NewProtoCodec(interfaceRegistry)
+
+	ctx := createTierTestContext(t, storeKey)
+	ctx = ctx.WithBlockTime(time.Now().UTC())
+
+	k := keeper.NewKeeper(cdc, storeKey, "gov")
+
+	// Initialize default params
+	err := k.SetParams(ctx, types.DefaultParams())
+	require.NoError(t, err)
+
+	return ctx, k
+}
+
+func createTierTestContext(t *testing.T, storeKey *storetypes.KVStoreKey) sdk.Context {
+	t.Helper()
+
+	db := dbm.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db, log.NewNopLogger(), storemetrics.NewNoOpMetrics())
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	err := stateStore.LoadLatestVersion()
+	require.NoError(t, err)
+
+	ctx := sdk.NewContext(stateStore, cmtproto.Header{
+		Time:   time.Now().UTC(),
+		Height: 100,
+	}, false, log.NewNopLogger())
+	return ctx
+}
+
+// scopeStoreTest mirrors the internal scopeStore for test marshaling
+type scopeStoreTest struct {
+	ScopeID          string                   `json:"scope_id"`
+	ScopeType        types.ScopeType          `json:"scope_type"`
+	Version          uint32                   `json:"version"`
+	EncryptedPayload json.RawMessage          `json:"encrypted_payload"`
+	UploadMetadata   types.UploadMetadata     `json:"upload_metadata"`
+	Status           types.VerificationStatus `json:"status"`
+	UploadedAt       int64                    `json:"uploaded_at"`
+	VerifiedAt       *int64                   `json:"verified_at,omitempty"`
+	ExpiresAt        *int64                   `json:"expires_at,omitempty"`
+	Revoked          bool                     `json:"revoked"`
+	RevokedAt        *int64                   `json:"revoked_at,omitempty"`
+	RevokedReason    string                   `json:"revoked_reason,omitempty"`
+}
+
+func addVerifiedScope(t *testing.T, ctx sdk.Context, k keeper.Keeper, addr sdk.AccAddress, scopeID string, scopeType types.ScopeType) {
+	t.Helper()
+
+	// Get or create identity record
+	record, found := k.GetIdentityRecord(ctx, addr)
+	if !found {
+		newRecord := types.NewIdentityRecord(addr.String(), ctx.BlockTime())
+		err := k.SetIdentityRecord(ctx, *newRecord)
+		require.NoError(t, err)
+		record = *newRecord
+	}
+
+	now := ctx.BlockTime()
+
+	scope := &types.IdentityScope{
+		ScopeID:   scopeID,
+		ScopeType: scopeType,
+		Version:   types.ScopeSchemaVersion,
+		EncryptedPayload: encryptiontypes.EncryptedPayloadEnvelope{
+			CiphertextB64: "dGVzdGNpcGhlcnRleHQ=",
+			NonceB64:      "dGVzdG5vbmNl",
+		},
+		UploadMetadata: types.UploadMetadata{
+			Salt:              []byte("testsalt12345678"),
+			ClientSignature:   []byte("sig"),
+			UserSignature:     []byte("usersig"),
+			DeviceFingerprint: "test-device",
+			ClientID:          "test-client",
+			UploadedAt:        now,
+		},
+		Status:     types.VerificationStatusVerified,
+		UploadedAt: now,
+		VerifiedAt: &now,
+	}
+
+	// Marshal the scope for storage
+	payloadBz, err := json.Marshal(scope.EncryptedPayload)
+	require.NoError(t, err)
+
+	ts := scope.VerifiedAt.Unix()
+	ss := scopeStoreTest{
+		ScopeID:          scope.ScopeID,
+		ScopeType:        scope.ScopeType,
+		Version:          scope.Version,
+		EncryptedPayload: payloadBz,
+		UploadMetadata:   scope.UploadMetadata,
+		Status:           scope.Status,
+		UploadedAt:       scope.UploadedAt.Unix(),
+		VerifiedAt:       &ts,
+		Revoked:          scope.Revoked,
+	}
+
+	scopeBytes, err := json.Marshal(&ss)
+	require.NoError(t, err)
+
+	// Store scope directly (bypass salt validation for testing)
+	store := ctx.KVStore(k.StoreKey())
+	store.Set(types.ScopeKey(addr.Bytes(), scopeID), scopeBytes)
+
+	// Update identity record with scope reference
+	record.AddScopeRef(types.NewScopeRef(scope))
+	record.UpdatedAt = now
+	err = k.SetIdentityRecord(ctx, record)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
**Priority:** CRITICAL
**Spec Reference:** veid-flow-spec.md - Account Tier System
**Current State:** Types defined but transition logic not implemented

**Implementation Path:**
1. File: `x/veid/keeper/tier_transitions.go` (new)
2. Implement `UpdateAccountTier(ctx, addr)` that:
   - Fetches all verified scopes for account
   - Calculates composite score from scope scores
   - Maps score to tier: 0-49→Tier0, 50-69→Tier1, 70-84→Tier2, 85-100→Tier3
   - Stores new tier and emits `VEIDTierChanged` event
3. Add `GetAccountTier(ctx, addr) AccountTier` query
4. Add `MeetsScoreThreshold(ctx, addr, threshold) bool` helper

**Acceptance Criteria:**
- Account tiers: Tier 0 (Unverified), Tier 1 (Basic 50-69), Tier 2 (Standard 70-84), Tier 3 (Premium 85-100)
- Tier changes emit events with old/new tier
- Query endpoints return current tier and score