### PR TITLE
feat: PAY-003: Dispute lifecycle persistence & gateway actions 

### DIFF
--- a/pkg/payment/dispute_store.go
+++ b/pkg/payment/dispute_store.go
@@ -1,0 +1,505 @@
+// Package payment provides payment gateway integration for Visa/Mastercard.
+//
+// PAY-003: Dispute lifecycle persistence and gateway actions
+package payment
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ============================================================================
+// Dispute Record Types
+// ============================================================================
+
+// DisputeRecord represents a persisted dispute with full metadata
+type DisputeRecord struct {
+	// Dispute contains the core dispute data from the gateway
+	Dispute
+
+	// Gateway-specific ID (may differ from our internal ID)
+	GatewayDisputeID string `json:"gateway_dispute_id"`
+
+	// CustomerID is the customer who made the original payment
+	CustomerID string `json:"customer_id,omitempty"`
+
+	// ChargeID is the underlying charge/transaction ID
+	ChargeID string `json:"charge_id,omitempty"`
+
+	// EvidenceSubmitted indicates if evidence has been submitted
+	EvidenceSubmitted bool `json:"evidence_submitted"`
+
+	// EvidenceSubmittedAt is when evidence was submitted
+	EvidenceSubmittedAt *time.Time `json:"evidence_submitted_at,omitempty"`
+
+	// Accepted indicates if the dispute was accepted (conceded)
+	Accepted bool `json:"accepted"`
+
+	// AcceptedAt is when the dispute was accepted
+	AcceptedAt *time.Time `json:"accepted_at,omitempty"`
+
+	// ClosedAt is when the dispute was closed (won/lost/accepted)
+	ClosedAt *time.Time `json:"closed_at,omitempty"`
+
+	// UpdatedAt is when the record was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// AuditLog contains the audit trail for this dispute
+	AuditLog []DisputeAuditEntry `json:"audit_log"`
+}
+
+// DisputeAuditEntry represents a single audit log entry for dispute actions
+type DisputeAuditEntry struct {
+	// Timestamp of the action
+	Timestamp time.Time `json:"timestamp"`
+
+	// Action performed (e.g., "created", "evidence_submitted", "accepted", "status_updated")
+	Action string `json:"action"`
+
+	// Actor is who performed the action (e.g., "webhook", "user:addr123", "system")
+	Actor string `json:"actor"`
+
+	// PreviousStatus before the action
+	PreviousStatus DisputeStatus `json:"previous_status,omitempty"`
+
+	// NewStatus after the action
+	NewStatus DisputeStatus `json:"new_status,omitempty"`
+
+	// Details contains additional context for the action
+	Details map[string]string `json:"details,omitempty"`
+}
+
+// NewDisputeRecord creates a new dispute record from a gateway dispute
+func NewDisputeRecord(dispute Dispute, gateway GatewayType, actor string) *DisputeRecord {
+	now := time.Now()
+	record := &DisputeRecord{
+		Dispute:          dispute,
+		GatewayDisputeID: dispute.ID,
+		UpdatedAt:        now,
+		AuditLog:         make([]DisputeAuditEntry, 0, 10),
+	}
+	record.Dispute.Gateway = gateway
+
+	record.AddAuditEntry(DisputeAuditEntry{
+		Timestamp: now,
+		Action:    "created",
+		Actor:     actor,
+		NewStatus: dispute.Status,
+		Details: map[string]string{
+			"reason":        string(dispute.Reason),
+			"payment_id":    dispute.PaymentIntentID,
+			"amount":        fmt.Sprintf("%d", dispute.Amount.Value),
+			"currency":      string(dispute.Amount.Currency),
+			"gateway":       string(gateway),
+		},
+	})
+
+	return record
+}
+
+// AddAuditEntry adds an audit entry to the dispute record
+func (r *DisputeRecord) AddAuditEntry(entry DisputeAuditEntry) {
+	r.AuditLog = append(r.AuditLog, entry)
+	r.UpdatedAt = entry.Timestamp
+}
+
+// UpdateStatus updates the dispute status with audit logging
+func (r *DisputeRecord) UpdateStatus(newStatus DisputeStatus, actor string, details map[string]string) {
+	now := time.Now()
+	previousStatus := r.Status
+
+	r.Status = newStatus
+	r.UpdatedAt = now
+
+	if newStatus == DisputeStatusWon || newStatus == DisputeStatusLost ||
+		newStatus == DisputeStatusAccepted || newStatus == DisputeStatusExpired {
+		r.ClosedAt = &now
+	}
+
+	r.AddAuditEntry(DisputeAuditEntry{
+		Timestamp:      now,
+		Action:         "status_updated",
+		Actor:          actor,
+		PreviousStatus: previousStatus,
+		NewStatus:      newStatus,
+		Details:        details,
+	})
+}
+
+// MarkEvidenceSubmitted marks evidence as submitted with audit logging
+func (r *DisputeRecord) MarkEvidenceSubmitted(actor string, evidenceType string) {
+	now := time.Now()
+	r.EvidenceSubmitted = true
+	r.EvidenceSubmittedAt = &now
+	r.UpdatedAt = now
+
+	if r.Status == DisputeStatusNeedsResponse {
+		r.Status = DisputeStatusUnderReview
+	}
+
+	r.AddAuditEntry(DisputeAuditEntry{
+		Timestamp: now,
+		Action:    "evidence_submitted",
+		Actor:     actor,
+		NewStatus: r.Status,
+		Details: map[string]string{
+			"evidence_type": evidenceType,
+		},
+	})
+}
+
+// MarkAccepted marks the dispute as accepted (conceded)
+func (r *DisputeRecord) MarkAccepted(actor string, reason string) {
+	now := time.Now()
+	previousStatus := r.Status
+
+	r.Accepted = true
+	r.AcceptedAt = &now
+	r.Status = DisputeStatusAccepted
+	r.ClosedAt = &now
+	r.UpdatedAt = now
+
+	r.AddAuditEntry(DisputeAuditEntry{
+		Timestamp:      now,
+		Action:         "accepted",
+		Actor:          actor,
+		PreviousStatus: previousStatus,
+		NewStatus:      DisputeStatusAccepted,
+		Details: map[string]string{
+			"reason": reason,
+		},
+	})
+}
+
+// ============================================================================
+// Dispute Store Interface
+// ============================================================================
+
+// DisputeStore defines the interface for persisting disputes
+type DisputeStore interface {
+	// Save persists a dispute record
+	Save(record *DisputeRecord) error
+
+	// Get retrieves a dispute by ID
+	Get(disputeID string) (*DisputeRecord, bool)
+
+	// GetByPaymentIntent retrieves disputes for a payment intent
+	GetByPaymentIntent(paymentIntentID string) []*DisputeRecord
+
+	// GetByCustomer retrieves disputes for a customer
+	GetByCustomer(customerID string) []*DisputeRecord
+
+	// GetByStatus retrieves disputes by status
+	GetByStatus(status DisputeStatus) []*DisputeRecord
+
+	// GetPendingResponse retrieves disputes needing response before deadline
+	GetPendingResponse() []*DisputeRecord
+
+	// List retrieves all disputes with optional filters
+	List(opts DisputeListOptions) []*DisputeRecord
+
+	// Delete removes a dispute record
+	Delete(disputeID string) error
+
+	// Count returns the total number of disputes
+	Count() int
+}
+
+// DisputeListOptions defines filtering options for listing disputes
+type DisputeListOptions struct {
+	// Gateway filters by payment gateway
+	Gateway *GatewayType `json:"gateway,omitempty"`
+
+	// Status filters by dispute status
+	Status *DisputeStatus `json:"status,omitempty"`
+
+	// CustomerID filters by customer
+	CustomerID string `json:"customer_id,omitempty"`
+
+	// CreatedAfter filters disputes created after this time
+	CreatedAfter *time.Time `json:"created_after,omitempty"`
+
+	// CreatedBefore filters disputes created before this time
+	CreatedBefore *time.Time `json:"created_before,omitempty"`
+
+	// Limit limits the number of results
+	Limit int `json:"limit,omitempty"`
+
+	// Offset for pagination
+	Offset int `json:"offset,omitempty"`
+}
+
+// ============================================================================
+// In-Memory Dispute Store Implementation
+// ============================================================================
+
+// InMemoryDisputeStore is a thread-safe in-memory implementation of DisputeStore
+// Suitable for testing and development. Production should use a persistent store.
+type InMemoryDisputeStore struct {
+	mu       sync.RWMutex
+	disputes map[string]*DisputeRecord
+
+	// Secondary indices
+	byPaymentIntent map[string][]string // paymentIntentID -> []disputeID
+	byCustomer      map[string][]string // customerID -> []disputeID
+	byStatus        map[DisputeStatus][]string
+}
+
+// NewInMemoryDisputeStore creates a new in-memory dispute store
+func NewInMemoryDisputeStore() *InMemoryDisputeStore {
+	return &InMemoryDisputeStore{
+		disputes:        make(map[string]*DisputeRecord),
+		byPaymentIntent: make(map[string][]string),
+		byCustomer:      make(map[string][]string),
+		byStatus:        make(map[DisputeStatus][]string),
+	}
+}
+
+// Save persists a dispute record
+func (s *InMemoryDisputeStore) Save(record *DisputeRecord) error {
+	if record == nil {
+		return fmt.Errorf("cannot save nil dispute record")
+	}
+	if record.ID == "" {
+		return fmt.Errorf("dispute ID cannot be empty")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if this is an update (need to update indices)
+	existing, exists := s.disputes[record.ID]
+	if exists {
+		// Remove from old status index if status changed
+		if existing.Status != record.Status {
+			s.removeFromStatusIndex(record.ID, existing.Status)
+			s.addToStatusIndex(record.ID, record.Status)
+		}
+	} else {
+		// New record - add to all indices
+		s.addToPaymentIntentIndex(record.ID, record.PaymentIntentID)
+		if record.CustomerID != "" {
+			s.addToCustomerIndex(record.ID, record.CustomerID)
+		}
+		s.addToStatusIndex(record.ID, record.Status)
+	}
+
+	// Make a copy to prevent external mutation
+	recordCopy := *record
+	recordCopy.AuditLog = make([]DisputeAuditEntry, len(record.AuditLog))
+	copy(recordCopy.AuditLog, record.AuditLog)
+
+	s.disputes[record.ID] = &recordCopy
+	return nil
+}
+
+// Get retrieves a dispute by ID
+func (s *InMemoryDisputeStore) Get(disputeID string) (*DisputeRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	record, exists := s.disputes[disputeID]
+	if !exists {
+		return nil, false
+	}
+
+	// Return a copy
+	recordCopy := *record
+	recordCopy.AuditLog = make([]DisputeAuditEntry, len(record.AuditLog))
+	copy(recordCopy.AuditLog, record.AuditLog)
+
+	return &recordCopy, true
+}
+
+// GetByPaymentIntent retrieves disputes for a payment intent
+func (s *InMemoryDisputeStore) GetByPaymentIntent(paymentIntentID string) []*DisputeRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ids := s.byPaymentIntent[paymentIntentID]
+	return s.getRecordsByIDs(ids)
+}
+
+// GetByCustomer retrieves disputes for a customer
+func (s *InMemoryDisputeStore) GetByCustomer(customerID string) []*DisputeRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ids := s.byCustomer[customerID]
+	return s.getRecordsByIDs(ids)
+}
+
+// GetByStatus retrieves disputes by status
+func (s *InMemoryDisputeStore) GetByStatus(status DisputeStatus) []*DisputeRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ids := s.byStatus[status]
+	return s.getRecordsByIDs(ids)
+}
+
+// GetPendingResponse retrieves disputes needing response before deadline
+func (s *InMemoryDisputeStore) GetPendingResponse() []*DisputeRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	now := time.Now()
+	var pending []*DisputeRecord
+
+	for _, record := range s.disputes {
+		if record.Status == DisputeStatusNeedsResponse && record.EvidenceDueBy.After(now) {
+			recordCopy := *record
+			recordCopy.AuditLog = make([]DisputeAuditEntry, len(record.AuditLog))
+			copy(recordCopy.AuditLog, record.AuditLog)
+			pending = append(pending, &recordCopy)
+		}
+	}
+
+	return pending
+}
+
+// List retrieves all disputes with optional filters
+func (s *InMemoryDisputeStore) List(opts DisputeListOptions) []*DisputeRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []*DisputeRecord
+	count := 0
+	skipped := 0
+
+	for _, record := range s.disputes {
+		// Apply filters
+		if opts.Gateway != nil && record.Gateway != *opts.Gateway {
+			continue
+		}
+		if opts.Status != nil && record.Status != *opts.Status {
+			continue
+		}
+		if opts.CustomerID != "" && record.CustomerID != opts.CustomerID {
+			continue
+		}
+		if opts.CreatedAfter != nil && record.CreatedAt.Before(*opts.CreatedAfter) {
+			continue
+		}
+		if opts.CreatedBefore != nil && record.CreatedAt.After(*opts.CreatedBefore) {
+			continue
+		}
+
+		// Apply offset
+		if opts.Offset > 0 && skipped < opts.Offset {
+			skipped++
+			continue
+		}
+
+		// Apply limit
+		if opts.Limit > 0 && count >= opts.Limit {
+			break
+		}
+
+		recordCopy := *record
+		recordCopy.AuditLog = make([]DisputeAuditEntry, len(record.AuditLog))
+		copy(recordCopy.AuditLog, record.AuditLog)
+		results = append(results, &recordCopy)
+		count++
+	}
+
+	return results
+}
+
+// Delete removes a dispute record
+func (s *InMemoryDisputeStore) Delete(disputeID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, exists := s.disputes[disputeID]
+	if !exists {
+		return nil // Idempotent
+	}
+
+	// Remove from indices
+	s.removeFromPaymentIntentIndex(disputeID, record.PaymentIntentID)
+	if record.CustomerID != "" {
+		s.removeFromCustomerIndex(disputeID, record.CustomerID)
+	}
+	s.removeFromStatusIndex(disputeID, record.Status)
+
+	delete(s.disputes, disputeID)
+	return nil
+}
+
+// Count returns the total number of disputes
+func (s *InMemoryDisputeStore) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.disputes)
+}
+
+// Helper methods for index management
+
+func (s *InMemoryDisputeStore) getRecordsByIDs(ids []string) []*DisputeRecord {
+	var records []*DisputeRecord
+	for _, id := range ids {
+		if record, exists := s.disputes[id]; exists {
+			recordCopy := *record
+			recordCopy.AuditLog = make([]DisputeAuditEntry, len(record.AuditLog))
+			copy(recordCopy.AuditLog, record.AuditLog)
+			records = append(records, &recordCopy)
+		}
+	}
+	return records
+}
+
+func (s *InMemoryDisputeStore) addToPaymentIntentIndex(disputeID, paymentIntentID string) {
+	if paymentIntentID == "" {
+		return
+	}
+	s.byPaymentIntent[paymentIntentID] = append(s.byPaymentIntent[paymentIntentID], disputeID)
+}
+
+func (s *InMemoryDisputeStore) removeFromPaymentIntentIndex(disputeID, paymentIntentID string) {
+	if paymentIntentID == "" {
+		return
+	}
+	ids := s.byPaymentIntent[paymentIntentID]
+	for i, id := range ids {
+		if id == disputeID {
+			s.byPaymentIntent[paymentIntentID] = append(ids[:i], ids[i+1:]...)
+			break
+		}
+	}
+}
+
+func (s *InMemoryDisputeStore) addToCustomerIndex(disputeID, customerID string) {
+	if customerID == "" {
+		return
+	}
+	s.byCustomer[customerID] = append(s.byCustomer[customerID], disputeID)
+}
+
+func (s *InMemoryDisputeStore) removeFromCustomerIndex(disputeID, customerID string) {
+	if customerID == "" {
+		return
+	}
+	ids := s.byCustomer[customerID]
+	for i, id := range ids {
+		if id == disputeID {
+			s.byCustomer[customerID] = append(ids[:i], ids[i+1:]...)
+			break
+		}
+	}
+}
+
+func (s *InMemoryDisputeStore) addToStatusIndex(disputeID string, status DisputeStatus) {
+	s.byStatus[status] = append(s.byStatus[status], disputeID)
+}
+
+func (s *InMemoryDisputeStore) removeFromStatusIndex(disputeID string, status DisputeStatus) {
+	ids := s.byStatus[status]
+	for i, id := range ids {
+		if id == disputeID {
+			s.byStatus[status] = append(ids[:i], ids[i+1:]...)
+			break
+		}
+	}
+}

--- a/pkg/payment/dispute_store_test.go
+++ b/pkg/payment/dispute_store_test.go
@@ -1,0 +1,433 @@
+// Package payment provides payment gateway integration for Visa/Mastercard.
+//
+// PAY-003: Tests for dispute lifecycle persistence and gateway actions
+package payment
+
+import (
+	"testing"
+	"time"
+)
+
+// ============================================================================
+// DisputeStore Tests
+// ============================================================================
+
+func TestInMemoryDisputeStore_SaveAndGet(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+
+	dispute := Dispute{
+		ID:              "dp_test123",
+		Gateway:         GatewayStripe,
+		PaymentIntentID: "pi_test456",
+		ChargeID:        "ch_test789",
+		Amount:          NewAmount(10000, CurrencyUSD),
+		Status:          DisputeStatusNeedsResponse,
+		Reason:          DisputeReasonFraudulent,
+		EvidenceDueBy:   time.Now().Add(7 * 24 * time.Hour),
+		CreatedAt:       time.Now(),
+	}
+
+	record := NewDisputeRecord(dispute, GatewayStripe, "test:create")
+
+	// Save
+	err := store.Save(record)
+	if err != nil {
+		t.Fatalf("Failed to save dispute record: %v", err)
+	}
+
+	// Get
+	retrieved, found := store.Get("dp_test123")
+	if !found {
+		t.Fatal("Failed to retrieve dispute record")
+	}
+
+	if retrieved.ID != dispute.ID {
+		t.Errorf("Expected ID %s, got %s", dispute.ID, retrieved.ID)
+	}
+	if retrieved.Status != dispute.Status {
+		t.Errorf("Expected status %s, got %s", dispute.Status, retrieved.Status)
+	}
+	if retrieved.Gateway != dispute.Gateway {
+		t.Errorf("Expected gateway %s, got %s", dispute.Gateway, retrieved.Gateway)
+	}
+	if len(retrieved.AuditLog) != 1 {
+		t.Errorf("Expected 1 audit entry, got %d", len(retrieved.AuditLog))
+	}
+	if retrieved.AuditLog[0].Action != "created" {
+		t.Errorf("Expected action 'created', got '%s'", retrieved.AuditLog[0].Action)
+	}
+}
+
+func TestInMemoryDisputeStore_GetByPaymentIntent(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+
+	// Create multiple disputes for the same payment intent
+	dispute1 := Dispute{
+		ID:              "dp_test1",
+		Gateway:         GatewayStripe,
+		PaymentIntentID: "pi_shared",
+		Status:          DisputeStatusNeedsResponse,
+	}
+	dispute2 := Dispute{
+		ID:              "dp_test2",
+		Gateway:         GatewayStripe,
+		PaymentIntentID: "pi_shared",
+		Status:          DisputeStatusWon,
+	}
+	dispute3 := Dispute{
+		ID:              "dp_test3",
+		Gateway:         GatewayStripe,
+		PaymentIntentID: "pi_other",
+		Status:          DisputeStatusLost,
+	}
+
+	_ = store.Save(NewDisputeRecord(dispute1, GatewayStripe, "test"))
+	_ = store.Save(NewDisputeRecord(dispute2, GatewayStripe, "test"))
+	_ = store.Save(NewDisputeRecord(dispute3, GatewayStripe, "test"))
+
+	// Query by payment intent
+	records := store.GetByPaymentIntent("pi_shared")
+	if len(records) != 2 {
+		t.Errorf("Expected 2 disputes for pi_shared, got %d", len(records))
+	}
+
+	records = store.GetByPaymentIntent("pi_other")
+	if len(records) != 1 {
+		t.Errorf("Expected 1 dispute for pi_other, got %d", len(records))
+	}
+}
+
+func TestInMemoryDisputeStore_GetByStatus(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+
+	disputes := []Dispute{
+		{ID: "dp_1", Status: DisputeStatusNeedsResponse},
+		{ID: "dp_2", Status: DisputeStatusNeedsResponse},
+		{ID: "dp_3", Status: DisputeStatusUnderReview},
+		{ID: "dp_4", Status: DisputeStatusWon},
+	}
+
+	for _, d := range disputes {
+		_ = store.Save(NewDisputeRecord(d, GatewayStripe, "test"))
+	}
+
+	needsResponse := store.GetByStatus(DisputeStatusNeedsResponse)
+	if len(needsResponse) != 2 {
+		t.Errorf("Expected 2 disputes needing response, got %d", len(needsResponse))
+	}
+
+	underReview := store.GetByStatus(DisputeStatusUnderReview)
+	if len(underReview) != 1 {
+		t.Errorf("Expected 1 dispute under review, got %d", len(underReview))
+	}
+
+	won := store.GetByStatus(DisputeStatusWon)
+	if len(won) != 1 {
+		t.Errorf("Expected 1 won dispute, got %d", len(won))
+	}
+}
+
+func TestInMemoryDisputeStore_UpdateWithAuditTrail(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+
+	dispute := Dispute{
+		ID:     "dp_audit",
+		Status: DisputeStatusNeedsResponse,
+	}
+
+	record := NewDisputeRecord(dispute, GatewayStripe, "test:create")
+	_ = store.Save(record)
+
+	// Retrieve and update
+	record, _ = store.Get("dp_audit")
+
+	// Mark evidence submitted
+	record.MarkEvidenceSubmitted("user:test@example.com", "product_description")
+	_ = store.Save(record)
+
+	// Verify audit trail
+	record, _ = store.Get("dp_audit")
+	if len(record.AuditLog) != 2 {
+		t.Errorf("Expected 2 audit entries, got %d", len(record.AuditLog))
+	}
+	if record.AuditLog[1].Action != "evidence_submitted" {
+		t.Errorf("Expected action 'evidence_submitted', got '%s'", record.AuditLog[1].Action)
+	}
+	if !record.EvidenceSubmitted {
+		t.Error("Expected EvidenceSubmitted to be true")
+	}
+	if record.EvidenceSubmittedAt == nil {
+		t.Error("Expected EvidenceSubmittedAt to be set")
+	}
+}
+
+func TestInMemoryDisputeStore_StatusTransition(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+
+	dispute := Dispute{
+		ID:     "dp_transition",
+		Status: DisputeStatusNeedsResponse,
+	}
+
+	record := NewDisputeRecord(dispute, GatewayStripe, "test:create")
+	_ = store.Save(record)
+
+	// Transition to under review
+	record, _ = store.Get("dp_transition")
+	record.UpdateStatus(DisputeStatusUnderReview, "webhook:evidence_submitted", nil)
+	_ = store.Save(record)
+
+	// Verify status changed in index
+	needsResponse := store.GetByStatus(DisputeStatusNeedsResponse)
+	if len(needsResponse) != 0 {
+		t.Errorf("Expected 0 disputes needing response after transition, got %d", len(needsResponse))
+	}
+
+	underReview := store.GetByStatus(DisputeStatusUnderReview)
+	if len(underReview) != 1 {
+		t.Errorf("Expected 1 dispute under review, got %d", len(underReview))
+	}
+}
+
+func TestInMemoryDisputeStore_AcceptDispute(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+
+	dispute := Dispute{
+		ID:     "dp_accept",
+		Status: DisputeStatusNeedsResponse,
+	}
+
+	record := NewDisputeRecord(dispute, GatewayStripe, "test:create")
+	_ = store.Save(record)
+
+	// Accept the dispute
+	record, _ = store.Get("dp_accept")
+	record.MarkAccepted("api:accept", "merchant_decision")
+	_ = store.Save(record)
+
+	// Verify
+	record, _ = store.Get("dp_accept")
+	if record.Status != DisputeStatusAccepted {
+		t.Errorf("Expected status %s, got %s", DisputeStatusAccepted, record.Status)
+	}
+	if !record.Accepted {
+		t.Error("Expected Accepted to be true")
+	}
+	if record.AcceptedAt == nil {
+		t.Error("Expected AcceptedAt to be set")
+	}
+	if record.ClosedAt == nil {
+		t.Error("Expected ClosedAt to be set")
+	}
+	if len(record.AuditLog) != 2 {
+		t.Errorf("Expected 2 audit entries, got %d", len(record.AuditLog))
+	}
+}
+
+func TestInMemoryDisputeStore_Delete(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+
+	dispute := Dispute{
+		ID:              "dp_delete",
+		PaymentIntentID: "pi_delete",
+		Status:          DisputeStatusNeedsResponse,
+	}
+
+	record := NewDisputeRecord(dispute, GatewayStripe, "test:create")
+	record.CustomerID = "cust_delete"
+	_ = store.Save(record)
+
+	// Verify exists
+	if store.Count() != 1 {
+		t.Errorf("Expected count 1, got %d", store.Count())
+	}
+
+	// Delete
+	err := store.Delete("dp_delete")
+	if err != nil {
+		t.Fatalf("Failed to delete: %v", err)
+	}
+
+	// Verify deleted
+	if store.Count() != 0 {
+		t.Errorf("Expected count 0 after delete, got %d", store.Count())
+	}
+
+	_, found := store.Get("dp_delete")
+	if found {
+		t.Error("Expected dispute to be deleted")
+	}
+
+	// Verify indices cleaned up
+	if len(store.GetByPaymentIntent("pi_delete")) != 0 {
+		t.Error("Expected payment intent index to be cleaned up")
+	}
+	if len(store.GetByStatus(DisputeStatusNeedsResponse)) != 0 {
+		t.Error("Expected status index to be cleaned up")
+	}
+}
+
+func TestInMemoryDisputeStore_ListWithFilters(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+
+	now := time.Now()
+	yesterday := now.Add(-24 * time.Hour)
+
+	disputes := []struct {
+		dispute    Dispute
+		customerID string
+		createdAt  time.Time
+	}{
+		{Dispute{ID: "dp_1", Status: DisputeStatusNeedsResponse, Gateway: GatewayStripe}, "cust_1", now},
+		{Dispute{ID: "dp_2", Status: DisputeStatusWon, Gateway: GatewayStripe}, "cust_1", yesterday},
+		{Dispute{ID: "dp_3", Status: DisputeStatusNeedsResponse, Gateway: GatewayAdyen}, "cust_2", now},
+	}
+
+	for _, d := range disputes {
+		record := NewDisputeRecord(d.dispute, d.dispute.Gateway, "test")
+		record.CustomerID = d.customerID
+		record.CreatedAt = d.createdAt
+		_ = store.Save(record)
+	}
+
+	// Filter by gateway
+	gatewayFilter := GatewayStripe
+	opts := DisputeListOptions{Gateway: &gatewayFilter}
+	results := store.List(opts)
+	if len(results) != 2 {
+		t.Errorf("Expected 2 Stripe disputes, got %d", len(results))
+	}
+
+	// Filter by status
+	statusFilter := DisputeStatusNeedsResponse
+	opts = DisputeListOptions{Status: &statusFilter}
+	results = store.List(opts)
+	if len(results) != 2 {
+		t.Errorf("Expected 2 disputes needing response, got %d", len(results))
+	}
+
+	// Filter by customer
+	opts = DisputeListOptions{CustomerID: "cust_1"}
+	results = store.List(opts)
+	if len(results) != 2 {
+		t.Errorf("Expected 2 disputes for cust_1, got %d", len(results))
+	}
+
+	// Filter with limit
+	opts = DisputeListOptions{Limit: 1}
+	results = store.List(opts)
+	if len(results) != 1 {
+		t.Errorf("Expected 1 dispute with limit, got %d", len(results))
+	}
+}
+
+func TestInMemoryDisputeStore_GetPendingResponse(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+
+	now := time.Now()
+	futureDeadline := now.Add(7 * 24 * time.Hour)
+	pastDeadline := now.Add(-24 * time.Hour)
+
+	disputes := []Dispute{
+		{ID: "dp_pending1", Status: DisputeStatusNeedsResponse, EvidenceDueBy: futureDeadline},
+		{ID: "dp_pending2", Status: DisputeStatusNeedsResponse, EvidenceDueBy: futureDeadline},
+		{ID: "dp_expired", Status: DisputeStatusNeedsResponse, EvidenceDueBy: pastDeadline},
+		{ID: "dp_closed", Status: DisputeStatusWon, EvidenceDueBy: futureDeadline},
+	}
+
+	for _, d := range disputes {
+		_ = store.Save(NewDisputeRecord(d, GatewayStripe, "test"))
+	}
+
+	pending := store.GetPendingResponse()
+	if len(pending) != 2 {
+		t.Errorf("Expected 2 pending disputes, got %d", len(pending))
+	}
+}
+
+// ============================================================================
+// DisputeRecord Tests
+// ============================================================================
+
+func TestDisputeRecord_NewDisputeRecord(t *testing.T) {
+	dispute := Dispute{
+		ID:              "dp_new",
+		PaymentIntentID: "pi_123",
+		Amount:          NewAmount(5000, CurrencyEUR),
+		Status:          DisputeStatusOpen,
+		Reason:          DisputeReasonDuplicate,
+	}
+
+	record := NewDisputeRecord(dispute, GatewayAdyen, "system:webhook")
+
+	if record.ID != dispute.ID {
+		t.Errorf("Expected ID %s, got %s", dispute.ID, record.ID)
+	}
+	if record.Gateway != GatewayAdyen {
+		t.Errorf("Expected gateway %s, got %s", GatewayAdyen, record.Gateway)
+	}
+	if record.GatewayDisputeID != dispute.ID {
+		t.Errorf("Expected gateway dispute ID %s, got %s", dispute.ID, record.GatewayDisputeID)
+	}
+	if len(record.AuditLog) != 1 {
+		t.Fatalf("Expected 1 audit entry, got %d", len(record.AuditLog))
+	}
+
+	entry := record.AuditLog[0]
+	if entry.Action != "created" {
+		t.Errorf("Expected action 'created', got '%s'", entry.Action)
+	}
+	if entry.Actor != "system:webhook" {
+		t.Errorf("Expected actor 'system:webhook', got '%s'", entry.Actor)
+	}
+	if entry.NewStatus != DisputeStatusOpen {
+		t.Errorf("Expected new status %s, got %s", DisputeStatusOpen, entry.NewStatus)
+	}
+}
+
+func TestDisputeRecord_UpdateStatus(t *testing.T) {
+	dispute := Dispute{ID: "dp_status", Status: DisputeStatusNeedsResponse}
+	record := NewDisputeRecord(dispute, GatewayStripe, "test")
+
+	record.UpdateStatus(DisputeStatusUnderReview, "user:admin", map[string]string{
+		"reason": "evidence_submitted",
+	})
+
+	if record.Status != DisputeStatusUnderReview {
+		t.Errorf("Expected status %s, got %s", DisputeStatusUnderReview, record.Status)
+	}
+	if len(record.AuditLog) != 2 {
+		t.Fatalf("Expected 2 audit entries, got %d", len(record.AuditLog))
+	}
+
+	entry := record.AuditLog[1]
+	if entry.PreviousStatus != DisputeStatusNeedsResponse {
+		t.Errorf("Expected previous status %s, got %s", DisputeStatusNeedsResponse, entry.PreviousStatus)
+	}
+	if entry.Details["reason"] != "evidence_submitted" {
+		t.Errorf("Expected reason 'evidence_submitted', got '%s'", entry.Details["reason"])
+	}
+}
+
+func TestDisputeStatus_IsFinal(t *testing.T) {
+	tests := []struct {
+		status   DisputeStatus
+		expected bool
+	}{
+		{DisputeStatusOpen, false},
+		{DisputeStatusNeedsResponse, false},
+		{DisputeStatusUnderReview, false},
+		{DisputeStatusWon, true},
+		{DisputeStatusLost, true},
+		{DisputeStatusAccepted, true},
+		{DisputeStatusExpired, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			if tt.status.IsFinal() != tt.expected {
+				t.Errorf("Expected IsFinal()=%v for status %s", tt.expected, tt.status)
+			}
+		})
+	}
+}

--- a/pkg/payment/types.go
+++ b/pkg/payment/types.go
@@ -607,7 +607,10 @@ const (
 	WebhookEventPaymentIntentProcessing   WebhookEventType = "payment_intent.processing"
 	WebhookEventChargeRefunded            WebhookEventType = "charge.refunded"
 	WebhookEventChargeDisputeCreated      WebhookEventType = "charge.dispute.created"
+	WebhookEventChargeDisputeUpdated      WebhookEventType = "charge.dispute.updated"
 	WebhookEventChargeDisputeClosed       WebhookEventType = "charge.dispute.closed"
+	WebhookEventChargeDisputeFundsWithdrawn  WebhookEventType = "charge.dispute.funds_withdrawn"
+	WebhookEventChargeDisputeFundsReinstated WebhookEventType = "charge.dispute.funds_reinstated"
 	WebhookEventPaymentMethodAttached     WebhookEventType = "payment_method.attached"
 	WebhookEventPaymentMethodDetached     WebhookEventType = "payment_method.detached"
 	WebhookEventCustomerCreated           WebhookEventType = "customer.created"
@@ -658,6 +661,16 @@ const (
 	DisputeStatusExpired          DisputeStatus = "expired"
 )
 
+// IsFinal returns true if the dispute is in a terminal state
+func (s DisputeStatus) IsFinal() bool {
+	switch s {
+	case DisputeStatusWon, DisputeStatusLost, DisputeStatusAccepted, DisputeStatusExpired:
+		return true
+	default:
+		return false
+	}
+}
+
 // DisputeReason represents dispute reason
 type DisputeReason string
 
@@ -674,8 +687,14 @@ type Dispute struct {
 	// ID is the dispute ID
 	ID string `json:"id"`
 
+	// Gateway is which gateway processed this dispute
+	Gateway GatewayType `json:"gateway,omitempty"`
+
 	// PaymentIntentID is the disputed payment
 	PaymentIntentID string `json:"payment_intent_id"`
+
+	// ChargeID is the underlying charge/transaction ID
+	ChargeID string `json:"charge_id,omitempty"`
 
 	// Amount is the disputed amount
 	Amount Amount `json:"amount"`
@@ -695,8 +714,14 @@ type Dispute struct {
 	// NetworkReasonCode is the card network reason code
 	NetworkReasonCode string `json:"network_reason_code,omitempty"`
 
+	// Metadata is additional key-value metadata
+	Metadata map[string]string `json:"metadata,omitempty"`
+
 	// CreatedAt when dispute was opened
 	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt when dispute was last updated
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // ============================================================================


### PR DESCRIPTION
Persist disputes and wire Stripe/Adyen dispute actions (submit evidence, accept, status updates).

Acceptance:
- Dispute records persisted in store
- Gateway dispute actions wired
- Webhooks update dispute state
- Audit trail for dispute actions