### PR TITLE
feat: PROVIDER-STREAM-001: Replace provider daemon polling with streaming 

### DIFF
--- a/pkg/provider_daemon/event_subscriber.go
+++ b/pkg/provider_daemon/event_subscriber.go
@@ -1,0 +1,126 @@
+package provider_daemon
+
+import (
+	"context"
+	"time"
+)
+
+// EventType represents the type of marketplace event.
+type EventType string
+
+const (
+	// EventTypeOrderCreated is emitted when a new order is created.
+	EventTypeOrderCreated EventType = "order_created"
+	// EventTypeOrderClosed is emitted when an order is closed.
+	EventTypeOrderClosed EventType = "order_closed"
+	// EventTypeBidCreated is emitted when a bid is placed.
+	EventTypeBidCreated EventType = "bid_created"
+	// EventTypeBidAccepted is emitted when a bid is accepted.
+	EventTypeBidAccepted EventType = "bid_accepted"
+	// EventTypeLeaseCreated is emitted when a lease is created.
+	EventTypeLeaseCreated EventType = "lease_created"
+	// EventTypeLeaseClosed is emitted when a lease is closed.
+	EventTypeLeaseClosed EventType = "lease_closed"
+	// EventTypeConfigUpdated is emitted when provider config changes.
+	EventTypeConfigUpdated EventType = "config_updated"
+)
+
+// MarketplaceEvent represents a marketplace event from the chain.
+type MarketplaceEvent struct {
+	Type        EventType              `json:"type"`
+	ID          string                 `json:"id"`
+	BlockHeight int64                  `json:"block_height"`
+	Sequence    uint64                 `json:"sequence"`
+	Timestamp   time.Time              `json:"timestamp"`
+	Data        map[string]interface{} `json:"data"`
+}
+
+// OrderEvent contains order-specific event data.
+type OrderEvent struct {
+	MarketplaceEvent
+	Order Order `json:"order"`
+}
+
+// ConfigEvent contains config-specific event data.
+type ConfigEvent struct {
+	MarketplaceEvent
+	Config *ProviderConfig `json:"config"`
+}
+
+// EventSubscriber defines the interface for subscribing to chain events.
+type EventSubscriber interface {
+	// Subscribe starts listening for events matching the given query.
+	// Events are delivered to the returned channel.
+	// The channel is closed when the context is cancelled or an error occurs.
+	Subscribe(ctx context.Context, subscriberID string, query string) (<-chan MarketplaceEvent, error)
+
+	// SubscribeOrders subscribes to order-related events for the given provider.
+	SubscribeOrders(ctx context.Context, providerAddress string) (<-chan OrderEvent, error)
+
+	// SubscribeConfig subscribes to provider config changes.
+	SubscribeConfig(ctx context.Context, providerAddress string) (<-chan ConfigEvent, error)
+
+	// LastCheckpoint returns the last processed event sequence.
+	LastCheckpoint() uint64
+
+	// SetCheckpoint sets the checkpoint for replay on reconnect.
+	SetCheckpoint(sequence uint64)
+
+	// Close terminates all subscriptions.
+	Close() error
+
+	// Status returns the current connection status.
+	Status() SubscriberStatus
+}
+
+// SubscriberStatus represents the connection status of an event subscriber.
+type SubscriberStatus struct {
+	Connected      bool      `json:"connected"`
+	LastEventTime  time.Time `json:"last_event_time"`
+	LastCheckpoint uint64    `json:"last_checkpoint"`
+	ReconnectCount int       `json:"reconnect_count"`
+	LastError      string    `json:"last_error,omitempty"`
+	UsingFallback  bool      `json:"using_fallback"`
+}
+
+// EventSubscriberConfig configures an event subscriber.
+type EventSubscriberConfig struct {
+	// CometRPC is the CometBFT RPC endpoint (http://host:port).
+	CometRPC string `json:"comet_rpc"`
+
+	// CometWS is the CometBFT WebSocket path (e.g., "/websocket").
+	CometWS string `json:"comet_ws"`
+
+	// SubscriberID identifies this subscriber for reconnection.
+	SubscriberID string `json:"subscriber_id"`
+
+	// EventBuffer is the size of the event channel buffer.
+	EventBuffer int `json:"event_buffer"`
+
+	// ReconnectDelay is the initial delay between reconnection attempts.
+	ReconnectDelay time.Duration `json:"reconnect_delay"`
+
+	// MaxReconnectDelay is the maximum delay between reconnection attempts.
+	MaxReconnectDelay time.Duration `json:"max_reconnect_delay"`
+
+	// ReconnectBackoffFactor is the multiplier for exponential backoff.
+	ReconnectBackoffFactor float64 `json:"reconnect_backoff_factor"`
+
+	// HealthCheckInterval is how often to check connection health.
+	HealthCheckInterval time.Duration `json:"health_check_interval"`
+
+	// CheckpointStore persists event checkpoints for replay.
+	CheckpointStore *EventCheckpointStore `json:"-"`
+}
+
+// DefaultEventSubscriberConfig returns default configuration.
+func DefaultEventSubscriberConfig() EventSubscriberConfig {
+	return EventSubscriberConfig{
+		CometWS:                "/websocket",
+		EventBuffer:            100,
+		ReconnectDelay:         time.Second,
+		MaxReconnectDelay:      time.Minute,
+		ReconnectBackoffFactor: 2.0,
+		HealthCheckInterval:    time.Second * 30,
+	}
+}

--- a/pkg/provider_daemon/stream_client.go
+++ b/pkg/provider_daemon/stream_client.go
@@ -1,0 +1,608 @@
+package provider_daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	tmtypes "github.com/cometbft/cometbft/types"
+
+	verrors "github.com/virtengine/virtengine/pkg/errors"
+)
+
+// CometEventSubscriber implements EventSubscriber using CometBFT WebSocket.
+type CometEventSubscriber struct {
+	cfg             EventSubscriberConfig
+	rpcClient       *rpchttp.HTTP
+	checkpointStore *EventCheckpointStore
+	checkpoint      *EventCheckpointState
+
+	mu             sync.RWMutex
+	connected      bool
+	lastEventTime  time.Time
+	reconnectCount int
+	lastError      string
+	usingFallback  bool
+	closed         bool
+
+	cancelFn context.CancelFunc
+	wg       sync.WaitGroup
+}
+
+// NewCometEventSubscriber creates a new CometBFT event subscriber.
+func NewCometEventSubscriber(cfg EventSubscriberConfig) (*CometEventSubscriber, error) {
+	if cfg.CometRPC == "" {
+		return nil, fmt.Errorf("comet RPC endpoint is required")
+	}
+	if cfg.SubscriberID == "" {
+		cfg.SubscriberID = fmt.Sprintf("provider-stream-%d", time.Now().UnixNano())
+	}
+	if cfg.CometWS == "" {
+		cfg.CometWS = "/websocket"
+	}
+	if cfg.EventBuffer <= 0 {
+		cfg.EventBuffer = 100
+	}
+	if cfg.ReconnectDelay <= 0 {
+		cfg.ReconnectDelay = time.Second
+	}
+	if cfg.MaxReconnectDelay <= 0 {
+		cfg.MaxReconnectDelay = time.Minute
+	}
+	if cfg.ReconnectBackoffFactor <= 0 {
+		cfg.ReconnectBackoffFactor = 2.0
+	}
+
+	sub := &CometEventSubscriber{
+		cfg:             cfg,
+		checkpointStore: cfg.CheckpointStore,
+	}
+
+	return sub, nil
+}
+
+// connect establishes the WebSocket connection.
+func (s *CometEventSubscriber) connect(ctx context.Context) error {
+	rpc, err := rpchttp.New(s.cfg.CometRPC, s.cfg.CometWS)
+	if err != nil {
+		return fmt.Errorf("create rpc client: %w", err)
+	}
+
+	if err := rpc.Start(); err != nil {
+		return fmt.Errorf("start rpc client: %w", err)
+	}
+
+	s.mu.Lock()
+	s.rpcClient = rpc
+	s.connected = true
+	s.lastError = ""
+	s.mu.Unlock()
+
+	// Load checkpoint if available
+	if s.checkpointStore != nil {
+		checkpoint, err := s.checkpointStore.Load(s.cfg.SubscriberID)
+		if err != nil {
+			log.Printf("[stream-client] failed to load checkpoint: %v", err)
+		} else {
+			s.checkpoint = checkpoint
+		}
+	}
+
+	return nil
+}
+
+// reconnect handles reconnection with exponential backoff.
+func (s *CometEventSubscriber) reconnect(ctx context.Context) error {
+	delay := s.cfg.ReconnectDelay
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		s.mu.Lock()
+		if s.closed {
+			s.mu.Unlock()
+			return fmt.Errorf("subscriber closed")
+		}
+		s.reconnectCount++
+		count := s.reconnectCount
+		s.mu.Unlock()
+
+		log.Printf("[stream-client] reconnection attempt %d after %v", count, delay)
+
+		// Wait before reconnecting
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+
+		if err := s.connect(ctx); err != nil {
+			s.mu.Lock()
+			s.lastError = err.Error()
+			s.mu.Unlock()
+			log.Printf("[stream-client] reconnect failed: %v", err)
+
+			// Exponential backoff
+			delay = time.Duration(float64(delay) * s.cfg.ReconnectBackoffFactor)
+			if delay > s.cfg.MaxReconnectDelay {
+				delay = s.cfg.MaxReconnectDelay
+			}
+			continue
+		}
+
+		log.Printf("[stream-client] reconnected successfully")
+		return nil
+	}
+}
+
+// Subscribe starts listening for events matching the given query.
+func (s *CometEventSubscriber) Subscribe(ctx context.Context, subscriberID string, query string) (<-chan MarketplaceEvent, error) {
+	if err := s.connect(ctx); err != nil {
+		return nil, err
+	}
+
+	eventCh := make(chan MarketplaceEvent, s.cfg.EventBuffer)
+
+	subCtx, cancel := context.WithCancel(ctx)
+	s.cancelFn = cancel
+
+	s.wg.Add(1)
+	verrors.SafeGo("provider-stream:subscribe", func() {
+		defer s.wg.Done()
+		defer close(eventCh)
+		s.subscriptionLoop(subCtx, subscriberID, query, eventCh)
+	})
+
+	return eventCh, nil
+}
+
+// subscriptionLoop manages the subscription with automatic reconnection.
+func (s *CometEventSubscriber) subscriptionLoop(ctx context.Context, subscriberID, query string, eventCh chan<- MarketplaceEvent) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		s.mu.RLock()
+		rpc := s.rpcClient
+		s.mu.RUnlock()
+
+		if rpc == nil {
+			if err := s.reconnect(ctx); err != nil {
+				log.Printf("[stream-client] reconnect failed permanently: %v", err)
+				return
+			}
+			s.mu.RLock()
+			rpc = s.rpcClient
+			s.mu.RUnlock()
+		}
+
+		sub, err := rpc.Subscribe(ctx, subscriberID, query, s.cfg.EventBuffer)
+		if err != nil {
+			log.Printf("[stream-client] subscribe failed: %v", err)
+			s.mu.Lock()
+			s.connected = false
+			s.lastError = err.Error()
+			s.rpcClient = nil
+			s.mu.Unlock()
+			continue
+		}
+
+		log.Printf("[stream-client] subscribed to: %s", query)
+		s.processEvents(ctx, sub, eventCh)
+
+		// If we exit processEvents, connection was lost
+		s.mu.Lock()
+		s.connected = false
+		s.rpcClient = nil
+		s.mu.Unlock()
+	}
+}
+
+// processEvents reads events from the subscription channel.
+func (s *CometEventSubscriber) processEvents(ctx context.Context, sub <-chan tmtypes.ResultEvent, eventCh chan<- MarketplaceEvent) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-sub:
+			if !ok {
+				log.Printf("[stream-client] subscription channel closed")
+				return
+			}
+
+			event, err := s.parseEvent(msg)
+			if err != nil {
+				log.Printf("[stream-client] parse event error: %v", err)
+				continue
+			}
+
+			// Skip if already processed (checkpoint-based dedup)
+			s.mu.RLock()
+			checkpoint := s.checkpoint
+			s.mu.RUnlock()
+
+			if checkpoint != nil && event.Sequence <= checkpoint.LastSequence {
+				continue
+			}
+
+			select {
+			case eventCh <- event:
+				s.mu.Lock()
+				s.lastEventTime = time.Now()
+				if s.checkpoint != nil {
+					s.checkpoint.LastSequence = event.Sequence
+				}
+				s.mu.Unlock()
+
+				// Persist checkpoint
+				if s.checkpointStore != nil && s.checkpoint != nil {
+					if err := s.checkpointStore.Save(s.checkpoint); err != nil {
+						log.Printf("[stream-client] checkpoint save failed: %v", err)
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// parseEvent converts a CometBFT event to MarketplaceEvent.
+func (s *CometEventSubscriber) parseEvent(msg tmtypes.ResultEvent) (MarketplaceEvent, error) {
+	event := MarketplaceEvent{
+		Timestamp: time.Now().UTC(),
+		Data:      make(map[string]interface{}),
+	}
+
+	data, ok := msg.Data.(tmtypes.EventDataTx)
+	if !ok {
+		return event, fmt.Errorf("unexpected event data type: %T", msg.Data)
+	}
+
+	event.BlockHeight = data.Height
+
+	// Extract marketplace events from ABCI events
+	envelopes, err := ExtractMarketplaceEvents(data.Result.Events)
+	if err != nil {
+		return event, err
+	}
+
+	if len(envelopes) == 0 {
+		return event, fmt.Errorf("no marketplace events in transaction")
+	}
+
+	// Use the first envelope (most transactions have one event)
+	env := envelopes[0]
+	event.Type = eventTypeFromString(env.EventType)
+	event.ID = env.EventID
+	event.Sequence = env.Sequence
+
+	if env.PayloadJSON != "" {
+		if err := json.Unmarshal([]byte(env.PayloadJSON), &event.Data); err != nil {
+			log.Printf("[stream-client] failed to parse payload: %v", err)
+		}
+	}
+
+	return event, nil
+}
+
+// eventTypeFromString maps string event types to EventType.
+func eventTypeFromString(s string) EventType {
+	switch s {
+	case "order_created":
+		return EventTypeOrderCreated
+	case "order_closed":
+		return EventTypeOrderClosed
+	case "bid_created":
+		return EventTypeBidCreated
+	case "bid_accepted":
+		return EventTypeBidAccepted
+	case "lease_created":
+		return EventTypeLeaseCreated
+	case "lease_closed":
+		return EventTypeLeaseClosed
+	case "config_updated":
+		return EventTypeConfigUpdated
+	default:
+		return EventType(s)
+	}
+}
+
+// SubscribeOrders subscribes to order-related events for the given provider.
+func (s *CometEventSubscriber) SubscribeOrders(ctx context.Context, providerAddress string) (<-chan OrderEvent, error) {
+	query := buildOrderQuery(providerAddress)
+	baseCh, err := s.Subscribe(ctx, s.cfg.SubscriberID+"-orders", query)
+	if err != nil {
+		return nil, err
+	}
+
+	orderCh := make(chan OrderEvent, s.cfg.EventBuffer)
+
+	s.wg.Add(1)
+	verrors.SafeGo("provider-stream:order-filter", func() {
+		defer s.wg.Done()
+		defer close(orderCh)
+
+		for event := range baseCh {
+			if event.Type != EventTypeOrderCreated && event.Type != EventTypeOrderClosed {
+				continue
+			}
+
+			orderEvent := OrderEvent{
+				MarketplaceEvent: event,
+			}
+
+			// Parse order from event data
+			if order, err := parseOrderFromEvent(event); err == nil {
+				orderEvent.Order = order
+			}
+
+			select {
+			case orderCh <- orderEvent:
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+
+	return orderCh, nil
+}
+
+// SubscribeConfig subscribes to provider config changes.
+func (s *CometEventSubscriber) SubscribeConfig(ctx context.Context, providerAddress string) (<-chan ConfigEvent, error) {
+	query := buildConfigQuery(providerAddress)
+	baseCh, err := s.Subscribe(ctx, s.cfg.SubscriberID+"-config", query)
+	if err != nil {
+		return nil, err
+	}
+
+	configCh := make(chan ConfigEvent, s.cfg.EventBuffer)
+
+	s.wg.Add(1)
+	verrors.SafeGo("provider-stream:config-filter", func() {
+		defer s.wg.Done()
+		defer close(configCh)
+
+		for event := range baseCh {
+			if event.Type != EventTypeConfigUpdated {
+				continue
+			}
+
+			configEvent := ConfigEvent{
+				MarketplaceEvent: event,
+			}
+
+			// Parse config from event data
+			if config, err := parseConfigFromEvent(event); err == nil {
+				configEvent.Config = config
+			}
+
+			select {
+			case configCh <- configEvent:
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+
+	return configCh, nil
+}
+
+// LastCheckpoint returns the last processed event sequence.
+func (s *CometEventSubscriber) LastCheckpoint() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.checkpoint != nil {
+		return s.checkpoint.LastSequence
+	}
+	return 0
+}
+
+// SetCheckpoint sets the checkpoint for replay on reconnect.
+func (s *CometEventSubscriber) SetCheckpoint(sequence uint64) {
+	s.mu.Lock()
+	if s.checkpoint == nil {
+		s.checkpoint = &EventCheckpointState{
+			SubscriberID: s.cfg.SubscriberID,
+		}
+	}
+	s.checkpoint.LastSequence = sequence
+	s.mu.Unlock()
+
+	if s.checkpointStore != nil {
+		if err := s.checkpointStore.Save(s.checkpoint); err != nil {
+			log.Printf("[stream-client] checkpoint save failed: %v", err)
+		}
+	}
+}
+
+// Close terminates all subscriptions.
+func (s *CometEventSubscriber) Close() error {
+	s.mu.Lock()
+	s.closed = true
+	if s.cancelFn != nil {
+		s.cancelFn()
+	}
+	rpc := s.rpcClient
+	s.mu.Unlock()
+
+	s.wg.Wait()
+
+	if rpc != nil {
+		return rpc.Stop()
+	}
+	return nil
+}
+
+// Status returns the current connection status.
+func (s *CometEventSubscriber) Status() SubscriberStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	status := SubscriberStatus{
+		Connected:      s.connected,
+		LastEventTime:  s.lastEventTime,
+		ReconnectCount: s.reconnectCount,
+		LastError:      s.lastError,
+		UsingFallback:  s.usingFallback,
+	}
+	if s.checkpoint != nil {
+		status.LastCheckpoint = s.checkpoint.LastSequence
+	}
+	return status
+}
+
+// SetFallbackMode marks the subscriber as using fallback polling.
+func (s *CometEventSubscriber) SetFallbackMode(fallback bool) {
+	s.mu.Lock()
+	s.usingFallback = fallback
+	s.mu.Unlock()
+}
+
+// buildOrderQuery constructs a CometBFT query for order events.
+func buildOrderQuery(providerAddress string) string {
+	return fmt.Sprintf(
+		"tm.event='Tx' AND (marketplace_event.event_type='order_created' OR marketplace_event.event_type='order_closed')",
+	)
+}
+
+// buildConfigQuery constructs a CometBFT query for config events.
+func buildConfigQuery(providerAddress string) string {
+	return fmt.Sprintf(
+		"tm.event='Tx' AND provider_config.provider_address='%s'",
+		providerAddress,
+	)
+}
+
+// parseOrderFromEvent extracts an Order from event data.
+func parseOrderFromEvent(event MarketplaceEvent) (Order, error) {
+	order := Order{}
+
+	if id, ok := event.Data["order_id"].(string); ok {
+		order.OrderID = id
+	}
+	if addr, ok := event.Data["customer_address"].(string); ok {
+		order.CustomerAddress = addr
+	}
+	if t, ok := event.Data["offering_type"].(string); ok {
+		order.OfferingType = t
+	}
+	if region, ok := event.Data["region"].(string); ok {
+		order.Region = region
+	}
+	if price, ok := event.Data["max_price"].(string); ok {
+		order.MaxPrice = price
+	}
+	if currency, ok := event.Data["currency"].(string); ok {
+		order.Currency = currency
+	}
+
+	// Parse requirements
+	if reqs, ok := event.Data["requirements"].(map[string]interface{}); ok {
+		if cpu, ok := reqs["cpu_cores"].(float64); ok {
+			order.Requirements.CPUCores = int64(cpu)
+		}
+		if mem, ok := reqs["memory_gb"].(float64); ok {
+			order.Requirements.MemoryGB = int64(mem)
+		}
+		if storage, ok := reqs["storage_gb"].(float64); ok {
+			order.Requirements.StorageGB = int64(storage)
+		}
+		if gpus, ok := reqs["gpus"].(float64); ok {
+			order.Requirements.GPUs = int64(gpus)
+		}
+		if gpuType, ok := reqs["gpu_type"].(string); ok {
+			order.Requirements.GPUType = gpuType
+		}
+	}
+
+	return order, nil
+}
+
+// parseConfigFromEvent extracts a ProviderConfig from event data.
+func parseConfigFromEvent(event MarketplaceEvent) (*ProviderConfig, error) {
+	config := &ProviderConfig{}
+
+	if addr, ok := event.Data["provider_address"].(string); ok {
+		config.ProviderAddress = addr
+	}
+	if active, ok := event.Data["active"].(bool); ok {
+		config.Active = active
+	}
+	if version, ok := event.Data["version"].(float64); ok {
+		config.Version = uint64(version)
+	}
+
+	// Parse pricing
+	if pricing, ok := event.Data["pricing"].(map[string]interface{}); ok {
+		if cpu, ok := pricing["cpu_price_per_core"].(string); ok {
+			config.Pricing.CPUPricePerCore = cpu
+		}
+		if mem, ok := pricing["memory_price_per_gb"].(string); ok {
+			config.Pricing.MemoryPricePerGB = mem
+		}
+		if storage, ok := pricing["storage_price_per_gb"].(string); ok {
+			config.Pricing.StoragePricePerGB = storage
+		}
+		if network, ok := pricing["network_price_per_gb"].(string); ok {
+			config.Pricing.NetworkPricePerGB = network
+		}
+		if gpu, ok := pricing["gpu_price_per_hour"].(string); ok {
+			config.Pricing.GPUPricePerHour = gpu
+		}
+		if min, ok := pricing["min_bid_price"].(string); ok {
+			config.Pricing.MinBidPrice = min
+		}
+		if markup, ok := pricing["bid_markup_percent"].(float64); ok {
+			config.Pricing.BidMarkupPercent = markup
+		}
+		if currency, ok := pricing["currency"].(string); ok {
+			config.Pricing.Currency = currency
+		}
+	}
+
+	// Parse capacity
+	if capacity, ok := event.Data["capacity"].(map[string]interface{}); ok {
+		if cpu, ok := capacity["total_cpu_cores"].(float64); ok {
+			config.Capacity.TotalCPUCores = int64(cpu)
+		}
+		if mem, ok := capacity["total_memory_gb"].(float64); ok {
+			config.Capacity.TotalMemoryGB = int64(mem)
+		}
+		if storage, ok := capacity["total_storage_gb"].(float64); ok {
+			config.Capacity.TotalStorageGB = int64(storage)
+		}
+		if gpus, ok := capacity["total_gpus"].(float64); ok {
+			config.Capacity.TotalGPUs = int64(gpus)
+		}
+	}
+
+	// Parse supported offerings and regions
+	if offerings, ok := event.Data["supported_offerings"].([]interface{}); ok {
+		for _, o := range offerings {
+			if s, ok := o.(string); ok {
+				config.SupportedOfferings = append(config.SupportedOfferings, s)
+			}
+		}
+	}
+	if regions, ok := event.Data["regions"].([]interface{}); ok {
+		for _, r := range regions {
+			if s, ok := r.(string); ok {
+				config.Regions = append(config.Regions, s)
+			}
+		}
+	}
+
+	return config, nil
+}

--- a/pkg/provider_daemon/stream_client_test.go
+++ b/pkg/provider_daemon/stream_client_test.go
@@ -1,0 +1,308 @@
+package provider_daemon
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MockEventSubscriber implements EventSubscriber for testing.
+type MockEventSubscriber struct {
+	mu             sync.Mutex
+	connected      bool
+	lastCheckpoint uint64
+	orderEvents    chan OrderEvent
+	configEvents   chan ConfigEvent
+	subscribeErr   error
+	closed         bool
+	fallbackMode   bool
+}
+
+func NewMockEventSubscriber() *MockEventSubscriber {
+	return &MockEventSubscriber{
+		connected:    true,
+		orderEvents:  make(chan OrderEvent, 100),
+		configEvents: make(chan ConfigEvent, 100),
+	}
+}
+
+func (m *MockEventSubscriber) Subscribe(ctx context.Context, subscriberID string, query string) (<-chan MarketplaceEvent, error) {
+	if m.subscribeErr != nil {
+		return nil, m.subscribeErr
+	}
+	ch := make(chan MarketplaceEvent, 100)
+	return ch, nil
+}
+
+func (m *MockEventSubscriber) SubscribeOrders(ctx context.Context, providerAddress string) (<-chan OrderEvent, error) {
+	if m.subscribeErr != nil {
+		return nil, m.subscribeErr
+	}
+	return m.orderEvents, nil
+}
+
+func (m *MockEventSubscriber) SubscribeConfig(ctx context.Context, providerAddress string) (<-chan ConfigEvent, error) {
+	if m.subscribeErr != nil {
+		return nil, m.subscribeErr
+	}
+	return m.configEvents, nil
+}
+
+func (m *MockEventSubscriber) LastCheckpoint() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastCheckpoint
+}
+
+func (m *MockEventSubscriber) SetCheckpoint(sequence uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastCheckpoint = sequence
+}
+
+func (m *MockEventSubscriber) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+func (m *MockEventSubscriber) Status() SubscriberStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return SubscriberStatus{
+		Connected:      m.connected,
+		LastCheckpoint: m.lastCheckpoint,
+		UsingFallback:  m.fallbackMode,
+	}
+}
+
+func (m *MockEventSubscriber) SetConnected(connected bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.connected = connected
+}
+
+func (m *MockEventSubscriber) SendOrderEvent(event OrderEvent) {
+	m.orderEvents <- event
+}
+
+func (m *MockEventSubscriber) SendConfigEvent(event ConfigEvent) {
+	m.configEvents <- event
+}
+
+func TestNewBidEngineWithStreaming(t *testing.T) {
+	config := DefaultBidEngineConfig()
+	config.ProviderAddress = "provider1"
+
+	km := createUnlockedKeyManager(t)
+	mockClient := NewMockChainClient()
+	mockSubscriber := NewMockEventSubscriber()
+
+	be := NewBidEngineWithStreaming(config, km, mockClient, mockSubscriber)
+	require.NotNil(t, be)
+	assert.True(t, be.IsStreamingMode())
+	assert.False(t, be.IsRunning())
+}
+
+func TestBidEngineStreamingModeNilSubscriber(t *testing.T) {
+	config := DefaultBidEngineConfig()
+	config.ProviderAddress = "provider1"
+
+	km := createUnlockedKeyManager(t)
+	mockClient := NewMockChainClient()
+
+	be := NewBidEngineWithStreaming(config, km, mockClient, nil)
+	require.NotNil(t, be)
+	assert.False(t, be.IsStreamingMode())
+}
+
+func TestBidEngineStreamStatus(t *testing.T) {
+	config := DefaultBidEngineConfig()
+	km := createUnlockedKeyManager(t)
+	mockClient := NewMockChainClient()
+	mockSubscriber := NewMockEventSubscriber()
+
+	be := NewBidEngineWithStreaming(config, km, mockClient, mockSubscriber)
+
+	// Check stream status
+	status := be.StreamStatus()
+	require.NotNil(t, status)
+	assert.True(t, status.Connected)
+	assert.Equal(t, uint64(0), status.LastCheckpoint)
+}
+
+func TestBidEngineStreamStatusNilSubscriber(t *testing.T) {
+	config := DefaultBidEngineConfig()
+	km := createUnlockedKeyManager(t)
+	mockClient := NewMockChainClient()
+
+	be := NewBidEngine(config, km, mockClient)
+
+	// No stream status without subscriber
+	status := be.StreamStatus()
+	assert.Nil(t, status)
+}
+
+func TestEventSubscriberCheckpoint(t *testing.T) {
+	subscriber := NewMockEventSubscriber()
+
+	assert.Equal(t, uint64(0), subscriber.LastCheckpoint())
+
+	subscriber.SetCheckpoint(42)
+	assert.Equal(t, uint64(42), subscriber.LastCheckpoint())
+
+	subscriber.SetCheckpoint(100)
+	assert.Equal(t, uint64(100), subscriber.LastCheckpoint())
+}
+
+func TestDefaultEventSubscriberConfig(t *testing.T) {
+	cfg := DefaultEventSubscriberConfig()
+
+	assert.Equal(t, "/websocket", cfg.CometWS)
+	assert.Equal(t, 100, cfg.EventBuffer)
+	assert.Equal(t, time.Second, cfg.ReconnectDelay)
+	assert.Equal(t, time.Minute, cfg.MaxReconnectDelay)
+	assert.Equal(t, 2.0, cfg.ReconnectBackoffFactor)
+	assert.Equal(t, time.Second*30, cfg.HealthCheckInterval)
+}
+
+func TestEventTypeFromString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected EventType
+	}{
+		{"order_created", EventTypeOrderCreated},
+		{"order_closed", EventTypeOrderClosed},
+		{"bid_created", EventTypeBidCreated},
+		{"bid_accepted", EventTypeBidAccepted},
+		{"lease_created", EventTypeLeaseCreated},
+		{"lease_closed", EventTypeLeaseClosed},
+		{"config_updated", EventTypeConfigUpdated},
+		{"unknown_type", EventType("unknown_type")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := eventTypeFromString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseOrderFromEvent(t *testing.T) {
+	event := MarketplaceEvent{
+		Type: EventTypeOrderCreated,
+		Data: map[string]interface{}{
+			"order_id":         "order-123",
+			"customer_address": "customer1",
+			"offering_type":    "compute",
+			"region":           "us-east",
+			"max_price":        "1000",
+			"currency":         "uve",
+			"requirements": map[string]interface{}{
+				"cpu_cores":  float64(4),
+				"memory_gb":  float64(8),
+				"storage_gb": float64(100),
+				"gpus":       float64(1),
+				"gpu_type":   "nvidia-a100",
+			},
+		},
+	}
+
+	order, err := parseOrderFromEvent(event)
+	require.NoError(t, err)
+	assert.Equal(t, "order-123", order.OrderID)
+	assert.Equal(t, "customer1", order.CustomerAddress)
+	assert.Equal(t, "compute", order.OfferingType)
+	assert.Equal(t, "us-east", order.Region)
+	assert.Equal(t, "1000", order.MaxPrice)
+	assert.Equal(t, "uve", order.Currency)
+	assert.Equal(t, int64(4), order.Requirements.CPUCores)
+	assert.Equal(t, int64(8), order.Requirements.MemoryGB)
+	assert.Equal(t, int64(100), order.Requirements.StorageGB)
+	assert.Equal(t, int64(1), order.Requirements.GPUs)
+	assert.Equal(t, "nvidia-a100", order.Requirements.GPUType)
+}
+
+func TestParseConfigFromEvent(t *testing.T) {
+	event := MarketplaceEvent{
+		Type: EventTypeConfigUpdated,
+		Data: map[string]interface{}{
+			"provider_address": "provider1",
+			"active":           true,
+			"version":          float64(5),
+			"pricing": map[string]interface{}{
+				"cpu_price_per_core":   "2.5",
+				"memory_price_per_gb":  "1.0",
+				"storage_price_per_gb": "0.5",
+				"min_bid_price":        "100",
+				"bid_markup_percent":   float64(10),
+				"currency":             "uve",
+			},
+			"capacity": map[string]interface{}{
+				"total_cpu_cores":  float64(100),
+				"total_memory_gb":  float64(256),
+				"total_storage_gb": float64(1000),
+				"total_gpus":       float64(4),
+			},
+			"supported_offerings": []interface{}{"compute", "storage"},
+			"regions":             []interface{}{"us-east", "eu-west"},
+		},
+	}
+
+	config, err := parseConfigFromEvent(event)
+	require.NoError(t, err)
+	assert.Equal(t, "provider1", config.ProviderAddress)
+	assert.True(t, config.Active)
+	assert.Equal(t, uint64(5), config.Version)
+	assert.Equal(t, "2.5", config.Pricing.CPUPricePerCore)
+	assert.Equal(t, "1.0", config.Pricing.MemoryPricePerGB)
+	assert.Equal(t, "0.5", config.Pricing.StoragePricePerGB)
+	assert.Equal(t, "100", config.Pricing.MinBidPrice)
+	assert.Equal(t, 10.0, config.Pricing.BidMarkupPercent)
+	assert.Equal(t, "uve", config.Pricing.Currency)
+	assert.Equal(t, int64(100), config.Capacity.TotalCPUCores)
+	assert.Equal(t, int64(256), config.Capacity.TotalMemoryGB)
+	assert.Equal(t, int64(1000), config.Capacity.TotalStorageGB)
+	assert.Equal(t, int64(4), config.Capacity.TotalGPUs)
+	assert.Contains(t, config.SupportedOfferings, "compute")
+	assert.Contains(t, config.SupportedOfferings, "storage")
+	assert.Contains(t, config.Regions, "us-east")
+	assert.Contains(t, config.Regions, "eu-west")
+}
+
+func TestBuildOrderQuery(t *testing.T) {
+	query := buildOrderQuery("provider1")
+	assert.Contains(t, query, "tm.event='Tx'")
+	assert.Contains(t, query, "order_created")
+	assert.Contains(t, query, "order_closed")
+}
+
+func TestBuildConfigQuery(t *testing.T) {
+	query := buildConfigQuery("provider1")
+	assert.Contains(t, query, "tm.event='Tx'")
+	assert.Contains(t, query, "provider1")
+	assert.Contains(t, query, "provider_config")
+}
+
+func TestSubscriberStatus(t *testing.T) {
+	status := SubscriberStatus{
+		Connected:      true,
+		LastEventTime:  time.Now(),
+		LastCheckpoint: 42,
+		ReconnectCount: 3,
+		LastError:      "test error",
+		UsingFallback:  true,
+	}
+
+	assert.True(t, status.Connected)
+	assert.Equal(t, uint64(42), status.LastCheckpoint)
+	assert.Equal(t, 3, status.ReconnectCount)
+	assert.Equal(t, "test error", status.LastError)
+	assert.True(t, status.UsingFallback)
+}


### PR DESCRIPTION
Use WebSocket/gRPC event subscriptions for orders/config instead of polling loops.

Acceptance:
- WebSocket/gRPC subscriptions to chain events
- Checkpointed replay on reconnect
- Polling fallback only for recovery