### PR TITLE
feat: PAY-001: Implement real price feed integration

### DIFF
--- a/pkg/payment/config.go
+++ b/pkg/payment/config.go
@@ -146,7 +146,13 @@ type ConversionConfig struct {
 	// CryptoDenom is the target cryptocurrency denomination
 	CryptoDenom string `json:"crypto_denom"`
 
-	// PriceFeedSource is the source for conversion rates
+	// PriceFeedSource is the source for conversion rates.
+	// Supported values: "coingecko", "chainlink", "pyth", "median", "weighted"
+	// - "coingecko": Use CoinGecko as primary source (free, rate-limited)
+	// - "chainlink": Use Chainlink oracle as primary source (decentralized)
+	// - "pyth": Use Pyth network as primary source (high-frequency)
+	// - "median": Use median price across all sources
+	// - "weighted": Use weighted average based on source confidence
 	PriceFeedSource string `json:"price_feed_source"`
 
 	// ConversionFeePercent is the fee percentage for conversion
@@ -157,6 +163,21 @@ type ConversionConfig struct {
 
 	// MinSlippagePercent is the minimum slippage tolerance
 	MinSlippagePercent float64 `json:"min_slippage_percent"`
+
+	// CoinGeckoAPIKey is the optional CoinGecko Pro API key
+	CoinGeckoAPIKey string `json:"coingecko_api_key,omitempty"`
+
+	// ChainlinkRPCURL is the Ethereum RPC URL for Chainlink feeds
+	ChainlinkRPCURL string `json:"chainlink_rpc_url,omitempty"`
+
+	// PythHermesURL is the Pyth Hermes API URL
+	PythHermesURL string `json:"pyth_hermes_url,omitempty"`
+
+	// CacheTTLSeconds is how long to cache prices (default: 30)
+	CacheTTLSeconds int `json:"cache_ttl_seconds,omitempty"`
+
+	// MaxPriceDeviation is the max allowed deviation between sources (0-1)
+	MaxPriceDeviation float64 `json:"max_price_deviation,omitempty"`
 }
 
 // DefaultConfig returns a Config with sensible defaults

--- a/pkg/pricefeed/FALLBACK.md
+++ b/pkg/pricefeed/FALLBACK.md
@@ -1,0 +1,227 @@
+# Price Feed Failure Fallback Behavior
+
+This document describes the failure fallback behavior for the price feed system used in fiat-to-crypto conversions.
+
+## Overview
+
+The price feed system (`pkg/pricefeed`) implements multiple layers of resilience to handle price source failures gracefully while maintaining system integrity.
+
+## Fallback Hierarchy
+
+When fetching a price, the system uses the following fallback hierarchy:
+
+```
+1. Primary Source → 2. Secondary Sources → 3. Cached Price → 4. Stale Cache → 5. Error
+```
+
+### 1. Primary Source (Strategy: Primary)
+
+The system queries configured sources in priority order. When using `StrategyPrimary`:
+
+- Sources are ordered by `Priority` field (lower = higher priority)
+- First healthy source to return a valid price wins
+- Unhealthy sources (circuit open, rate limited) are skipped
+
+### 2. Secondary Sources (Automatic Fallback)
+
+If the primary source fails:
+- **Rate limited**: Tries next source immediately
+- **Timeout/Network error**: Retries with exponential backoff, then tries next source
+- **Invalid data**: Skips to next source
+
+### 3. Cached Price
+
+If all live sources fail but cache is enabled:
+- Returns cached price if within TTL (default: 30 seconds)
+- Cache is populated on every successful price fetch
+
+### 4. Stale Cache (Optional)
+
+If `AllowStale: true` in cache config:
+- Returns stale price if within `StaleMaxAge` (default: 5 minutes)
+- Stale prices are marked with increased age
+- Useful for brief outages
+
+### 5. Error Response
+
+If all fallbacks fail:
+- Returns `ErrAllSourcesFailed` or `ErrPriceFeedUnavailable`
+- Payment service rejects the conversion request
+- User sees appropriate error message
+
+## Circuit Breaker
+
+Each price source has an independent circuit breaker:
+
+| State | Behavior |
+|-------|----------|
+| **Closed** | Normal operation, requests allowed |
+| **Open** | Source failed repeatedly, requests blocked for timeout period (30s) |
+| **Half-Open** | After timeout, allows limited requests to test recovery |
+
+Configuration:
+- `FailureThreshold`: 5 consecutive failures opens circuit
+- `SuccessThreshold`: 2 consecutive successes closes circuit
+- `Timeout`: 30 seconds before half-open transition
+
+## Rate Limiting
+
+### CoinGecko
+- Free tier: 10-30 requests/minute
+- Pro tier: Higher limits with API key
+- Rate limit errors trigger fallback to next source
+
+### Chainlink
+- No explicit rate limits (on-chain reads)
+- Subject to RPC provider limits
+- Recommended: Use dedicated RPC endpoint
+
+### Pyth
+- High throughput (Hermes API)
+- No aggressive rate limiting
+- Sub-second price updates available
+
+## Retry Configuration
+
+```go
+RetryConfig{
+    MaxRetries:    3,           // Maximum retry attempts
+    InitialDelay:  100ms,       // First retry delay
+    MaxDelay:      5s,          // Maximum retry delay
+    BackoffFactor: 2.0,         // Exponential backoff multiplier
+    RetryableErrors: []string{  // Errors that trigger retry
+        "timeout",
+        "connection refused",
+        "rate limit",
+        "503", "504",
+    },
+}
+```
+
+## Aggregation Strategies
+
+### StrategyPrimary (Default)
+- Uses first healthy source in priority order
+- Fastest response time
+- Best for low-latency requirements
+
+### StrategyMedian
+- Queries all sources in parallel
+- Returns median price
+- Protects against single-source manipulation
+- Rejects if deviation > `MaxPriceDeviation` (default: 5%)
+
+### StrategyWeighted
+- Queries all sources in parallel
+- Weighted average by source confidence/volume
+- Best accuracy for large transactions
+
+## Monitoring
+
+### Metrics Exposed
+
+| Metric | Description |
+|--------|-------------|
+| `pricefeed_fetch_total` | Total price fetch requests by source |
+| `pricefeed_fetch_errors` | Failed requests by source |
+| `pricefeed_fetch_latency` | Request latency by source |
+| `pricefeed_cache_hits` | Cache hit count |
+| `pricefeed_cache_misses` | Cache miss count |
+| `pricefeed_price_deviation` | Price deviation between sources |
+| `pricefeed_source_healthy` | Source health status |
+
+### Health Checks
+
+```go
+sources := aggregator.ListSources()
+for _, source := range sources {
+    fmt.Printf("%s: healthy=%v, error_rate=%.2f%%\n",
+        source.Source, source.Healthy, source.ErrorRate())
+}
+```
+
+### Alerts (Recommended)
+
+1. **All sources unhealthy**: Critical - conversion service degraded
+2. **Price deviation > 5%**: Warning - potential price manipulation
+3. **Cache hit rate < 50%**: Info - high API load
+4. **Single source error rate > 20%**: Warning - source degraded
+
+## Configuration Example
+
+```go
+conversionConfig := ConversionConfig{
+    Enabled:              true,
+    CryptoDenom:          "uve",
+    PriceFeedSource:      "coingecko",  // or "chainlink", "pyth", "median", "weighted"
+    ConversionFeePercent: 1.5,
+    QuoteValiditySeconds: 60,
+    MinSlippagePercent:   0.5,
+    
+    // Optional advanced settings
+    CoinGeckoAPIKey:   "your-api-key",        // For Pro tier
+    ChainlinkRPCURL:   "https://eth.rpc.url", // For Chainlink
+    PythHermesURL:     "https://hermes.pyth.network",
+    CacheTTLSeconds:   30,
+    MaxPriceDeviation: 0.05,  // 5%
+}
+```
+
+## Failure Scenarios
+
+### Scenario 1: CoinGecko Rate Limited
+
+```
+Request → CoinGecko (429) → Chainlink (success) → Return price
+```
+
+### Scenario 2: All Sources Down
+
+```
+Request → CoinGecko (timeout) → Chainlink (timeout) → Pyth (timeout)
+        → Check cache (hit, age=20s) → Return cached price
+```
+
+### Scenario 3: Stale Cache Only
+
+```
+Request → All sources fail → Cache miss → Stale cache (age=2min)
+        → AllowStale=true → Return stale price with warning
+```
+
+### Scenario 4: Complete Failure
+
+```
+Request → All sources fail → Cache miss → Stale cache expired
+        → Return ErrAllSourcesFailed → Reject conversion
+```
+
+## Best Practices
+
+1. **Configure multiple sources**: Enable at least 2 sources for redundancy
+2. **Use appropriate strategy**: Primary for speed, Median for accuracy
+3. **Set reasonable cache TTL**: 30s is good balance for crypto volatility
+4. **Monitor metrics**: Alert on source health and deviation
+5. **Test fallbacks**: Periodically simulate source failures
+6. **Use API keys**: Unlock higher rate limits for production
+
+## Troubleshooting
+
+### "price feed unavailable" Error
+
+1. Check if price feed is initialized: `cfg.ConversionConfig.Enabled`
+2. Verify network connectivity to price sources
+3. Check for rate limiting (too many requests)
+4. Verify RPC endpoints for Chainlink/Pyth
+
+### Stale Prices Being Returned
+
+1. Check cache configuration: `CacheTTLSeconds`
+2. Verify source health: `aggregator.ListSources()`
+3. Check for rate limiting issues
+
+### High Price Deviation
+
+1. Normal during volatile markets
+2. If persistent, check for source misconfiguration
+3. Consider switching to single trusted source temporarily

--- a/pkg/pricefeed/aggregator.go
+++ b/pkg/pricefeed/aggregator.go
@@ -1,0 +1,563 @@
+package pricefeed
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// ============================================================================
+// Aggregator Implementation
+// ============================================================================
+
+// PriceFeedAggregator implements the Aggregator interface
+type PriceFeedAggregator struct {
+	config    Config
+	providers map[string]Provider
+	cache     *InMemoryCache
+	metrics   Metrics
+	mu        sync.RWMutex
+	closed    bool
+
+	// Background health checker
+	healthCheckStop chan struct{}
+}
+
+// NewAggregator creates a new price feed aggregator
+func NewAggregator(cfg Config) (*PriceFeedAggregator, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	agg := &PriceFeedAggregator{
+		config:          cfg,
+		providers:       make(map[string]Provider),
+		healthCheckStop: make(chan struct{}),
+	}
+
+	// Initialize cache if enabled
+	if cfg.CacheConfig.Enabled {
+		agg.cache = NewInMemoryCache(cfg.CacheConfig)
+	}
+
+	// Initialize providers
+	for _, provCfg := range cfg.EnabledProviders() {
+		provider, err := createProvider(provCfg, cfg.RetryConfig)
+		if err != nil {
+			// Log error but continue with other providers
+			continue
+		}
+		agg.providers[provCfg.Name] = provider
+	}
+
+	if len(agg.providers) == 0 {
+		return nil, ErrPriceFeedUnavailable
+	}
+
+	// Start background health checker
+	if cfg.HealthCheckInterval > 0 {
+		go agg.healthCheckLoop()
+	}
+
+	return agg, nil
+}
+
+// createProvider creates a provider based on configuration
+func createProvider(cfg ProviderConfig, retryCfg RetryConfig) (Provider, error) {
+	switch cfg.Type {
+	case SourceTypeCoinGecko:
+		if cfg.CoinGeckoConfig == nil {
+			return nil, fmt.Errorf("CoinGecko config required")
+		}
+		return NewCoinGeckoProvider(cfg.Name, *cfg.CoinGeckoConfig, retryCfg)
+
+	case SourceTypeChainlink:
+		if cfg.ChainlinkConfig == nil {
+			return nil, fmt.Errorf("Chainlink config required")
+		}
+		return NewChainlinkProvider(cfg.Name, *cfg.ChainlinkConfig, retryCfg)
+
+	case SourceTypePyth:
+		if cfg.PythConfig == nil {
+			return nil, fmt.Errorf("Pyth config required")
+		}
+		return NewPythProvider(cfg.Name, *cfg.PythConfig, retryCfg)
+
+	default:
+		return nil, fmt.Errorf("unsupported provider type: %s", cfg.Type)
+	}
+}
+
+// GetPrice returns the aggregated price from configured sources
+func (a *PriceFeedAggregator) GetPrice(ctx context.Context, baseAsset, quoteAsset string) (AggregatedPrice, error) {
+	a.mu.RLock()
+	if a.closed {
+		a.mu.RUnlock()
+		return AggregatedPrice{}, ErrPriceFeedUnavailable
+	}
+	a.mu.RUnlock()
+
+	cacheKey := cacheKey(baseAsset, quoteAsset)
+
+	// Check cache first
+	if a.cache != nil {
+		if cached, ok := a.cache.Get(cacheKey); ok {
+			if a.metrics != nil {
+				a.metrics.RecordCacheHit(baseAsset, quoteAsset)
+			}
+			return AggregatedPrice{
+				PriceData:    cached,
+				Strategy:     a.config.Strategy,
+				SourcePrices: []PriceData{cached},
+				SourceCount:  1,
+			}, nil
+		}
+		if a.metrics != nil {
+			a.metrics.RecordCacheMiss(baseAsset, quoteAsset)
+		}
+	}
+
+	// Fetch from providers based on strategy
+	switch a.config.Strategy {
+	case StrategyPrimary:
+		return a.getPricePrimary(ctx, baseAsset, quoteAsset)
+	case StrategyMedian:
+		return a.getPriceMedian(ctx, baseAsset, quoteAsset)
+	case StrategyWeighted:
+		return a.getPriceWeighted(ctx, baseAsset, quoteAsset)
+	default:
+		return a.getPricePrimary(ctx, baseAsset, quoteAsset)
+	}
+}
+
+// getPricePrimary uses the first healthy source in priority order
+func (a *PriceFeedAggregator) getPricePrimary(ctx context.Context, baseAsset, quoteAsset string) (AggregatedPrice, error) {
+	providers := a.getProvidersByPriority()
+
+	var lastErr error
+	for _, provider := range providers {
+		if !provider.IsHealthy(ctx) {
+			continue
+		}
+
+		price, err := provider.GetPrice(ctx, baseAsset, quoteAsset)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		// Cache the result
+		if a.cache != nil {
+			a.cache.Set(cacheKey(baseAsset, quoteAsset), price)
+		}
+
+		return AggregatedPrice{
+			PriceData:    price,
+			Strategy:     StrategyPrimary,
+			SourcePrices: []PriceData{price},
+			SourceCount:  1,
+		}, nil
+	}
+
+	// Try stale cache as fallback
+	if a.cache != nil && a.config.CacheConfig.AllowStale {
+		if stale, ok := a.cache.GetStale(cacheKey(baseAsset, quoteAsset)); ok {
+			return AggregatedPrice{
+				PriceData:    stale,
+				Strategy:     StrategyPrimary,
+				SourcePrices: []PriceData{stale},
+				SourceCount:  1,
+			}, nil
+		}
+	}
+
+	if lastErr != nil {
+		return AggregatedPrice{}, lastErr
+	}
+	return AggregatedPrice{}, ErrAllSourcesFailed
+}
+
+// getPriceMedian uses the median price across all sources
+func (a *PriceFeedAggregator) getPriceMedian(ctx context.Context, baseAsset, quoteAsset string) (AggregatedPrice, error) {
+	prices, err := a.fetchFromAllProviders(ctx, baseAsset, quoteAsset)
+	if err != nil {
+		return AggregatedPrice{}, err
+	}
+
+	if len(prices) == 0 {
+		return AggregatedPrice{}, ErrAllSourcesFailed
+	}
+
+	// Sort by price
+	sort.Slice(prices, func(i, j int) bool {
+		return prices[i].Price.LT(prices[j].Price)
+	})
+
+	// Get median
+	medianIdx := len(prices) / 2
+	medianPrice := prices[medianIdx]
+
+	// Check deviation
+	if len(prices) > 1 {
+		deviation := a.calculateDeviation(prices)
+		if deviation > a.config.MaxPriceDeviation {
+			if a.metrics != nil {
+				a.metrics.RecordPriceDeviation(baseAsset, quoteAsset, deviation)
+			}
+			return AggregatedPrice{}, ErrPriceDeviation
+		}
+	}
+
+	// Cache the result
+	if a.cache != nil {
+		a.cache.Set(cacheKey(baseAsset, quoteAsset), medianPrice)
+	}
+
+	return AggregatedPrice{
+		PriceData:    medianPrice,
+		Strategy:     StrategyMedian,
+		SourcePrices: prices,
+		Deviation:    a.calculateDeviation(prices),
+		SourceCount:  len(prices),
+	}, nil
+}
+
+// getPriceWeighted weights prices by source confidence/volume
+func (a *PriceFeedAggregator) getPriceWeighted(ctx context.Context, baseAsset, quoteAsset string) (AggregatedPrice, error) {
+	prices, err := a.fetchFromAllProviders(ctx, baseAsset, quoteAsset)
+	if err != nil {
+		return AggregatedPrice{}, err
+	}
+
+	if len(prices) == 0 {
+		return AggregatedPrice{}, ErrAllSourcesFailed
+	}
+
+	// Calculate weighted average
+	var totalWeight float64
+	weightedSum := sdkmath.LegacyZeroDec()
+
+	providerWeights := make(map[string]float64)
+	for _, cfg := range a.config.Providers {
+		providerWeights[cfg.Name] = cfg.Weight
+	}
+
+	for _, p := range prices {
+		weight := providerWeights[p.Source]
+		if weight == 0 {
+			weight = 1.0 / float64(len(prices)) // Default equal weight
+		}
+		// Adjust weight by confidence
+		weight *= p.Confidence
+
+		totalWeight += weight
+		weightDec := sdkmath.LegacyMustNewDecFromStr(fmt.Sprintf("%f", weight))
+		contribution := p.Price.MulTruncate(weightDec)
+		weightedSum = weightedSum.Add(contribution)
+	}
+
+	if totalWeight == 0 {
+		return AggregatedPrice{}, ErrAllSourcesFailed
+	}
+
+	totalWeightDec := sdkmath.LegacyMustNewDecFromStr(fmt.Sprintf("%f", totalWeight))
+	avgPrice := weightedSum.QuoTruncate(totalWeightDec)
+
+	result := PriceData{
+		BaseAsset:  baseAsset,
+		QuoteAsset: quoteAsset,
+		Price:      avgPrice,
+		Timestamp:  time.Now().UTC(),
+		Source:     "aggregated",
+		Confidence: a.calculateAggregatedConfidence(prices),
+	}
+
+	// Cache the result
+	if a.cache != nil {
+		a.cache.Set(cacheKey(baseAsset, quoteAsset), result)
+	}
+
+	return AggregatedPrice{
+		PriceData:    result,
+		Strategy:     StrategyWeighted,
+		SourcePrices: prices,
+		Deviation:    a.calculateDeviation(prices),
+		SourceCount:  len(prices),
+	}, nil
+}
+
+// fetchFromAllProviders fetches prices from all healthy providers
+func (a *PriceFeedAggregator) fetchFromAllProviders(ctx context.Context, baseAsset, quoteAsset string) ([]PriceData, error) {
+	a.mu.RLock()
+	providers := make([]Provider, 0, len(a.providers))
+	for _, p := range a.providers {
+		providers = append(providers, p)
+	}
+	a.mu.RUnlock()
+
+	var prices []PriceData
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, provider := range providers {
+		if !provider.IsHealthy(ctx) {
+			continue
+		}
+
+		wg.Add(1)
+		go func(p Provider) {
+			defer wg.Done()
+			price, err := p.GetPrice(ctx, baseAsset, quoteAsset)
+			if err == nil && price.IsValid() {
+				mu.Lock()
+				prices = append(prices, price)
+				mu.Unlock()
+			}
+		}(provider)
+	}
+
+	wg.Wait()
+
+	if len(prices) == 0 {
+		// Try stale cache as fallback
+		if a.cache != nil && a.config.CacheConfig.AllowStale {
+			if stale, ok := a.cache.GetStale(cacheKey(baseAsset, quoteAsset)); ok {
+				return []PriceData{stale}, nil
+			}
+		}
+		return nil, ErrAllSourcesFailed
+	}
+
+	return prices, nil
+}
+
+// calculateDeviation calculates the max percentage deviation between prices
+func (a *PriceFeedAggregator) calculateDeviation(prices []PriceData) float64 {
+	if len(prices) < 2 {
+		return 0
+	}
+
+	var minPrice, maxPrice sdkmath.LegacyDec
+	for i, p := range prices {
+		if i == 0 || p.Price.LT(minPrice) {
+			minPrice = p.Price
+		}
+		if i == 0 || p.Price.GT(maxPrice) {
+			maxPrice = p.Price
+		}
+	}
+
+	if minPrice.IsZero() {
+		return 0
+	}
+
+	deviation := maxPrice.Sub(minPrice).Quo(minPrice)
+	devFloat, _ := deviation.Float64()
+	return devFloat
+}
+
+// calculateAggregatedConfidence calculates aggregated confidence
+func (a *PriceFeedAggregator) calculateAggregatedConfidence(prices []PriceData) float64 {
+	if len(prices) == 0 {
+		return 0
+	}
+
+	var sum float64
+	for _, p := range prices {
+		sum += p.Confidence
+	}
+	return sum / float64(len(prices))
+}
+
+// getProvidersByPriority returns providers sorted by priority
+func (a *PriceFeedAggregator) getProvidersByPriority() []Provider {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	// Get enabled providers config sorted by priority
+	configs := a.config.EnabledProviders()
+
+	providers := make([]Provider, 0, len(configs))
+	for _, cfg := range configs {
+		if p, ok := a.providers[cfg.Name]; ok {
+			providers = append(providers, p)
+		}
+	}
+
+	return providers
+}
+
+// GetPrices returns aggregated prices for multiple pairs
+func (a *PriceFeedAggregator) GetPrices(ctx context.Context, pairs []AssetPair) (map[string]AggregatedPrice, error) {
+	results := make(map[string]AggregatedPrice)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, pair := range pairs {
+		wg.Add(1)
+		go func(p AssetPair) {
+			defer wg.Done()
+			price, err := a.GetPrice(ctx, p.Base, p.Quote)
+			if err == nil {
+				mu.Lock()
+				results[p.String()] = price
+				mu.Unlock()
+			}
+		}(pair)
+	}
+
+	wg.Wait()
+	return results, nil
+}
+
+// GetPriceFromSource returns price from a specific source
+func (a *PriceFeedAggregator) GetPriceFromSource(ctx context.Context, source string, baseAsset, quoteAsset string) (PriceData, error) {
+	a.mu.RLock()
+	provider, ok := a.providers[source]
+	a.mu.RUnlock()
+
+	if !ok {
+		return PriceData{}, fmt.Errorf("provider not found: %s", source)
+	}
+
+	return provider.GetPrice(ctx, baseAsset, quoteAsset)
+}
+
+// ListSources returns all configured price sources
+func (a *PriceFeedAggregator) ListSources() []SourceHealth {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	sources := make([]SourceHealth, 0, len(a.providers))
+	for _, p := range a.providers {
+		sources = append(sources, p.Health())
+	}
+	return sources
+}
+
+// AddProvider adds a new price provider
+func (a *PriceFeedAggregator) AddProvider(provider Provider) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed {
+		return ErrPriceFeedUnavailable
+	}
+
+	name := provider.Name()
+	if _, exists := a.providers[name]; exists {
+		return fmt.Errorf("provider already exists: %s", name)
+	}
+
+	a.providers[name] = provider
+	return nil
+}
+
+// RemoveProvider removes a price provider by name
+func (a *PriceFeedAggregator) RemoveProvider(name string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	provider, ok := a.providers[name]
+	if !ok {
+		return fmt.Errorf("provider not found: %s", name)
+	}
+
+	delete(a.providers, name)
+	return provider.Close()
+}
+
+// RefreshCache forces a cache refresh for the given pairs
+func (a *PriceFeedAggregator) RefreshCache(ctx context.Context, pairs []AssetPair) error {
+	if a.cache == nil {
+		return nil
+	}
+
+	for _, pair := range pairs {
+		a.cache.Delete(cacheKey(pair.Base, pair.Quote))
+	}
+
+	// Fetch fresh prices
+	_, err := a.GetPrices(ctx, pairs)
+	return err
+}
+
+// healthCheckLoop periodically checks provider health
+func (a *PriceFeedAggregator) healthCheckLoop() {
+	ticker := time.NewTicker(a.config.HealthCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			a.checkHealth()
+		case <-a.healthCheckStop:
+			return
+		}
+	}
+}
+
+// checkHealth checks health of all providers
+func (a *PriceFeedAggregator) checkHealth() {
+	a.mu.RLock()
+	providers := make([]Provider, 0, len(a.providers))
+	for _, p := range a.providers {
+		providers = append(providers, p)
+	}
+	a.mu.RUnlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for _, p := range providers {
+		healthy := p.IsHealthy(ctx)
+		if a.metrics != nil {
+			latency := p.Health().Latency.Seconds()
+			a.metrics.RecordSourceHealth(p.Name(), healthy, latency)
+		}
+	}
+}
+
+// SetMetrics sets the metrics collector
+func (a *PriceFeedAggregator) SetMetrics(m Metrics) {
+	a.metrics = m
+}
+
+// CacheStats returns cache statistics
+func (a *PriceFeedAggregator) CacheStats() CacheStats {
+	if a.cache == nil {
+		return CacheStats{}
+	}
+	return a.cache.Stats()
+}
+
+// Close closes the aggregator and all providers
+func (a *PriceFeedAggregator) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.closed {
+		return nil
+	}
+
+	a.closed = true
+	close(a.healthCheckStop)
+
+	var errs []string
+	for name, p := range a.providers {
+		if err := p.Close(); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", name, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors closing providers: %s", strings.Join(errs, "; "))
+	}
+
+	return nil
+}

--- a/pkg/pricefeed/cache.go
+++ b/pkg/pricefeed/cache.go
@@ -1,0 +1,200 @@
+package pricefeed
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ============================================================================
+// In-Memory Cache Implementation
+// ============================================================================
+
+// cacheEntry represents a cached price with metadata
+type cacheEntry struct {
+	Price     PriceData
+	CachedAt  time.Time
+	ExpiresAt time.Time
+}
+
+// IsExpired checks if the entry has expired
+func (e cacheEntry) IsExpired() bool {
+	return time.Now().After(e.ExpiresAt)
+}
+
+// InMemoryCache is a thread-safe in-memory cache for price data
+type InMemoryCache struct {
+	entries      map[string]cacheEntry
+	mu           sync.RWMutex
+	ttl          time.Duration
+	maxSize      int
+	allowStale   bool
+	staleMaxAge  time.Duration
+	hits         atomic.Int64
+	misses       atomic.Int64
+	staleCount   atomic.Int64
+	evictedCount atomic.Int64
+}
+
+// NewInMemoryCache creates a new in-memory cache
+func NewInMemoryCache(cfg CacheConfig) *InMemoryCache {
+	c := &InMemoryCache{
+		entries:     make(map[string]cacheEntry),
+		ttl:         cfg.TTL,
+		maxSize:     cfg.MaxSize,
+		allowStale:  cfg.AllowStale,
+		staleMaxAge: cfg.StaleMaxAge,
+	}
+
+	// Start background cleanup goroutine
+	go c.cleanupLoop()
+
+	return c
+}
+
+// cacheKey generates a cache key for an asset pair
+func cacheKey(baseAsset, quoteAsset string) string {
+	return baseAsset + "/" + quoteAsset
+}
+
+// Get retrieves a cached price
+func (c *InMemoryCache) Get(key string) (PriceData, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+
+	if !ok {
+		c.misses.Add(1)
+		return PriceData{}, false
+	}
+
+	if entry.IsExpired() {
+		// Check if stale data is acceptable
+		if c.allowStale && time.Since(entry.CachedAt) <= c.staleMaxAge {
+			c.staleCount.Add(1)
+			c.hits.Add(1)
+			return entry.Price, true
+		}
+		c.misses.Add(1)
+		return PriceData{}, false
+	}
+
+	c.hits.Add(1)
+	return entry.Price, true
+}
+
+// Set stores a price in the cache
+func (c *InMemoryCache) Set(key string, price PriceData) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Evict oldest entries if at capacity
+	if len(c.entries) >= c.maxSize {
+		c.evictOldest()
+	}
+
+	c.entries[key] = cacheEntry{
+		Price:     price,
+		CachedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+// Delete removes a price from the cache
+func (c *InMemoryCache) Delete(key string) {
+	c.mu.Lock()
+	delete(c.entries, key)
+	c.mu.Unlock()
+}
+
+// Clear clears all cached prices
+func (c *InMemoryCache) Clear() {
+	c.mu.Lock()
+	c.entries = make(map[string]cacheEntry)
+	c.mu.Unlock()
+}
+
+// Stats returns cache statistics
+func (c *InMemoryCache) Stats() CacheStats {
+	c.mu.RLock()
+	size := len(c.entries)
+	c.mu.RUnlock()
+
+	return CacheStats{
+		Hits:         c.hits.Load(),
+		Misses:       c.misses.Load(),
+		Size:         size,
+		EvictedCount: c.evictedCount.Load(),
+		StaleCount:   c.staleCount.Load(),
+	}
+}
+
+// evictOldest removes the oldest entry (must be called with lock held)
+func (c *InMemoryCache) evictOldest() {
+	var oldestKey string
+	var oldestTime time.Time
+
+	for key, entry := range c.entries {
+		if oldestKey == "" || entry.CachedAt.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = entry.CachedAt
+		}
+	}
+
+	if oldestKey != "" {
+		delete(c.entries, oldestKey)
+		c.evictedCount.Add(1)
+	}
+}
+
+// cleanupLoop periodically removes expired entries
+func (c *InMemoryCache) cleanupLoop() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.cleanup()
+	}
+}
+
+// cleanup removes all expired entries
+func (c *InMemoryCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for key, entry := range c.entries {
+		// Remove entries that are beyond stale max age
+		if now.Sub(entry.CachedAt) > c.staleMaxAge {
+			delete(c.entries, key)
+			c.evictedCount.Add(1)
+		}
+	}
+}
+
+// GetStale retrieves a stale price if available (for fallback scenarios)
+func (c *InMemoryCache) GetStale(key string) (PriceData, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+
+	if !ok {
+		return PriceData{}, false
+	}
+
+	// Return stale data regardless of expiry, up to staleMaxAge
+	if time.Since(entry.CachedAt) <= c.staleMaxAge {
+		c.staleCount.Add(1)
+		return entry.Price, true
+	}
+
+	return PriceData{}, false
+}
+
+// GetEntry returns the full cache entry for debugging
+func (c *InMemoryCache) GetEntry(key string) (cacheEntry, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	return entry, ok
+}

--- a/pkg/pricefeed/chainlink.go
+++ b/pkg/pricefeed/chainlink.go
@@ -1,0 +1,269 @@
+package pricefeed
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// ============================================================================
+// Chainlink Provider Implementation
+// ============================================================================
+
+// ChainlinkProvider implements the Provider interface for Chainlink price feeds
+type ChainlinkProvider struct {
+	name      string
+	config    ChainlinkConfig
+	health    SourceHealth
+	healthMu  sync.RWMutex
+	circuit   *CircuitBreaker
+	retryer   *Retryer
+	closed    atomic.Bool
+	ethClient ChainlinkEthClient
+}
+
+// ChainlinkEthClient is an interface for Ethereum RPC calls
+// In production, this would use go-ethereum's ethclient
+type ChainlinkEthClient interface {
+	// CallContract calls a smart contract method
+	CallContract(ctx context.Context, address string, data []byte) ([]byte, error)
+	// Close closes the client
+	Close() error
+}
+
+// defaultEthClient is a stub implementation that can be replaced in production
+type defaultEthClient struct {
+	rpcURL string
+}
+
+func newDefaultEthClient(rpcURL string) *defaultEthClient {
+	return &defaultEthClient{rpcURL: rpcURL}
+}
+
+func (c *defaultEthClient) CallContract(ctx context.Context, address string, data []byte) ([]byte, error) {
+	// In production, this would use go-ethereum's ethclient to make RPC calls
+	// For now, return an error indicating the client needs to be configured
+	return nil, fmt.Errorf("Chainlink ETH client not configured - set RPCURL in ChainlinkConfig")
+}
+
+func (c *defaultEthClient) Close() error {
+	return nil
+}
+
+// NewChainlinkProvider creates a new Chainlink provider
+func NewChainlinkProvider(name string, cfg ChainlinkConfig, retryCfg RetryConfig) (*ChainlinkProvider, error) {
+	if cfg.RPCURL == "" {
+		return nil, fmt.Errorf("Chainlink provider requires RPC URL")
+	}
+
+	provider := &ChainlinkProvider{
+		name:      name,
+		config:    cfg,
+		ethClient: newDefaultEthClient(cfg.RPCURL),
+		health: SourceHealth{
+			Source:    name,
+			Type:      SourceTypeChainlink,
+			Healthy:   true,
+			LastCheck: time.Now(),
+		},
+		circuit: NewCircuitBreaker(5, 2, 30*time.Second),
+		retryer: NewRetryer(retryCfg),
+	}
+
+	return provider, nil
+}
+
+// SetEthClient sets a custom Ethereum client (for production use)
+func (p *ChainlinkProvider) SetEthClient(client ChainlinkEthClient) {
+	p.ethClient = client
+}
+
+// Name returns the provider name
+func (p *ChainlinkProvider) Name() string {
+	return p.name
+}
+
+// Type returns the provider type
+func (p *ChainlinkProvider) Type() SourceType {
+	return SourceTypeChainlink
+}
+
+// GetPrice fetches the current price for an asset pair
+func (p *ChainlinkProvider) GetPrice(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error) {
+	if p.closed.Load() {
+		return PriceData{}, ErrSourceUnhealthy
+	}
+
+	// Check circuit breaker
+	if !p.circuit.Allow() {
+		return PriceData{}, ErrSourceUnhealthy
+	}
+
+	startTime := time.Now()
+
+	price, err := DoWithResult(ctx, p.retryer, func(ctx context.Context) (PriceData, error) {
+		return p.fetchPrice(ctx, baseAsset, quoteAsset)
+	})
+
+	latency := time.Since(startTime)
+
+	p.healthMu.Lock()
+	p.health.LastCheck = time.Now()
+	p.health.RequestCount++
+	p.health.Latency = latency
+	if err != nil {
+		p.health.ErrorCount++
+		p.health.LastError = err.Error()
+		p.circuit.RecordFailure()
+	} else {
+		p.health.Healthy = true
+		p.health.LastSuccess = time.Now()
+		p.health.LastError = ""
+		p.circuit.RecordSuccess()
+	}
+	p.healthMu.Unlock()
+
+	return price, err
+}
+
+// fetchPrice fetches the price from Chainlink oracle
+func (p *ChainlinkProvider) fetchPrice(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error) {
+	// Look up the feed address
+	pairKey := fmt.Sprintf("%s/%s", strings.ToUpper(baseAsset), strings.ToUpper(quoteAsset))
+	feedAddress, ok := p.config.FeedAddresses[pairKey]
+	if !ok {
+		return PriceData{}, fmt.Errorf("%w: no Chainlink feed for %s", ErrPriceNotFound, pairKey)
+	}
+
+	// Call the Chainlink aggregator contract
+	// Function selector for latestRoundData(): 0xfeaf968c
+	latestRoundDataSelector := []byte{0xfe, 0xaf, 0x96, 0x8c}
+
+	result, err := p.ethClient.CallContract(ctx, feedAddress, latestRoundDataSelector)
+	if err != nil {
+		return PriceData{}, fmt.Errorf("failed to call Chainlink feed: %w", err)
+	}
+
+	// Parse the result
+	// latestRoundData returns: (roundId, answer, startedAt, updatedAt, answeredInRound)
+	// answer is at bytes 32-64 (second 32-byte word)
+	if len(result) < 64 {
+		return PriceData{}, fmt.Errorf("invalid response from Chainlink feed")
+	}
+
+	// Extract the answer (price with 8 decimals for most Chainlink feeds)
+	answerBytes := result[32:64]
+	answer := new(big.Int).SetBytes(answerBytes)
+
+	// Chainlink price feeds typically use 8 decimals
+	decimals := int64(8)
+
+	// Convert to sdkmath.LegacyDec
+	price := sdkmath.LegacyNewDecFromBigIntWithPrec(answer, decimals)
+
+	// Extract updatedAt timestamp (bytes 96-128)
+	var updatedAt time.Time
+	if len(result) >= 128 {
+		updatedAtBytes := result[96:128]
+		updatedAtInt := new(big.Int).SetBytes(updatedAtBytes).Int64()
+		updatedAt = time.Unix(updatedAtInt, 0).UTC()
+	}
+
+	return PriceData{
+		BaseAsset:     baseAsset,
+		QuoteAsset:    quoteAsset,
+		Price:         price,
+		Timestamp:     time.Now().UTC(),
+		Source:        p.name,
+		Confidence:    0.99, // Chainlink is highly trusted
+		LastUpdatedAt: updatedAt,
+	}, nil
+}
+
+// GetPrices fetches prices for multiple asset pairs
+func (p *ChainlinkProvider) GetPrices(ctx context.Context, pairs []AssetPair) (map[string]PriceData, error) {
+	if p.closed.Load() {
+		return nil, ErrSourceUnhealthy
+	}
+
+	if !p.circuit.Allow() {
+		return nil, ErrSourceUnhealthy
+	}
+
+	results := make(map[string]PriceData)
+
+	for _, pair := range pairs {
+		price, err := p.GetPrice(ctx, pair.Base, pair.Quote)
+		if err != nil {
+			continue
+		}
+		results[pair.String()] = price
+	}
+
+	return results, nil
+}
+
+// IsHealthy checks if the provider is responding
+func (p *ChainlinkProvider) IsHealthy(ctx context.Context) bool {
+	if p.closed.Load() {
+		return false
+	}
+
+	p.healthMu.RLock()
+	health := p.health.Healthy
+	lastSuccess := p.health.LastSuccess
+	p.healthMu.RUnlock()
+
+	// Consider unhealthy if no successful request in 5 minutes
+	if time.Since(lastSuccess) > 5*time.Minute && !lastSuccess.IsZero() {
+		return false
+	}
+
+	return health && p.circuit.State() != CircuitOpen
+}
+
+// Health returns detailed health information
+func (p *ChainlinkProvider) Health() SourceHealth {
+	p.healthMu.RLock()
+	defer p.healthMu.RUnlock()
+	health := p.health
+	health.Healthy = p.circuit.State() != CircuitOpen && p.health.Healthy
+	return health
+}
+
+// Close closes the provider
+func (p *ChainlinkProvider) Close() error {
+	p.closed.Store(true)
+	if p.ethClient != nil {
+		return p.ethClient.Close()
+	}
+	return nil
+}
+
+// ============================================================================
+// Common Chainlink Feed Addresses (Ethereum Mainnet)
+// ============================================================================
+
+// ChainlinkMainnetFeeds contains common Chainlink price feed addresses on Ethereum mainnet
+var ChainlinkMainnetFeeds = map[string]string{
+	"ETH/USD":  "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+	"BTC/USD":  "0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c",
+	"LINK/USD": "0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c",
+	"USDC/USD": "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6",
+	"USDT/USD": "0x3E7d1eAB13ad0104d2750B8863b489D65364e32D",
+	"DAI/USD":  "0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9",
+	"ATOM/USD": "0xDC4BDB458C6361093069Ca2aD30D74cc152EdC75",
+}
+
+// ChainlinkSepoliaFeeds contains common Chainlink price feed addresses on Sepolia testnet
+var ChainlinkSepoliaFeeds = map[string]string{
+	"ETH/USD":  "0x694AA1769357215DE4FAC081bf1f309aDC325306",
+	"BTC/USD":  "0x1b44F3514812d835EB1BDB0acB33d3fA3351Ee43",
+	"LINK/USD": "0xc59E3633BAAC79493d908e63626716e204A45EdF",
+}

--- a/pkg/pricefeed/coingecko.go
+++ b/pkg/pricefeed/coingecko.go
@@ -1,0 +1,467 @@
+package pricefeed
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// ============================================================================
+// CoinGecko Provider Implementation
+// ============================================================================
+
+// CoinGeckoProvider implements the Provider interface for CoinGecko API
+type CoinGeckoProvider struct {
+	name       string
+	config     CoinGeckoConfig
+	client     *http.Client
+	rateLimiter *rateLimiter
+	health     SourceHealth
+	healthMu   sync.RWMutex
+	circuit    *CircuitBreaker
+	retryer    *Retryer
+	closed     atomic.Bool
+}
+
+// rateLimiter implements simple rate limiting
+type rateLimiter struct {
+	mu        sync.Mutex
+	tokens    int
+	maxTokens int
+	lastFill  time.Time
+	fillRate  time.Duration
+}
+
+func newRateLimiter(maxPerMinute int) *rateLimiter {
+	return &rateLimiter{
+		tokens:    maxPerMinute,
+		maxTokens: maxPerMinute,
+		lastFill:  time.Now(),
+		fillRate:  time.Minute / time.Duration(maxPerMinute),
+	}
+}
+
+func (r *rateLimiter) acquire() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Refill tokens based on time passed
+	now := time.Now()
+	elapsed := now.Sub(r.lastFill)
+	tokensToAdd := int(elapsed / r.fillRate)
+	if tokensToAdd > 0 {
+		r.tokens += tokensToAdd
+		if r.tokens > r.maxTokens {
+			r.tokens = r.maxTokens
+		}
+		r.lastFill = now
+	}
+
+	if r.tokens > 0 {
+		r.tokens--
+		return true
+	}
+	return false
+}
+
+// NewCoinGeckoProvider creates a new CoinGecko provider
+func NewCoinGeckoProvider(name string, cfg CoinGeckoConfig, retryCfg RetryConfig) (*CoinGeckoProvider, error) {
+	if cfg.APIURL == "" {
+		cfg.APIURL = "https://api.coingecko.com/api/v3"
+	}
+	if cfg.RateLimitPerMinute <= 0 {
+		cfg.RateLimitPerMinute = 10 // Default free tier limit
+	}
+
+	provider := &CoinGeckoProvider{
+		name:   name,
+		config: cfg,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		rateLimiter: newRateLimiter(cfg.RateLimitPerMinute),
+		health: SourceHealth{
+			Source:    name,
+			Type:      SourceTypeCoinGecko,
+			Healthy:   true,
+			LastCheck: time.Now(),
+		},
+		circuit: NewCircuitBreaker(5, 2, 30*time.Second),
+		retryer: NewRetryer(retryCfg),
+	}
+
+	return provider, nil
+}
+
+// Name returns the provider name
+func (p *CoinGeckoProvider) Name() string {
+	return p.name
+}
+
+// Type returns the provider type
+func (p *CoinGeckoProvider) Type() SourceType {
+	return SourceTypeCoinGecko
+}
+
+// GetPrice fetches the current price for an asset pair
+func (p *CoinGeckoProvider) GetPrice(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error) {
+	if p.closed.Load() {
+		return PriceData{}, ErrSourceUnhealthy
+	}
+
+	// Check circuit breaker
+	if !p.circuit.Allow() {
+		return PriceData{}, ErrSourceUnhealthy
+	}
+
+	// Check rate limit
+	if !p.rateLimiter.acquire() {
+		return PriceData{}, ErrRateLimitExceeded
+	}
+
+	startTime := time.Now()
+
+	price, err := DoWithResult(ctx, p.retryer, func(ctx context.Context) (PriceData, error) {
+		return p.fetchPrice(ctx, baseAsset, quoteAsset)
+	})
+
+	latency := time.Since(startTime)
+
+	p.healthMu.Lock()
+	p.health.LastCheck = time.Now()
+	p.health.RequestCount++
+	p.health.Latency = latency
+	if err != nil {
+		p.health.ErrorCount++
+		p.health.LastError = err.Error()
+		p.circuit.RecordFailure()
+	} else {
+		p.health.Healthy = true
+		p.health.LastSuccess = time.Now()
+		p.health.LastError = ""
+		p.circuit.RecordSuccess()
+	}
+	p.healthMu.Unlock()
+
+	return price, err
+}
+
+// fetchPrice makes the actual HTTP request to CoinGecko
+func (p *CoinGeckoProvider) fetchPrice(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error) {
+	// Map internal asset names to CoinGecko IDs
+	coinID := p.mapToCoinGeckoID(baseAsset)
+	currency := strings.ToLower(quoteAsset)
+
+	// Build URL
+	endpoint := fmt.Sprintf("%s/simple/price", p.config.APIURL)
+	params := url.Values{}
+	params.Set("ids", coinID)
+	params.Set("vs_currencies", currency)
+	params.Set("include_24hr_vol", "true")
+	params.Set("include_last_updated_at", "true")
+	params.Set("include_market_cap", "true")
+
+	reqURL := fmt.Sprintf("%s?%s", endpoint, params.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return PriceData{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Add headers
+	req.Header.Set("Accept", "application/json")
+	if p.config.APIKey != "" {
+		if p.config.UsePro {
+			req.Header.Set("x-cg-pro-api-key", p.config.APIKey)
+		} else {
+			req.Header.Set("x-cg-demo-api-key", p.config.APIKey)
+		}
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return PriceData{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return PriceData{}, ErrRateLimitExceeded
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return PriceData{}, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse response
+	var result map[string]map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return PriceData{}, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	coinData, ok := result[coinID]
+	if !ok {
+		return PriceData{}, ErrPriceNotFound
+	}
+
+	priceVal, ok := coinData[currency]
+	if !ok {
+		return PriceData{}, ErrPriceNotFound
+	}
+
+	price, err := p.parseFloat(priceVal)
+	if err != nil {
+		return PriceData{}, fmt.Errorf("failed to parse price: %w", err)
+	}
+
+	// Parse optional fields
+	var volume24h, marketCap sdkmath.LegacyDec
+	var lastUpdated time.Time
+
+	if v, ok := coinData[currency+"_24h_vol"]; ok {
+		if vol, err := p.parseFloat(v); err == nil {
+			volume24h = sdkmath.LegacyNewDecFromBigInt(vol.BigInt())
+		}
+	}
+
+	if v, ok := coinData[currency+"_market_cap"]; ok {
+		if mc, err := p.parseFloat(v); err == nil {
+			marketCap = sdkmath.LegacyNewDecFromBigInt(mc.BigInt())
+		}
+	}
+
+	if v, ok := coinData["last_updated_at"]; ok {
+		if ts, err := p.parseInt(v); err == nil {
+			lastUpdated = time.Unix(ts, 0).UTC()
+		}
+	}
+
+	return PriceData{
+		BaseAsset:     baseAsset,
+		QuoteAsset:    quoteAsset,
+		Price:         price,
+		Timestamp:     time.Now().UTC(),
+		Source:        p.name,
+		Confidence:    0.95, // CoinGecko aggregates from multiple exchanges
+		Volume24h:     volume24h,
+		MarketCap:     marketCap,
+		LastUpdatedAt: lastUpdated,
+	}, nil
+}
+
+// parseFloat parses a float value from JSON
+func (p *CoinGeckoProvider) parseFloat(v interface{}) (sdkmath.LegacyDec, error) {
+	switch val := v.(type) {
+	case float64:
+		return sdkmath.LegacyMustNewDecFromStr(fmt.Sprintf("%.18f", val)), nil
+	case int64:
+		return sdkmath.LegacyNewDec(val), nil
+	case int:
+		return sdkmath.LegacyNewDec(int64(val)), nil
+	default:
+		return sdkmath.LegacyDec{}, fmt.Errorf("unexpected type %T", v)
+	}
+}
+
+// parseInt parses an int value from JSON
+func (p *CoinGeckoProvider) parseInt(v interface{}) (int64, error) {
+	switch val := v.(type) {
+	case float64:
+		return int64(val), nil
+	case int64:
+		return val, nil
+	case int:
+		return int64(val), nil
+	default:
+		return 0, fmt.Errorf("unexpected type %T", v)
+	}
+}
+
+// mapToCoinGeckoID maps internal asset IDs to CoinGecko IDs
+func (p *CoinGeckoProvider) mapToCoinGeckoID(asset string) string {
+	// Common mappings
+	mappings := map[string]string{
+		"uve":        "virtengine",
+		"virtengine": "virtengine",
+		"atom":       "cosmos",
+		"cosmos":     "cosmos",
+		"usdc":       "usd-coin",
+		"usdt":       "tether",
+		"eth":        "ethereum",
+		"btc":        "bitcoin",
+	}
+
+	if id, ok := mappings[strings.ToLower(asset)]; ok {
+		return id
+	}
+	return strings.ToLower(asset)
+}
+
+// GetPrices fetches prices for multiple asset pairs
+func (p *CoinGeckoProvider) GetPrices(ctx context.Context, pairs []AssetPair) (map[string]PriceData, error) {
+	if p.closed.Load() {
+		return nil, ErrSourceUnhealthy
+	}
+
+	if !p.circuit.Allow() {
+		return nil, ErrSourceUnhealthy
+	}
+
+	if !p.rateLimiter.acquire() {
+		return nil, ErrRateLimitExceeded
+	}
+
+	// Group by quote currency to minimize API calls
+	byQuote := make(map[string][]string)
+	for _, pair := range pairs {
+		quote := strings.ToLower(pair.Quote)
+		coinID := p.mapToCoinGeckoID(pair.Base)
+		byQuote[quote] = append(byQuote[quote], coinID)
+	}
+
+	results := make(map[string]PriceData)
+
+	for quote, coinIDs := range byQuote {
+		// Build URL
+		endpoint := fmt.Sprintf("%s/simple/price", p.config.APIURL)
+		params := url.Values{}
+		params.Set("ids", strings.Join(unique(coinIDs), ","))
+		params.Set("vs_currencies", quote)
+		params.Set("include_last_updated_at", "true")
+
+		reqURL := fmt.Sprintf("%s?%s", endpoint, params.Encode())
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			continue
+		}
+
+		req.Header.Set("Accept", "application/json")
+		if p.config.APIKey != "" {
+			if p.config.UsePro {
+				req.Header.Set("x-cg-pro-api-key", p.config.APIKey)
+			} else {
+				req.Header.Set("x-cg-demo-api-key", p.config.APIKey)
+			}
+		}
+
+		resp, err := p.client.Do(req)
+		if err != nil {
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			continue
+		}
+
+		var result map[string]map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			resp.Body.Close()
+			continue
+		}
+		resp.Body.Close()
+
+		for coinID, data := range result {
+			if priceVal, ok := data[quote]; ok {
+				if price, err := p.parseFloat(priceVal); err == nil {
+					baseAsset := p.reverseMapCoinGeckoID(coinID)
+					key := baseAsset + "/" + strings.ToUpper(quote)
+					results[key] = PriceData{
+						BaseAsset:  baseAsset,
+						QuoteAsset: strings.ToUpper(quote),
+						Price:      price,
+						Timestamp:  time.Now().UTC(),
+						Source:     p.name,
+						Confidence: 0.95,
+					}
+				}
+			}
+		}
+	}
+
+	p.healthMu.Lock()
+	p.health.LastCheck = time.Now()
+	p.health.RequestCount++
+	if len(results) > 0 {
+		p.health.Healthy = true
+		p.health.LastSuccess = time.Now()
+		p.circuit.RecordSuccess()
+	}
+	p.healthMu.Unlock()
+
+	return results, nil
+}
+
+// reverseMapCoinGeckoID maps CoinGecko IDs back to internal IDs
+func (p *CoinGeckoProvider) reverseMapCoinGeckoID(coinID string) string {
+	mappings := map[string]string{
+		"virtengine": "uve",
+		"cosmos":     "atom",
+		"usd-coin":   "usdc",
+		"tether":     "usdt",
+		"ethereum":   "eth",
+		"bitcoin":    "btc",
+	}
+
+	if id, ok := mappings[coinID]; ok {
+		return id
+	}
+	return coinID
+}
+
+// IsHealthy checks if the provider is responding
+func (p *CoinGeckoProvider) IsHealthy(ctx context.Context) bool {
+	if p.closed.Load() {
+		return false
+	}
+
+	p.healthMu.RLock()
+	health := p.health.Healthy
+	lastSuccess := p.health.LastSuccess
+	p.healthMu.RUnlock()
+
+	// Consider unhealthy if no successful request in 5 minutes
+	if time.Since(lastSuccess) > 5*time.Minute {
+		return false
+	}
+
+	return health && p.circuit.State() != CircuitOpen
+}
+
+// Health returns detailed health information
+func (p *CoinGeckoProvider) Health() SourceHealth {
+	p.healthMu.RLock()
+	defer p.healthMu.RUnlock()
+	health := p.health
+	health.Healthy = p.circuit.State() != CircuitOpen && p.health.Healthy
+	return health
+}
+
+// Close closes the provider
+func (p *CoinGeckoProvider) Close() error {
+	p.closed.Store(true)
+	return nil
+}
+
+// unique returns unique strings from a slice
+func unique(strs []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, s := range strs {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/pkg/pricefeed/config.go
+++ b/pkg/pricefeed/config.go
@@ -1,0 +1,300 @@
+package pricefeed
+
+import (
+	"time"
+)
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+// Config contains the configuration for the price feed service
+type Config struct {
+	// Providers is the list of enabled price providers in priority order
+	Providers []ProviderConfig `json:"providers"`
+
+	// Strategy is the aggregation strategy to use
+	Strategy AggregationStrategy `json:"strategy"`
+
+	// CacheConfig is the caching configuration
+	CacheConfig CacheConfig `json:"cache_config"`
+
+	// RetryConfig is the retry configuration
+	RetryConfig RetryConfig `json:"retry_config"`
+
+	// AssetMappings maps internal asset IDs to external source IDs
+	AssetMappings []AssetMapping `json:"asset_mappings"`
+
+	// MaxPriceDeviation is the max allowed price deviation between sources (0-1)
+	// If deviation exceeds this, ErrPriceDeviation is returned
+	MaxPriceDeviation float64 `json:"max_price_deviation"`
+
+	// StaleThreshold is the max age for cached prices before they're considered stale
+	StaleThreshold time.Duration `json:"stale_threshold"`
+
+	// HealthCheckInterval is how often to check source health
+	HealthCheckInterval time.Duration `json:"health_check_interval"`
+
+	// EnableMetrics enables Prometheus metrics collection
+	EnableMetrics bool `json:"enable_metrics"`
+
+	// EnableLogging enables debug logging
+	EnableLogging bool `json:"enable_logging"`
+}
+
+// ProviderConfig contains configuration for a single price provider
+type ProviderConfig struct {
+	// Name is the unique name for this provider instance
+	Name string `json:"name"`
+
+	// Type is the provider type
+	Type SourceType `json:"type"`
+
+	// Enabled controls whether this provider is active
+	Enabled bool `json:"enabled"`
+
+	// Priority is the priority order (lower = higher priority)
+	Priority int `json:"priority"`
+
+	// Weight is the weight for weighted aggregation (0-1)
+	Weight float64 `json:"weight"`
+
+	// CoinGeckoConfig is config for CoinGecko provider
+	CoinGeckoConfig *CoinGeckoConfig `json:"coingecko_config,omitempty"`
+
+	// ChainlinkConfig is config for Chainlink provider
+	ChainlinkConfig *ChainlinkConfig `json:"chainlink_config,omitempty"`
+
+	// PythConfig is config for Pyth provider
+	PythConfig *PythConfig `json:"pyth_config,omitempty"`
+
+	// RequestTimeout is the timeout for requests to this provider
+	RequestTimeout time.Duration `json:"request_timeout"`
+}
+
+// CoinGeckoConfig contains CoinGecko-specific configuration
+type CoinGeckoConfig struct {
+	// APIURL is the base API URL
+	APIURL string `json:"api_url"`
+
+	// APIKey is the optional API key for Pro tier
+	APIKey string `json:"api_key,omitempty"`
+
+	// RateLimitPerMinute is the rate limit (free tier: 10-30/min)
+	RateLimitPerMinute int `json:"rate_limit_per_minute"`
+
+	// UsePro indicates whether to use the Pro API
+	UsePro bool `json:"use_pro"`
+}
+
+// ChainlinkConfig contains Chainlink-specific configuration
+type ChainlinkConfig struct {
+	// RPCURL is the Ethereum RPC URL to query feeds
+	RPCURL string `json:"rpc_url"`
+
+	// NetworkID is the chain ID (1 = mainnet, 11155111 = sepolia)
+	NetworkID int `json:"network_id"`
+
+	// FeedAddresses maps asset pairs to feed contract addresses
+	FeedAddresses map[string]string `json:"feed_addresses"`
+}
+
+// PythConfig contains Pyth-specific configuration
+type PythConfig struct {
+	// HermesURL is the Pyth Hermes API URL
+	HermesURL string `json:"hermes_url"`
+
+	// PriceServiceURL is the Pyth price service URL
+	PriceServiceURL string `json:"price_service_url"`
+
+	// PriceIDs maps asset pairs to Pyth price feed IDs
+	PriceIDs map[string]string `json:"price_ids"`
+}
+
+// CacheConfig contains caching configuration
+type CacheConfig struct {
+	// Enabled enables caching
+	Enabled bool `json:"enabled"`
+
+	// TTL is the time-to-live for cached prices
+	TTL time.Duration `json:"ttl"`
+
+	// MaxSize is the maximum number of cached prices
+	MaxSize int `json:"max_size"`
+
+	// AllowStale allows returning stale prices when sources are unavailable
+	AllowStale bool `json:"allow_stale"`
+
+	// StaleMaxAge is the max age for stale prices (if AllowStale is true)
+	StaleMaxAge time.Duration `json:"stale_max_age"`
+}
+
+// RetryConfig contains retry configuration
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retries
+	MaxRetries int `json:"max_retries"`
+
+	// InitialDelay is the initial retry delay
+	InitialDelay time.Duration `json:"initial_delay"`
+
+	// MaxDelay is the maximum retry delay
+	MaxDelay time.Duration `json:"max_delay"`
+
+	// BackoffFactor is the exponential backoff multiplier
+	BackoffFactor float64 `json:"backoff_factor"`
+
+	// RetryableErrors is a list of errors that trigger retries
+	RetryableErrors []string `json:"retryable_errors"`
+}
+
+// DefaultConfig returns a Config with sensible defaults
+func DefaultConfig() Config {
+	return Config{
+		Providers: []ProviderConfig{
+			{
+				Name:     "coingecko-primary",
+				Type:     SourceTypeCoinGecko,
+				Enabled:  true,
+				Priority: 1,
+				Weight:   0.5,
+				CoinGeckoConfig: &CoinGeckoConfig{
+					APIURL:             "https://api.coingecko.com/api/v3",
+					RateLimitPerMinute: 10,
+					UsePro:             false,
+				},
+				RequestTimeout: 10 * time.Second,
+			},
+			{
+				Name:     "chainlink-primary",
+				Type:     SourceTypeChainlink,
+				Enabled:  true,
+				Priority: 2,
+				Weight:   0.3,
+				ChainlinkConfig: &ChainlinkConfig{
+					NetworkID: 1, // Ethereum mainnet
+					FeedAddresses: map[string]string{
+						// Example feeds - would be configured per deployment
+						"ETH/USD": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+					},
+				},
+				RequestTimeout: 15 * time.Second,
+			},
+			{
+				Name:     "pyth-primary",
+				Type:     SourceTypePyth,
+				Enabled:  true,
+				Priority: 3,
+				Weight:   0.2,
+				PythConfig: &PythConfig{
+					HermesURL:       "https://hermes.pyth.network",
+					PriceServiceURL: "https://xc-mainnet.pyth.network",
+					PriceIDs: map[string]string{
+						// Example feeds - would be configured per deployment
+						"ETH/USD": "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
+					},
+				},
+				RequestTimeout: 10 * time.Second,
+			},
+		},
+		Strategy: StrategyPrimary,
+		CacheConfig: CacheConfig{
+			Enabled:     true,
+			TTL:         30 * time.Second,
+			MaxSize:     1000,
+			AllowStale:  true,
+			StaleMaxAge: 5 * time.Minute,
+		},
+		RetryConfig: RetryConfig{
+			MaxRetries:    3,
+			InitialDelay:  100 * time.Millisecond,
+			MaxDelay:      5 * time.Second,
+			BackoffFactor: 2.0,
+			RetryableErrors: []string{
+				"timeout",
+				"connection refused",
+				"rate limit",
+				"503",
+				"504",
+			},
+		},
+		AssetMappings:       DefaultAssetMappings(),
+		MaxPriceDeviation:   0.05, // 5% max deviation
+		StaleThreshold:      1 * time.Minute,
+		HealthCheckInterval: 30 * time.Second,
+		EnableMetrics:       true,
+		EnableLogging:       false,
+	}
+}
+
+// Validate validates the configuration
+func (c Config) Validate() error {
+	if len(c.Providers) == 0 {
+		return ErrPriceFeedUnavailable
+	}
+
+	if !c.Strategy.IsValid() {
+		return ErrInvalidPair
+	}
+
+	enabledCount := 0
+	for _, p := range c.Providers {
+		if p.Enabled {
+			enabledCount++
+			if !p.Type.IsValid() {
+				return ErrInvalidPair
+			}
+			if p.RequestTimeout <= 0 {
+				return ErrInvalidPair
+			}
+		}
+	}
+
+	if enabledCount == 0 {
+		return ErrPriceFeedUnavailable
+	}
+
+	if c.MaxPriceDeviation <= 0 || c.MaxPriceDeviation > 1 {
+		return ErrInvalidPair
+	}
+
+	return nil
+}
+
+// GetProviderConfig returns the config for a specific provider by name
+func (c Config) GetProviderConfig(name string) (ProviderConfig, bool) {
+	for _, p := range c.Providers {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return ProviderConfig{}, false
+}
+
+// GetAssetMapping returns the mapping for an internal asset ID
+func (c Config) GetAssetMapping(internalID string) (AssetMapping, bool) {
+	for _, m := range c.AssetMappings {
+		if m.InternalID == internalID {
+			return m, true
+		}
+	}
+	return AssetMapping{}, false
+}
+
+// EnabledProviders returns only enabled providers sorted by priority
+func (c Config) EnabledProviders() []ProviderConfig {
+	var enabled []ProviderConfig
+	for _, p := range c.Providers {
+		if p.Enabled {
+			enabled = append(enabled, p)
+		}
+	}
+	// Sort by priority (lower = higher priority)
+	for i := 0; i < len(enabled)-1; i++ {
+		for j := i + 1; j < len(enabled); j++ {
+			if enabled[j].Priority < enabled[i].Priority {
+				enabled[i], enabled[j] = enabled[j], enabled[i]
+			}
+		}
+	}
+	return enabled
+}

--- a/pkg/pricefeed/doc.go
+++ b/pkg/pricefeed/doc.go
@@ -1,0 +1,62 @@
+// Package pricefeed provides real-time price feed integration for cryptocurrency
+// price discovery.
+//
+// # Overview
+//
+// This package implements a multi-source price feed system with support for:
+//   - CoinGecko API (centralized, free tier available)
+//   - Chainlink price feeds (decentralized oracles)
+//   - Pyth Network (high-frequency decentralized oracles)
+//
+// # Architecture
+//
+// The package uses an aggregator pattern where multiple price sources are queried
+// and their results are aggregated with configurable strategies:
+//   - Primary: Use first healthy source in priority order
+//   - Median: Use median price across all sources
+//   - Weighted: Weight by source confidence/liquidity
+//
+// # Caching
+//
+// All price feeds are cached with configurable TTL to reduce API calls and improve
+// response times. Cache staleness is tracked for monitoring.
+//
+// # Retry Logic
+//
+// Failed requests are retried with exponential backoff. Circuit breakers prevent
+// cascading failures when a source is unavailable.
+//
+// # Failure Fallback
+//
+// When all sources fail, the aggregator returns an error. Callers should:
+//  1. Check cache for stale-but-valid prices (if acceptable for use case)
+//  2. Use last known good price with increased slippage tolerance
+//  3. Reject the conversion request with appropriate user messaging
+//
+// # Monitoring
+//
+// The package exposes Prometheus metrics for:
+//   - Price fetch latency by source
+//   - Cache hit/miss rates
+//   - Error rates and types
+//   - Price deviation between sources
+//
+// # Usage
+//
+//	cfg := pricefeed.DefaultConfig()
+//	agg, err := pricefeed.NewAggregator(cfg)
+//	if err != nil {
+//	    return err
+//	}
+//	defer agg.Close()
+//
+//	price, err := agg.GetPrice(ctx, "virtengine", "usd")
+//	if err != nil {
+//	    // Handle failure - see Failure Fallback section
+//	    return err
+//	}
+//
+//	// Use price.Rate, price.Timestamp, price.Source
+//
+// PAY-001: Real price feed integration for payment conversions
+package pricefeed

--- a/pkg/pricefeed/interfaces.go
+++ b/pkg/pricefeed/interfaces.go
@@ -1,0 +1,132 @@
+package pricefeed
+
+import (
+	"context"
+	"io"
+)
+
+// Provider is the interface for a price feed source
+type Provider interface {
+	// Name returns the unique name of this provider
+	Name() string
+
+	// Type returns the provider type (coingecko, chainlink, pyth, etc.)
+	Type() SourceType
+
+	// GetPrice fetches the current price for an asset pair
+	// baseAsset: the asset being priced (e.g., "virtengine", "uve")
+	// quoteAsset: the quote currency (e.g., "usd", "eur")
+	GetPrice(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error)
+
+	// GetPrices fetches prices for multiple asset pairs in a single request
+	// Returns a map of "baseAsset/quoteAsset" -> PriceData
+	GetPrices(ctx context.Context, pairs []AssetPair) (map[string]PriceData, error)
+
+	// IsHealthy checks if the provider is responding correctly
+	IsHealthy(ctx context.Context) bool
+
+	// Health returns detailed health information
+	Health() SourceHealth
+
+	io.Closer
+}
+
+// AssetPair represents a trading pair
+type AssetPair struct {
+	Base  string `json:"base"`
+	Quote string `json:"quote"`
+}
+
+// String returns the pair as "base/quote"
+func (p AssetPair) String() string {
+	return p.Base + "/" + p.Quote
+}
+
+// Aggregator combines multiple providers and provides a unified price interface
+type Aggregator interface {
+	// GetPrice returns the aggregated price from configured sources
+	GetPrice(ctx context.Context, baseAsset, quoteAsset string) (AggregatedPrice, error)
+
+	// GetPrices returns aggregated prices for multiple pairs
+	GetPrices(ctx context.Context, pairs []AssetPair) (map[string]AggregatedPrice, error)
+
+	// GetPriceFromSource returns price from a specific source
+	GetPriceFromSource(ctx context.Context, source string, baseAsset, quoteAsset string) (PriceData, error)
+
+	// ListSources returns all configured price sources
+	ListSources() []SourceHealth
+
+	// AddProvider adds a new price provider
+	AddProvider(provider Provider) error
+
+	// RemoveProvider removes a price provider by name
+	RemoveProvider(name string) error
+
+	// RefreshCache forces a cache refresh for the given pairs
+	RefreshCache(ctx context.Context, pairs []AssetPair) error
+
+	io.Closer
+}
+
+// Cache provides caching for price data
+type Cache interface {
+	// Get retrieves a cached price
+	Get(key string) (PriceData, bool)
+
+	// Set stores a price in the cache
+	Set(key string, price PriceData)
+
+	// Delete removes a price from the cache
+	Delete(key string)
+
+	// Clear clears all cached prices
+	Clear()
+
+	// Stats returns cache statistics
+	Stats() CacheStats
+}
+
+// CacheStats contains cache performance statistics
+type CacheStats struct {
+	// Hits is the number of cache hits
+	Hits int64 `json:"hits"`
+
+	// Misses is the number of cache misses
+	Misses int64 `json:"misses"`
+
+	// Size is the number of items in cache
+	Size int `json:"size"`
+
+	// EvictedCount is the number of items evicted
+	EvictedCount int64 `json:"evicted_count"`
+
+	// StaleCount is the number of stale items returned
+	StaleCount int64 `json:"stale_count"`
+}
+
+// HitRate returns the cache hit rate as a percentage
+func (s CacheStats) HitRate() float64 {
+	total := s.Hits + s.Misses
+	if total == 0 {
+		return 0
+	}
+	return float64(s.Hits) / float64(total) * 100
+}
+
+// Metrics collects price feed metrics for observability
+type Metrics interface {
+	// RecordFetch records a price fetch operation
+	RecordFetch(source string, baseAsset, quoteAsset string, latency float64, success bool)
+
+	// RecordCacheHit records a cache hit
+	RecordCacheHit(baseAsset, quoteAsset string)
+
+	// RecordCacheMiss records a cache miss
+	RecordCacheMiss(baseAsset, quoteAsset string)
+
+	// RecordPriceDeviation records price deviation between sources
+	RecordPriceDeviation(baseAsset, quoteAsset string, deviation float64)
+
+	// RecordSourceHealth records source health status
+	RecordSourceHealth(source string, healthy bool, latency float64)
+}

--- a/pkg/pricefeed/metrics.go
+++ b/pkg/pricefeed/metrics.go
@@ -1,0 +1,190 @@
+package pricefeed
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// ============================================================================
+// Prometheus Metrics Implementation
+// ============================================================================
+
+// PrometheusMetrics implements the Metrics interface for Prometheus
+type PrometheusMetrics struct {
+	// Fetch metrics
+	fetchTotal   map[string]*atomic.Int64 // source -> count
+	fetchSuccess map[string]*atomic.Int64 // source -> count
+	fetchErrors  map[string]*atomic.Int64 // source -> count
+
+	// Cache metrics
+	cacheHits   atomic.Int64
+	cacheMisses atomic.Int64
+
+	// Deviation metrics
+	deviations map[string]float64 // pair -> last deviation
+
+	// Health metrics
+	sourceHealthy map[string]bool    // source -> healthy
+	sourceLatency map[string]float64 // source -> latency seconds
+
+	mu sync.RWMutex
+}
+
+// NewPrometheusMetrics creates a new Prometheus metrics collector
+func NewPrometheusMetrics() *PrometheusMetrics {
+	return &PrometheusMetrics{
+		fetchTotal:    make(map[string]*atomic.Int64),
+		fetchSuccess:  make(map[string]*atomic.Int64),
+		fetchErrors:   make(map[string]*atomic.Int64),
+		deviations:    make(map[string]float64),
+		sourceHealthy: make(map[string]bool),
+		sourceLatency: make(map[string]float64),
+	}
+}
+
+// RecordFetch records a price fetch operation
+func (m *PrometheusMetrics) RecordFetch(source string, baseAsset, quoteAsset string, latency float64, success bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.fetchTotal[source]; !ok {
+		m.fetchTotal[source] = &atomic.Int64{}
+		m.fetchSuccess[source] = &atomic.Int64{}
+		m.fetchErrors[source] = &atomic.Int64{}
+	}
+
+	m.fetchTotal[source].Add(1)
+	if success {
+		m.fetchSuccess[source].Add(1)
+	} else {
+		m.fetchErrors[source].Add(1)
+	}
+
+	m.sourceLatency[source] = latency
+}
+
+// RecordCacheHit records a cache hit
+func (m *PrometheusMetrics) RecordCacheHit(baseAsset, quoteAsset string) {
+	m.cacheHits.Add(1)
+}
+
+// RecordCacheMiss records a cache miss
+func (m *PrometheusMetrics) RecordCacheMiss(baseAsset, quoteAsset string) {
+	m.cacheMisses.Add(1)
+}
+
+// RecordPriceDeviation records price deviation between sources
+func (m *PrometheusMetrics) RecordPriceDeviation(baseAsset, quoteAsset string, deviation float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := baseAsset + "/" + quoteAsset
+	m.deviations[key] = deviation
+}
+
+// RecordSourceHealth records source health status
+func (m *PrometheusMetrics) RecordSourceHealth(source string, healthy bool, latency float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sourceHealthy[source] = healthy
+	m.sourceLatency[source] = latency
+}
+
+// ============================================================================
+// Metrics Export Methods
+// ============================================================================
+
+// MetricsSummary contains a summary of all metrics
+type MetricsSummary struct {
+	// Per-source metrics
+	Sources map[string]SourceMetrics `json:"sources"`
+
+	// Cache metrics
+	CacheHits   int64   `json:"cache_hits"`
+	CacheMisses int64   `json:"cache_misses"`
+	CacheHitRate float64 `json:"cache_hit_rate"`
+
+	// Deviation metrics
+	Deviations map[string]float64 `json:"deviations"`
+}
+
+// SourceMetrics contains metrics for a single source
+type SourceMetrics struct {
+	TotalRequests   int64   `json:"total_requests"`
+	SuccessRequests int64   `json:"success_requests"`
+	ErrorRequests   int64   `json:"error_requests"`
+	ErrorRate       float64 `json:"error_rate"`
+	Healthy         bool    `json:"healthy"`
+	LatencySeconds  float64 `json:"latency_seconds"`
+}
+
+// Summary returns a summary of all collected metrics
+func (m *PrometheusMetrics) Summary() MetricsSummary {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	summary := MetricsSummary{
+		Sources:     make(map[string]SourceMetrics),
+		CacheHits:   m.cacheHits.Load(),
+		CacheMisses: m.cacheMisses.Load(),
+		Deviations:  make(map[string]float64),
+	}
+
+	totalCache := summary.CacheHits + summary.CacheMisses
+	if totalCache > 0 {
+		summary.CacheHitRate = float64(summary.CacheHits) / float64(totalCache) * 100
+	}
+
+	for source := range m.fetchTotal {
+		total := m.fetchTotal[source].Load()
+		success := m.fetchSuccess[source].Load()
+		errors := m.fetchErrors[source].Load()
+
+		var errorRate float64
+		if total > 0 {
+			errorRate = float64(errors) / float64(total) * 100
+		}
+
+		summary.Sources[source] = SourceMetrics{
+			TotalRequests:   total,
+			SuccessRequests: success,
+			ErrorRequests:   errors,
+			ErrorRate:       errorRate,
+			Healthy:         m.sourceHealthy[source],
+			LatencySeconds:  m.sourceLatency[source],
+		}
+	}
+
+	for pair, dev := range m.deviations {
+		summary.Deviations[pair] = dev
+	}
+
+	return summary
+}
+
+// Reset resets all metrics
+func (m *PrometheusMetrics) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.fetchTotal = make(map[string]*atomic.Int64)
+	m.fetchSuccess = make(map[string]*atomic.Int64)
+	m.fetchErrors = make(map[string]*atomic.Int64)
+	m.deviations = make(map[string]float64)
+	m.sourceHealthy = make(map[string]bool)
+	m.sourceLatency = make(map[string]float64)
+	m.cacheHits.Store(0)
+	m.cacheMisses.Store(0)
+}
+
+// ============================================================================
+// No-Op Metrics (for testing or when metrics are disabled)
+// ============================================================================
+
+// NoOpMetrics is a no-op implementation of Metrics
+type NoOpMetrics struct{}
+
+func (m *NoOpMetrics) RecordFetch(source string, baseAsset, quoteAsset string, latency float64, success bool) {}
+func (m *NoOpMetrics) RecordCacheHit(baseAsset, quoteAsset string)                                           {}
+func (m *NoOpMetrics) RecordCacheMiss(baseAsset, quoteAsset string)                                          {}
+func (m *NoOpMetrics) RecordPriceDeviation(baseAsset, quoteAsset string, deviation float64)                  {}
+func (m *NoOpMetrics) RecordSourceHealth(source string, healthy bool, latency float64)                       {}

--- a/pkg/pricefeed/mock.go
+++ b/pkg/pricefeed/mock.go
@@ -1,0 +1,201 @@
+package pricefeed
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// ============================================================================
+// Mock Provider for Testing
+// ============================================================================
+
+// MockProvider is a mock implementation of Provider for testing
+type MockProvider struct {
+	name           string
+	prices         map[string]PriceData
+	pricesMu       sync.RWMutex
+	healthy        bool
+	healthyMu      sync.RWMutex
+	errorOnGet     error
+	requestCount   atomic.Int64
+	closed         atomic.Bool
+	getLatency     time.Duration
+	onGetPrice     func(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error)
+}
+
+// NewMockProvider creates a new mock provider
+func NewMockProvider(name string) *MockProvider {
+	return &MockProvider{
+		name:    name,
+		prices:  make(map[string]PriceData),
+		healthy: true,
+	}
+}
+
+// Name returns the provider name
+func (m *MockProvider) Name() string {
+	return m.name
+}
+
+// Type returns the provider type
+func (m *MockProvider) Type() SourceType {
+	return SourceTypeMock
+}
+
+// SetPrice sets a mock price for testing
+func (m *MockProvider) SetPrice(baseAsset, quoteAsset string, price sdkmath.LegacyDec) {
+	m.pricesMu.Lock()
+	defer m.pricesMu.Unlock()
+	key := baseAsset + "/" + quoteAsset
+	m.prices[key] = PriceData{
+		BaseAsset:  baseAsset,
+		QuoteAsset: quoteAsset,
+		Price:      price,
+		Timestamp:  time.Now().UTC(),
+		Source:     m.name,
+		Confidence: 0.95,
+	}
+}
+
+// SetPriceData sets a full price data object
+func (m *MockProvider) SetPriceData(data PriceData) {
+	m.pricesMu.Lock()
+	defer m.pricesMu.Unlock()
+	key := data.BaseAsset + "/" + data.QuoteAsset
+	m.prices[key] = data
+}
+
+// SetError sets an error to return on GetPrice
+func (m *MockProvider) SetError(err error) {
+	m.errorOnGet = err
+}
+
+// SetHealthy sets the health status
+func (m *MockProvider) SetHealthy(healthy bool) {
+	m.healthyMu.Lock()
+	defer m.healthyMu.Unlock()
+	m.healthy = healthy
+}
+
+// SetLatency sets artificial latency for testing
+func (m *MockProvider) SetLatency(d time.Duration) {
+	m.getLatency = d
+}
+
+// SetOnGetPrice sets a custom handler for GetPrice
+func (m *MockProvider) SetOnGetPrice(fn func(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error)) {
+	m.onGetPrice = fn
+}
+
+// GetPrice returns a mock price
+func (m *MockProvider) GetPrice(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error) {
+	if m.closed.Load() {
+		return PriceData{}, ErrSourceUnhealthy
+	}
+
+	m.requestCount.Add(1)
+
+	// Simulate latency
+	if m.getLatency > 0 {
+		select {
+		case <-time.After(m.getLatency):
+		case <-ctx.Done():
+			return PriceData{}, ctx.Err()
+		}
+	}
+
+	// Check custom handler
+	if m.onGetPrice != nil {
+		return m.onGetPrice(ctx, baseAsset, quoteAsset)
+	}
+
+	// Check for error
+	if m.errorOnGet != nil {
+		return PriceData{}, m.errorOnGet
+	}
+
+	m.pricesMu.RLock()
+	defer m.pricesMu.RUnlock()
+
+	key := baseAsset + "/" + quoteAsset
+	if price, ok := m.prices[key]; ok {
+		return price, nil
+	}
+
+	return PriceData{}, ErrPriceNotFound
+}
+
+// GetPrices returns mock prices for multiple pairs
+func (m *MockProvider) GetPrices(ctx context.Context, pairs []AssetPair) (map[string]PriceData, error) {
+	if m.closed.Load() {
+		return nil, ErrSourceUnhealthy
+	}
+
+	if m.errorOnGet != nil {
+		return nil, m.errorOnGet
+	}
+
+	results := make(map[string]PriceData)
+	for _, pair := range pairs {
+		price, err := m.GetPrice(ctx, pair.Base, pair.Quote)
+		if err == nil {
+			results[pair.String()] = price
+		}
+	}
+
+	return results, nil
+}
+
+// IsHealthy returns the mock health status
+func (m *MockProvider) IsHealthy(ctx context.Context) bool {
+	if m.closed.Load() {
+		return false
+	}
+	m.healthyMu.RLock()
+	defer m.healthyMu.RUnlock()
+	return m.healthy
+}
+
+// Health returns mock health information
+func (m *MockProvider) Health() SourceHealth {
+	m.healthyMu.RLock()
+	healthy := m.healthy
+	m.healthyMu.RUnlock()
+
+	return SourceHealth{
+		Source:       m.name,
+		Type:         SourceTypeMock,
+		Healthy:      healthy && !m.closed.Load(),
+		LastCheck:    time.Now(),
+		LastSuccess:  time.Now(),
+		RequestCount: m.requestCount.Load(),
+	}
+}
+
+// RequestCount returns the number of requests made
+func (m *MockProvider) RequestCount() int64 {
+	return m.requestCount.Load()
+}
+
+// Close closes the mock provider
+func (m *MockProvider) Close() error {
+	m.closed.Store(true)
+	return nil
+}
+
+// Reset resets the mock provider state
+func (m *MockProvider) Reset() {
+	m.pricesMu.Lock()
+	m.prices = make(map[string]PriceData)
+	m.pricesMu.Unlock()
+	m.errorOnGet = nil
+	m.SetHealthy(true)
+	m.requestCount.Store(0)
+	m.closed.Store(false)
+	m.getLatency = 0
+	m.onGetPrice = nil
+}

--- a/pkg/pricefeed/pricefeed_test.go
+++ b/pkg/pricefeed/pricefeed_test.go
@@ -1,0 +1,564 @@
+package pricefeed
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+func TestMockProvider_GetPrice(t *testing.T) {
+	provider := NewMockProvider("test-mock")
+	ctx := context.Background()
+
+	// Set a price
+	price := sdkmath.LegacyMustNewDecFromStr("1.5")
+	provider.SetPrice("uve", "usd", price)
+
+	// Get the price
+	result, err := provider.GetPrice(ctx, "uve", "usd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.Price.Equal(price) {
+		t.Errorf("expected price %s, got %s", price, result.Price)
+	}
+
+	if result.Source != "test-mock" {
+		t.Errorf("expected source test-mock, got %s", result.Source)
+	}
+}
+
+func TestMockProvider_NotFound(t *testing.T) {
+	provider := NewMockProvider("test-mock")
+	ctx := context.Background()
+
+	_, err := provider.GetPrice(ctx, "unknown", "usd")
+	if err != ErrPriceNotFound {
+		t.Errorf("expected ErrPriceNotFound, got %v", err)
+	}
+}
+
+func TestMockProvider_Error(t *testing.T) {
+	provider := NewMockProvider("test-mock")
+	ctx := context.Background()
+
+	provider.SetError(ErrRateLimitExceeded)
+
+	_, err := provider.GetPrice(ctx, "uve", "usd")
+	if err != ErrRateLimitExceeded {
+		t.Errorf("expected ErrRateLimitExceeded, got %v", err)
+	}
+}
+
+func TestMockProvider_Unhealthy(t *testing.T) {
+	provider := NewMockProvider("test-mock")
+	ctx := context.Background()
+
+	provider.SetHealthy(false)
+
+	if provider.IsHealthy(ctx) {
+		t.Error("expected provider to be unhealthy")
+	}
+}
+
+func TestInMemoryCache_Basic(t *testing.T) {
+	cfg := CacheConfig{
+		Enabled:     true,
+		TTL:         1 * time.Second,
+		MaxSize:     100,
+		AllowStale:  true,
+		StaleMaxAge: 5 * time.Second,
+	}
+
+	cache := NewInMemoryCache(cfg)
+
+	// Set a price
+	price := PriceData{
+		BaseAsset:  "uve",
+		QuoteAsset: "usd",
+		Price:      sdkmath.LegacyOneDec(),
+		Timestamp:  time.Now(),
+		Source:     "test",
+	}
+
+	key := "uve/usd"
+	cache.Set(key, price)
+
+	// Get the price
+	result, ok := cache.Get(key)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+
+	if !result.Price.Equal(price.Price) {
+		t.Errorf("expected price %s, got %s", price.Price, result.Price)
+	}
+
+	// Check stats
+	stats := cache.Stats()
+	if stats.Hits != 1 {
+		t.Errorf("expected 1 hit, got %d", stats.Hits)
+	}
+}
+
+func TestInMemoryCache_Expiry(t *testing.T) {
+	cfg := CacheConfig{
+		Enabled:     true,
+		TTL:         50 * time.Millisecond,
+		MaxSize:     100,
+		AllowStale:  false,
+		StaleMaxAge: 100 * time.Millisecond,
+	}
+
+	cache := NewInMemoryCache(cfg)
+
+	price := PriceData{
+		BaseAsset:  "uve",
+		QuoteAsset: "usd",
+		Price:      sdkmath.LegacyOneDec(),
+		Timestamp:  time.Now(),
+		Source:     "test",
+	}
+
+	key := "uve/usd"
+	cache.Set(key, price)
+
+	// Wait for expiry
+	time.Sleep(100 * time.Millisecond)
+
+	// Should not find expired entry
+	_, ok := cache.Get(key)
+	if ok {
+		t.Error("expected cache miss for expired entry")
+	}
+}
+
+func TestInMemoryCache_StaleAllowed(t *testing.T) {
+	cfg := CacheConfig{
+		Enabled:     true,
+		TTL:         50 * time.Millisecond,
+		MaxSize:     100,
+		AllowStale:  true,
+		StaleMaxAge: 200 * time.Millisecond,
+	}
+
+	cache := NewInMemoryCache(cfg)
+
+	price := PriceData{
+		BaseAsset:  "uve",
+		QuoteAsset: "usd",
+		Price:      sdkmath.LegacyOneDec(),
+		Timestamp:  time.Now(),
+		Source:     "test",
+	}
+
+	key := "uve/usd"
+	cache.Set(key, price)
+
+	// Wait for TTL expiry but within stale max age
+	time.Sleep(100 * time.Millisecond)
+
+	// Should still find stale entry
+	_, ok := cache.Get(key)
+	if !ok {
+		t.Error("expected stale cache hit")
+	}
+}
+
+func TestRetryer_Success(t *testing.T) {
+	cfg := RetryConfig{
+		MaxRetries:    3,
+		InitialDelay:  10 * time.Millisecond,
+		MaxDelay:      100 * time.Millisecond,
+		BackoffFactor: 2.0,
+		RetryableErrors: []string{
+			"timeout",
+			"connection refused",
+		},
+	}
+
+	retryer := NewRetryer(cfg)
+
+	callCount := 0
+	err := retryer.Do(context.Background(), func(ctx context.Context) error {
+		callCount++
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 call, got %d", callCount)
+	}
+}
+
+func TestRetryer_RetryOnError(t *testing.T) {
+	cfg := RetryConfig{
+		MaxRetries:      2,
+		InitialDelay:   10 * time.Millisecond,
+		MaxDelay:       100 * time.Millisecond,
+		BackoffFactor:  2.0,
+		RetryableErrors: []string{"timeout"},
+	}
+
+	retryer := NewRetryer(cfg)
+
+	callCount := 0
+	err := retryer.Do(context.Background(), func(ctx context.Context) error {
+		callCount++
+		if callCount < 3 {
+			return &retryableError{msg: "timeout occurred"}
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if callCount != 3 {
+		t.Errorf("expected 3 calls, got %d", callCount)
+	}
+}
+
+type retryableError struct {
+	msg string
+}
+
+func (e *retryableError) Error() string {
+	return e.msg
+}
+
+func TestCircuitBreaker_Open(t *testing.T) {
+	cb := NewCircuitBreaker(3, 2, 100*time.Millisecond)
+
+	// Record failures to open circuit
+	for i := 0; i < 3; i++ {
+		cb.RecordFailure()
+	}
+
+	if cb.State() != CircuitOpen {
+		t.Errorf("expected circuit open, got %s", cb.State())
+	}
+
+	if cb.Allow() {
+		t.Error("expected request to be blocked when circuit is open")
+	}
+}
+
+func TestCircuitBreaker_HalfOpen(t *testing.T) {
+	cb := NewCircuitBreaker(3, 2, 50*time.Millisecond)
+
+	// Open the circuit
+	for i := 0; i < 3; i++ {
+		cb.RecordFailure()
+	}
+
+	// Wait for timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// Should be half-open now
+	if cb.State() != CircuitHalfOpen {
+		t.Errorf("expected circuit half-open, got %s", cb.State())
+	}
+
+	// Should allow requests
+	if !cb.Allow() {
+		t.Error("expected request to be allowed in half-open state")
+	}
+}
+
+func TestCircuitBreaker_Close(t *testing.T) {
+	cb := NewCircuitBreaker(3, 2, 50*time.Millisecond)
+
+	// Open the circuit
+	for i := 0; i < 3; i++ {
+		cb.RecordFailure()
+	}
+
+	// Wait for timeout to transition to half-open
+	time.Sleep(60 * time.Millisecond)
+
+	// Check state to trigger transition to half-open (Allow() does this)
+	if !cb.Allow() {
+		t.Error("expected circuit to allow in half-open")
+	}
+
+	// Record successes to close circuit
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+
+	if cb.State() != CircuitClosed {
+		t.Errorf("expected circuit closed, got %s", cb.State())
+	}
+}
+
+func TestPriceData_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		price PriceData
+		valid bool
+	}{
+		{
+			name: "valid price",
+			price: PriceData{
+				BaseAsset:  "uve",
+				QuoteAsset: "usd",
+				Price:      sdkmath.LegacyOneDec(),
+				Timestamp:  time.Now(),
+			},
+			valid: true,
+		},
+		{
+			name: "missing base asset",
+			price: PriceData{
+				QuoteAsset: "usd",
+				Price:      sdkmath.LegacyOneDec(),
+				Timestamp:  time.Now(),
+			},
+			valid: false,
+		},
+		{
+			name: "zero price",
+			price: PriceData{
+				BaseAsset:  "uve",
+				QuoteAsset: "usd",
+				Price:      sdkmath.LegacyZeroDec(),
+				Timestamp:  time.Now(),
+			},
+			valid: false,
+		},
+		{
+			name: "negative price",
+			price: PriceData{
+				BaseAsset:  "uve",
+				QuoteAsset: "usd",
+				Price:      sdkmath.LegacyNewDec(-1),
+				Timestamp:  time.Now(),
+			},
+			valid: false,
+		},
+		{
+			name: "zero timestamp",
+			price: PriceData{
+				BaseAsset:  "uve",
+				QuoteAsset: "usd",
+				Price:      sdkmath.LegacyOneDec(),
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.price.IsValid() != tc.valid {
+				t.Errorf("expected valid=%v, got %v", tc.valid, tc.price.IsValid())
+			}
+		})
+	}
+}
+
+func TestAggregator_PrimaryStrategy(t *testing.T) {
+	// Create mock providers
+	primary := NewMockProvider("primary")
+	secondary := NewMockProvider("secondary")
+
+	primaryPrice := sdkmath.LegacyMustNewDecFromStr("1.5")
+	secondaryPrice := sdkmath.LegacyMustNewDecFromStr("1.6")
+
+	primary.SetPrice("uve", "usd", primaryPrice)
+	secondary.SetPrice("uve", "usd", secondaryPrice)
+
+	// Create aggregator with primary strategy
+	cfg := Config{
+		Providers: []ProviderConfig{
+			{Name: "primary", Type: SourceTypeMock, Enabled: true, Priority: 1},
+			{Name: "secondary", Type: SourceTypeMock, Enabled: true, Priority: 2},
+		},
+		Strategy: StrategyPrimary,
+		CacheConfig: CacheConfig{
+			Enabled:     true,
+			TTL:         30 * time.Second,
+			MaxSize:     100,
+			AllowStale:  true,
+			StaleMaxAge: 5 * time.Minute,
+		},
+		RetryConfig: RetryConfig{
+			MaxRetries:    1,
+			InitialDelay:  10 * time.Millisecond,
+			MaxDelay:      100 * time.Millisecond,
+			BackoffFactor: 2.0,
+		},
+		MaxPriceDeviation:   0.1,
+		HealthCheckInterval: 0, // Disable background health check
+	}
+
+	agg := &PriceFeedAggregator{
+		config:          cfg,
+		providers:       make(map[string]Provider),
+		healthCheckStop: make(chan struct{}),
+	}
+	agg.cache = NewInMemoryCache(cfg.CacheConfig)
+	agg.providers["primary"] = primary
+	agg.providers["secondary"] = secondary
+
+	ctx := context.Background()
+	result, err := agg.GetPrice(ctx, "uve", "usd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should get price from primary
+	if !result.Price.Equal(primaryPrice) {
+		t.Errorf("expected primary price %s, got %s", primaryPrice, result.Price)
+	}
+
+	// Primary should have been called
+	if primary.RequestCount() != 1 {
+		t.Errorf("expected 1 primary request, got %d", primary.RequestCount())
+	}
+
+	agg.Close()
+}
+
+func TestAggregator_FallbackOnError(t *testing.T) {
+	primary := NewMockProvider("primary")
+	secondary := NewMockProvider("secondary")
+
+	// Primary returns error
+	primary.SetError(ErrRateLimitExceeded)
+
+	secondaryPrice := sdkmath.LegacyMustNewDecFromStr("1.6")
+	secondary.SetPrice("uve", "usd", secondaryPrice)
+
+	cfg := Config{
+		Providers: []ProviderConfig{
+			{Name: "primary", Type: SourceTypeMock, Enabled: true, Priority: 1},
+			{Name: "secondary", Type: SourceTypeMock, Enabled: true, Priority: 2},
+		},
+		Strategy: StrategyPrimary,
+		CacheConfig: CacheConfig{
+			Enabled:     true,
+			TTL:         30 * time.Second,
+			MaxSize:     100,
+			AllowStale:  true,
+			StaleMaxAge: 5 * time.Minute,
+		},
+		RetryConfig: RetryConfig{
+			MaxRetries:    0, // No retries for faster test
+			InitialDelay:  10 * time.Millisecond,
+			MaxDelay:      100 * time.Millisecond,
+			BackoffFactor: 2.0,
+		},
+		MaxPriceDeviation:   0.1,
+		HealthCheckInterval: 0,
+	}
+
+	agg := &PriceFeedAggregator{
+		config:          cfg,
+		providers:       make(map[string]Provider),
+		healthCheckStop: make(chan struct{}),
+	}
+	agg.cache = NewInMemoryCache(cfg.CacheConfig)
+	agg.providers["primary"] = primary
+	agg.providers["secondary"] = secondary
+
+	ctx := context.Background()
+	result, err := agg.GetPrice(ctx, "uve", "usd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should fall back to secondary
+	if !result.Price.Equal(secondaryPrice) {
+		t.Errorf("expected secondary price %s, got %s", secondaryPrice, result.Price)
+	}
+
+	agg.Close()
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name:    "valid default config",
+			config:  DefaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "no providers",
+			config: Config{
+				Providers: []ProviderConfig{},
+				Strategy:  StrategyPrimary,
+			},
+			wantErr: true,
+		},
+		{
+			name: "all providers disabled",
+			config: Config{
+				Providers: []ProviderConfig{
+					{Name: "test", Enabled: false},
+				},
+				Strategy:          StrategyPrimary,
+				MaxPriceDeviation: 0.1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid max deviation",
+			config: Config{
+				Providers: []ProviderConfig{
+					{Name: "test", Type: SourceTypeCoinGecko, Enabled: true, RequestTimeout: 10 * time.Second},
+				},
+				Strategy:          StrategyPrimary,
+				MaxPriceDeviation: 1.5, // > 1 is invalid
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSourceType_IsValid(t *testing.T) {
+	validTypes := []SourceType{SourceTypeCoinGecko, SourceTypeChainlink, SourceTypePyth, SourceTypeMock}
+	for _, st := range validTypes {
+		if !st.IsValid() {
+			t.Errorf("expected %s to be valid", st)
+		}
+	}
+
+	invalidType := SourceType("invalid")
+	if invalidType.IsValid() {
+		t.Error("expected invalid type to be invalid")
+	}
+}
+
+func TestAggregationStrategy_IsValid(t *testing.T) {
+	validStrategies := []AggregationStrategy{StrategyPrimary, StrategyMedian, StrategyWeighted}
+	for _, s := range validStrategies {
+		if !s.IsValid() {
+			t.Errorf("expected %s to be valid", s)
+		}
+	}
+
+	invalidStrategy := AggregationStrategy("invalid")
+	if invalidStrategy.IsValid() {
+		t.Error("expected invalid strategy to be invalid")
+	}
+}

--- a/pkg/pricefeed/pyth.go
+++ b/pkg/pricefeed/pyth.go
@@ -1,0 +1,381 @@
+package pricefeed
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// ============================================================================
+// Pyth Provider Implementation
+// ============================================================================
+
+// PythProvider implements the Provider interface for Pyth Network price feeds
+type PythProvider struct {
+	name     string
+	config   PythConfig
+	client   *http.Client
+	health   SourceHealth
+	healthMu sync.RWMutex
+	circuit  *CircuitBreaker
+	retryer  *Retryer
+	closed   atomic.Bool
+}
+
+// NewPythProvider creates a new Pyth provider
+func NewPythProvider(name string, cfg PythConfig, retryCfg RetryConfig) (*PythProvider, error) {
+	if cfg.HermesURL == "" {
+		cfg.HermesURL = "https://hermes.pyth.network"
+	}
+
+	provider := &PythProvider{
+		name:   name,
+		config: cfg,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		health: SourceHealth{
+			Source:    name,
+			Type:      SourceTypePyth,
+			Healthy:   true,
+			LastCheck: time.Now(),
+		},
+		circuit: NewCircuitBreaker(5, 2, 30*time.Second),
+		retryer: NewRetryer(retryCfg),
+	}
+
+	return provider, nil
+}
+
+// Name returns the provider name
+func (p *PythProvider) Name() string {
+	return p.name
+}
+
+// Type returns the provider type
+func (p *PythProvider) Type() SourceType {
+	return SourceTypePyth
+}
+
+// GetPrice fetches the current price for an asset pair
+func (p *PythProvider) GetPrice(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error) {
+	if p.closed.Load() {
+		return PriceData{}, ErrSourceUnhealthy
+	}
+
+	// Check circuit breaker
+	if !p.circuit.Allow() {
+		return PriceData{}, ErrSourceUnhealthy
+	}
+
+	startTime := time.Now()
+
+	price, err := DoWithResult(ctx, p.retryer, func(ctx context.Context) (PriceData, error) {
+		return p.fetchPrice(ctx, baseAsset, quoteAsset)
+	})
+
+	latency := time.Since(startTime)
+
+	p.healthMu.Lock()
+	p.health.LastCheck = time.Now()
+	p.health.RequestCount++
+	p.health.Latency = latency
+	if err != nil {
+		p.health.ErrorCount++
+		p.health.LastError = err.Error()
+		p.circuit.RecordFailure()
+	} else {
+		p.health.Healthy = true
+		p.health.LastSuccess = time.Now()
+		p.health.LastError = ""
+		p.circuit.RecordSuccess()
+	}
+	p.healthMu.Unlock()
+
+	return price, err
+}
+
+// pythPriceResponse represents the Pyth API response
+type pythPriceResponse struct {
+	ID    string `json:"id"`
+	Price struct {
+		Price       string `json:"price"`
+		Conf        string `json:"conf"`
+		Expo        int    `json:"expo"`
+		PublishTime int64  `json:"publish_time"`
+	} `json:"price"`
+	EMAPrice struct {
+		Price       string `json:"price"`
+		Conf        string `json:"conf"`
+		Expo        int    `json:"expo"`
+		PublishTime int64  `json:"publish_time"`
+	} `json:"ema_price"`
+}
+
+// fetchPrice fetches the price from Pyth Network
+func (p *PythProvider) fetchPrice(ctx context.Context, baseAsset, quoteAsset string) (PriceData, error) {
+	// Look up the price feed ID
+	pairKey := fmt.Sprintf("%s/%s", strings.ToUpper(baseAsset), strings.ToUpper(quoteAsset))
+	priceID, ok := p.config.PriceIDs[pairKey]
+	if !ok {
+		// Try alternative mapping
+		priceID = p.mapToPythPriceID(baseAsset, quoteAsset)
+		if priceID == "" {
+			return PriceData{}, fmt.Errorf("%w: no Pyth price feed for %s", ErrPriceNotFound, pairKey)
+		}
+	}
+
+	// Remove 0x prefix if present
+	priceID = strings.TrimPrefix(priceID, "0x")
+
+	// Build URL for Hermes API
+	endpoint := fmt.Sprintf("%s/api/latest_price_feeds?ids[]=%s", p.config.HermesURL, priceID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return PriceData{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return PriceData{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return PriceData{}, fmt.Errorf("Pyth API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var responses []pythPriceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&responses); err != nil {
+		return PriceData{}, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if len(responses) == 0 {
+		return PriceData{}, ErrPriceNotFound
+	}
+
+	priceResp := responses[0]
+
+	// Parse price
+	priceInt, ok := sdkmath.NewIntFromString(priceResp.Price.Price)
+	if !ok {
+		return PriceData{}, fmt.Errorf("failed to parse price: invalid format")
+	}
+
+	// Apply exponent (Pyth uses negative exponents)
+	price := sdkmath.LegacyNewDecFromBigIntWithPrec(priceInt.BigInt(), int64(-priceResp.Price.Expo))
+
+	// Parse confidence interval
+	confInt, _ := sdkmath.NewIntFromString(priceResp.Price.Conf)
+
+	// Calculate confidence as percentage (lower conf = higher reliability)
+	var confidence float64 = 0.95
+	if !confInt.IsZero() && !priceInt.IsZero() {
+		confPct := float64(confInt.Int64()) / float64(priceInt.Int64())
+		confidence = 1 - confPct // Lower conf% = higher confidence
+		if confidence < 0.5 {
+			confidence = 0.5
+		}
+	}
+
+	publishTime := time.Unix(priceResp.Price.PublishTime, 0).UTC()
+
+	return PriceData{
+		BaseAsset:     baseAsset,
+		QuoteAsset:    quoteAsset,
+		Price:         price,
+		Timestamp:     time.Now().UTC(),
+		Source:        p.name,
+		Confidence:    confidence,
+		LastUpdatedAt: publishTime,
+	}, nil
+}
+
+// mapToPythPriceID maps common pairs to Pyth price feed IDs
+func (p *PythProvider) mapToPythPriceID(baseAsset, quoteAsset string) string {
+	base := strings.ToUpper(baseAsset)
+	quote := strings.ToUpper(quoteAsset)
+
+	// Common Pyth price feed IDs (mainnet)
+	feeds := map[string]string{
+		"BTC/USD":  "e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+		"ETH/USD":  "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
+		"ATOM/USD": "b00b60f88b03a6a625a8d1c048c3f66653edf217439983d037e7222c4e612819",
+		"USDC/USD": "eaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
+		"SOL/USD":  "ef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
+		"LINK/USD": "8ac0c70fff57e9aefdf5edf44b51d62c2d433653cbb2cf5cc06bb115af04d221",
+	}
+
+	key := fmt.Sprintf("%s/%s", base, quote)
+	if id, ok := feeds[key]; ok {
+		return id
+	}
+
+	return ""
+}
+
+// GetPrices fetches prices for multiple asset pairs
+func (p *PythProvider) GetPrices(ctx context.Context, pairs []AssetPair) (map[string]PriceData, error) {
+	if p.closed.Load() {
+		return nil, ErrSourceUnhealthy
+	}
+
+	if !p.circuit.Allow() {
+		return nil, ErrSourceUnhealthy
+	}
+
+	// Collect all price IDs
+	priceIDs := make([]string, 0, len(pairs))
+	pairMap := make(map[string]AssetPair) // priceID -> pair
+
+	for _, pair := range pairs {
+		pairKey := fmt.Sprintf("%s/%s", strings.ToUpper(pair.Base), strings.ToUpper(pair.Quote))
+		priceID, ok := p.config.PriceIDs[pairKey]
+		if !ok {
+			priceID = p.mapToPythPriceID(pair.Base, pair.Quote)
+		}
+		if priceID != "" {
+			priceID = strings.TrimPrefix(priceID, "0x")
+			priceIDs = append(priceIDs, priceID)
+			pairMap[priceID] = pair
+		}
+	}
+
+	if len(priceIDs) == 0 {
+		return nil, ErrPriceNotFound
+	}
+
+	// Build URL with multiple IDs
+	endpoint := p.config.HermesURL + "/api/latest_price_feeds?"
+	for i, id := range priceIDs {
+		if i > 0 {
+			endpoint += "&"
+		}
+		endpoint += "ids[]=" + id
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Pyth API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var responses []pythPriceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&responses); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	results := make(map[string]PriceData)
+
+	for _, priceResp := range responses {
+		pair, ok := pairMap[priceResp.ID]
+		if !ok {
+			continue
+		}
+
+		priceInt, ok := sdkmath.NewIntFromString(priceResp.Price.Price)
+		if !ok {
+			continue
+		}
+
+		price := sdkmath.LegacyNewDecFromBigIntWithPrec(priceInt.BigInt(), int64(-priceResp.Price.Expo))
+		publishTime := time.Unix(priceResp.Price.PublishTime, 0).UTC()
+
+		results[pair.String()] = PriceData{
+			BaseAsset:     pair.Base,
+			QuoteAsset:    pair.Quote,
+			Price:         price,
+			Timestamp:     time.Now().UTC(),
+			Source:        p.name,
+			Confidence:    0.95,
+			LastUpdatedAt: publishTime,
+		}
+	}
+
+	p.healthMu.Lock()
+	p.health.LastCheck = time.Now()
+	p.health.RequestCount++
+	if len(results) > 0 {
+		p.health.Healthy = true
+		p.health.LastSuccess = time.Now()
+		p.circuit.RecordSuccess()
+	}
+	p.healthMu.Unlock()
+
+	return results, nil
+}
+
+// IsHealthy checks if the provider is responding
+func (p *PythProvider) IsHealthy(ctx context.Context) bool {
+	if p.closed.Load() {
+		return false
+	}
+
+	p.healthMu.RLock()
+	health := p.health.Healthy
+	lastSuccess := p.health.LastSuccess
+	p.healthMu.RUnlock()
+
+	if time.Since(lastSuccess) > 5*time.Minute && !lastSuccess.IsZero() {
+		return false
+	}
+
+	return health && p.circuit.State() != CircuitOpen
+}
+
+// Health returns detailed health information
+func (p *PythProvider) Health() SourceHealth {
+	p.healthMu.RLock()
+	defer p.healthMu.RUnlock()
+	health := p.health
+	health.Healthy = p.circuit.State() != CircuitOpen && p.health.Healthy
+	return health
+}
+
+// Close closes the provider
+func (p *PythProvider) Close() error {
+	p.closed.Store(true)
+	return nil
+}
+
+// ============================================================================
+// Common Pyth Price Feed IDs
+// ============================================================================
+
+// PythMainnetPriceIDs contains common Pyth price feed IDs
+var PythMainnetPriceIDs = map[string]string{
+	"BTC/USD":   "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43",
+	"ETH/USD":   "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
+	"ATOM/USD":  "0xb00b60f88b03a6a625a8d1c048c3f66653edf217439983d037e7222c4e612819",
+	"USDC/USD":  "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a",
+	"USDT/USD":  "0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b",
+	"SOL/USD":   "0xef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
+	"LINK/USD":  "0x8ac0c70fff57e9aefdf5edf44b51d62c2d433653cbb2cf5cc06bb115af04d221",
+	"AVAX/USD":  "0x93da3352f9f1d105fdfe4971cfa80e9dd777bfc5d0f683ebb6e1294b92137bb7",
+	"DOGE/USD":  "0xdcef50dd0a4cd2dcc17e45df1676dcb336a11a61c69df7a0299b0150c672d25c",
+	"MATIC/USD": "0x5de33440f6c50b5d2b4e8f65c4d2e03d7f2a8dd8d3b9d0e2d7a8b7c8d9e0f1a2",
+}

--- a/pkg/pricefeed/retry.go
+++ b/pkg/pricefeed/retry.go
@@ -1,0 +1,272 @@
+package pricefeed
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// ============================================================================
+// Retry Logic with Exponential Backoff
+// ============================================================================
+
+// Retryer provides retry logic with exponential backoff
+type Retryer struct {
+	maxRetries    int
+	initialDelay  time.Duration
+	maxDelay      time.Duration
+	backoffFactor float64
+	retryableErrs []string
+}
+
+// NewRetryer creates a new Retryer with the given config
+func NewRetryer(cfg RetryConfig) *Retryer {
+	return &Retryer{
+		maxRetries:    cfg.MaxRetries,
+		initialDelay:  cfg.InitialDelay,
+		maxDelay:      cfg.MaxDelay,
+		backoffFactor: cfg.BackoffFactor,
+		retryableErrs: cfg.RetryableErrors,
+	}
+}
+
+// RetryFunc is a function that can be retried
+type RetryFunc func(ctx context.Context) error
+
+// RetryFuncWithResult is a function that returns a result and can be retried
+type RetryFuncWithResult[T any] func(ctx context.Context) (T, error)
+
+// Do executes the function with retries
+func (r *Retryer) Do(ctx context.Context, fn RetryFunc) error {
+	var lastErr error
+
+	for attempt := 0; attempt <= r.maxRetries; attempt++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		err := fn(ctx)
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
+
+		// Check if error is retryable
+		if !r.isRetryable(err) {
+			return err
+		}
+
+		// Don't sleep after the last attempt
+		if attempt < r.maxRetries {
+			delay := r.calculateDelay(attempt)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+
+	return lastErr
+}
+
+// DoWithResult executes the function with retries and returns a result
+func DoWithResult[T any](ctx context.Context, r *Retryer, fn RetryFuncWithResult[T]) (T, error) {
+	var zero T
+	var lastErr error
+	var result T
+
+	for attempt := 0; attempt <= r.maxRetries; attempt++ {
+		if ctx.Err() != nil {
+			return zero, ctx.Err()
+		}
+
+		var err error
+		result, err = fn(ctx)
+		if err == nil {
+			return result, nil
+		}
+
+		lastErr = err
+
+		// Check if error is retryable
+		if !r.isRetryable(err) {
+			return zero, err
+		}
+
+		// Don't sleep after the last attempt
+		if attempt < r.maxRetries {
+			delay := r.calculateDelay(attempt)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return zero, ctx.Err()
+			}
+		}
+	}
+
+	return zero, lastErr
+}
+
+// isRetryable checks if an error should be retried
+func (r *Retryer) isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := strings.ToLower(err.Error())
+	for _, retryable := range r.retryableErrs {
+		if strings.Contains(errStr, strings.ToLower(retryable)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// calculateDelay calculates the delay for a given attempt with jitter
+func (r *Retryer) calculateDelay(attempt int) time.Duration {
+	// Exponential backoff
+	delay := float64(r.initialDelay) * pow(r.backoffFactor, float64(attempt))
+
+	// Cap at max delay
+	if delay > float64(r.maxDelay) {
+		delay = float64(r.maxDelay)
+	}
+
+	// Add jitter (±25%)
+	jitter := delay * 0.25 * (rand.Float64()*2 - 1)
+	delay += jitter
+
+	return time.Duration(delay)
+}
+
+// pow calculates x^y for float64
+func pow(x, y float64) float64 {
+	result := 1.0
+	for i := 0; i < int(y); i++ {
+		result *= x
+	}
+	return result
+}
+
+// ============================================================================
+// Circuit Breaker
+// ============================================================================
+
+// CircuitState represents the state of a circuit breaker
+type CircuitState int
+
+const (
+	// CircuitClosed means requests are allowed
+	CircuitClosed CircuitState = iota
+
+	// CircuitOpen means requests are blocked
+	CircuitOpen
+
+	// CircuitHalfOpen means limited requests are allowed to test recovery
+	CircuitHalfOpen
+)
+
+// String returns the string representation
+func (s CircuitState) String() string {
+	switch s {
+	case CircuitClosed:
+		return "closed"
+	case CircuitOpen:
+		return "open"
+	case CircuitHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+// CircuitBreaker implements the circuit breaker pattern
+type CircuitBreaker struct {
+	state            CircuitState
+	failureCount     int
+	successCount     int
+	lastFailure      time.Time
+	failureThreshold int
+	successThreshold int
+	timeout          time.Duration
+}
+
+// NewCircuitBreaker creates a new circuit breaker
+func NewCircuitBreaker(failureThreshold, successThreshold int, timeout time.Duration) *CircuitBreaker {
+	return &CircuitBreaker{
+		state:            CircuitClosed,
+		failureThreshold: failureThreshold,
+		successThreshold: successThreshold,
+		timeout:          timeout,
+	}
+}
+
+// Allow checks if a request is allowed
+func (cb *CircuitBreaker) Allow() bool {
+	switch cb.state {
+	case CircuitClosed:
+		return true
+	case CircuitOpen:
+		// Check if timeout has passed
+		if time.Since(cb.lastFailure) > cb.timeout {
+			cb.state = CircuitHalfOpen
+			cb.successCount = 0
+			return true
+		}
+		return false
+	case CircuitHalfOpen:
+		return true
+	default:
+		return false
+	}
+}
+
+// RecordSuccess records a successful request
+func (cb *CircuitBreaker) RecordSuccess() {
+	switch cb.state {
+	case CircuitHalfOpen:
+		cb.successCount++
+		if cb.successCount >= cb.successThreshold {
+			cb.state = CircuitClosed
+			cb.failureCount = 0
+		}
+	case CircuitClosed:
+		cb.failureCount = 0
+	}
+}
+
+// RecordFailure records a failed request
+func (cb *CircuitBreaker) RecordFailure() {
+	cb.failureCount++
+	cb.lastFailure = time.Now()
+
+	switch cb.state {
+	case CircuitHalfOpen:
+		cb.state = CircuitOpen
+	case CircuitClosed:
+		if cb.failureCount >= cb.failureThreshold {
+			cb.state = CircuitOpen
+		}
+	}
+}
+
+// State returns the current circuit state
+func (cb *CircuitBreaker) State() CircuitState {
+	// Check if we should transition from open to half-open
+	if cb.state == CircuitOpen && time.Since(cb.lastFailure) > cb.timeout {
+		cb.state = CircuitHalfOpen
+		cb.successCount = 0
+	}
+	return cb.state
+}
+
+// Reset resets the circuit breaker to closed state
+func (cb *CircuitBreaker) Reset() {
+	cb.state = CircuitClosed
+	cb.failureCount = 0
+	cb.successCount = 0
+}

--- a/pkg/pricefeed/types.go
+++ b/pkg/pricefeed/types.go
@@ -1,0 +1,265 @@
+package pricefeed
+
+import (
+	"errors"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+var (
+	// ErrPriceFeedUnavailable is returned when no price feed sources are available
+	ErrPriceFeedUnavailable = errors.New("price feed unavailable")
+
+	// ErrPriceNotFound is returned when a price for the requested pair is not found
+	ErrPriceNotFound = errors.New("price not found for requested pair")
+
+	// ErrPriceStale is returned when the cached price is too old
+	ErrPriceStale = errors.New("price data is stale")
+
+	// ErrInvalidPair is returned for unsupported trading pairs
+	ErrInvalidPair = errors.New("invalid or unsupported trading pair")
+
+	// ErrRateLimitExceeded is returned when API rate limits are hit
+	ErrRateLimitExceeded = errors.New("rate limit exceeded")
+
+	// ErrSourceUnhealthy is returned when a price source is not responding
+	ErrSourceUnhealthy = errors.New("price source is unhealthy")
+
+	// ErrAllSourcesFailed is returned when all configured sources fail
+	ErrAllSourcesFailed = errors.New("all price feed sources failed")
+
+	// ErrPriceDeviation is returned when prices deviate too much between sources
+	ErrPriceDeviation = errors.New("price deviation exceeds threshold")
+)
+
+// ============================================================================
+// Price Types
+// ============================================================================
+
+// PriceData represents a price quote from a price feed source
+type PriceData struct {
+	// BaseAsset is the asset being priced (e.g., "virtengine", "uve")
+	BaseAsset string `json:"base_asset"`
+
+	// QuoteAsset is the quote currency (e.g., "usd", "eur")
+	QuoteAsset string `json:"quote_asset"`
+
+	// Price is the price of 1 unit of base asset in quote currency
+	Price sdkmath.LegacyDec `json:"price"`
+
+	// Timestamp is when the price was fetched
+	Timestamp time.Time `json:"timestamp"`
+
+	// Source is the identifier of the price source
+	Source string `json:"source"`
+
+	// Confidence is a 0-1 score indicating price reliability (optional)
+	Confidence float64 `json:"confidence,omitempty"`
+
+	// Volume24h is the 24-hour trading volume (optional)
+	Volume24h sdkmath.LegacyDec `json:"volume_24h,omitempty"`
+
+	// MarketCap is the market capitalization (optional)
+	MarketCap sdkmath.LegacyDec `json:"market_cap,omitempty"`
+
+	// LastUpdatedAt is when the source last updated this price
+	LastUpdatedAt time.Time `json:"last_updated_at,omitempty"`
+}
+
+// IsValid checks if the price data is valid
+func (p PriceData) IsValid() bool {
+	if p.BaseAsset == "" || p.QuoteAsset == "" {
+		return false
+	}
+	if p.Price.IsNil() || p.Price.IsNegative() || p.Price.IsZero() {
+		return false
+	}
+	if p.Timestamp.IsZero() {
+		return false
+	}
+	return true
+}
+
+// Age returns how old the price data is
+func (p PriceData) Age() time.Duration {
+	return time.Since(p.Timestamp)
+}
+
+// IsStale checks if the price is older than the given threshold
+func (p PriceData) IsStale(maxAge time.Duration) bool {
+	return p.Age() > maxAge
+}
+
+// ============================================================================
+// Source Types
+// ============================================================================
+
+// SourceType identifies the type of price feed source
+type SourceType string
+
+const (
+	// SourceTypeCoinGecko is the CoinGecko API source
+	SourceTypeCoinGecko SourceType = "coingecko"
+
+	// SourceTypeChainlink is the Chainlink oracle source
+	SourceTypeChainlink SourceType = "chainlink"
+
+	// SourceTypePyth is the Pyth network source
+	SourceTypePyth SourceType = "pyth"
+
+	// SourceTypeMock is a mock source for testing
+	SourceTypeMock SourceType = "mock"
+)
+
+// String returns the string representation
+func (s SourceType) String() string {
+	return string(s)
+}
+
+// IsValid checks if the source type is valid
+func (s SourceType) IsValid() bool {
+	switch s {
+	case SourceTypeCoinGecko, SourceTypeChainlink, SourceTypePyth, SourceTypeMock:
+		return true
+	default:
+		return false
+	}
+}
+
+// SourceHealth represents the health status of a price source
+type SourceHealth struct {
+	// Source is the source identifier
+	Source string `json:"source"`
+
+	// Type is the source type
+	Type SourceType `json:"type"`
+
+	// Healthy indicates if the source is responding
+	Healthy bool `json:"healthy"`
+
+	// LastCheck is when health was last checked
+	LastCheck time.Time `json:"last_check"`
+
+	// LastSuccess is when the source last returned valid data
+	LastSuccess time.Time `json:"last_success"`
+
+	// LastError is the most recent error (if any)
+	LastError string `json:"last_error,omitempty"`
+
+	// Latency is the average response time
+	Latency time.Duration `json:"latency"`
+
+	// RequestCount is total requests made
+	RequestCount int64 `json:"request_count"`
+
+	// ErrorCount is total errors
+	ErrorCount int64 `json:"error_count"`
+}
+
+// ErrorRate returns the error rate as a percentage
+func (h SourceHealth) ErrorRate() float64 {
+	if h.RequestCount == 0 {
+		return 0
+	}
+	return float64(h.ErrorCount) / float64(h.RequestCount) * 100
+}
+
+// ============================================================================
+// Aggregation Types
+// ============================================================================
+
+// AggregationStrategy defines how to combine prices from multiple sources
+type AggregationStrategy string
+
+const (
+	// StrategyPrimary uses the first healthy source in priority order
+	StrategyPrimary AggregationStrategy = "primary"
+
+	// StrategyMedian uses the median price across all sources
+	StrategyMedian AggregationStrategy = "median"
+
+	// StrategyWeighted weights prices by source confidence/volume
+	StrategyWeighted AggregationStrategy = "weighted"
+)
+
+// String returns the string representation
+func (s AggregationStrategy) String() string {
+	return string(s)
+}
+
+// IsValid checks if the strategy is valid
+func (s AggregationStrategy) IsValid() bool {
+	switch s {
+	case StrategyPrimary, StrategyMedian, StrategyWeighted:
+		return true
+	default:
+		return false
+	}
+}
+
+// AggregatedPrice represents a price derived from multiple sources
+type AggregatedPrice struct {
+	PriceData
+
+	// Strategy is the aggregation strategy used
+	Strategy AggregationStrategy `json:"strategy"`
+
+	// SourcePrices contains prices from each individual source
+	SourcePrices []PriceData `json:"source_prices"`
+
+	// Deviation is the max percentage deviation between sources
+	Deviation float64 `json:"deviation"`
+
+	// SourceCount is the number of sources that contributed
+	SourceCount int `json:"source_count"`
+}
+
+// ============================================================================
+// Asset Mapping Types
+// ============================================================================
+
+// AssetMapping maps internal asset identifiers to external source identifiers
+type AssetMapping struct {
+	// InternalID is the asset identifier used internally (e.g., "uve")
+	InternalID string `json:"internal_id"`
+
+	// CoinGeckoID is the CoinGecko asset ID (e.g., "virtengine")
+	CoinGeckoID string `json:"coingecko_id,omitempty"`
+
+	// ChainlinkFeedAddress is the Chainlink price feed contract address
+	ChainlinkFeedAddress string `json:"chainlink_feed_address,omitempty"`
+
+	// PythPriceID is the Pyth price feed ID (32-byte hex)
+	PythPriceID string `json:"pyth_price_id,omitempty"`
+
+	// Decimals is the number of decimals for this asset
+	Decimals int `json:"decimals"`
+}
+
+// DefaultAssetMappings returns default mappings for common assets
+func DefaultAssetMappings() []AssetMapping {
+	return []AssetMapping{
+		{
+			InternalID:   "uve",
+			CoinGeckoID:  "virtengine",
+			Decimals:     6,
+			// Chainlink/Pyth IDs would be added when feeds are available
+		},
+		{
+			InternalID:           "atom",
+			CoinGeckoID:          "cosmos",
+			ChainlinkFeedAddress: "0x...", // Example
+			Decimals:             6,
+		},
+		{
+			InternalID:  "usdc",
+			CoinGeckoID: "usd-coin",
+			Decimals:    6,
+		},
+	}
+}


### PR DESCRIPTION
Replace placeholder conversion rates with real price feeds (CoinGecko/Chainlink/Pyth) with caching + retries.

Acceptance:
- Price feeds queried from configured source(s)
- Caching + retry logic implemented
- Quote source + timestamp recorded
- Failure fallback documented and monitored