### PR TITLE
feat: NLI-001: Redis-backed NLI sessions & rate limiting

### DIFF
--- a/pkg/nli/config.go
+++ b/pkg/nli/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	// MinConfidenceThreshold is the minimum confidence for intent classification
 	MinConfidenceThreshold float32 `json:"min_confidence_threshold"`
 
-	// RateLimitRequests is the max requests per minute per session
+	// RateLimitRequests is the max requests per minute per session (legacy, use DistributedRateLimiter)
 	RateLimitRequests int `json:"rate_limit_requests"`
 
 	// EnableQueryExecution enables blockchain query execution
@@ -51,6 +51,48 @@ type Config struct {
 
 	// LogLevel controls logging verbosity
 	LogLevel string `json:"log_level"`
+
+	// SessionStore configures the session store backend
+	SessionStore SessionStoreConfig `json:"session_store"`
+
+	// DistributedRateLimiter enables the distributed rate limiter from pkg/ratelimit
+	DistributedRateLimiter DistributedRateLimiterConfig `json:"distributed_rate_limiter"`
+
+	// MetricsNamespace is the namespace for Prometheus metrics
+	MetricsNamespace string `json:"metrics_namespace"`
+}
+
+// DistributedRateLimiterConfig configures distributed rate limiting
+type DistributedRateLimiterConfig struct {
+	// Enabled enables the distributed rate limiter
+	Enabled bool `json:"enabled"`
+
+	// RedisURL is the Redis connection URL
+	RedisURL string `json:"redis_url"`
+
+	// RedisPrefix is the key prefix for rate limit keys
+	RedisPrefix string `json:"redis_prefix"`
+
+	// RequestsPerMinute is the max requests per minute per session
+	RequestsPerMinute int `json:"requests_per_minute"`
+
+	// RequestsPerSecond is the max requests per second per session
+	RequestsPerSecond int `json:"requests_per_second"`
+
+	// BurstSize is the maximum burst size
+	BurstSize int `json:"burst_size"`
+}
+
+// DefaultDistributedRateLimiterConfig returns the default distributed rate limiter configuration
+func DefaultDistributedRateLimiterConfig() DistributedRateLimiterConfig {
+	return DistributedRateLimiterConfig{
+		Enabled:           false,
+		RedisURL:          "redis://localhost:6379/0",
+		RedisPrefix:       "virtengine:nli:ratelimit",
+		RequestsPerMinute: 60,
+		RequestsPerSecond: 5,
+		BurstSize:         10,
+	}
 }
 
 // Validate validates the configuration
@@ -115,6 +157,9 @@ func DefaultConfig() Config {
 		MaxTokens:              1024,
 		EnableSuggestions:      true,
 		LogLevel:               "info",
+		SessionStore:           DefaultSessionStoreConfig(),
+		DistributedRateLimiter: DefaultDistributedRateLimiterConfig(),
+		MetricsNamespace:       "virtengine",
 	}
 }
 

--- a/pkg/nli/errors.go
+++ b/pkg/nli/errors.go
@@ -2,7 +2,6 @@ package nli
 
 import (
 	"errors"
-	verrors "github.com/virtengine/virtengine/pkg/errors"
 )
 
 // Service errors
@@ -63,4 +62,16 @@ var (
 
 	// ErrLowConfidence is returned when classification confidence is too low
 	ErrLowConfidence = errors.New("nli: classification confidence too low")
+)
+
+// Session errors
+var (
+	// ErrSessionNotFound is returned when a session is not found
+	ErrSessionNotFound = errors.New("nli: session not found")
+
+	// ErrSessionExpired is returned when a session has expired
+	ErrSessionExpired = errors.New("nli: session expired")
+
+	// ErrSessionStoreClosed is returned when the session store is closed
+	ErrSessionStoreClosed = errors.New("nli: session store closed")
 )

--- a/pkg/nli/llm_backend.go
+++ b/pkg/nli/llm_backend.go
@@ -1,7 +1,6 @@
 package nli
 
 import (
-	verrors "github.com/virtengine/virtengine/pkg/errors"
 	"bytes"
 	"context"
 	"encoding/json"

--- a/pkg/nli/metrics.go
+++ b/pkg/nli/metrics.go
@@ -1,0 +1,268 @@
+package nli
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/telemetry"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+)
+
+var (
+	metricsOnce     sync.Once
+	defaultMetrics  *NLIMetrics
+	metricsRegistry = prometheus.NewRegistry()
+)
+
+// NLIMetrics provides metrics collection for the NLI service
+type NLIMetrics struct {
+	// Session metrics
+	activeSessions       prometheus.Gauge
+	sessionOperations    *prometheus.CounterVec
+	sessionOperationTime *prometheus.HistogramVec
+
+	// Rate limit metrics
+	rateLimitHits   prometheus.Counter
+	rateLimitMisses prometheus.Counter
+
+	// Request metrics
+	requestsTotal    *prometheus.CounterVec
+	requestDuration  *prometheus.HistogramVec
+	intentClassified *prometheus.CounterVec
+
+	// Error metrics
+	errors *prometheus.CounterVec
+
+	logger zerolog.Logger
+}
+
+// NewNLIMetrics creates a new metrics collector (singleton for tests)
+func NewNLIMetrics(namespace string, logger zerolog.Logger) *NLIMetrics {
+	if namespace == "" {
+		namespace = "virtengine"
+	}
+
+	metricsOnce.Do(func() {
+		defaultMetrics = createMetrics(namespace, logger)
+	})
+
+	// Update logger for this instance
+	defaultMetrics.logger = logger
+	return defaultMetrics
+}
+
+// createMetrics creates the actual metric instances
+func createMetrics(namespace string, logger zerolog.Logger) *NLIMetrics {
+	activeSessions := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "nli",
+		Name:      "active_sessions",
+		Help:      "Number of active NLI sessions",
+	})
+
+	sessionOperations := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "nli",
+			Name:      "session_operations_total",
+			Help:      "Total number of session operations",
+		},
+		[]string{"operation"},
+	)
+
+	sessionOperationTime := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "nli",
+			Name:      "session_operation_duration_seconds",
+			Help:      "Duration of session operations in seconds",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"operation"},
+	)
+
+	rateLimitHits := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "nli",
+		Name:      "ratelimit_hits_total",
+		Help:      "Total number of rate limit hits (blocked requests)",
+	})
+
+	rateLimitMisses := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "nli",
+		Name:      "ratelimit_passes_total",
+		Help:      "Total number of requests that passed rate limiting",
+	})
+
+	requestsTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "nli",
+			Name:      "requests_total",
+			Help:      "Total number of NLI requests",
+		},
+		[]string{"status"},
+	)
+
+	requestDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: "nli",
+			Name:      "request_duration_seconds",
+			Help:      "Duration of NLI requests in seconds",
+			Buckets:   []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{"intent"},
+	)
+
+	intentClassified := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "nli",
+			Name:      "intents_classified_total",
+			Help:      "Total number of intents classified",
+		},
+		[]string{"intent"},
+	)
+
+	errors := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: "nli",
+			Name:      "errors_total",
+			Help:      "Total number of errors",
+		},
+		[]string{"type"},
+	)
+
+	// Register with custom registry (won't panic on re-registration)
+	metricsRegistry.MustRegister(
+		activeSessions,
+		sessionOperations,
+		sessionOperationTime,
+		rateLimitHits,
+		rateLimitMisses,
+		requestsTotal,
+		requestDuration,
+		intentClassified,
+		errors,
+	)
+
+	return &NLIMetrics{
+		activeSessions:       activeSessions,
+		sessionOperations:    sessionOperations,
+		sessionOperationTime: sessionOperationTime,
+		rateLimitHits:        rateLimitHits,
+		rateLimitMisses:      rateLimitMisses,
+		requestsTotal:        requestsTotal,
+		requestDuration:      requestDuration,
+		intentClassified:     intentClassified,
+		errors:               errors,
+		logger:               logger,
+	}
+}
+
+// RecordSessionCount updates the active session count
+func (m *NLIMetrics) RecordSessionCount(count int64) {
+	m.activeSessions.Set(float64(count))
+	telemetry.SetGauge(float32(count), "nli", "active_sessions")
+}
+
+// RecordSessionOperation records a session store operation
+func (m *NLIMetrics) RecordSessionOperation(operation string, duration time.Duration) {
+	m.sessionOperations.WithLabelValues(operation).Inc()
+	m.sessionOperationTime.WithLabelValues(operation).Observe(duration.Seconds())
+	telemetry.IncrCounter(1, "nli", "session_operations", operation)
+}
+
+// RecordRateLimitHit records a rate limit hit (blocked request)
+func (m *NLIMetrics) RecordRateLimitHit() {
+	m.rateLimitHits.Inc()
+	telemetry.IncrCounter(1, "nli", "ratelimit_hits")
+}
+
+// RecordRateLimitPass records a request that passed rate limiting
+func (m *NLIMetrics) RecordRateLimitPass() {
+	m.rateLimitMisses.Inc()
+	telemetry.IncrCounter(1, "nli", "ratelimit_passes")
+}
+
+// RecordRequest records a completed request
+func (m *NLIMetrics) RecordRequest(status string, intent string, duration time.Duration) {
+	m.requestsTotal.WithLabelValues(status).Inc()
+	m.requestDuration.WithLabelValues(intent).Observe(duration.Seconds())
+	telemetry.IncrCounter(1, "nli", "requests", status)
+	telemetry.MeasureSince(time.Now().Add(-duration), "nli", "request_duration")
+}
+
+// RecordIntentClassified records an intent classification
+func (m *NLIMetrics) RecordIntentClassified(intent string) {
+	m.intentClassified.WithLabelValues(intent).Inc()
+	telemetry.IncrCounter(1, "nli", "intents_classified", intent)
+}
+
+// RecordError records an error
+func (m *NLIMetrics) RecordError(errorType string) {
+	m.errors.WithLabelValues(errorType).Inc()
+	telemetry.IncrCounter(1, "nli", "errors", errorType)
+}
+
+// MetricsCollector collects and reports metrics periodically
+type MetricsCollector struct {
+	metrics      *NLIMetrics
+	sessionStore SessionStore
+	logger       zerolog.Logger
+	stopCh       chan struct{}
+}
+
+// NewMetricsCollector creates a new metrics collector
+func NewMetricsCollector(metrics *NLIMetrics, sessionStore SessionStore, logger zerolog.Logger) *MetricsCollector {
+	return &MetricsCollector{
+		metrics:      metrics,
+		sessionStore: sessionStore,
+		logger:       logger,
+		stopCh:       make(chan struct{}),
+	}
+}
+
+// Start starts the metrics collection loop
+func (c *MetricsCollector) Start(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	c.logger.Info().Dur("interval", interval).Msg("starting NLI metrics collector")
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info().Msg("stopping NLI metrics collector")
+			return
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+			c.collectMetrics(ctx)
+		}
+	}
+}
+
+// Stop stops the metrics collector
+func (c *MetricsCollector) Stop() {
+	close(c.stopCh)
+}
+
+// collectMetrics collects metrics from the session store
+func (c *MetricsCollector) collectMetrics(ctx context.Context) {
+	// Get session count
+	count, err := c.sessionStore.Count(ctx)
+	if err != nil {
+		c.logger.Warn().Err(err).Msg("failed to get session count")
+		return
+	}
+
+	c.metrics.RecordSessionCount(count)
+
+	c.logger.Debug().Int64("session_count", count).Msg("metrics collected")
+}

--- a/pkg/nli/response_generator.go
+++ b/pkg/nli/response_generator.go
@@ -1,7 +1,6 @@
 package nli
 
 import (
-	verrors "github.com/virtengine/virtengine/pkg/errors"
 	"context"
 	"fmt"
 	"strings"

--- a/pkg/nli/session_store.go
+++ b/pkg/nli/session_store.go
@@ -1,0 +1,523 @@
+package nli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+// SessionStore defines the interface for session storage
+type SessionStore interface {
+	// Get retrieves a session by ID
+	Get(ctx context.Context, sessionID string) (*Session, error)
+
+	// Set stores or updates a session
+	Set(ctx context.Context, session *Session) error
+
+	// Delete removes a session
+	Delete(ctx context.Context, sessionID string) error
+
+	// Touch updates the session's last activity time
+	Touch(ctx context.Context, sessionID string) error
+
+	// Count returns the number of active sessions
+	Count(ctx context.Context) (int64, error)
+
+	// Close closes the session store
+	Close() error
+}
+
+// Session represents a stored NLI session
+type Session struct {
+	ID           string        `json:"id"`
+	History      []ChatMessage `json:"history"`
+	LastActivity time.Time     `json:"last_activity"`
+	UserAddress  string        `json:"user_address,omitempty"`
+	Context      *ChatContext  `json:"context,omitempty"`
+	CreatedAt    time.Time     `json:"created_at"`
+}
+
+// SessionStoreConfig holds configuration for session storage
+type SessionStoreConfig struct {
+	// Backend specifies the session store backend ("memory" or "redis")
+	Backend string `json:"backend"`
+
+	// RedisURL is the Redis connection URL
+	RedisURL string `json:"redis_url"`
+
+	// RedisPrefix is the key prefix for session keys
+	RedisPrefix string `json:"redis_prefix"`
+
+	// SessionTTL is the TTL for session data
+	SessionTTL time.Duration `json:"session_ttl"`
+
+	// MaxSessions is the maximum number of sessions (for memory store)
+	MaxSessions int `json:"max_sessions"`
+
+	// MaxHistoryLength limits conversation history per session
+	MaxHistoryLength int `json:"max_history_length"`
+}
+
+// DefaultSessionStoreConfig returns the default session store configuration
+func DefaultSessionStoreConfig() SessionStoreConfig {
+	return SessionStoreConfig{
+		Backend:          "memory",
+		RedisURL:         "redis://localhost:6379/0",
+		RedisPrefix:      "virtengine:nli:session:",
+		SessionTTL:       30 * time.Minute,
+		MaxSessions:      10000,
+		MaxHistoryLength: 20,
+	}
+}
+
+// ============================================================================
+// Redis Session Store
+// ============================================================================
+
+// RedisSessionStore implements SessionStore using Redis
+type RedisSessionStore struct {
+	client  *redis.Client
+	config  SessionStoreConfig
+	logger  zerolog.Logger
+	metrics *sessionMetrics
+}
+
+// sessionMetrics tracks session store metrics
+type sessionMetrics struct {
+	mu         sync.RWMutex
+	gets       uint64
+	sets       uint64
+	deletes    uint64
+	hits       uint64
+	misses     uint64
+	expiredTTL uint64
+}
+
+// NewRedisSessionStore creates a new Redis-based session store
+func NewRedisSessionStore(ctx context.Context, config SessionStoreConfig, logger zerolog.Logger) (*RedisSessionStore, error) {
+	opts, err := redis.ParseURL(config.RedisURL)
+	if err != nil {
+		return nil, fmt.Errorf("nli: invalid redis URL: %w", err)
+	}
+
+	client := redis.NewClient(opts)
+
+	// Test connection
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("nli: failed to connect to redis: %w", err)
+	}
+
+	store := &RedisSessionStore{
+		client:  client,
+		config:  config,
+		logger:  logger.With().Str("component", "nli-session-store").Logger(),
+		metrics: &sessionMetrics{},
+	}
+
+	logger.Info().
+		Str("redis_url", config.RedisURL).
+		Str("prefix", config.RedisPrefix).
+		Dur("ttl", config.SessionTTL).
+		Msg("redis session store initialized")
+
+	return store, nil
+}
+
+// Get retrieves a session by ID
+func (s *RedisSessionStore) Get(ctx context.Context, sessionID string) (*Session, error) {
+	s.metrics.mu.Lock()
+	s.metrics.gets++
+	s.metrics.mu.Unlock()
+
+	key := s.formatKey(sessionID)
+	data, err := s.client.Get(ctx, key).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			s.metrics.mu.Lock()
+			s.metrics.misses++
+			s.metrics.mu.Unlock()
+			return nil, ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("nli: redis get failed: %w", err)
+	}
+
+	var session Session
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("nli: session unmarshal failed: %w", err)
+	}
+
+	s.metrics.mu.Lock()
+	s.metrics.hits++
+	s.metrics.mu.Unlock()
+
+	return &session, nil
+}
+
+// Set stores or updates a session
+func (s *RedisSessionStore) Set(ctx context.Context, session *Session) error {
+	s.metrics.mu.Lock()
+	s.metrics.sets++
+	s.metrics.mu.Unlock()
+
+	// Ensure session has required fields
+	if session.ID == "" {
+		return ErrMissingSessionID
+	}
+
+	// Trim history if needed
+	if len(session.History) > s.config.MaxHistoryLength*2 {
+		session.History = session.History[len(session.History)-s.config.MaxHistoryLength*2:]
+	}
+
+	// Update last activity
+	session.LastActivity = time.Now()
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("nli: session marshal failed: %w", err)
+	}
+
+	key := s.formatKey(session.ID)
+	if err := s.client.Set(ctx, key, data, s.config.SessionTTL).Err(); err != nil {
+		return fmt.Errorf("nli: redis set failed: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes a session
+func (s *RedisSessionStore) Delete(ctx context.Context, sessionID string) error {
+	s.metrics.mu.Lock()
+	s.metrics.deletes++
+	s.metrics.mu.Unlock()
+
+	key := s.formatKey(sessionID)
+	return s.client.Del(ctx, key).Err()
+}
+
+// Touch updates the session's last activity time and refreshes TTL
+func (s *RedisSessionStore) Touch(ctx context.Context, sessionID string) error {
+	key := s.formatKey(sessionID)
+
+	// Get, update, and set back
+	session, err := s.Get(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+
+	session.LastActivity = time.Now()
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("nli: session marshal failed: %w", err)
+	}
+
+	return s.client.Set(ctx, key, data, s.config.SessionTTL).Err()
+}
+
+// Count returns the number of active sessions
+func (s *RedisSessionStore) Count(ctx context.Context) (int64, error) {
+	pattern := s.config.RedisPrefix + "*"
+
+	var count int64
+	var cursor uint64
+	for {
+		keys, nextCursor, err := s.client.Scan(ctx, cursor, pattern, 1000).Result()
+		if err != nil {
+			return 0, fmt.Errorf("nli: redis scan failed: %w", err)
+		}
+		count += int64(len(keys))
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+
+	return count, nil
+}
+
+// Close closes the Redis connection
+func (s *RedisSessionStore) Close() error {
+	return s.client.Close()
+}
+
+// GetMetrics returns session store metrics
+func (s *RedisSessionStore) GetMetrics() SessionStoreMetrics {
+	s.metrics.mu.RLock()
+	defer s.metrics.mu.RUnlock()
+
+	return SessionStoreMetrics{
+		Gets:    s.metrics.gets,
+		Sets:    s.metrics.sets,
+		Deletes: s.metrics.deletes,
+		Hits:    s.metrics.hits,
+		Misses:  s.metrics.misses,
+	}
+}
+
+// formatKey formats a session key with the prefix
+func (s *RedisSessionStore) formatKey(sessionID string) string {
+	return s.config.RedisPrefix + sessionID
+}
+
+// ============================================================================
+// In-Memory Session Store (fallback)
+// ============================================================================
+
+// InMemorySessionStore implements SessionStore using in-memory storage
+type InMemorySessionStore struct {
+	sessions   map[string]*Session
+	mu         sync.RWMutex
+	config     SessionStoreConfig
+	logger     zerolog.Logger
+	metrics    *sessionMetrics
+	cleanupTTL time.Duration
+	stopCh     chan struct{}
+}
+
+// NewInMemorySessionStore creates a new in-memory session store
+func NewInMemorySessionStore(config SessionStoreConfig, logger zerolog.Logger) *InMemorySessionStore {
+	store := &InMemorySessionStore{
+		sessions: make(map[string]*Session),
+		config:   config,
+		logger:   logger.With().Str("component", "nli-memory-session-store").Logger(),
+		metrics:  &sessionMetrics{},
+		stopCh:   make(chan struct{}),
+	}
+
+	// Start background cleanup
+	go store.cleanupLoop()
+
+	logger.Info().
+		Int("max_sessions", config.MaxSessions).
+		Dur("ttl", config.SessionTTL).
+		Msg("in-memory session store initialized")
+
+	return store
+}
+
+// Get retrieves a session by ID
+func (s *InMemorySessionStore) Get(ctx context.Context, sessionID string) (*Session, error) {
+	s.metrics.mu.Lock()
+	s.metrics.gets++
+	s.metrics.mu.Unlock()
+
+	s.mu.RLock()
+	session, exists := s.sessions[sessionID]
+	s.mu.RUnlock()
+
+	if !exists {
+		s.metrics.mu.Lock()
+		s.metrics.misses++
+		s.metrics.mu.Unlock()
+		return nil, ErrSessionNotFound
+	}
+
+	// Check if expired
+	if time.Since(session.LastActivity) > s.config.SessionTTL {
+		s.mu.Lock()
+		delete(s.sessions, sessionID)
+		s.mu.Unlock()
+
+		s.metrics.mu.Lock()
+		s.metrics.expiredTTL++
+		s.metrics.misses++
+		s.metrics.mu.Unlock()
+		return nil, ErrSessionNotFound
+	}
+
+	s.metrics.mu.Lock()
+	s.metrics.hits++
+	s.metrics.mu.Unlock()
+
+	// Return a copy to prevent mutation
+	sessionCopy := *session
+	historyCopy := make([]ChatMessage, len(session.History))
+	copy(historyCopy, session.History)
+	sessionCopy.History = historyCopy
+
+	return &sessionCopy, nil
+}
+
+// Set stores or updates a session
+func (s *InMemorySessionStore) Set(ctx context.Context, session *Session) error {
+	s.metrics.mu.Lock()
+	s.metrics.sets++
+	s.metrics.mu.Unlock()
+
+	if session.ID == "" {
+		return ErrMissingSessionID
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Enforce max sessions limit
+	if _, exists := s.sessions[session.ID]; !exists && len(s.sessions) >= s.config.MaxSessions {
+		s.evictOldest()
+	}
+
+	// Trim history if needed
+	if len(session.History) > s.config.MaxHistoryLength*2 {
+		session.History = session.History[len(session.History)-s.config.MaxHistoryLength*2:]
+	}
+
+	// Make a copy and update timestamp
+	sessionCopy := *session
+	sessionCopy.LastActivity = time.Now()
+	historyCopy := make([]ChatMessage, len(session.History))
+	copy(historyCopy, session.History)
+	sessionCopy.History = historyCopy
+
+	s.sessions[session.ID] = &sessionCopy
+
+	return nil
+}
+
+// Delete removes a session
+func (s *InMemorySessionStore) Delete(ctx context.Context, sessionID string) error {
+	s.metrics.mu.Lock()
+	s.metrics.deletes++
+	s.metrics.mu.Unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.sessions, sessionID)
+	return nil
+}
+
+// Touch updates the session's last activity time
+func (s *InMemorySessionStore) Touch(ctx context.Context, sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	session, exists := s.sessions[sessionID]
+	if !exists {
+		return ErrSessionNotFound
+	}
+
+	session.LastActivity = time.Now()
+	return nil
+}
+
+// Count returns the number of active sessions
+func (s *InMemorySessionStore) Count(ctx context.Context) (int64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return int64(len(s.sessions)), nil
+}
+
+// Close stops the cleanup loop
+func (s *InMemorySessionStore) Close() error {
+	close(s.stopCh)
+	return nil
+}
+
+// GetMetrics returns session store metrics
+func (s *InMemorySessionStore) GetMetrics() SessionStoreMetrics {
+	s.metrics.mu.RLock()
+	defer s.metrics.mu.RUnlock()
+
+	return SessionStoreMetrics{
+		Gets:    s.metrics.gets,
+		Sets:    s.metrics.sets,
+		Deletes: s.metrics.deletes,
+		Hits:    s.metrics.hits,
+		Misses:  s.metrics.misses,
+	}
+}
+
+// evictOldest removes the oldest 10% of sessions
+func (s *InMemorySessionStore) evictOldest() {
+	toRemove := len(s.sessions) / 10
+	if toRemove < 1 {
+		toRemove = 1
+	}
+
+	type sessionAge struct {
+		id   string
+		time time.Time
+	}
+
+	ages := make([]sessionAge, 0, len(s.sessions))
+	for id, session := range s.sessions {
+		ages = append(ages, sessionAge{id: id, time: session.LastActivity})
+	}
+
+	// Sort by age (oldest first)
+	for i := range ages {
+		for j := i + 1; j < len(ages); j++ {
+			if ages[j].time.Before(ages[i].time) {
+				ages[i], ages[j] = ages[j], ages[i]
+			}
+		}
+	}
+
+	// Remove oldest sessions
+	for i := 0; i < toRemove && i < len(ages); i++ {
+		delete(s.sessions, ages[i].id)
+	}
+}
+
+// cleanupLoop periodically removes expired sessions
+func (s *InMemorySessionStore) cleanupLoop() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			s.cleanup()
+		}
+	}
+}
+
+// cleanup removes expired sessions
+func (s *InMemorySessionStore) cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	for id, session := range s.sessions {
+		if now.Sub(session.LastActivity) > s.config.SessionTTL {
+			delete(s.sessions, id)
+			s.metrics.mu.Lock()
+			s.metrics.expiredTTL++
+			s.metrics.mu.Unlock()
+		}
+	}
+}
+
+// ============================================================================
+// Session Store Metrics
+// ============================================================================
+
+// SessionStoreMetrics contains session store metrics
+type SessionStoreMetrics struct {
+	Gets    uint64 `json:"gets"`
+	Sets    uint64 `json:"sets"`
+	Deletes uint64 `json:"deletes"`
+	Hits    uint64 `json:"hits"`
+	Misses  uint64 `json:"misses"`
+}
+
+// NewSessionStore creates a session store based on configuration
+func NewSessionStore(ctx context.Context, config SessionStoreConfig, logger zerolog.Logger) (SessionStore, error) {
+	switch config.Backend {
+	case "redis":
+		return NewRedisSessionStore(ctx, config, logger)
+	case "memory", "":
+		return NewInMemorySessionStore(config, logger), nil
+	default:
+		return nil, fmt.Errorf("nli: unknown session store backend: %s", config.Backend)
+	}
+}

--- a/pkg/nli/session_store_test.go
+++ b/pkg/nli/session_store_test.go
@@ -1,0 +1,369 @@
+package nli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestInMemorySessionStore_BasicOperations(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+	config.MaxSessions = 100
+	config.SessionTTL = time.Minute
+
+	store := NewInMemorySessionStore(config, zerolog.Nop())
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Test Set and Get
+	session := &Session{
+		ID:          "test-session-1",
+		UserAddress: "virtengine1abc...",
+		History: []ChatMessage{
+			{Role: "user", Content: "Hello", Timestamp: time.Now()},
+		},
+		CreatedAt: time.Now(),
+	}
+
+	err := store.Set(ctx, session)
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	retrieved, err := store.Get(ctx, "test-session-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if retrieved.ID != session.ID {
+		t.Errorf("Expected ID %s, got %s", session.ID, retrieved.ID)
+	}
+
+	if retrieved.UserAddress != session.UserAddress {
+		t.Errorf("Expected UserAddress %s, got %s", session.UserAddress, retrieved.UserAddress)
+	}
+
+	if len(retrieved.History) != 1 {
+		t.Errorf("Expected 1 history item, got %d", len(retrieved.History))
+	}
+}
+
+func TestInMemorySessionStore_SessionNotFound(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+
+	store := NewInMemorySessionStore(config, zerolog.Nop())
+	defer store.Close()
+
+	ctx := context.Background()
+
+	_, err := store.Get(ctx, "nonexistent-session")
+	if err != ErrSessionNotFound {
+		t.Errorf("Expected ErrSessionNotFound, got %v", err)
+	}
+}
+
+func TestInMemorySessionStore_Count(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+
+	store := NewInMemorySessionStore(config, zerolog.Nop())
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Initially empty
+	count, err := store.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count failed: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("Expected 0 sessions, got %d", count)
+	}
+
+	// Add sessions
+	for i := 0; i < 5; i++ {
+		session := &Session{
+			ID:        "session-" + string(rune('a'+i)),
+			CreatedAt: time.Now(),
+		}
+		if err := store.Set(ctx, session); err != nil {
+			t.Fatalf("Set failed: %v", err)
+		}
+	}
+
+	count, err = store.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count failed: %v", err)
+	}
+	if count != 5 {
+		t.Errorf("Expected 5 sessions, got %d", count)
+	}
+}
+
+func TestInMemorySessionStore_Delete(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+
+	store := NewInMemorySessionStore(config, zerolog.Nop())
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Add a session
+	session := &Session{
+		ID:        "delete-test",
+		CreatedAt: time.Now(),
+	}
+	if err := store.Set(ctx, session); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Delete it
+	if err := store.Delete(ctx, "delete-test"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify it's gone
+	_, err := store.Get(ctx, "delete-test")
+	if err != ErrSessionNotFound {
+		t.Errorf("Expected ErrSessionNotFound, got %v", err)
+	}
+}
+
+func TestInMemorySessionStore_Touch(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+	config.SessionTTL = time.Hour
+
+	store := NewInMemorySessionStore(config, zerolog.Nop())
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Add a session
+	session := &Session{
+		ID:           "touch-test",
+		LastActivity: time.Now().Add(-time.Hour),
+		CreatedAt:    time.Now().Add(-time.Hour),
+	}
+	if err := store.Set(ctx, session); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Touch it
+	if err := store.Touch(ctx, "touch-test"); err != nil {
+		t.Fatalf("Touch failed: %v", err)
+	}
+
+	// Verify last activity is updated
+	retrieved, err := store.Get(ctx, "touch-test")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if time.Since(retrieved.LastActivity) > time.Second {
+		t.Errorf("LastActivity not updated, got %v", retrieved.LastActivity)
+	}
+}
+
+func TestInMemorySessionStore_MaxSessions(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+	config.MaxSessions = 10
+
+	store := NewInMemorySessionStore(config, zerolog.Nop())
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Add more sessions than the limit
+	for i := 0; i < 15; i++ {
+		session := &Session{
+			ID:        "session-" + string(rune('0'+i)),
+			CreatedAt: time.Now(),
+		}
+		// Sleep briefly to ensure different timestamps
+		time.Sleep(time.Millisecond)
+		if err := store.Set(ctx, session); err != nil {
+			t.Fatalf("Set failed: %v", err)
+		}
+	}
+
+	// Count should not exceed max
+	count, err := store.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count failed: %v", err)
+	}
+	if count > int64(config.MaxSessions) {
+		t.Errorf("Expected at most %d sessions, got %d", config.MaxSessions, count)
+	}
+}
+
+func TestInMemorySessionStore_TTLExpiry(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+	config.SessionTTL = 50 * time.Millisecond
+
+	store := NewInMemorySessionStore(config, zerolog.Nop())
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Add a session
+	session := &Session{
+		ID:        "expiry-test",
+		CreatedAt: time.Now(),
+	}
+	if err := store.Set(ctx, session); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Verify it exists
+	_, err := store.Get(ctx, "expiry-test")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	// Wait for expiry
+	time.Sleep(100 * time.Millisecond)
+
+	// Should be expired now
+	_, err = store.Get(ctx, "expiry-test")
+	if err != ErrSessionNotFound {
+		t.Errorf("Expected ErrSessionNotFound after TTL, got %v", err)
+	}
+}
+
+func TestInMemorySessionStore_HistoryTrimming(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+	config.MaxHistoryLength = 5
+
+	store := NewInMemorySessionStore(config, zerolog.Nop())
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Create session with too many history items
+	history := make([]ChatMessage, 20)
+	for i := 0; i < 20; i++ {
+		history[i] = ChatMessage{
+			Role:      "user",
+			Content:   "message",
+			Timestamp: time.Now(),
+		}
+	}
+
+	session := &Session{
+		ID:        "history-test",
+		History:   history,
+		CreatedAt: time.Now(),
+	}
+	if err := store.Set(ctx, session); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Retrieve and check trimmed
+	retrieved, err := store.Get(ctx, "history-test")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	// History should be trimmed to MaxHistoryLength*2
+	if len(retrieved.History) > config.MaxHistoryLength*2 {
+		t.Errorf("Expected at most %d history items, got %d", config.MaxHistoryLength*2, len(retrieved.History))
+	}
+}
+
+func TestInMemorySessionStore_Metrics(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+
+	store := NewInMemorySessionStore(config, zerolog.Nop())
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Perform operations
+	session := &Session{ID: "metrics-test", CreatedAt: time.Now()}
+	store.Set(ctx, session)
+	store.Get(ctx, "metrics-test")
+	store.Get(ctx, "nonexistent") // Miss
+	store.Delete(ctx, "metrics-test")
+
+	metrics := store.GetMetrics()
+
+	if metrics.Sets != 1 {
+		t.Errorf("Expected 1 set, got %d", metrics.Sets)
+	}
+	if metrics.Gets != 2 {
+		t.Errorf("Expected 2 gets, got %d", metrics.Gets)
+	}
+	if metrics.Hits != 1 {
+		t.Errorf("Expected 1 hit, got %d", metrics.Hits)
+	}
+	if metrics.Misses != 1 {
+		t.Errorf("Expected 1 miss, got %d", metrics.Misses)
+	}
+	if metrics.Deletes != 1 {
+		t.Errorf("Expected 1 delete, got %d", metrics.Deletes)
+	}
+}
+
+func TestNewSessionStore_Memory(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "memory"
+
+	store, err := NewSessionStore(context.Background(), config, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewSessionStore failed: %v", err)
+	}
+	defer store.Close()
+
+	// Verify it works
+	ctx := context.Background()
+	session := &Session{ID: "factory-test", CreatedAt: time.Now()}
+	if err := store.Set(ctx, session); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	retrieved, err := store.Get(ctx, "factory-test")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if retrieved.ID != "factory-test" {
+		t.Errorf("Expected ID 'factory-test', got %s", retrieved.ID)
+	}
+}
+
+func TestNewSessionStore_UnknownBackend(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+	config.Backend = "unknown"
+
+	_, err := NewSessionStore(context.Background(), config, zerolog.Nop())
+	if err == nil {
+		t.Error("Expected error for unknown backend")
+	}
+}
+
+func TestDefaultSessionStoreConfig(t *testing.T) {
+	config := DefaultSessionStoreConfig()
+
+	if config.Backend != "memory" {
+		t.Errorf("Expected backend 'memory', got %s", config.Backend)
+	}
+	if config.SessionTTL != 30*time.Minute {
+		t.Errorf("Expected TTL 30m, got %v", config.SessionTTL)
+	}
+	if config.MaxSessions != 10000 {
+		t.Errorf("Expected MaxSessions 10000, got %d", config.MaxSessions)
+	}
+	if config.RedisPrefix != "virtengine:nli:session:" {
+		t.Errorf("Expected prefix 'virtengine:nli:session:', got %s", config.RedisPrefix)
+	}
+}


### PR DESCRIPTION
Move NLI session state and rate limits to Redis for distributed scaling.

Acceptance:
- Redis-backed session store with TTL
- Distributed rate limiting (reuse pkg/ratelimit)
- Metrics for session count + rate-limit hits