### PR TITLE
feat: PAY-002: Implement conversion execution & treasury transfer

### DIFF
--- a/pkg/payment/conversion.go
+++ b/pkg/payment/conversion.go
@@ -1,0 +1,740 @@
+// Package payment provides payment gateway integration for Visa/Mastercard.
+//
+// PAY-002: Conversion execution and treasury transfer implementation
+package payment
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// ============================================================================
+// Conversion Executor Errors
+// ============================================================================
+
+var (
+	// ErrConversionNotFound indicates ledger entry not found
+	ErrConversionNotFound = errors.New("conversion ledger entry not found")
+
+	// ErrConversionAlreadyCompleted indicates conversion already finished
+	ErrConversionAlreadyCompleted = errors.New("conversion already completed")
+
+	// ErrConversionNotRetryable indicates conversion cannot be retried
+	ErrConversionNotRetryable = errors.New("conversion is not retryable")
+
+	// ErrConversionInProgress indicates conversion is already executing
+	ErrConversionInProgress = errors.New("conversion is already in progress")
+
+	// ErrTreasuryTransferFailed indicates treasury transfer failed
+	ErrTreasuryTransferFailed = errors.New("treasury transfer failed")
+
+	// ErrInvalidReconciliation indicates invalid reconciliation attempt
+	ErrInvalidReconciliation = errors.New("invalid reconciliation")
+)
+
+// ============================================================================
+// Conversion Executor Configuration
+// ============================================================================
+
+// ConversionExecutorConfig configures the conversion executor
+type ConversionExecutorConfig struct {
+	// MaxRetries is the maximum number of retry attempts
+	MaxRetries int `json:"max_retries"`
+
+	// BaseRetryDelay is the base delay for exponential backoff
+	BaseRetryDelay time.Duration `json:"base_retry_delay"`
+
+	// TreasuryAddress is the treasury source address
+	TreasuryAddress string `json:"treasury_address"`
+
+	// DefaultDenom is the default crypto denomination
+	DefaultDenom string `json:"default_denom"`
+
+	// RequirePaymentVerification requires payment intent to be verified
+	RequirePaymentVerification bool `json:"require_payment_verification"`
+}
+
+// DefaultConversionExecutorConfig returns default configuration
+func DefaultConversionExecutorConfig() ConversionExecutorConfig {
+	return ConversionExecutorConfig{
+		MaxRetries:                 3,
+		BaseRetryDelay:             5 * time.Second,
+		TreasuryAddress:            "",
+		DefaultDenom:               "uve",
+		RequirePaymentVerification: true,
+	}
+}
+
+// ============================================================================
+// Conversion Executor Implementation
+// ============================================================================
+
+// conversionExecutor implements ConversionExecutor
+type conversionExecutor struct {
+	config   ConversionExecutorConfig
+	store    ConversionLedgerStore
+	treasury TreasuryTransfer
+	payment  Service
+
+	// Mutex for concurrent access control
+	executionMu sync.Mutex
+	// Track in-flight executions by idempotency key
+	inFlight map[string]struct{}
+}
+
+// NewConversionExecutor creates a new conversion executor
+func NewConversionExecutor(
+	config ConversionExecutorConfig,
+	store ConversionLedgerStore,
+	treasury TreasuryTransfer,
+	payment Service,
+) ConversionExecutor {
+	return &conversionExecutor{
+		config:   config,
+		store:    store,
+		treasury: treasury,
+		payment:  payment,
+		inFlight: make(map[string]struct{}),
+	}
+}
+
+// ExecuteConversion executes a conversion with idempotency guarantees
+func (e *conversionExecutor) ExecuteConversion(ctx context.Context, req ConversionExecutionRequest) (*ConversionExecutionResult, error) {
+	// Validate request
+	if err := e.validateRequest(ctx, req); err != nil {
+		return &ConversionExecutionResult{
+			Success:   false,
+			ErrorCode: ConversionErrorInvalidAddress,
+			Error:     err,
+		}, err
+	}
+
+	// Check for existing execution by idempotency key
+	existing, err := e.store.GetByIdempotencyKey(ctx, req.IdempotencyKey)
+	if err == nil && existing != nil {
+		// Idempotent check: return existing result if completed
+		if existing.Status == ConversionStatusCompleted {
+			return &ConversionExecutionResult{
+				LedgerEntry:      existing,
+				Success:          true,
+				TxHash:           existing.TxHash,
+				AlreadyCompleted: true,
+			}, nil
+		}
+
+		// If failed but not retryable, return the failure
+		if existing.Status.IsFinal() {
+			return &ConversionExecutionResult{
+				LedgerEntry: existing,
+				Success:     false,
+				ErrorCode:   existing.ErrorCode,
+				Error:       fmt.Errorf("%s: %s", existing.ErrorCode, existing.ErrorMessage),
+			}, nil
+		}
+
+		// If in progress, return error
+		if existing.Status == ConversionStatusExecuting {
+			return &ConversionExecutionResult{
+				LedgerEntry: existing,
+				Success:     false,
+				ErrorCode:   ConversionErrorDuplicate,
+				Error:       ErrConversionInProgress,
+			}, ErrConversionInProgress
+		}
+
+		// Otherwise, this is a retry of a pending entry
+		return e.executeEntry(ctx, existing)
+	}
+
+	// Create new ledger entry
+	entryID := e.generateEntryID(req)
+	entry := NewConversionLedgerEntry(
+		entryID,
+		req.IdempotencyKey,
+		req.Quote,
+		req.PaymentIntentID,
+		e.config.MaxRetries,
+	)
+
+	if req.Metadata != nil {
+		entry.Metadata = req.Metadata
+	}
+
+	// Save initial entry
+	if err := e.store.Save(ctx, entry); err != nil {
+		return &ConversionExecutionResult{
+			Success:   false,
+			ErrorCode: ConversionErrorInternal,
+			Error:     fmt.Errorf("failed to save ledger entry: %w", err),
+		}, err
+	}
+
+	return e.executeEntry(ctx, entry)
+}
+
+// executeEntry performs the actual conversion execution
+func (e *conversionExecutor) executeEntry(ctx context.Context, entry *ConversionLedgerEntry) (*ConversionExecutionResult, error) {
+	// Acquire execution lock for this idempotency key
+	if !e.acquireExecution(entry.IdempotencyKey) {
+		return &ConversionExecutionResult{
+			LedgerEntry: entry,
+			Success:     false,
+			ErrorCode:   ConversionErrorDuplicate,
+			Error:       ErrConversionInProgress,
+		}, ErrConversionInProgress
+	}
+	defer e.releaseExecution(entry.IdempotencyKey)
+
+	// Check if entry is ready for execution
+	if !entry.IsReadyForExecution() {
+		if entry.Status.IsFinal() {
+			return &ConversionExecutionResult{
+				LedgerEntry:      entry,
+				Success:          entry.Status == ConversionStatusCompleted,
+				TxHash:           entry.TxHash,
+				ErrorCode:        entry.ErrorCode,
+				AlreadyCompleted: entry.Status == ConversionStatusCompleted,
+			}, nil
+		}
+		return &ConversionExecutionResult{
+			LedgerEntry: entry,
+			Success:     false,
+			ErrorCode:   ConversionErrorDuplicate,
+			Error:       errors.New("entry not ready for execution"),
+		}, nil
+	}
+
+	// Mark as executing
+	if err := entry.MarkExecuting(); err != nil {
+		return &ConversionExecutionResult{
+			LedgerEntry: entry,
+			Success:     false,
+			ErrorCode:   ConversionErrorInternal,
+			Error:       err,
+		}, err
+	}
+	if err := e.store.Save(ctx, entry); err != nil {
+		return &ConversionExecutionResult{
+			Success:   false,
+			ErrorCode: ConversionErrorInternal,
+			Error:     fmt.Errorf("failed to update entry status: %w", err),
+		}, err
+	}
+
+	// Verify payment if required
+	if e.config.RequirePaymentVerification && e.payment != nil {
+		intent, err := e.payment.GetPaymentIntent(ctx, entry.PaymentIntentID)
+		if err != nil {
+			return e.handleExecutionError(ctx, entry, ConversionErrorPaymentNotSucceeded,
+				fmt.Sprintf("failed to verify payment: %v", err))
+		}
+		if !intent.Status.IsSuccessful() {
+			return e.handleExecutionError(ctx, entry, ConversionErrorPaymentNotSucceeded,
+				fmt.Sprintf("payment status is %s, not succeeded", intent.Status))
+		}
+	}
+
+	// Validate treasury has sufficient funds
+	balance, err := e.treasury.GetTreasuryBalance(ctx, entry.CryptoDenom)
+	if err != nil {
+		return e.handleExecutionError(ctx, entry, ConversionErrorInsufficientTreasury,
+			fmt.Sprintf("failed to check treasury balance: %v", err))
+	}
+	if balance.Available < entry.CryptoAmount.Int64() {
+		return e.handleExecutionError(ctx, entry, ConversionErrorInsufficientTreasury,
+			fmt.Sprintf("treasury has %d available, need %d", balance.Available, entry.CryptoAmount.Int64()))
+	}
+
+	// Execute treasury transfer
+	transferReq := TreasuryTransferRequest{
+		DestinationAddress: entry.DestinationAddress,
+		Amount:             entry.CryptoAmount.Int64(),
+		Denom:              entry.CryptoDenom,
+		Memo:               fmt.Sprintf("conversion:%s", entry.ID),
+		IdempotencyKey:     entry.IdempotencyKey,
+	}
+
+	result, err := e.treasury.SendFromTreasury(ctx, transferReq)
+	if err != nil || result == nil || !result.Success {
+		errMsg := "transfer failed"
+		if err != nil {
+			errMsg = err.Error()
+		} else if result != nil && result.Error != nil {
+			errMsg = result.Error.Error()
+		}
+		return e.handleExecutionError(ctx, entry, ConversionErrorTransferFailed, errMsg)
+	}
+
+	// Mark as completed
+	entry.MarkCompleted(result.TxHash, result.BlockHeight, result.TreasuryAddress)
+	if err := e.store.Save(ctx, entry); err != nil {
+		// Transfer succeeded but save failed - mark for reconciliation
+		entry.MarkReconciling(ConversionErrorInternal, fmt.Sprintf("transfer succeeded but save failed: %v", err))
+		_ = e.store.Save(ctx, entry)
+		return &ConversionExecutionResult{
+			LedgerEntry: entry,
+			Success:     true,
+			TxHash:      result.TxHash,
+		}, nil
+	}
+
+	return &ConversionExecutionResult{
+		LedgerEntry: entry,
+		Success:     true,
+		TxHash:      result.TxHash,
+	}, nil
+}
+
+// handleExecutionError processes an execution error with retry logic
+func (e *conversionExecutor) handleExecutionError(
+	ctx context.Context,
+	entry *ConversionLedgerEntry,
+	errCode ConversionErrorCode,
+	errMsg string,
+) (*ConversionExecutionResult, error) {
+	// If error is retryable, schedule retry
+	if errCode.IsRetryable() {
+		retried := entry.MarkForRetry(errCode, errMsg, e.config.BaseRetryDelay)
+		if retried {
+			if err := e.store.Save(ctx, entry); err != nil {
+				// Log but don't fail - entry state is still valid
+			}
+			return &ConversionExecutionResult{
+				LedgerEntry: entry,
+				Success:     false,
+				ErrorCode:   errCode,
+				Error:       errors.New(errMsg),
+			}, errors.New(errMsg)
+		}
+		// Max retries exhausted - entry already marked as failed
+	} else {
+		// Non-retryable error - mark as failed immediately
+		entry.MarkFailed(errCode, errMsg)
+	}
+
+	if err := e.store.Save(ctx, entry); err != nil {
+		// Log but continue - the error state is what matters
+	}
+
+	return &ConversionExecutionResult{
+		LedgerEntry: entry,
+		Success:     false,
+		ErrorCode:   errCode,
+		Error:       errors.New(errMsg),
+	}, errors.New(errMsg)
+}
+
+// GetLedgerEntry retrieves a ledger entry by ID
+func (e *conversionExecutor) GetLedgerEntry(ctx context.Context, id string) (*ConversionLedgerEntry, error) {
+	entry, err := e.store.GetByID(ctx, id)
+	if err != nil {
+		return nil, ErrConversionNotFound
+	}
+	return entry, nil
+}
+
+// GetLedgerEntryByIdempotencyKey retrieves a ledger entry by idempotency key
+func (e *conversionExecutor) GetLedgerEntryByIdempotencyKey(ctx context.Context, key string) (*ConversionLedgerEntry, error) {
+	entry, err := e.store.GetByIdempotencyKey(ctx, key)
+	if err != nil {
+		return nil, ErrConversionNotFound
+	}
+	return entry, nil
+}
+
+// RetryFailedConversion retries a failed conversion
+func (e *conversionExecutor) RetryFailedConversion(ctx context.Context, id string) (*ConversionExecutionResult, error) {
+	entry, err := e.store.GetByID(ctx, id)
+	if err != nil {
+		return nil, ErrConversionNotFound
+	}
+
+	if entry.Status == ConversionStatusCompleted {
+		return &ConversionExecutionResult{
+			LedgerEntry:      entry,
+			Success:          true,
+			TxHash:           entry.TxHash,
+			AlreadyCompleted: true,
+		}, nil
+	}
+
+	if !entry.Status.IsRetryable() {
+		return nil, ErrConversionNotRetryable
+	}
+
+	// Reset entry for retry
+	entry.Status = ConversionStatusPending
+	entry.NextRetryAt = nil
+	entry.UpdatedAt = time.Now()
+
+	if err := e.store.Save(ctx, entry); err != nil {
+		return nil, fmt.Errorf("failed to reset entry for retry: %w", err)
+	}
+
+	return e.executeEntry(ctx, entry)
+}
+
+// ReconcileConversion manually reconciles a stuck conversion
+func (e *conversionExecutor) ReconcileConversion(ctx context.Context, id string, txHash string, blockHeight int64) error {
+	entry, err := e.store.GetByID(ctx, id)
+	if err != nil {
+		return ErrConversionNotFound
+	}
+
+	if entry.Status == ConversionStatusCompleted {
+		return ErrConversionAlreadyCompleted
+	}
+
+	if entry.Status != ConversionStatusReconciling && entry.Status != ConversionStatusExecuting {
+		return ErrInvalidReconciliation
+	}
+
+	if txHash == "" || blockHeight <= 0 {
+		return fmt.Errorf("txHash and blockHeight are required for reconciliation")
+	}
+
+	entry.MarkCompleted(txHash, blockHeight, e.config.TreasuryAddress)
+
+	if err := e.store.Save(ctx, entry); err != nil {
+		return fmt.Errorf("failed to save reconciled entry: %w", err)
+	}
+
+	return nil
+}
+
+// RefundConversion refunds a failed conversion
+func (e *conversionExecutor) RefundConversion(ctx context.Context, id string, reason string) error {
+	entry, err := e.store.GetByID(ctx, id)
+	if err != nil {
+		return ErrConversionNotFound
+	}
+
+	if entry.Status == ConversionStatusCompleted {
+		return errors.New("cannot refund completed conversion")
+	}
+
+	if entry.Status == ConversionStatusRefunded {
+		return nil // Already refunded
+	}
+
+	// Mark as refunded
+	entry.MarkRefunded()
+	entry.Metadata["refund_reason"] = reason
+
+	if err := e.store.Save(ctx, entry); err != nil {
+		return fmt.Errorf("failed to save refunded entry: %w", err)
+	}
+
+	// Note: Actual payment refund would be triggered here via payment service
+	// This is out of scope for this implementation
+
+	return nil
+}
+
+// ListPendingConversions lists conversions ready for execution
+func (e *conversionExecutor) ListPendingConversions(ctx context.Context) ([]*ConversionLedgerEntry, error) {
+	return e.store.ListPendingReadyForExecution(ctx)
+}
+
+// ListConversionsForReconciliation lists conversions needing manual reconciliation
+func (e *conversionExecutor) ListConversionsForReconciliation(ctx context.Context) ([]*ConversionLedgerEntry, error) {
+	return e.store.ListByStatus(ctx, ConversionStatusReconciling)
+}
+
+// validateRequest validates a conversion execution request
+func (e *conversionExecutor) validateRequest(ctx context.Context, req ConversionExecutionRequest) error {
+	if req.IdempotencyKey == "" {
+		return errors.New("idempotency key is required")
+	}
+	if req.Quote.ID == "" {
+		return errors.New("quote ID is required")
+	}
+	if req.PaymentIntentID == "" {
+		return errors.New("payment intent ID is required")
+	}
+	if req.Quote.IsExpired() {
+		return ErrQuoteExpired
+	}
+	if req.Quote.DestinationAddress == "" {
+		return errors.New("destination address is required")
+	}
+
+	// Validate destination address format
+	if !strings.HasPrefix(req.Quote.DestinationAddress, "virtengine1") {
+		return fmt.Errorf("invalid destination address format: must start with virtengine1")
+	}
+
+	// Validate with treasury
+	if e.treasury != nil {
+		if err := e.treasury.ValidateAddress(ctx, req.Quote.DestinationAddress); err != nil {
+			return fmt.Errorf("invalid destination address: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// generateEntryID generates a unique entry ID
+func (e *conversionExecutor) generateEntryID(req ConversionExecutionRequest) string {
+	hash := sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%d", req.IdempotencyKey, req.Quote.ID, time.Now().UnixNano())))
+	return fmt.Sprintf("conv_%s", hex.EncodeToString(hash[:])[:16])
+}
+
+// acquireExecution attempts to acquire an execution lock for the idempotency key
+func (e *conversionExecutor) acquireExecution(key string) bool {
+	e.executionMu.Lock()
+	defer e.executionMu.Unlock()
+
+	if _, exists := e.inFlight[key]; exists {
+		return false
+	}
+	e.inFlight[key] = struct{}{}
+	return true
+}
+
+// releaseExecution releases the execution lock
+func (e *conversionExecutor) releaseExecution(key string) {
+	e.executionMu.Lock()
+	defer e.executionMu.Unlock()
+	delete(e.inFlight, key)
+}
+
+// ============================================================================
+// In-Memory Ledger Store (for testing/development)
+// ============================================================================
+
+// inMemoryLedgerStore is an in-memory implementation of ConversionLedgerStore
+type inMemoryLedgerStore struct {
+	mu              sync.RWMutex
+	entries         map[string]*ConversionLedgerEntry
+	byIdempotency   map[string]string // idempotency key -> entry ID
+}
+
+// NewInMemoryLedgerStore creates a new in-memory ledger store
+func NewInMemoryLedgerStore() ConversionLedgerStore {
+	return &inMemoryLedgerStore{
+		entries:       make(map[string]*ConversionLedgerEntry),
+		byIdempotency: make(map[string]string),
+	}
+}
+
+func (s *inMemoryLedgerStore) Save(ctx context.Context, entry *ConversionLedgerEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Create a copy to avoid mutation issues
+	entryCopy := *entry
+	s.entries[entry.ID] = &entryCopy
+	s.byIdempotency[entry.IdempotencyKey] = entry.ID
+	return nil
+}
+
+func (s *inMemoryLedgerStore) GetByID(ctx context.Context, id string) (*ConversionLedgerEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entry, ok := s.entries[id]
+	if !ok {
+		return nil, ErrConversionNotFound
+	}
+	// Return a copy
+	entryCopy := *entry
+	return &entryCopy, nil
+}
+
+func (s *inMemoryLedgerStore) GetByIdempotencyKey(ctx context.Context, key string) (*ConversionLedgerEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	id, ok := s.byIdempotency[key]
+	if !ok {
+		return nil, ErrConversionNotFound
+	}
+	entry := s.entries[id]
+	if entry == nil {
+		return nil, ErrConversionNotFound
+	}
+	// Return a copy
+	entryCopy := *entry
+	return &entryCopy, nil
+}
+
+func (s *inMemoryLedgerStore) ListByStatus(ctx context.Context, status ConversionStatus) ([]*ConversionLedgerEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []*ConversionLedgerEntry
+	for _, entry := range s.entries {
+		if entry.Status == status {
+			entryCopy := *entry
+			result = append(result, &entryCopy)
+		}
+	}
+	return result, nil
+}
+
+func (s *inMemoryLedgerStore) ListPendingReadyForExecution(ctx context.Context) ([]*ConversionLedgerEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	now := time.Now()
+	var result []*ConversionLedgerEntry
+	for _, entry := range s.entries {
+		if entry.Status == ConversionStatusPending {
+			// Entry is ready if NextRetryAt is nil or the retry time has passed (or equals now)
+			if entry.NextRetryAt == nil || !now.Before(*entry.NextRetryAt) {
+				entryCopy := *entry
+				result = append(result, &entryCopy)
+			}
+		}
+	}
+	return result, nil
+}
+
+// ============================================================================
+// Mock Treasury Transfer (for testing/development)
+// ============================================================================
+
+// mockTreasuryTransfer is a mock implementation of TreasuryTransfer
+type mockTreasuryTransfer struct {
+	mu       sync.Mutex
+	address  string
+	balances map[string]int64
+	txSeq    int64
+
+	// For testing: simulate failures
+	SimulateFailure    bool
+	FailureError       error
+	SimulateNoBalance  bool
+}
+
+// NewMockTreasuryTransfer creates a new mock treasury transfer
+func NewMockTreasuryTransfer(address string, initialBalances map[string]int64) *mockTreasuryTransfer {
+	balances := make(map[string]int64)
+	for k, v := range initialBalances {
+		balances[k] = v
+	}
+	return &mockTreasuryTransfer{
+		address:  address,
+		balances: balances,
+	}
+}
+
+func (m *mockTreasuryTransfer) SendFromTreasury(ctx context.Context, req TreasuryTransferRequest) (*TreasuryTransferResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.SimulateFailure {
+		err := m.FailureError
+		if err == nil {
+			err = errors.New("simulated treasury failure")
+		}
+		return &TreasuryTransferResult{
+			Success: false,
+			Error:   err,
+		}, err
+	}
+
+	balance := m.balances[req.Denom]
+	if balance < req.Amount || m.SimulateNoBalance {
+		return &TreasuryTransferResult{
+			Success: false,
+			Error:   fmt.Errorf("insufficient treasury balance: have %d, need %d", balance, req.Amount),
+		}, fmt.Errorf("insufficient treasury balance")
+	}
+
+	// Deduct balance
+	m.balances[req.Denom] -= req.Amount
+	m.txSeq++
+
+	return &TreasuryTransferResult{
+		TxHash:          fmt.Sprintf("0x%064x", m.txSeq),
+		BlockHeight:     1000 + m.txSeq,
+		TreasuryAddress: m.address,
+		Success:         true,
+	}, nil
+}
+
+func (m *mockTreasuryTransfer) GetTreasuryBalance(ctx context.Context, denom string) (TreasuryBalance, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.SimulateNoBalance {
+		return TreasuryBalance{
+			Denom:     denom,
+			Available: 0,
+			Reserved:  0,
+			Total:     0,
+		}, nil
+	}
+
+	balance := m.balances[denom]
+	return TreasuryBalance{
+		Denom:     denom,
+		Available: balance,
+		Reserved:  0,
+		Total:     balance,
+	}, nil
+}
+
+func (m *mockTreasuryTransfer) ValidateAddress(ctx context.Context, address string) error {
+	if !strings.HasPrefix(address, "virtengine1") {
+		return fmt.Errorf("invalid address format")
+	}
+	if len(address) < 20 {
+		return fmt.Errorf("address too short")
+	}
+	return nil
+}
+
+// SetBalance sets a balance for testing
+func (m *mockTreasuryTransfer) SetBalance(denom string, amount int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.balances[denom] = amount
+}
+
+// GetBalance gets a balance for testing
+func (m *mockTreasuryTransfer) GetBalance(denom string) int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.balances[denom]
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+// CreateTestQuote creates a test conversion quote
+func CreateTestQuote(fiatValue int64, cryptoAmount int64, destAddr string) ConversionQuote {
+	return ConversionQuote{
+		ID: fmt.Sprintf("quote_%d", time.Now().UnixNano()),
+		FiatAmount: Amount{
+			Value:    fiatValue,
+			Currency: CurrencyUSD,
+		},
+		CryptoAmount:       sdkmath.NewInt(cryptoAmount),
+		CryptoDenom:        "uve",
+		DestinationAddress: destAddr,
+		Rate: ConversionRate{
+			FromCurrency: CurrencyUSD,
+			ToCrypto:     "uve",
+			Rate:         sdkmath.LegacyNewDec(1),
+			Timestamp:    time.Now(),
+			Source:       "test",
+		},
+		Fee: Amount{
+			Value:    fiatValue / 100, // 1% fee
+			Currency: CurrencyUSD,
+		},
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+	}
+}

--- a/pkg/payment/conversion_test.go
+++ b/pkg/payment/conversion_test.go
@@ -1,0 +1,779 @@
+// Package payment provides payment gateway integration for Visa/Mastercard.
+//
+// PAY-002: Tests for conversion execution and treasury transfer
+package payment
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// ============================================================================
+// Conversion Executor Tests
+// ============================================================================
+
+func TestConversionExecutor_ExecuteConversion_Success(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000000})
+	config := DefaultConversionExecutorConfig()
+	config.RequirePaymentVerification = false // Disable for this test
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	quote := CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789")
+	req := ConversionExecutionRequest{
+		Quote:           quote,
+		PaymentIntentID: "pi_test123",
+		IdempotencyKey:  "test-key-001",
+	}
+
+	result, err := executor.ExecuteConversion(ctx, req)
+	if err != nil {
+		t.Fatalf("ExecuteConversion failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Fatalf("Expected success, got failure: %v", result.ErrorCode)
+	}
+
+	if result.TxHash == "" {
+		t.Error("Expected TxHash to be set")
+	}
+
+	if result.LedgerEntry == nil {
+		t.Fatal("Expected LedgerEntry to be set")
+	}
+
+	if result.LedgerEntry.Status != ConversionStatusCompleted {
+		t.Errorf("Expected status Completed, got %s", result.LedgerEntry.Status)
+	}
+}
+
+func TestConversionExecutor_Idempotency(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000000})
+	config := DefaultConversionExecutorConfig()
+	config.RequirePaymentVerification = false
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	quote := CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789")
+	req := ConversionExecutionRequest{
+		Quote:           quote,
+		PaymentIntentID: "pi_test123",
+		IdempotencyKey:  "idempotent-key-001",
+	}
+
+	// First execution
+	result1, err := executor.ExecuteConversion(ctx, req)
+	if err != nil {
+		t.Fatalf("First execution failed: %v", err)
+	}
+	if !result1.Success {
+		t.Fatalf("First execution should succeed")
+	}
+
+	// Second execution with same idempotency key
+	result2, err := executor.ExecuteConversion(ctx, req)
+	if err != nil {
+		t.Fatalf("Second execution failed: %v", err)
+	}
+	if !result2.Success {
+		t.Fatalf("Second execution should succeed (idempotent)")
+	}
+	if !result2.AlreadyCompleted {
+		t.Error("Second execution should be marked as AlreadyCompleted")
+	}
+	if result1.TxHash != result2.TxHash {
+		t.Error("TxHash should be the same for idempotent requests")
+	}
+	if result1.LedgerEntry.ID != result2.LedgerEntry.ID {
+		t.Error("Ledger entry ID should be the same for idempotent requests")
+	}
+}
+
+func TestConversionExecutor_InsufficientTreasury(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 100}) // Low balance
+	config := DefaultConversionExecutorConfig()
+	config.RequirePaymentVerification = false
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	quote := CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789")
+	req := ConversionExecutionRequest{
+		Quote:           quote,
+		PaymentIntentID: "pi_test123",
+		IdempotencyKey:  "insufficient-key-001",
+	}
+
+	result, _ := executor.ExecuteConversion(ctx, req)
+
+	if result.Success {
+		t.Fatal("Expected failure due to insufficient treasury")
+	}
+
+	if result.ErrorCode != ConversionErrorInsufficientTreasury {
+		t.Errorf("Expected error code InsufficientTreasury, got %s", result.ErrorCode)
+	}
+
+	// Should be marked for retry since insufficient treasury is retryable
+	entry, _ := store.GetByID(ctx, result.LedgerEntry.ID)
+	if entry.RetryCount == 0 {
+		t.Error("Expected retry count to be incremented")
+	}
+}
+
+func TestConversionExecutor_ExpiredQuote(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000000})
+	config := DefaultConversionExecutorConfig()
+	config.RequirePaymentVerification = false
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	quote := CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789")
+	quote.ExpiresAt = time.Now().Add(-1 * time.Hour) // Already expired
+
+	req := ConversionExecutionRequest{
+		Quote:           quote,
+		PaymentIntentID: "pi_test123",
+		IdempotencyKey:  "expired-key-001",
+	}
+
+	result, err := executor.ExecuteConversion(ctx, req)
+
+	if result.Success {
+		t.Fatal("Expected failure due to expired quote")
+	}
+
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func TestConversionExecutor_InvalidAddress(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000000})
+	config := DefaultConversionExecutorConfig()
+	config.RequirePaymentVerification = false
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	quote := CreateTestQuote(10000, 10000000, "cosmos1invalid") // Wrong prefix
+
+	req := ConversionExecutionRequest{
+		Quote:           quote,
+		PaymentIntentID: "pi_test123",
+		IdempotencyKey:  "invalid-addr-001",
+	}
+
+	result, err := executor.ExecuteConversion(ctx, req)
+
+	if result.Success {
+		t.Fatal("Expected failure due to invalid address")
+	}
+
+	if err == nil {
+		t.Error("Expected error to be returned")
+	}
+}
+
+func TestConversionExecutor_TransferFailure(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000000})
+	treasury.SimulateFailure = true
+	config := DefaultConversionExecutorConfig()
+	config.RequirePaymentVerification = false
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	quote := CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789")
+	req := ConversionExecutionRequest{
+		Quote:           quote,
+		PaymentIntentID: "pi_test123",
+		IdempotencyKey:  "transfer-fail-001",
+	}
+
+	result, _ := executor.ExecuteConversion(ctx, req)
+
+	if result.Success {
+		t.Fatal("Expected failure due to transfer failure")
+	}
+
+	if result.ErrorCode != ConversionErrorTransferFailed {
+		t.Errorf("Expected error code TransferFailed, got %s", result.ErrorCode)
+	}
+
+	// Transfer failures are retryable
+	entry, _ := store.GetByID(ctx, result.LedgerEntry.ID)
+	if entry.RetryCount == 0 {
+		t.Error("Expected retry count to be incremented")
+	}
+}
+
+func TestConversionExecutor_RetryFailedConversion(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000000})
+	treasury.SimulateFailure = true
+	config := DefaultConversionExecutorConfig()
+	config.RequirePaymentVerification = false
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	quote := CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789")
+	req := ConversionExecutionRequest{
+		Quote:           quote,
+		PaymentIntentID: "pi_test123",
+		IdempotencyKey:  "retry-test-001",
+	}
+
+	// First attempt fails
+	result1, _ := executor.ExecuteConversion(ctx, req)
+	if result1.Success {
+		t.Fatal("Expected first attempt to fail")
+	}
+
+	// Fix the treasury
+	treasury.SimulateFailure = false
+
+	// Retry
+	result2, err := executor.RetryFailedConversion(ctx, result1.LedgerEntry.ID)
+	if err != nil {
+		t.Fatalf("Retry failed unexpectedly: %v", err)
+	}
+
+	if !result2.Success {
+		t.Errorf("Expected retry to succeed, got error: %v", result2.ErrorCode)
+	}
+}
+
+func TestConversionExecutor_ReconcileConversion(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000000})
+	config := DefaultConversionExecutorConfig()
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	// Manually create an entry in reconciling state
+	entry := NewConversionLedgerEntry(
+		"conv_test_reconcile",
+		"reconcile-key-001",
+		CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789"),
+		"pi_test123",
+		3,
+	)
+	entry.MarkReconciling(ConversionErrorInternal, "test reconciliation")
+	store.Save(ctx, entry)
+
+	// Reconcile
+	err := executor.ReconcileConversion(ctx, entry.ID, "0x123abc", 12345)
+	if err != nil {
+		t.Fatalf("Reconciliation failed: %v", err)
+	}
+
+	// Verify entry is now completed
+	updated, _ := executor.GetLedgerEntry(ctx, entry.ID)
+	if updated.Status != ConversionStatusCompleted {
+		t.Errorf("Expected status Completed, got %s", updated.Status)
+	}
+	if updated.TxHash != "0x123abc" {
+		t.Error("TxHash not set correctly")
+	}
+	if updated.BlockHeight != 12345 {
+		t.Error("BlockHeight not set correctly")
+	}
+}
+
+func TestConversionExecutor_RefundConversion(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000000})
+	treasury.SimulateFailure = true
+	config := DefaultConversionExecutorConfig()
+	config.RequirePaymentVerification = false
+	config.MaxRetries = 0 // No retries for this test
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	quote := CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789")
+	req := ConversionExecutionRequest{
+		Quote:           quote,
+		PaymentIntentID: "pi_test123",
+		IdempotencyKey:  "refund-test-001",
+	}
+
+	// Execute and fail
+	result, _ := executor.ExecuteConversion(ctx, req)
+	if result.Success {
+		t.Fatal("Expected execution to fail")
+	}
+
+	// Refund
+	err := executor.RefundConversion(ctx, result.LedgerEntry.ID, "customer requested refund")
+	if err != nil {
+		t.Fatalf("Refund failed: %v", err)
+	}
+
+	// Verify entry is refunded
+	updated, _ := executor.GetLedgerEntry(ctx, result.LedgerEntry.ID)
+	if updated.Status != ConversionStatusRefunded {
+		t.Errorf("Expected status Refunded, got %s", updated.Status)
+	}
+	if updated.Metadata["refund_reason"] != "customer requested refund" {
+		t.Error("Refund reason not set correctly")
+	}
+}
+
+func TestConversionExecutor_ListPendingConversions(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000000})
+	config := DefaultConversionExecutorConfig()
+	config.RequirePaymentVerification = false
+	config.MaxRetries = 5 // High retry count so entries stay pending after first failure
+	config.BaseRetryDelay = 0 // No delay for test
+
+	// Simulate failure initially
+	treasury.SimulateFailure = true
+
+	executor := NewConversionExecutor(config, store, treasury, nil)
+
+	// Create multiple failed conversions that should be pending (scheduled for retry)
+	for i := 0; i < 3; i++ {
+		quote := CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789")
+		req := ConversionExecutionRequest{
+			Quote:           quote,
+			PaymentIntentID: fmt.Sprintf("pi_test%d", i),
+			IdempotencyKey:  fmt.Sprintf("pending-test-%d", i),
+		}
+		executor.ExecuteConversion(ctx, req)
+	}
+
+	// List pending - entries should be pending with retry scheduled
+	pending, err := executor.ListPendingConversions(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingConversions failed: %v", err)
+	}
+
+	if len(pending) != 3 {
+		t.Errorf("Expected 3 pending conversions, got %d", len(pending))
+	}
+
+	// Verify they are all in pending status
+	for _, entry := range pending {
+		if entry.Status != ConversionStatusPending {
+			t.Errorf("Expected status Pending, got %s", entry.Status)
+		}
+		if entry.RetryCount == 0 {
+			t.Error("Expected retry count to be > 0")
+		}
+	}
+}
+
+// ============================================================================
+// Ledger Entry Tests
+// ============================================================================
+
+func TestConversionLedgerEntry_StatusTransitions(t *testing.T) {
+	entry := NewConversionLedgerEntry(
+		"test-id",
+		"test-key",
+		CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789"),
+		"pi_test",
+		3,
+	)
+
+	// Initial state
+	if entry.Status != ConversionStatusPending {
+		t.Errorf("Expected initial status Pending, got %s", entry.Status)
+	}
+
+	// Pending -> Executing
+	if err := entry.MarkExecuting(); err != nil {
+		t.Errorf("MarkExecuting failed: %v", err)
+	}
+	if entry.Status != ConversionStatusExecuting {
+		t.Errorf("Expected status Executing, got %s", entry.Status)
+	}
+
+	// Executing -> Completed
+	entry.MarkCompleted("0xabc", 1234, "virtengine1treasury")
+	if entry.Status != ConversionStatusCompleted {
+		t.Errorf("Expected status Completed, got %s", entry.Status)
+	}
+	if entry.TxHash != "0xabc" {
+		t.Error("TxHash not set")
+	}
+	if entry.BlockHeight != 1234 {
+		t.Error("BlockHeight not set")
+	}
+	if entry.CompletedAt == nil {
+		t.Error("CompletedAt should be set")
+	}
+}
+
+func TestConversionLedgerEntry_RetryWithBackoff(t *testing.T) {
+	entry := NewConversionLedgerEntry(
+		"test-id",
+		"test-key",
+		CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789"),
+		"pi_test",
+		3,
+	)
+
+	baseDelay := 1 * time.Second
+
+	// First retry
+	retried := entry.MarkForRetry(ConversionErrorTransferFailed, "transfer failed", baseDelay)
+	if !retried {
+		t.Error("First retry should succeed")
+	}
+	if entry.RetryCount != 1 {
+		t.Errorf("Expected retry count 1, got %d", entry.RetryCount)
+	}
+	if entry.NextRetryAt == nil {
+		t.Error("NextRetryAt should be set")
+	}
+
+	// Second retry
+	retried = entry.MarkForRetry(ConversionErrorTransferFailed, "transfer failed", baseDelay)
+	if !retried {
+		t.Error("Second retry should succeed")
+	}
+	if entry.RetryCount != 2 {
+		t.Errorf("Expected retry count 2, got %d", entry.RetryCount)
+	}
+
+	// Third retry
+	retried = entry.MarkForRetry(ConversionErrorTransferFailed, "transfer failed", baseDelay)
+	if !retried {
+		t.Error("Third retry should succeed")
+	}
+	if entry.RetryCount != 3 {
+		t.Errorf("Expected retry count 3, got %d", entry.RetryCount)
+	}
+
+	// Fourth retry should fail (max retries = 3)
+	retried = entry.MarkForRetry(ConversionErrorTransferFailed, "transfer failed", baseDelay)
+	if retried {
+		t.Error("Fourth retry should not succeed (max retries)")
+	}
+	if entry.Status != ConversionStatusFailed {
+		t.Errorf("Expected status Failed, got %s", entry.Status)
+	}
+}
+
+func TestConversionLedgerEntry_CanRetry(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     ConversionStatus
+		errorCode  ConversionErrorCode
+		retryCount int
+		maxRetries int
+		expected   bool
+	}{
+		{
+			name:       "Pending with retryable error",
+			status:     ConversionStatusPending,
+			errorCode:  ConversionErrorTransferFailed,
+			retryCount: 0,
+			maxRetries: 3,
+			expected:   true,
+		},
+		{
+			name:       "Completed cannot retry",
+			status:     ConversionStatusCompleted,
+			errorCode:  ConversionErrorNone,
+			retryCount: 0,
+			maxRetries: 3,
+			expected:   false,
+		},
+		{
+			name:       "Max retries exceeded",
+			status:     ConversionStatusPending,
+			errorCode:  ConversionErrorTransferFailed,
+			retryCount: 3,
+			maxRetries: 3,
+			expected:   false,
+		},
+		{
+			name:       "Non-retryable error",
+			status:     ConversionStatusPending,
+			errorCode:  ConversionErrorQuoteExpired,
+			retryCount: 0,
+			maxRetries: 3,
+			expected:   false,
+		},
+		{
+			name:       "Failed with retryable error",
+			status:     ConversionStatusFailed,
+			errorCode:  ConversionErrorInsufficientTreasury,
+			retryCount: 1,
+			maxRetries: 3,
+			expected:   true,
+		},
+		{
+			name:       "Reconciling can retry",
+			status:     ConversionStatusReconciling,
+			errorCode:  ConversionErrorInternal,
+			retryCount: 0,
+			maxRetries: 3,
+			expected:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := &ConversionLedgerEntry{
+				Status:     tc.status,
+				ErrorCode:  tc.errorCode,
+				RetryCount: tc.retryCount,
+				MaxRetries: tc.maxRetries,
+			}
+			result := entry.CanRetry()
+			if result != tc.expected {
+				t.Errorf("CanRetry() = %v, expected %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// In-Memory Store Tests
+// ============================================================================
+
+func TestInMemoryLedgerStore_BasicOperations(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+
+	entry := NewConversionLedgerEntry(
+		"test-id-001",
+		"test-key-001",
+		CreateTestQuote(10000, 10000000, "virtengine1abc123def456ghi789"),
+		"pi_test",
+		3,
+	)
+
+	// Save
+	if err := store.Save(ctx, entry); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Get by ID
+	retrieved, err := store.GetByID(ctx, entry.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if retrieved.ID != entry.ID {
+		t.Error("Retrieved entry ID mismatch")
+	}
+
+	// Get by idempotency key
+	retrieved2, err := store.GetByIdempotencyKey(ctx, entry.IdempotencyKey)
+	if err != nil {
+		t.Fatalf("GetByIdempotencyKey failed: %v", err)
+	}
+	if retrieved2.ID != entry.ID {
+		t.Error("Retrieved entry ID mismatch")
+	}
+
+	// Not found
+	_, err = store.GetByID(ctx, "nonexistent")
+	if err == nil {
+		t.Error("Expected error for nonexistent entry")
+	}
+}
+
+func TestInMemoryLedgerStore_ListByStatus(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryLedgerStore()
+
+	// Create entries with different statuses
+	pending := NewConversionLedgerEntry("id1", "key1", CreateTestQuote(10000, 10000000, "virtengine1abc"), "pi1", 3)
+	pending.Status = ConversionStatusPending
+
+	completed := NewConversionLedgerEntry("id2", "key2", CreateTestQuote(10000, 10000000, "virtengine1def"), "pi2", 3)
+	completed.Status = ConversionStatusCompleted
+
+	failed := NewConversionLedgerEntry("id3", "key3", CreateTestQuote(10000, 10000000, "virtengine1ghi"), "pi3", 3)
+	failed.Status = ConversionStatusFailed
+
+	store.Save(ctx, pending)
+	store.Save(ctx, completed)
+	store.Save(ctx, failed)
+
+	// List pending
+	pendingList, _ := store.ListByStatus(ctx, ConversionStatusPending)
+	if len(pendingList) != 1 {
+		t.Errorf("Expected 1 pending entry, got %d", len(pendingList))
+	}
+
+	// List completed
+	completedList, _ := store.ListByStatus(ctx, ConversionStatusCompleted)
+	if len(completedList) != 1 {
+		t.Errorf("Expected 1 completed entry, got %d", len(completedList))
+	}
+}
+
+// ============================================================================
+// Mock Treasury Tests
+// ============================================================================
+
+func TestMockTreasuryTransfer(t *testing.T) {
+	ctx := context.Background()
+	treasury := NewMockTreasuryTransfer("virtengine1treasury", map[string]int64{"uve": 1000000})
+
+	// Check balance
+	balance, err := treasury.GetTreasuryBalance(ctx, "uve")
+	if err != nil {
+		t.Fatalf("GetTreasuryBalance failed: %v", err)
+	}
+	if balance.Available != 1000000 {
+		t.Errorf("Expected balance 1000000, got %d", balance.Available)
+	}
+
+	// Send transfer
+	req := TreasuryTransferRequest{
+		DestinationAddress: "virtengine1abc123def456ghi789",
+		Amount:             100000,
+		Denom:              "uve",
+		IdempotencyKey:     "test-transfer",
+	}
+	result, err := treasury.SendFromTreasury(ctx, req)
+	if err != nil {
+		t.Fatalf("SendFromTreasury failed: %v", err)
+	}
+	if !result.Success {
+		t.Error("Expected transfer to succeed")
+	}
+	if result.TxHash == "" {
+		t.Error("Expected TxHash to be set")
+	}
+
+	// Check balance after transfer
+	balance, _ = treasury.GetTreasuryBalance(ctx, "uve")
+	if balance.Available != 900000 {
+		t.Errorf("Expected balance 900000 after transfer, got %d", balance.Available)
+	}
+
+	// Validate address
+	if err := treasury.ValidateAddress(ctx, "virtengine1validaddress123456789"); err != nil {
+		t.Errorf("Valid address rejected: %v", err)
+	}
+	if err := treasury.ValidateAddress(ctx, "cosmos1invalid"); err == nil {
+		t.Error("Invalid address should be rejected")
+	}
+}
+
+// ============================================================================
+// Conversion Types Tests
+// ============================================================================
+
+func TestConversionStatus_IsFinal(t *testing.T) {
+	tests := []struct {
+		status   ConversionStatus
+		expected bool
+	}{
+		{ConversionStatusPending, false},
+		{ConversionStatusExecuting, false},
+		{ConversionStatusCompleted, true},
+		{ConversionStatusFailed, true},
+		{ConversionStatusRefunded, true},
+		{ConversionStatusReconciling, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			if tc.status.IsFinal() != tc.expected {
+				t.Errorf("IsFinal() = %v, expected %v", tc.status.IsFinal(), tc.expected)
+			}
+		})
+	}
+}
+
+func TestConversionErrorCode_IsRetryable(t *testing.T) {
+	tests := []struct {
+		code     ConversionErrorCode
+		expected bool
+	}{
+		{ConversionErrorNone, false},
+		{ConversionErrorQuoteExpired, false},
+		{ConversionErrorPaymentNotSucceeded, false},
+		{ConversionErrorInsufficientTreasury, true},
+		{ConversionErrorTransferFailed, true},
+		{ConversionErrorInvalidAddress, false},
+		{ConversionErrorDuplicate, false},
+		{ConversionErrorInternal, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.code), func(t *testing.T) {
+			if tc.code.IsRetryable() != tc.expected {
+				t.Errorf("IsRetryable() = %v, expected %v", tc.code.IsRetryable(), tc.expected)
+			}
+		})
+	}
+}
+
+func TestNewConversionLedgerEntry(t *testing.T) {
+	quote := ConversionQuote{
+		ID: "quote-123",
+		FiatAmount: Amount{
+			Value:    10000,
+			Currency: CurrencyUSD,
+		},
+		CryptoAmount:       sdkmath.NewInt(10000000),
+		CryptoDenom:        "uve",
+		DestinationAddress: "virtengine1abc123def456ghi789",
+		Rate: ConversionRate{
+			FromCurrency: CurrencyUSD,
+			ToCrypto:     "uve",
+			Rate:         sdkmath.LegacyNewDec(1000),
+		},
+		Fee: Amount{
+			Value:    100,
+			Currency: CurrencyUSD,
+		},
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+	}
+
+	entry := NewConversionLedgerEntry("entry-001", "key-001", quote, "pi_123", 5)
+
+	if entry.ID != "entry-001" {
+		t.Error("ID not set correctly")
+	}
+	if entry.IdempotencyKey != "key-001" {
+		t.Error("IdempotencyKey not set correctly")
+	}
+	if entry.QuoteID != "quote-123" {
+		t.Error("QuoteID not set correctly")
+	}
+	if entry.PaymentIntentID != "pi_123" {
+		t.Error("PaymentIntentID not set correctly")
+	}
+	if entry.MaxRetries != 5 {
+		t.Error("MaxRetries not set correctly")
+	}
+	if entry.Status != ConversionStatusPending {
+		t.Error("Initial status should be Pending")
+	}
+	if entry.CryptoAmount.Int64() != 10000000 {
+		t.Error("CryptoAmount not set correctly")
+	}
+	if entry.DestinationAddress != "virtengine1abc123def456ghi789" {
+		t.Error("DestinationAddress not set correctly")
+	}
+}


### PR DESCRIPTION
Execute conversion settlement on-chain and persist conversion ledger entries.

Acceptance:
- On-chain transfer executed for conversion
- Idempotent conversion execution
- Ledger persistence with audit trail
- Clear failure handling + reconciliation flow