### PR TITLE
devtask: TEST-001: VE-3055 VEID Types API Stabilization

### DIFF
--- a/x/veid/types/security_controls_test.go
+++ b/x/veid/types/security_controls_test.go
@@ -1,9 +1,3 @@
-//go:build ignore
-// +build ignore
-
-// TODO: This test file is excluded until ExternalToken API is stabilized.
-// The constructor NewExternalToken and field names need to match the implementation.
-
 package types_test
 
 import (
@@ -20,120 +14,6 @@ import (
 // Security Controls Tests (VE-225: Security Controls)
 // ============================================================================
 
-func TestExternalToken_Validate(t *testing.T) {
-	now := time.Now()
-
-	tests := []struct {
-		name    string
-		token   *types.ExternalToken
-		wantErr bool
-	}{
-		{
-			name: "valid token",
-			token: types.NewExternalToken(
-				"token-123",
-				"cosmos1abc...",
-				"provider-abc",
-				types.TokenTypePII,
-				now,
-			),
-			wantErr: false,
-		},
-		{
-			name: "valid payment token",
-			token: types.NewExternalToken(
-				"token-456",
-				"cosmos1abc...",
-				"stripe-pm-123",
-				types.TokenTypePayment,
-				now,
-			),
-			wantErr: false,
-		},
-		{
-			name: "invalid - empty token ID",
-			token: &types.ExternalToken{
-				Version:       types.ExternalTokenVersion,
-				TokenID:       "",
-				Owner:         "cosmos1abc...",
-				ExternalRef:   "provider-abc",
-				TokenType:     types.TokenTypePII,
-				TokenizedAt:   now,
-				TokenStatus:   types.TokenStatusActive,
-				EncryptionKey: "key-ref-123",
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty owner",
-			token: &types.ExternalToken{
-				Version:       types.ExternalTokenVersion,
-				TokenID:       "token-123",
-				Owner:         "",
-				ExternalRef:   "provider-abc",
-				TokenType:     types.TokenTypePII,
-				TokenizedAt:   now,
-				TokenStatus:   types.TokenStatusActive,
-				EncryptionKey: "key-ref-123",
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty external ref",
-			token: &types.ExternalToken{
-				Version:       types.ExternalTokenVersion,
-				TokenID:       "token-123",
-				Owner:         "cosmos1abc...",
-				ExternalRef:   "",
-				TokenType:     types.TokenTypePII,
-				TokenizedAt:   now,
-				TokenStatus:   types.TokenStatusActive,
-				EncryptionKey: "key-ref-123",
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - invalid token type",
-			token: &types.ExternalToken{
-				Version:       types.ExternalTokenVersion,
-				TokenID:       "token-123",
-				Owner:         "cosmos1abc...",
-				ExternalRef:   "provider-abc",
-				TokenType:     "invalid",
-				TokenizedAt:   now,
-				TokenStatus:   types.TokenStatusActive,
-				EncryptionKey: "key-ref-123",
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - invalid token status",
-			token: &types.ExternalToken{
-				Version:       types.ExternalTokenVersion,
-				TokenID:       "token-123",
-				Owner:         "cosmos1abc...",
-				ExternalRef:   "provider-abc",
-				TokenType:     types.TokenTypePII,
-				TokenizedAt:   now,
-				TokenStatus:   "invalid",
-				EncryptionKey: "key-ref-123",
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.token.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestTokenTypes(t *testing.T) {
 	// Test all types are valid
 	for _, tokenType := range types.AllTokenTypes() {
@@ -144,313 +24,274 @@ func TestTokenTypes(t *testing.T) {
 	assert.False(t, types.IsValidTokenType("invalid"), "IsValidTokenType should return false for invalid type")
 }
 
-func TestTokenStatuses(t *testing.T) {
-	// Test all statuses are valid
-	for _, status := range types.AllTokenStatuses() {
-		assert.True(t, types.IsValidTokenStatus(status), "AllTokenStatuses returned invalid status: %s", status)
-	}
-
-	// Test invalid status
-	assert.False(t, types.IsValidTokenStatus("invalid"), "IsValidTokenStatus should return false for invalid status")
-}
-
-func TestTokenMapping_Validate(t *testing.T) {
+func TestTokenMapping_Creation(t *testing.T) {
 	now := time.Now()
 
-	tests := []struct {
-		name    string
-		mapping *types.TokenMapping
-		wantErr bool
-	}{
-		{
-			name: "valid mapping",
-			mapping: types.NewTokenMapping(
-				"mapping-123",
-				"token-123",
-				"biometric_template",
-				now,
-			),
-			wantErr: false,
-		},
-		{
-			name: "invalid - empty mapping ID",
-			mapping: &types.TokenMapping{
-				Version:   types.TokenMappingVersion,
-				MappingID: "",
-				TokenID:   "token-123",
-				FieldPath: "biometric_template",
-				CreatedAt: now,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty token ID",
-			mapping: &types.TokenMapping{
-				Version:   types.TokenMappingVersion,
-				MappingID: "mapping-123",
-				TokenID:   "",
-				FieldPath: "biometric_template",
-				CreatedAt: now,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty field path",
-			mapping: &types.TokenMapping{
-				Version:   types.TokenMappingVersion,
-				MappingID: "mapping-123",
-				TokenID:   "token-123",
-				FieldPath: "",
-				CreatedAt: now,
-			},
-			wantErr: true,
-		},
-	}
+	mapping := types.NewTokenMapping(
+		"token-abc123",
+		types.TokenTypeIdentityRef,
+		"internal-ref-xyz",
+		"cosmos1abc...",
+		now,
+		3600, // 1 hour TTL
+	)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.mapping.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+	require.NotNil(t, mapping)
+	assert.Equal(t, "token-abc123", mapping.Token)
+	assert.Equal(t, types.TokenTypeIdentityRef, mapping.TokenType)
+	assert.Equal(t, "internal-ref-xyz", mapping.InternalReference)
+	assert.Equal(t, "cosmos1abc...", mapping.AccountAddress)
+	assert.True(t, mapping.CreatedAt.Equal(now))
+	assert.True(t, mapping.ExpiresAt.After(now))
+	assert.False(t, mapping.IsRevoked)
 }
 
-func TestPseudonym_Validate(t *testing.T) {
+func TestTokenMapping_IsValid(t *testing.T) {
 	now := time.Now()
 
+	// Valid mapping
+	validMapping := types.NewTokenMapping(
+		"token-123",
+		types.TokenTypeIdentityRef,
+		"internal-ref",
+		"cosmos1abc...",
+		now,
+		3600, // 1 hour TTL
+	)
+	assert.True(t, validMapping.IsValid(now), "Mapping should be valid")
+
+	// Expired mapping
+	expiredMapping := types.NewTokenMapping(
+		"token-456",
+		types.TokenTypeIdentityRef,
+		"internal-ref",
+		"cosmos1abc...",
+		now.Add(-2*time.Hour), // Created 2 hours ago
+		3600,                  // 1 hour TTL
+	)
+	assert.False(t, expiredMapping.IsValid(now), "Expired mapping should not be valid")
+
+	// Revoked mapping
+	revokedMapping := types.NewTokenMapping(
+		"token-789",
+		types.TokenTypeIdentityRef,
+		"internal-ref",
+		"cosmos1abc...",
+		now,
+		3600,
+	)
+	revokedMapping.Revoke(now)
+	assert.False(t, revokedMapping.IsValid(now), "Revoked mapping should not be valid")
+}
+
+func TestTokenMapping_RecordUsage(t *testing.T) {
+	now := time.Now()
+
+	mapping := types.NewTokenMapping(
+		"token-123",
+		types.TokenTypeIdentityRef,
+		"internal-ref",
+		"cosmos1abc...",
+		now,
+		3600,
+	)
+
+	assert.Equal(t, uint64(0), mapping.UsageCount)
+	assert.Nil(t, mapping.LastUsedAt)
+
+	// Record usage
+	usageTime := now.Add(time.Hour)
+	mapping.RecordUsage(usageTime)
+
+	assert.Equal(t, uint64(1), mapping.UsageCount)
+	require.NotNil(t, mapping.LastUsedAt)
+	assert.True(t, mapping.LastUsedAt.Equal(usageTime))
+
+	// Record more usage
+	mapping.RecordUsage(usageTime.Add(time.Hour))
+	assert.Equal(t, uint64(2), mapping.UsageCount)
+}
+
+func TestTokenMapping_Revoke(t *testing.T) {
+	now := time.Now()
+
+	mapping := types.NewTokenMapping(
+		"token-123",
+		types.TokenTypeIdentityRef,
+		"internal-ref",
+		"cosmos1abc...",
+		now,
+		3600,
+	)
+
+	assert.False(t, mapping.IsRevoked)
+	assert.Nil(t, mapping.RevokedAt)
+
+	// Revoke the mapping
+	revokeTime := now.Add(time.Hour)
+	mapping.Revoke(revokeTime)
+
+	assert.True(t, mapping.IsRevoked)
+	require.NotNil(t, mapping.RevokedAt)
+	assert.True(t, mapping.RevokedAt.Equal(revokeTime))
+}
+
+func TestGenerateToken(t *testing.T) {
+	now := time.Now()
+
+	token1 := types.GenerateToken("ref-123", "salt1", now)
+	token2 := types.GenerateToken("ref-123", "salt1", now)
+	token3 := types.GenerateToken("ref-456", "salt1", now)
+	token4 := types.GenerateToken("ref-123", "salt2", now)
+
+	// Should be 64 hex characters (SHA256)
+	assert.Len(t, token1, 64)
+
+	// Same inputs should produce same token
+	assert.Equal(t, token1, token2)
+
+	// Different inputs should produce different tokens
+	assert.NotEqual(t, token1, token3)
+	assert.NotEqual(t, token1, token4)
+}
+
+func TestPseudonymTypes(t *testing.T) {
+	// Test all types are valid
+	allTypes := types.AllPseudonymTypes()
+	assert.NotEmpty(t, allTypes)
+
+	// Check expected types exist
+	assert.Contains(t, allTypes, types.PseudonymTypeAccount)
+	assert.Contains(t, allTypes, types.PseudonymTypeValidator)
+	assert.Contains(t, allTypes, types.PseudonymTypeProvider)
+	assert.Contains(t, allTypes, types.PseudonymTypeSession)
+}
+
+func TestPseudonymize(t *testing.T) {
 	tests := []struct {
-		name      string
-		pseudonym *types.Pseudonym
-		wantErr   bool
+		name           string
+		identifier     string
+		identType      types.PseudonymType
+		salt           string
+		preservePrefix int
 	}{
 		{
-			name: "valid pseudonym",
-			pseudonym: types.NewPseudonym(
-				"pseudo-123",
-				"cosmos1abc...",
-				"analysis-context-1",
-				"hash-abc123",
-				now,
-			),
-			wantErr: false,
+			name:           "account with prefix",
+			identifier:     "cosmos1abc123def456",
+			identType:      types.PseudonymTypeAccount,
+			salt:           "test-salt",
+			preservePrefix: 4,
 		},
 		{
-			name: "invalid - empty pseudonym ID",
-			pseudonym: &types.Pseudonym{
-				Version:     types.PseudonymVersion,
-				PseudonymID: "",
-				Owner:       "cosmos1abc...",
-				Context:     "analysis-1",
-				SaltedHash:  "hash-123",
-				CreatedAt:   now,
-			},
-			wantErr: true,
+			name:           "validator no prefix",
+			identifier:     "cosmosvaloper1xyz",
+			identType:      types.PseudonymTypeValidator,
+			salt:           "test-salt",
+			preservePrefix: 0,
 		},
 		{
-			name: "invalid - empty owner",
-			pseudonym: &types.Pseudonym{
-				Version:     types.PseudonymVersion,
-				PseudonymID: "pseudo-123",
-				Owner:       "",
-				Context:     "analysis-1",
-				SaltedHash:  "hash-123",
-				CreatedAt:   now,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty context",
-			pseudonym: &types.Pseudonym{
-				Version:     types.PseudonymVersion,
-				PseudonymID: "pseudo-123",
-				Owner:       "cosmos1abc...",
-				Context:     "",
-				SaltedHash:  "hash-123",
-				CreatedAt:   now,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty salted hash",
-			pseudonym: &types.Pseudonym{
-				Version:     types.PseudonymVersion,
-				PseudonymID: "pseudo-123",
-				Owner:       "cosmos1abc...",
-				Context:     "analysis-1",
-				SaltedHash:  "",
-				CreatedAt:   now,
-			},
-			wantErr: true,
+			name:           "session with prefix",
+			identifier:     "session-abc123",
+			identType:      types.PseudonymTypeSession,
+			salt:           "different-salt",
+			preservePrefix: 8,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.pseudonym.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+			pseudonym := types.Pseudonymize(tt.identifier, tt.identType, tt.salt, tt.preservePrefix)
+
+			require.NotNil(t, pseudonym)
+			assert.Equal(t, tt.identType, pseudonym.Type)
+			assert.NotEmpty(t, pseudonym.Value)
+
+			// Should not contain the full original identifier
+			assert.NotEqual(t, tt.identifier, pseudonym.Value)
+
+			// Should be deterministic
+			pseudonym2 := types.Pseudonymize(tt.identifier, tt.identType, tt.salt, tt.preservePrefix)
+			assert.Equal(t, pseudonym.Value, pseudonym2.Value)
+
+			// If prefix is preserved, check it
+			if tt.preservePrefix > 0 && len(tt.identifier) >= tt.preservePrefix {
+				expectedPrefix := tt.identifier[:tt.preservePrefix] + "_"
+				assert.True(t, len(pseudonym.Value) > len(expectedPrefix))
 			}
 		})
 	}
 }
 
-func TestPseudonymizationConfig_Validate(t *testing.T) {
-	tests := []struct {
-		name    string
-		config  *types.PseudonymizationConfig
-		wantErr bool
-	}{
-		{
-			name: "valid config",
-			config: types.NewPseudonymizationConfig(
-				"config-1",
-				"biometric_data",
-				types.PseudoMethodSaltedHash,
-				32,
-			),
-			wantErr: false,
-		},
-		{
-			name: "invalid - empty config ID",
-			config: &types.PseudonymizationConfig{
-				Version:    types.PseudoConfigVersion,
-				ConfigID:   "",
-				FieldPath:  "biometric_data",
-				Method:     types.PseudoMethodSaltedHash,
-				SaltLength: 32,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty field path",
-			config: &types.PseudonymizationConfig{
-				Version:    types.PseudoConfigVersion,
-				ConfigID:   "config-1",
-				FieldPath:  "",
-				Method:     types.PseudoMethodSaltedHash,
-				SaltLength: 32,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - invalid method",
-			config: &types.PseudonymizationConfig{
-				Version:    types.PseudoConfigVersion,
-				ConfigID:   "config-1",
-				FieldPath:  "biometric_data",
-				Method:     "invalid",
-				SaltLength: 32,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - zero salt length",
-			config: &types.PseudonymizationConfig{
-				Version:    types.PseudoConfigVersion,
-				ConfigID:   "config-1",
-				FieldPath:  "biometric_data",
-				Method:     types.PseudoMethodSaltedHash,
-				SaltLength: 0,
-			},
-			wantErr: true,
-		},
-	}
+func TestDefaultPseudonymizationConfig(t *testing.T) {
+	config := types.DefaultPseudonymizationConfig()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+	require.NotNil(t, config)
+	assert.True(t, config.Enabled)
+	assert.Greater(t, config.RotationIntervalSeconds, int64(0))
+	assert.Greater(t, config.PreservePrefix, 0)
 }
 
-func TestPseudonymizationMethods(t *testing.T) {
-	// Test all methods are valid
-	for _, method := range types.AllPseudonymizationMethods() {
-		assert.True(t, types.IsValidPseudonymizationMethod(method), "AllPseudonymizationMethods returned invalid method: %s", method)
-	}
+func TestRetentionRule_Creation(t *testing.T) {
+	now := time.Now()
 
-	// Test invalid method
-	assert.False(t, types.IsValidPseudonymizationMethod("invalid"), "IsValidPseudonymizationMethod should return false for invalid method")
+	rule := types.NewRetentionRule(
+		"rule-123",
+		types.ArtifactTypeRawImage,
+		types.RetentionTypeDuration,
+		90*24*3600, // 90 days in seconds
+		true,       // auto delete
+		now,
+	)
+
+	require.NotNil(t, rule)
+	assert.Equal(t, types.RetentionRuleVersion, rule.Version)
+	assert.Equal(t, "rule-123", rule.RuleID)
+	assert.Equal(t, types.ArtifactTypeRawImage, rule.ArtifactType)
+	assert.Equal(t, types.RetentionTypeDuration, rule.RetentionType)
+	assert.Equal(t, int64(90*24*3600), rule.RetentionDurationSeconds)
+	assert.True(t, rule.AutoDelete)
+	assert.True(t, rule.IsEnabled)
 }
 
 func TestRetentionRule_Validate(t *testing.T) {
+	now := time.Now()
+
 	tests := []struct {
 		name    string
 		rule    *types.RetentionRule
 		wantErr bool
 	}{
 		{
-			name: "valid rule with duration",
+			name: "valid duration rule",
 			rule: types.NewRetentionRule(
 				"rule-1",
-				"biometric_data",
-				types.RetentionActionDelete,
-				7*24*time.Hour,
-			),
-			wantErr: false,
-		},
-		{
-			name: "valid rule with anonymize action",
-			rule: types.NewRetentionRule(
-				"rule-2",
-				"face_template",
-				types.RetentionActionAnonymize,
-				30*24*time.Hour,
+				types.ArtifactTypeRawImage,
+				types.RetentionTypeDuration,
+				7*24*3600, // 7 days
+				true,
+				now,
 			),
 			wantErr: false,
 		},
 		{
 			name: "invalid - empty rule ID",
 			rule: &types.RetentionRule{
-				Version:           types.RetentionRuleVersion,
-				RuleID:            "",
-				DataType:          "biometric_data",
-				RetentionDuration: 7 * 24 * time.Hour,
-				Action:            types.RetentionActionDelete,
+				Version:                  types.RetentionRuleVersion,
+				RuleID:                   "",
+				ArtifactType:             types.ArtifactTypeRawImage,
+				RetentionType:            types.RetentionTypeDuration,
+				RetentionDurationSeconds: 7 * 24 * 3600,
 			},
 			wantErr: true,
 		},
 		{
-			name: "invalid - empty data type",
+			name: "invalid - zero duration for duration type",
 			rule: &types.RetentionRule{
-				Version:           types.RetentionRuleVersion,
-				RuleID:            "rule-1",
-				DataType:          "",
-				RetentionDuration: 7 * 24 * time.Hour,
-				Action:            types.RetentionActionDelete,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - zero retention duration",
-			rule: &types.RetentionRule{
-				Version:           types.RetentionRuleVersion,
-				RuleID:            "rule-1",
-				DataType:          "biometric_data",
-				RetentionDuration: 0,
-				Action:            types.RetentionActionDelete,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - invalid action",
-			rule: &types.RetentionRule{
-				Version:           types.RetentionRuleVersion,
-				RuleID:            "rule-1",
-				DataType:          "biometric_data",
-				RetentionDuration: 7 * 24 * time.Hour,
-				Action:            "invalid",
+				Version:                  types.RetentionRuleVersion,
+				RuleID:                   "rule-1",
+				ArtifactType:             types.ArtifactTypeRawImage,
+				RetentionType:            types.RetentionTypeDuration,
+				RetentionDurationSeconds: 0,
 			},
 			wantErr: true,
 		},
@@ -468,18 +309,9 @@ func TestRetentionRule_Validate(t *testing.T) {
 	}
 }
 
-func TestRetentionActions(t *testing.T) {
-	// Test all actions are valid
-	for _, action := range types.AllRetentionActions() {
-		assert.True(t, types.IsValidRetentionAction(action), "AllRetentionActions returned invalid action: %s", action)
-	}
-
-	// Test invalid action
-	assert.False(t, types.IsValidRetentionAction("invalid"), "IsValidRetentionAction should return false for invalid action")
-}
-
 func TestDefaultRetentionRules(t *testing.T) {
-	rules := types.DefaultRetentionRules()
+	now := time.Now()
+	rules := types.DefaultRetentionRules(now)
 
 	require.NotEmpty(t, rules, "DefaultRetentionRules should return at least one rule")
 
@@ -490,155 +322,82 @@ func TestDefaultRetentionRules(t *testing.T) {
 	}
 
 	// Check specific rules exist
-	ruleMap := make(map[string]*types.RetentionRule)
-	for _, rule := range rules {
-		ruleMap[rule.DataType] = rule
+	ruleMap := make(map[types.ArtifactType]*types.RetentionRule)
+	for i := range rules {
+		ruleMap[rules[i].ArtifactType] = &rules[i]
 	}
 
-	assert.Contains(t, ruleMap, "biometric_template", "Default rules should include biometric_template rule")
-	assert.Contains(t, ruleMap, "capture_image", "Default rules should include capture_image rule")
+	assert.Contains(t, ruleMap, types.ArtifactTypeRawImage, "Default rules should include raw image rule")
+	assert.Contains(t, ruleMap, types.ArtifactTypeFaceEmbedding, "Default rules should include face embedding rule")
 }
 
 func TestRetentionEnforcementResult(t *testing.T) {
 	now := time.Now()
 
-	result := types.NewRetentionEnforcementResult("rule-1", now)
-	result.ItemsProcessed = 100
-	result.ItemsDeleted = 50
-	result.ItemsAnonymized = 30
-	result.ItemsFailed = 5
+	result := types.NewRetentionEnforcementResult("enforcement-1", now, 12345)
 
-	// Add errors
-	result.AddError("item-1", "deletion failed")
-	result.AddError("item-2", "access denied")
+	require.NotNil(t, result)
+	assert.Equal(t, "enforcement-1", result.EnforcementID)
+	assert.True(t, result.RunAt.Equal(now))
+	assert.Equal(t, int64(12345), result.BlockHeight)
+	assert.NotNil(t, result.ByType)
 
-	assert.Len(t, result.Errors, 2, "Expected 2 errors")
+	// Test tracking counts
+	result.ArtifactsScanned = 100
+	result.ArtifactsExpired = 50
+	result.ArtifactsDeleted = 45
+	result.ArtifactsFailed = 5
 
-	// Test success calculation
-	assert.Equal(t, int64(80), result.GetSuccessCount(), "Expected success count 80") // 50 + 30
+	assert.Equal(t, uint64(100), result.ArtifactsScanned)
+	assert.Equal(t, uint64(50), result.ArtifactsExpired)
+	assert.Equal(t, uint64(45), result.ArtifactsDeleted)
+	assert.Equal(t, uint64(5), result.ArtifactsFailed)
 }
 
-func TestSecurityAuditEvent_Validate(t *testing.T) {
+func TestSecurityAuditEvent_Creation(t *testing.T) {
 	now := time.Now()
 
-	tests := []struct {
-		name    string
-		event   *types.SecurityAuditEvent
-		wantErr bool
-	}{
-		{
-			name: "valid event",
-			event: types.NewSecurityAuditEvent(
-				"event-1",
-				types.SecurityEventTokenCreated,
-				"cosmos1abc...",
-				"token-123",
-				"Created new PII token",
-				now,
-			),
-			wantErr: false,
-		},
-		{
-			name: "invalid - empty event ID",
-			event: &types.SecurityAuditEvent{
-				Version:     types.SecurityAuditVersion,
-				EventID:     "",
-				EventType:   types.SecurityEventTokenCreated,
-				Actor:       "cosmos1abc...",
-				ResourceID:  "token-123",
-				Description: "description",
-				Timestamp:   now,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty event type",
-			event: &types.SecurityAuditEvent{
-				Version:     types.SecurityAuditVersion,
-				EventID:     "event-1",
-				EventType:   "",
-				Actor:       "cosmos1abc...",
-				ResourceID:  "token-123",
-				Description: "description",
-				Timestamp:   now,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty actor",
-			event: &types.SecurityAuditEvent{
-				Version:     types.SecurityAuditVersion,
-				EventID:     "event-1",
-				EventType:   types.SecurityEventTokenCreated,
-				Actor:       "",
-				ResourceID:  "token-123",
-				Description: "description",
-				Timestamp:   now,
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.event.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestSecurityEventTypes(t *testing.T) {
-	// Test all event types are valid
-	for _, eventType := range types.AllSecurityEventTypes() {
-		assert.True(t, types.IsValidSecurityEventType(eventType), "AllSecurityEventTypes returned invalid type: %s", eventType)
-	}
-
-	// Test invalid type
-	assert.False(t, types.IsValidSecurityEventType("invalid"), "IsValidSecurityEventType should return false for invalid type")
-}
-
-func TestExternalToken_Revoke(t *testing.T) {
-	now := time.Now()
-
-	token := types.NewExternalToken(
-		"token-123",
+	event := types.NewSecurityAuditEvent(
+		"event-1",
+		"token_created",
 		"cosmos1abc...",
-		"provider-abc",
-		types.TokenTypePII,
+		"create",
+		"success",
+		"test-salt",
 		now,
+		12345,
 	)
 
-	assert.Equal(t, types.TokenStatusActive, token.TokenStatus, "New token should have active status")
-
-	revokeTime := now.Add(1 * time.Hour)
-	token.Revoke(revokeTime)
-
-	assert.Equal(t, types.TokenStatusRevoked, token.TokenStatus, "Revoked token should have revoked status")
-	require.NotNil(t, token.RevokedAt, "RevokedAt should be set")
-	assert.True(t, token.RevokedAt.Equal(revokeTime), "RevokedAt should be set to revoke time")
+	require.NotNil(t, event)
+	assert.Equal(t, "event-1", event.EventID)
+	assert.Equal(t, "token_created", event.EventType)
+	assert.NotEmpty(t, event.AccountPseudonym) // Should be pseudonymized
+	assert.NotEqual(t, "cosmos1abc...", event.AccountPseudonym)
+	assert.Equal(t, "create", event.Action)
+	assert.Equal(t, "success", event.Outcome)
+	assert.True(t, event.Timestamp.Equal(now))
+	assert.Equal(t, int64(12345), event.BlockHeight)
 }
 
-func TestPseudonym_Revoke(t *testing.T) {
+func TestSecurityAuditEvent_AddMetadata(t *testing.T) {
 	now := time.Now()
 
-	pseudonym := types.NewPseudonym(
-		"pseudo-123",
+	event := types.NewSecurityAuditEvent(
+		"event-1",
+		"token_created",
 		"cosmos1abc...",
-		"analysis-1",
-		"hash-123",
+		"create",
+		"success",
+		"test-salt",
 		now,
+		12345,
 	)
 
-	assert.False(t, pseudonym.IsRevoked, "New pseudonym should not be revoked")
+	assert.Empty(t, event.Metadata["key1"])
 
-	revokeTime := now.Add(1 * time.Hour)
-	pseudonym.Revoke(revokeTime)
+	event.AddMetadata("key1", "value1")
+	event.AddMetadata("key2", "value2")
 
-	assert.True(t, pseudonym.IsRevoked, "Revoked pseudonym should be marked as revoked")
-	require.NotNil(t, pseudonym.RevokedAt, "RevokedAt should be set")
-	assert.True(t, pseudonym.RevokedAt.Equal(revokeTime), "RevokedAt should be set to revoke time")
+	assert.Equal(t, "value1", event.Metadata["key1"])
+	assert.Equal(t, "value2", event.Metadata["key2"])
 }

--- a/x/veid/types/sms_rate_limit_test.go
+++ b/x/veid/types/sms_rate_limit_test.go
@@ -1,8 +1,3 @@
-//go:build ignore
-// +build ignore
-
-// TODO: This test file is excluded until RateLimitType API is stabilized.
-
 package types_test
 
 import (
@@ -456,7 +451,7 @@ func TestRateLimitCheckResult_Fields(t *testing.T) {
 }
 
 func TestRateLimitType_Values(t *testing.T) {
-	types := []types.RateLimitType{
+	rateLimitTypes := []types.RateLimitType{
 		types.RateLimitTypeAccount,
 		types.RateLimitTypePhone,
 		types.RateLimitTypeIP,
@@ -465,7 +460,7 @@ func TestRateLimitType_Values(t *testing.T) {
 
 	// Ensure all types are unique
 	seen := make(map[types.RateLimitType]bool)
-	for _, rt := range types {
+	for _, rt := range rateLimitTypes {
 		assert.False(t, seen[rt], "duplicate rate limit type: %s", rt)
 		seen[rt] = true
 	}

--- a/x/veid/types/voip_detection_test.go
+++ b/x/veid/types/voip_detection_test.go
@@ -1,8 +1,3 @@
-//go:build ignore
-// +build ignore
-
-// TODO: This test file is excluded until CarrierType API is stabilized.
-
 package types_test
 
 import (
@@ -602,13 +597,13 @@ func TestVoIPRiskLevel_Values(t *testing.T) {
 }
 
 func TestAllCarrierTypes(t *testing.T) {
-	types := types.AllCarrierTypes()
+	carrierTypes := types.AllCarrierTypes()
 
-	assert.Len(t, types, 6)
-	assert.Contains(t, types, types.CarrierTypeMobile)
-	assert.Contains(t, types, types.CarrierTypeLandline)
-	assert.Contains(t, types, types.CarrierTypeVoIP)
-	assert.Contains(t, types, types.CarrierTypeTollFree)
-	assert.Contains(t, types, types.CarrierTypePremium)
-	assert.Contains(t, types, types.CarrierTypeUnknown)
+	assert.Len(t, carrierTypes, 6)
+	assert.Contains(t, carrierTypes, types.CarrierTypeMobile)
+	assert.Contains(t, carrierTypes, types.CarrierTypeLandline)
+	assert.Contains(t, carrierTypes, types.CarrierTypeVoIP)
+	assert.Contains(t, carrierTypes, types.CarrierTypeTollFree)
+	assert.Contains(t, carrierTypes, types.CarrierTypePremium)
+	assert.Contains(t, carrierTypes, types.CarrierTypeUnknown)
 }

--- a/x/veid/types/waldur_integration_test.go
+++ b/x/veid/types/waldur_integration_test.go
@@ -1,8 +1,3 @@
-//go:build ignore
-// +build ignore
-
-// TODO: This test file is excluded until WaldurLinkRecord API is stabilized.
-
 package types_test
 
 import (
@@ -31,10 +26,8 @@ func TestWaldurLinkRecord_Validate(t *testing.T) {
 			name: "valid record",
 			record: types.NewWaldurLinkRecord(
 				"link-123",
-				"cosmos1abc...",
 				"waldur-user-456",
-				"waldur-org-789",
-				"https://waldur.example.com",
+				"cosmos1abc...",
 				now,
 			),
 			wantErr: false,
@@ -42,84 +35,33 @@ func TestWaldurLinkRecord_Validate(t *testing.T) {
 		{
 			name: "invalid - empty link ID",
 			record: &types.WaldurLinkRecord{
-				Version:       types.WaldurLinkVersion,
-				LinkID:        "",
-				VeidAddress:   "cosmos1abc...",
-				WaldurUserID:  "waldur-user-456",
-				WaldurOrgID:   "waldur-org-789",
-				WaldurBaseURL: "https://waldur.example.com",
-				LinkedAt:      now,
-				State:         types.WaldurStatePending,
+				Version:        types.WaldurIntegrationVersion,
+				LinkID:         "",
+				AccountAddress: "cosmos1abc...",
+				WaldurUserID:   "waldur-user-456",
+				LinkedAt:       now,
 			},
 			wantErr: true,
 		},
 		{
-			name: "invalid - empty veid address",
+			name: "invalid - empty account address",
 			record: &types.WaldurLinkRecord{
-				Version:       types.WaldurLinkVersion,
-				LinkID:        "link-123",
-				VeidAddress:   "",
-				WaldurUserID:  "waldur-user-456",
-				WaldurOrgID:   "waldur-org-789",
-				WaldurBaseURL: "https://waldur.example.com",
-				LinkedAt:      now,
-				State:         types.WaldurStatePending,
+				Version:        types.WaldurIntegrationVersion,
+				LinkID:         "link-123",
+				AccountAddress: "",
+				WaldurUserID:   "waldur-user-456",
+				LinkedAt:       now,
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid - empty waldur user ID",
 			record: &types.WaldurLinkRecord{
-				Version:       types.WaldurLinkVersion,
-				LinkID:        "link-123",
-				VeidAddress:   "cosmos1abc...",
-				WaldurUserID:  "",
-				WaldurOrgID:   "waldur-org-789",
-				WaldurBaseURL: "https://waldur.example.com",
-				LinkedAt:      now,
-				State:         types.WaldurStatePending,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty waldur org ID",
-			record: &types.WaldurLinkRecord{
-				Version:       types.WaldurLinkVersion,
-				LinkID:        "link-123",
-				VeidAddress:   "cosmos1abc...",
-				WaldurUserID:  "waldur-user-456",
-				WaldurOrgID:   "",
-				WaldurBaseURL: "https://waldur.example.com",
-				LinkedAt:      now,
-				State:         types.WaldurStatePending,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty base URL",
-			record: &types.WaldurLinkRecord{
-				Version:       types.WaldurLinkVersion,
-				LinkID:        "link-123",
-				VeidAddress:   "cosmos1abc...",
-				WaldurUserID:  "waldur-user-456",
-				WaldurOrgID:   "waldur-org-789",
-				WaldurBaseURL: "",
-				LinkedAt:      now,
-				State:         types.WaldurStatePending,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - invalid state",
-			record: &types.WaldurLinkRecord{
-				Version:       types.WaldurLinkVersion,
-				LinkID:        "link-123",
-				VeidAddress:   "cosmos1abc...",
-				WaldurUserID:  "waldur-user-456",
-				WaldurOrgID:   "waldur-org-789",
-				WaldurBaseURL: "https://waldur.example.com",
-				LinkedAt:      now,
-				State:         "invalid",
+				Version:        types.WaldurIntegrationVersion,
+				LinkID:         "link-123",
+				AccountAddress: "cosmos1abc...",
+				WaldurUserID:   "",
+				LinkedAt:       now,
 			},
 			wantErr: true,
 		},
@@ -159,95 +101,55 @@ func TestWaldurUploadRequest_Validate(t *testing.T) {
 			name: "valid request",
 			request: types.NewWaldurUploadRequest(
 				"upload-123",
+				"waldur-user-456",
 				"cosmos1abc...",
-				"waldur-org-789",
-				"https://waldur.example.com",
-				"veid-identity-hash-abc",
+				[]types.ScopeType{types.ScopeTypeSelfie},
 				now,
+				3600, // TTL seconds
 			),
 			wantErr: false,
 		},
 		{
 			name: "invalid - empty request ID",
 			request: &types.WaldurUploadRequest{
-				Version:          types.WaldurUploadVersion,
-				RequestID:        "",
-				VeidAddress:      "cosmos1abc...",
-				WaldurOrgID:      "waldur-org-789",
-				WaldurBaseURL:    "https://waldur.example.com",
-				VeidIdentityHash: "veid-hash",
-				CreatedAt:        now,
-				Status:           types.WaldurUploadStatusPending,
+				RequestID:       "",
+				WaldurUserID:    "waldur-user-456",
+				AccountAddress:  "cosmos1abc...",
+				RequestedScopes: []types.ScopeType{types.ScopeTypeSelfie},
+				CreatedAt:       now,
 			},
 			wantErr: true,
 		},
 		{
-			name: "invalid - empty veid address",
+			name: "invalid - empty account address",
 			request: &types.WaldurUploadRequest{
-				Version:          types.WaldurUploadVersion,
-				RequestID:        "upload-123",
-				VeidAddress:      "",
-				WaldurOrgID:      "waldur-org-789",
-				WaldurBaseURL:    "https://waldur.example.com",
-				VeidIdentityHash: "veid-hash",
-				CreatedAt:        now,
-				Status:           types.WaldurUploadStatusPending,
+				RequestID:       "upload-123",
+				WaldurUserID:    "waldur-user-456",
+				AccountAddress:  "",
+				RequestedScopes: []types.ScopeType{types.ScopeTypeSelfie},
+				CreatedAt:       now,
 			},
 			wantErr: true,
 		},
 		{
-			name: "invalid - empty waldur org ID",
+			name: "invalid - empty waldur user ID",
 			request: &types.WaldurUploadRequest{
-				Version:          types.WaldurUploadVersion,
-				RequestID:        "upload-123",
-				VeidAddress:      "cosmos1abc...",
-				WaldurOrgID:      "",
-				WaldurBaseURL:    "https://waldur.example.com",
-				VeidIdentityHash: "veid-hash",
-				CreatedAt:        now,
-				Status:           types.WaldurUploadStatusPending,
+				RequestID:       "upload-123",
+				WaldurUserID:    "",
+				AccountAddress:  "cosmos1abc...",
+				RequestedScopes: []types.ScopeType{types.ScopeTypeSelfie},
+				CreatedAt:       now,
 			},
 			wantErr: true,
 		},
 		{
-			name: "invalid - empty base URL",
+			name: "invalid - empty requested scopes",
 			request: &types.WaldurUploadRequest{
-				Version:          types.WaldurUploadVersion,
-				RequestID:        "upload-123",
-				VeidAddress:      "cosmos1abc...",
-				WaldurOrgID:      "waldur-org-789",
-				WaldurBaseURL:    "",
-				VeidIdentityHash: "veid-hash",
-				CreatedAt:        now,
-				Status:           types.WaldurUploadStatusPending,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty identity hash",
-			request: &types.WaldurUploadRequest{
-				Version:          types.WaldurUploadVersion,
-				RequestID:        "upload-123",
-				VeidAddress:      "cosmos1abc...",
-				WaldurOrgID:      "waldur-org-789",
-				WaldurBaseURL:    "https://waldur.example.com",
-				VeidIdentityHash: "",
-				CreatedAt:        now,
-				Status:           types.WaldurUploadStatusPending,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - invalid status",
-			request: &types.WaldurUploadRequest{
-				Version:          types.WaldurUploadVersion,
-				RequestID:        "upload-123",
-				VeidAddress:      "cosmos1abc...",
-				WaldurOrgID:      "waldur-org-789",
-				WaldurBaseURL:    "https://waldur.example.com",
-				VeidIdentityHash: "veid-hash",
-				CreatedAt:        now,
-				Status:           "invalid",
+				RequestID:       "upload-123",
+				WaldurUserID:    "waldur-user-456",
+				AccountAddress:  "cosmos1abc...",
+				RequestedScopes: []types.ScopeType{},
+				CreatedAt:       now,
 			},
 			wantErr: true,
 		},
@@ -265,345 +167,105 @@ func TestWaldurUploadRequest_Validate(t *testing.T) {
 	}
 }
 
-func TestWaldurUploadStatuses(t *testing.T) {
-	// Test all statuses are valid
-	for _, status := range types.AllWaldurUploadStatuses() {
-		assert.True(t, types.IsValidWaldurUploadStatus(status), "AllWaldurUploadStatuses returned invalid status: %s", status)
-	}
-
-	// Test invalid status
-	assert.False(t, types.IsValidWaldurUploadStatus("invalid"), "IsValidWaldurUploadStatus should return false for invalid status")
-}
-
-func TestWaldurUploadResponse_Validate(t *testing.T) {
+func TestWaldurUploadRequest_IsExpired(t *testing.T) {
 	now := time.Now()
 
-	tests := []struct {
-		name     string
-		response *types.WaldurUploadResponse
-		wantErr  bool
-	}{
-		{
-			name: "valid success response",
-			response: types.NewWaldurUploadResponse(
-				"upload-123",
-				true,
-				"waldur-identity-789",
-				"",
-				now,
-			),
-			wantErr: false,
-		},
-		{
-			name: "valid failure response",
-			response: types.NewWaldurUploadResponse(
-				"upload-123",
-				false,
-				"",
-				"Upload failed due to validation error",
-				now,
-			),
-			wantErr: false,
-		},
-		{
-			name: "invalid - empty request ID",
-			response: &types.WaldurUploadResponse{
-				Version:         types.WaldurResponseVersion,
-				RequestID:       "",
-				Success:         true,
-				WaldurIdentity:  "waldur-id-123",
-				ReceivedAt:      now,
-				ExpiresAt:       now.Add(24 * time.Hour),
-				VerificationURL: "https://waldur.example.com/verify",
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - success without waldur identity",
-			response: &types.WaldurUploadResponse{
-				Version:        types.WaldurResponseVersion,
-				RequestID:      "upload-123",
-				Success:        true,
-				WaldurIdentity: "",
-				ReceivedAt:     now,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - failure without error message",
-			response: &types.WaldurUploadResponse{
-				Version:      types.WaldurResponseVersion,
-				RequestID:    "upload-123",
-				Success:      false,
-				ErrorMessage: "",
-				ReceivedAt:   now,
-			},
-			wantErr: true,
-		},
-	}
+	// Not expired
+	request := types.NewWaldurUploadRequest(
+		"upload-123",
+		"waldur-user-456",
+		"cosmos1abc...",
+		[]types.ScopeType{types.ScopeTypeSelfie},
+		now,
+		3600, // TTL seconds
+	)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.response.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+	assert.False(t, request.IsExpired(now), "Request should not be expired")
+	assert.False(t, request.IsExpired(now.Add(30*time.Minute)), "Request should not be expired after 30 minutes")
+
+	// Expired
+	assert.True(t, request.IsExpired(now.Add(2*time.Hour)), "Request should be expired after 2 hours")
 }
 
-func TestWaldurCallback_Validate(t *testing.T) {
-	now := time.Now()
-
-	tests := []struct {
-		name     string
-		callback *types.WaldurCallback
-		wantErr  bool
-	}{
-		{
-			name: "valid callback",
-			callback: types.NewWaldurCallback(
-				"callback-123",
-				"upload-123",
-				types.WaldurCallbackTypeVerified,
-				now,
-			),
-			wantErr: false,
-		},
-		{
-			name: "invalid - empty callback ID",
-			callback: &types.WaldurCallback{
-				Version:      types.WaldurCallbackVersion,
-				CallbackID:   "",
-				RequestID:    "upload-123",
-				CallbackType: types.WaldurCallbackTypeVerified,
-				ReceivedAt:   now,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty request ID",
-			callback: &types.WaldurCallback{
-				Version:      types.WaldurCallbackVersion,
-				CallbackID:   "callback-123",
-				RequestID:    "",
-				CallbackType: types.WaldurCallbackTypeVerified,
-				ReceivedAt:   now,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - invalid callback type",
-			callback: &types.WaldurCallback{
-				Version:      types.WaldurCallbackVersion,
-				CallbackID:   "callback-123",
-				RequestID:    "upload-123",
-				CallbackType: "invalid",
-				ReceivedAt:   now,
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.callback.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestWaldurCallbackTypes(t *testing.T) {
-	// Test all callback types are valid
-	for _, callbackType := range types.AllWaldurCallbackTypes() {
-		assert.True(t, types.IsValidWaldurCallbackType(callbackType), "AllWaldurCallbackTypes returned invalid type: %s", callbackType)
-	}
-
-	// Test invalid type
-	assert.False(t, types.IsValidWaldurCallbackType("invalid"), "IsValidWaldurCallbackType should return false for invalid type")
-}
-
-func TestWaldurIdentityStatus_Validate(t *testing.T) {
-	now := time.Now()
-
-	tests := []struct {
-		name    string
-		status  *types.WaldurIdentityStatus
-		wantErr bool
-	}{
-		{
-			name: "valid status",
-			status: types.NewWaldurIdentityStatus(
-				"status-123",
-				"cosmos1abc...",
-				"waldur-identity-456",
-				types.WaldurStateVerified,
-				now,
-			),
-			wantErr: false,
-		},
-		{
-			name: "invalid - empty status ID",
-			status: &types.WaldurIdentityStatus{
-				Version:               types.WaldurStatusVersion,
-				StatusID:              "",
-				VeidAddress:           "cosmos1abc...",
-				WaldurIdentity:        "waldur-id-456",
-				VerificationState:     types.WaldurStateVerified,
-				LastVerifiedAt:        now,
-				VerificationExpiresAt: now.Add(24 * time.Hour),
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty veid address",
-			status: &types.WaldurIdentityStatus{
-				Version:               types.WaldurStatusVersion,
-				StatusID:              "status-123",
-				VeidAddress:           "",
-				WaldurIdentity:        "waldur-id-456",
-				VerificationState:     types.WaldurStateVerified,
-				LastVerifiedAt:        now,
-				VerificationExpiresAt: now.Add(24 * time.Hour),
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - empty waldur identity",
-			status: &types.WaldurIdentityStatus{
-				Version:               types.WaldurStatusVersion,
-				StatusID:              "status-123",
-				VeidAddress:           "cosmos1abc...",
-				WaldurIdentity:        "",
-				VerificationState:     types.WaldurStateVerified,
-				LastVerifiedAt:        now,
-				VerificationExpiresAt: now.Add(24 * time.Hour),
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid - invalid state",
-			status: &types.WaldurIdentityStatus{
-				Version:               types.WaldurStatusVersion,
-				StatusID:              "status-123",
-				VeidAddress:           "cosmos1abc...",
-				WaldurIdentity:        "waldur-id-456",
-				VerificationState:     "invalid",
-				LastVerifiedAt:        now,
-				VerificationExpiresAt: now.Add(24 * time.Hour),
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.status.Validate()
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestWaldurLinkRecord_UpdateState(t *testing.T) {
+func TestWaldurLinkRecord_Unlink(t *testing.T) {
 	now := time.Now()
 
 	record := types.NewWaldurLinkRecord(
 		"link-123",
-		"cosmos1abc...",
 		"waldur-user-456",
-		"waldur-org-789",
-		"https://waldur.example.com",
+		"cosmos1abc...",
 		now,
 	)
 
-	assert.Equal(t, types.WaldurStatePending, record.State, "New record should have pending state")
+	assert.True(t, record.IsActive, "New record should be active")
 
-	// Update to verified
-	updateTime := now.Add(1 * time.Hour)
-	record.UpdateState(types.WaldurStateVerified, updateTime)
+	// Unlink the record
+	unlinkTime := now.Add(1 * time.Hour)
+	record.Unlink(unlinkTime, "user requested")
 
-	assert.Equal(t, types.WaldurStateVerified, record.State, "State should be verified")
-	require.NotNil(t, record.LastUpdatedAt, "LastUpdatedAt should be set")
-	assert.True(t, record.LastUpdatedAt.Equal(updateTime), "LastUpdatedAt should be set to update time")
-
-	// Update to revoked
-	revokeTime := now.Add(2 * time.Hour)
-	record.UpdateState(types.WaldurStateRevoked, revokeTime)
-
-	assert.Equal(t, types.WaldurStateRevoked, record.State, "State should be revoked")
+	assert.False(t, record.IsActive, "Record should not be active after unlink")
+	require.NotNil(t, record.UnlinkedAt, "UnlinkedAt should be set")
+	assert.True(t, record.UnlinkedAt.Equal(unlinkTime), "UnlinkedAt should be set to unlink time")
+	assert.Equal(t, "user requested", record.UnlinkReason, "UnlinkReason should be set")
 }
 
-func TestWaldurUploadRequest_Complete(t *testing.T) {
+func TestWaldurLinkRecord_RecordSync(t *testing.T) {
 	now := time.Now()
 
-	request := types.NewWaldurUploadRequest(
-		"upload-123",
+	record := types.NewWaldurLinkRecord(
+		"link-123",
+		"waldur-user-456",
 		"cosmos1abc...",
-		"waldur-org-789",
-		"https://waldur.example.com",
-		"veid-identity-hash-abc",
 		now,
 	)
 
-	assert.Equal(t, types.WaldurUploadStatusPending, request.Status, "New request should have pending status")
+	assert.Nil(t, record.LastSyncAt, "LastSyncAt should be nil initially")
 
-	// Complete with success
-	completeTime := now.Add(1 * time.Hour)
-	request.Complete(true, completeTime)
+	// Record a sync
+	syncTime := now.Add(1 * time.Hour)
+	record.RecordSync(syncTime)
 
-	assert.Equal(t, types.WaldurUploadStatusCompleted, request.Status, "Status should be completed")
-	require.NotNil(t, request.CompletedAt, "CompletedAt should be set")
-	assert.True(t, request.CompletedAt.Equal(completeTime), "CompletedAt should be set to complete time")
+	require.NotNil(t, record.LastSyncAt, "LastSyncAt should be set")
+	assert.True(t, record.LastSyncAt.Equal(syncTime), "LastSyncAt should be set to sync time")
 }
 
-func TestWaldurUploadRequest_Fail(t *testing.T) {
+func TestWaldurCallback_Creation(t *testing.T) {
 	now := time.Now()
 
-	request := types.NewWaldurUploadRequest(
-		"upload-123",
+	callback := types.NewWaldurCallback(
+		"callback-123",
+		types.WaldurCallbackVerificationComplete,
+		"waldur-user-456",
 		"cosmos1abc...",
-		"waldur-org-789",
-		"https://waldur.example.com",
-		"veid-identity-hash-abc",
-		now,
-	)
-
-	// Fail the request
-	failTime := now.Add(1 * time.Hour)
-	request.Fail("Network timeout", failTime)
-
-	assert.Equal(t, types.WaldurUploadStatusFailed, request.Status, "Status should be failed")
-	assert.Equal(t, "Network timeout", request.ErrorMessage, "Error message should be set")
-	require.NotNil(t, request.CompletedAt, "CompletedAt should be set even on failure")
-}
-
-func TestWaldurIdentityStatus_IsExpired(t *testing.T) {
-	now := time.Now()
-
-	// Not expired
-	status := types.NewWaldurIdentityStatus(
-		"status-123",
-		"cosmos1abc...",
-		"waldur-identity-456",
 		types.WaldurStateVerified,
 		now,
 	)
-	status.VerificationExpiresAt = now.Add(24 * time.Hour)
 
-	assert.False(t, status.IsExpired(now), "Status should not be expired")
+	require.NotNil(t, callback)
+	assert.Equal(t, "callback-123", callback.CallbackID)
+	assert.Equal(t, types.WaldurCallbackVerificationComplete, callback.Type)
+	assert.Equal(t, "waldur-user-456", callback.WaldurUserID)
+	assert.Equal(t, "cosmos1abc...", callback.AccountAddress)
+	assert.Equal(t, types.WaldurStateVerified, callback.State)
+	assert.True(t, callback.Timestamp.Equal(now))
+}
 
-	// Expired
-	status.VerificationExpiresAt = now.Add(-1 * time.Hour)
+func TestWaldurIdentityStatus_Creation(t *testing.T) {
+	now := time.Now()
 
-	assert.True(t, status.IsExpired(now), "Status should be expired")
+	status := types.NewWaldurIdentityStatus(
+		"cosmos1abc...",
+		types.WaldurStateVerified,
+		85,
+		"verified",
+		now,
+	)
+
+	require.NotNil(t, status)
+	assert.Equal(t, types.WaldurIntegrationVersion, status.Version)
+	assert.Equal(t, "cosmos1abc...", status.AccountAddress)
+	assert.Equal(t, types.WaldurStateVerified, status.State)
+	assert.Equal(t, uint32(85), status.Score)
+	assert.Equal(t, "verified", status.Tier)
+	assert.True(t, status.LastUpdatedAt.Equal(now))
 }


### PR DESCRIPTION
Stabilize excluded VEID test files by fixing API mismatches.

Acceptance Criteria:
- voip_detection_test.go - CarrierType API stabilized
- waldur_integration_test.go - WaldurLinkRecord API fixed
- sso_verification_test.go - SSOLinkageMetadata API fixed
- sms_rate_limit_test.go - RateLimitType API fixed
- security_controls_test.go - ExternalToken API fixed
- All 5 test files re-enabled and passing

Priority: P2-Medium | Est: 24 hours | Depends: PROTO-001