### PR TITLE
feat(veid): define ML feature schema + data contract 

### DIFF
--- a/_docs/veid-ml-feature-schema.md
+++ b/_docs/veid-ml-feature-schema.md
@@ -1,0 +1,656 @@
+# VEID ML Feature Schema Specification
+
+**Version:** 1.0.0  
+**Status:** Draft  
+**Last Updated:** 2026-01-30  
+**Authors:** VirtEngine Team
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Scope Types](#scope-types)
+3. [Feature Groups](#feature-groups)
+4. [Feature Definitions](#feature-definitions)
+5. [Normalization Rules](#normalization-rules)
+6. [Missing Data Handling](#missing-data-handling)
+7. [Schema Versioning](#schema-versioning)
+8. [Training and Inference Mapping](#training-and-inference-mapping)
+9. [Consent and Retention Constraints](#consent-and-retention-constraints)
+10. [Migration Policy](#migration-policy)
+11. [Examples](#examples)
+
+---
+
+## Overview
+
+This document defines the canonical ML feature schema and data contract for the VirtEngine Identity (VEID) verification system. The schema ensures deterministic feature extraction across training and inference pipelines, enabling consensus-safe ML scoring on the blockchain.
+
+### Design Principles
+
+1. **Determinism**: All feature extraction and normalization must be deterministic across validators
+2. **Privacy-by-Design**: Features are derived from encrypted data; raw PII is never stored on-chain
+3. **Backward Compatibility**: Schema changes must not break existing verification records
+4. **Consent-Aware**: Feature groups are mapped to consent requirements
+
+### Feature Vector Dimensions
+
+| Component | Dimensions | Description |
+|-----------|------------|-------------|
+| Face Embedding | 512 | Normalized face embedding from selfie/document |
+| Document Quality | 5 | Image quality metrics |
+| OCR Features | 10 | Field confidence and validation (5 fields × 2) |
+| Metadata Features | 16 | Scope types, counts, and contextual data |
+| Padding/Reserved | 225 | Reserved for future expansion |
+| **Total** | **768** | Combined feature vector dimension |
+
+---
+
+## Scope Types
+
+The VEID system supports the following scope types, each contributing specific features:
+
+| Scope Type | Code | Weight | Required Features | Consent Category |
+|------------|------|--------|-------------------|------------------|
+| ID Document | `id_document` | 30 | Document quality, OCR, face extraction | biometric_pii |
+| Selfie | `selfie` | 20 | Face embedding, face quality | biometric |
+| Face Video | `face_video` | 25 | Liveness features, face embedding | biometric |
+| Biometric | `biometric` | 20 | Biometric hash, template features | biometric |
+| SSO Metadata | `sso_metadata` | 5 | Provider metadata, claims | identity_attestation |
+| Email Proof | `email_proof` | 10 | Verification status | contact_verification |
+| SMS Proof | `sms_proof` | 10 | Verification status | contact_verification |
+| Domain Verify | `domain_verify` | 15 | DNS record validation | domain_ownership |
+| AD SSO | `ad_sso` | 12 | Enterprise claims, tenant info | enterprise_identity |
+
+### Scope Type Definitions
+
+```go
+// From x/veid/types/scope.go
+const (
+    ScopeTypeIDDocument   ScopeType = "id_document"
+    ScopeTypeSelfie       ScopeType = "selfie"
+    ScopeTypeFaceVideo    ScopeType = "face_video"
+    ScopeTypeBiometric    ScopeType = "biometric"
+    ScopeTypeSSOMetadata  ScopeType = "sso_metadata"
+    ScopeTypeEmailProof   ScopeType = "email_proof"
+    ScopeTypeSMSProof     ScopeType = "sms_proof"
+    ScopeTypeDomainVerify ScopeType = "domain_verify"
+    ScopeTypeADSSO        ScopeType = "ad_sso"
+)
+```
+
+---
+
+## Feature Groups
+
+### Group 1: Face Features (512 + 7 = 519 dimensions in training)
+
+Features extracted from facial verification pipeline.
+
+| Feature Name | Type | Dimensions | Unit | Range | Description |
+|--------------|------|------------|------|-------|-------------|
+| `face_embedding` | float32[] | 512 | - | [-1.0, 1.0] | L2-normalized face embedding vector |
+| `document_face_embedding` | float32[] | 512 | - | [-1.0, 1.0] | Face embedding from ID document |
+| `selfie_face_embedding` | float32[] | 512 | - | [-1.0, 1.0] | Face embedding from selfie |
+| `face_similarity` | float32 | 1 | cosine | [0.0, 1.0] | Cosine similarity between document and selfie |
+| `document_face_confidence` | float32 | 1 | probability | [0.0, 1.0] | Detection confidence for document face |
+| `selfie_face_confidence` | float32 | 1 | probability | [0.0, 1.0] | Detection confidence for selfie face |
+| `document_face_detected` | bool | 1 | binary | {0, 1} | Whether face was detected in document |
+| `selfie_face_detected` | bool | 1 | binary | {0, 1} | Whether face was detected in selfie |
+| `document_face_quality` | float32 | 1 | score | [0.0, 1.0] | Quality score for document face |
+| `selfie_face_quality` | float32 | 1 | score | [0.0, 1.0] | Quality score for selfie face |
+
+**Inference Mapping**: Combined into 512-dimensional embedding for model input.
+
+### Group 2: Document Quality Features (17 dimensions in training, 5 in inference)
+
+Features extracted from document image quality analysis.
+
+| Feature Name | Type | Unit | Range | Description |
+|--------------|------|------|-------|-------------|
+| `sharpness_score` | float32 | score | [0.0, 1.0] | Laplacian variance-based sharpness |
+| `brightness_score` | float32 | score | [0.0, 1.0] | Deviation from ideal brightness (0.5) |
+| `contrast_score` | float32 | score | [0.0, 1.0] | Standard deviation-based contrast |
+| `noise_level` | float32 | ratio | [0.0, 1.0] | Estimated noise level (lower is better) |
+| `blur_score` | float32 | score | [0.0, 1.0] | Blur detection score (lower is better) |
+| `saturation_score` | float32 | score | [0.0, 1.0] | Average color saturation |
+| `color_uniformity` | float32 | score | [0.0, 1.0] | Inverse of color variance |
+| `edge_density` | float32 | ratio | [0.0, 1.0] | Ratio of edge pixels |
+| `corner_count` | int | count | [0, ∞) | Number of detected corners |
+| `text_region_ratio` | float32 | ratio | [0.0, 1.0] | Estimated text region coverage |
+| `has_photo_region` | bool | binary | {0, 1} | Photo region detected |
+| `has_mrz_region` | bool | binary | {0, 1} | MRZ region detected |
+| `has_barcode` | bool | binary | {0, 1} | Barcode detected |
+| `document_bounds_confidence` | float32 | probability | [0.0, 1.0] | Document boundary detection confidence |
+| `orientation_corrected` | bool | binary | {0, 1} | Whether orientation was corrected |
+| `perspective_corrected` | bool | binary | {0, 1} | Whether perspective was corrected |
+| `overall_quality_score` | float32 | score | [0.0, 1.0] | Composite quality score |
+
+**Inference Mapping**: Condensed to 5 core metrics: sharpness, brightness, contrast, noise_level, blur_score.
+
+### Group 3: OCR Features (5 fields × 5 = 25 dimensions in training, 10 in inference)
+
+Features extracted from OCR field extraction.
+
+#### Per-Field Features
+
+For each OCR field (`name`, `date_of_birth`, `document_number`, `expiry_date`, `nationality`):
+
+| Feature Name | Type | Unit | Range | Description |
+|--------------|------|------|-------|-------------|
+| `{field}_extracted` | bool | binary | {0, 1} | Whether field was extracted |
+| `{field}_confidence` | float32 | probability | [0.0, 1.0] | OCR confidence for field |
+| `{field}_validated` | bool | binary | {0, 1} | Whether field passed validation |
+| `{field}_validation_score` | float32 | score | [0.0, 1.0] | Field validation score |
+| `{field}_char_count` | int | count | [0, 50] | Character count (normalized) |
+
+#### Aggregate OCR Features
+
+| Feature Name | Type | Unit | Range | Description |
+|--------------|------|------|-------|-------------|
+| `overall_ocr_confidence` | float32 | probability | [0.0, 1.0] | Mean confidence of extracted fields |
+| `fields_extracted_ratio` | float32 | ratio | [0.0, 1.0] | Ratio of successfully extracted fields |
+| `fields_validated_ratio` | float32 | ratio | [0.0, 1.0] | Ratio of validated fields |
+| `average_character_confidence` | float32 | probability | [0.0, 1.0] | Mean character-level confidence |
+| `text_density` | float32 | ratio | [0.0, 1.0] | Text coverage estimation |
+| `ocr_success` | bool | binary | {0, 1} | Overall OCR success flag |
+| `ocr_timeout` | bool | binary | {0, 1} | OCR timeout flag (inverted) |
+| `has_name` | bool | binary | {0, 1} | Name field extracted |
+| `has_dob` | bool | binary | {0, 1} | Date of birth extracted |
+| `has_doc_number` | bool | binary | {0, 1} | Document number extracted |
+| `has_expiry` | bool | binary | {0, 1} | Expiry date extracted |
+| `has_nationality` | bool | binary | {0, 1} | Nationality extracted |
+
+**Inference Mapping**: Condensed to 10 dimensions (5 fields × 2: confidence + validation).
+
+### Group 4: Metadata Features (16 dimensions)
+
+Contextual features from verification request.
+
+| Feature Name | Type | Unit | Range | Description |
+|--------------|------|------|-------|-------------|
+| `scope_count` | float32 | count | [0.0, 1.0] | Normalized scope count (÷10) |
+| `has_id_document` | bool | binary | {0, 1} | ID document scope present |
+| `has_selfie` | bool | binary | {0, 1} | Selfie scope present |
+| `has_face_video` | bool | binary | {0, 1} | Face video scope present |
+| `has_biometric` | bool | binary | {0, 1} | Biometric scope present |
+| `has_sso_metadata` | bool | binary | {0, 1} | SSO metadata present |
+| `has_email_proof` | bool | binary | {0, 1} | Email proof present |
+| `has_sms_proof` | bool | binary | {0, 1} | SMS proof present |
+| `has_domain_verify` | bool | binary | {0, 1} | Domain verify present |
+| `face_confidence` | float32 | probability | [0.0, 1.0] | Best face confidence |
+| `block_height_normalized` | float32 | ratio | [0.0, 1.0] | Block height mod 1M / 1M |
+| `reserved_11` | float32 | - | - | Reserved for future use |
+| `reserved_12` | float32 | - | - | Reserved for future use |
+| `reserved_13` | float32 | - | - | Reserved for future use |
+| `reserved_14` | float32 | - | - | Reserved for future use |
+| `reserved_15` | float32 | - | - | Reserved for future use |
+
+---
+
+## Normalization Rules
+
+All normalization operations must be deterministic and reproducible across validators.
+
+### Face Embedding Normalization
+
+```python
+# L2 normalization to unit length
+def normalize_embedding(embedding: np.ndarray) -> np.ndarray:
+    norm = np.linalg.norm(embedding)
+    if norm > 1e-10:
+        return embedding / norm
+    return np.zeros_like(embedding)
+```
+
+```go
+// Go implementation in pkg/inference/feature_extractor.go
+func (fe *FeatureExtractor) normalizeEmbedding(embedding []float32) {
+    var sumSquares float64
+    for _, v := range embedding {
+        sumSquares += float64(v) * float64(v)
+    }
+    norm := math.Sqrt(sumSquares)
+    if norm > 1e-10 {
+        for i := range embedding {
+            embedding[i] = float32(float64(embedding[i]) / norm)
+        }
+    }
+}
+```
+
+### Score Normalization
+
+| Feature Type | Normalization | Formula |
+|--------------|---------------|---------|
+| Probability scores | Clamp | `clamp(value, 0.0, 1.0)` |
+| Count features | Scale | `min(1.0, count / max_count)` |
+| Quality scores | Identity | Already in [0, 1] range |
+| Boolean features | Binary | `1.0 if true else 0.0` |
+
+### Inverted Features
+
+Some features are inverted so that higher values are always better:
+
+| Feature | Inversion Formula |
+|---------|-------------------|
+| `noise_level` | `1.0 - noise_level` |
+| `blur_score` | `1.0 - blur_score` (in inference) |
+| `ocr_timeout` | `1.0 if not timeout else 0.0` |
+
+### Z-Score Normalization (Optional)
+
+For training pipelines with feature scaling enabled:
+
+```python
+def zscore_normalize(features: np.ndarray, mean: np.ndarray, std: np.ndarray) -> np.ndarray:
+    # Avoid division by zero
+    std_safe = np.where(std > 1e-8, std, 1.0)
+    return (features - mean) / std_safe
+```
+
+**Note**: Z-score normalization parameters (mean, std) must be computed from training data and frozen during inference.
+
+---
+
+## Missing Data Handling
+
+### Default Values by Feature Type
+
+| Feature Type | Default Value | Rationale |
+|--------------|---------------|-----------|
+| Face embedding | zeros(512) | No face detected |
+| Confidence scores | 0.0 | No detection = zero confidence |
+| Quality scores | 0.5 | Neutral quality assumption |
+| Boolean indicators | 0.0 | Feature absent |
+| Count features | 0.0 | No items counted |
+
+### Missing Scope Handling
+
+When a scope type is missing from the verification request:
+
+1. All features from that scope receive default values
+2. The corresponding `has_{scope_type}` metadata feature is set to 0
+3. `scope_count` is decremented
+
+### Partial Feature Handling
+
+When a scope is present but feature extraction fails:
+
+| Scenario | Handling |
+|----------|----------|
+| Face not detected | `face_confidence = 0.0`, embedding = zeros |
+| OCR timeout | `ocr_timeout = 1.0`, all field features = 0.0 |
+| Document quality failure | All quality features = 0.5 |
+| Validation failure | `*_validated = 0.0`, `*_validation_score = 0.0` |
+
+---
+
+## Schema Versioning
+
+### Version Format
+
+Schema versions follow semantic versioning: `MAJOR.MINOR.PATCH`
+
+- **MAJOR**: Breaking changes to feature dimensions or semantics
+- **MINOR**: New features added (backward compatible)
+- **PATCH**: Bug fixes, documentation updates
+
+### Current Version
+
+```
+Schema Version: 1.0.0
+Feature Vector Version: 768
+Model Compatibility: v1.x
+```
+
+### Version Constants
+
+```go
+// x/veid/types/scope.go
+const ScopeSchemaVersion uint32 = 1
+
+// pkg/inference/types.go
+const (
+    FaceEmbeddingDim = 512
+    DocQualityDim    = 5
+    OCRFieldsDim     = 10
+    MetadataDim      = 16
+    TotalFeatureDim  = 768
+    PaddingDim       = 225
+)
+```
+
+### Backward Compatibility Rules
+
+1. **Dimension Stability**: `TotalFeatureDim` (768) must remain constant within a major version
+2. **Feature Semantics**: Existing feature meanings cannot change within a major version
+3. **Default Values**: Default values for new features must ensure backward compatibility
+4. **Padding Usage**: New features should consume padding dimensions before requiring a major version bump
+
+### Version Migration
+
+When upgrading schema versions:
+
+1. Old verification records retain their original schema version
+2. New verifications use the current schema version
+3. Inference service must support all schema versions within the same major version
+
+---
+
+## Training and Inference Mapping
+
+### Training Pipeline Input (Python)
+
+```python
+# ml/training/features/feature_combiner.py
+
+@dataclass
+class TrainingFeatures:
+    # Face features (1031 dims in training, 512 combined for inference)
+    face_features: FaceFeatures      # 512*2 + 7 = 1031
+    
+    # Document features (17 dims in training, 5 for inference)
+    doc_features: DocumentFeatures   # 17
+    
+    # OCR features (25 + 12 = 37 dims in training, 10 for inference)
+    ocr_features: OCRFeatures        # 37
+    
+    # Metadata features (16 dims)
+    metadata_features: np.ndarray    # 16
+
+def combine_for_inference(features: TrainingFeatures) -> np.ndarray:
+    """Combine training features into 768-dim inference vector."""
+    combined = np.zeros(768, dtype=np.float32)
+    
+    # Face embedding (512)
+    combined[0:512] = features.face_features.combined_embedding
+    
+    # Document quality (5)
+    combined[512:517] = features.doc_features.to_inference_vector()
+    
+    # OCR features (10)
+    combined[517:527] = features.ocr_features.to_inference_vector()
+    
+    # Metadata (16)
+    combined[527:543] = features.metadata_features
+    
+    # Padding (225) - zeros
+    return combined
+```
+
+### Inference Pipeline Input (Go)
+
+```go
+// pkg/inference/feature_extractor.go
+
+type ScoreInputs struct {
+    FaceEmbedding      []float32            // 512 dims
+    FaceConfidence     float32
+    DocQualityScore    float32
+    DocQualityFeatures DocQualityFeatures   // 5 dims
+    OCRConfidences     map[string]float32   // 5 fields
+    OCRFieldValidation map[string]bool      // 5 fields
+    ScopeTypes         []string
+    ScopeCount         int
+    Metadata           InferenceMetadata
+}
+
+// Extracted feature vector layout:
+// [0:512]   - Face embedding
+// [512:517] - Document quality (sharpness, brightness, contrast, 1-noise, 1-blur)
+// [517:527] - OCR features (5 fields × 2)
+// [527:543] - Metadata features
+// [543:768] - Padding (zeros)
+```
+
+### Feature Consistency Validation
+
+Training and inference must produce identical features for the same input:
+
+```python
+def validate_consistency(
+    training_features: np.ndarray,
+    inference_features: np.ndarray,
+    tolerance: float = 1e-6
+) -> bool:
+    return np.allclose(training_features, inference_features, atol=tolerance)
+```
+
+---
+
+## Consent and Retention Constraints
+
+### Consent Categories
+
+| Category | Scope Types | Required Consent |
+|----------|-------------|------------------|
+| `biometric_pii` | id_document | Explicit, purpose-specific |
+| `biometric` | selfie, face_video, biometric | Explicit |
+| `identity_attestation` | sso_metadata | Implicit via SSO flow |
+| `contact_verification` | email_proof, sms_proof | Implicit via verification |
+| `domain_ownership` | domain_verify | Implicit via DNS record |
+| `enterprise_identity` | ad_sso | Delegated via enterprise |
+
+### Feature-to-Consent Mapping
+
+| Feature Group | Consent Category | Can Share | Retention Policy |
+|---------------|------------------|-----------|------------------|
+| Face Embedding | biometric | With consent | Hash: indefinite; Raw: 7 days |
+| Document Quality | biometric_pii | With consent | 30 days max |
+| OCR Features | biometric_pii | Field hashes only | Hash: indefinite; Raw: 7 days |
+| Metadata Features | identity_attestation | Anonymized only | Indefinite |
+
+### Retention Constraints by Feature Type
+
+From `x/veid/types/data_lifecycle.go`:
+
+| Artifact Type | On-Chain | Encryption Required | Default Retention | Max Retention |
+|---------------|----------|---------------------|-------------------|---------------|
+| Raw Image | ❌ | ✅ | 7 days | 30 days |
+| Processed Image | ❌ | ✅ | 1 day | 7 days |
+| Face Embedding | ✅ (hash) | ✅ (raw) | 365 days | Indefinite |
+| Document Hash | ✅ | ❌ | 365 days | Indefinite |
+| OCR Data | ❌ | ✅ | 7 days | 30 days |
+| Verification Record | ✅ | ❌ | Indefinite | Indefinite |
+
+### Derived Feature Sharing
+
+Derived feature hashes can be shared when:
+
+1. `AllowDerivedFeatureSharing` consent is granted
+2. Features are cryptographically hashed before sharing
+3. Original data has been deleted per retention policy
+
+---
+
+## Migration Policy
+
+### Schema Migration Process
+
+1. **Proposal**: Submit schema change via governance proposal
+2. **Review**: Security and privacy impact assessment
+3. **Soft Fork**: Deploy new schema version with backward compatibility
+4. **Migration Window**: Allow validators to update (14-day minimum)
+5. **Hard Fork**: If breaking changes, require network upgrade
+
+### Feature Addition Process
+
+To add a new feature within a major version:
+
+1. Allocate dimensions from padding (`PaddingDim`)
+2. Define default value for backward compatibility
+3. Update training pipeline to extract new feature
+4. Deploy model trained with new feature
+5. Update inference pipeline
+6. Bump MINOR version
+
+### Breaking Change Process
+
+Breaking changes require:
+
+1. MAJOR version bump
+2. Governance approval
+3. Model retraining with version migration
+4. Verification record migration plan
+5. Minimum 30-day notice period
+
+### Model Versioning
+
+Models must be versioned alongside schema:
+
+```go
+type ModelMetadata struct {
+    Version           string  // e.g., "v1.2.0"
+    SchemaVersion     string  // e.g., "1.0.0"
+    Hash              string  // SHA256 of weights
+    InputShape        []int64 // [1, 768]
+    OutputShape       []int64 // [1, 1]
+}
+```
+
+---
+
+## Examples
+
+### Example 1: Full Verification Request Features
+
+```json
+{
+  "schema_version": "1.0.0",
+  "scope_types": ["id_document", "selfie"],
+  "features": {
+    "face_embedding": [0.123, -0.456, ...],  // 512 values
+    "face_confidence": 0.95,
+    "doc_quality": {
+      "sharpness": 0.85,
+      "brightness": 0.72,
+      "contrast": 0.68,
+      "noise_level": 0.12,
+      "blur_score": 0.08
+    },
+    "ocr": {
+      "name": {"confidence": 0.92, "validated": true},
+      "date_of_birth": {"confidence": 0.88, "validated": true},
+      "document_number": {"confidence": 0.95, "validated": true},
+      "expiry_date": {"confidence": 0.90, "validated": true},
+      "nationality": {"confidence": 0.85, "validated": true}
+    },
+    "metadata": {
+      "scope_count": 0.2,
+      "has_id_document": 1.0,
+      "has_selfie": 1.0,
+      "face_confidence": 0.95,
+      "block_height_normalized": 0.123456
+    }
+  }
+}
+```
+
+### Example 2: Minimal Verification (Email Only)
+
+```json
+{
+  "schema_version": "1.0.0",
+  "scope_types": ["email_proof"],
+  "features": {
+    "face_embedding": [0.0, 0.0, ...],  // 512 zeros
+    "face_confidence": 0.0,
+    "doc_quality": {
+      "sharpness": 0.5,
+      "brightness": 0.5,
+      "contrast": 0.5,
+      "noise_level": 0.5,
+      "blur_score": 0.5
+    },
+    "ocr": {
+      "name": {"confidence": 0.0, "validated": false},
+      "date_of_birth": {"confidence": 0.0, "validated": false},
+      "document_number": {"confidence": 0.0, "validated": false},
+      "expiry_date": {"confidence": 0.0, "validated": false},
+      "nationality": {"confidence": 0.0, "validated": false}
+    },
+    "metadata": {
+      "scope_count": 0.1,
+      "has_email_proof": 1.0,
+      "block_height_normalized": 0.234567
+    }
+  }
+}
+```
+
+### Example 3: Feature Vector Reconstruction
+
+```go
+// Reconstruct 768-dim feature vector from ScoreInputs
+func (fe *FeatureExtractor) ExtractFeatures(inputs *ScoreInputs) ([]float32, error) {
+    features := make([]float32, TotalFeatureDim)  // 768
+    
+    // [0:512] Face embedding
+    copy(features[0:512], inputs.FaceEmbedding)
+    fe.normalizeEmbedding(features[0:512])
+    
+    // [512:517] Document quality
+    features[512] = inputs.DocQualityScore
+    features[513] = inputs.DocQualityFeatures.Sharpness
+    features[514] = inputs.DocQualityFeatures.Brightness
+    features[515] = inputs.DocQualityFeatures.Contrast
+    features[516] = 1.0 - inputs.DocQualityFeatures.NoiseLevel
+    
+    // [517:527] OCR features
+    for i, field := range OCRFieldNames {
+        features[517+i*2] = inputs.OCRConfidences[field]
+        if inputs.OCRFieldValidation[field] {
+            features[517+i*2+1] = 1.0
+        }
+    }
+    
+    // [527:543] Metadata
+    features[527] = float32(inputs.ScopeCount) / 10.0
+    // ... scope type indicators
+    
+    return features, nil
+}
+```
+
+---
+
+## Appendix A: Feature Dimension Map
+
+| Offset | End | Dimension | Feature Group | Description |
+|--------|-----|-----------|---------------|-------------|
+| 0 | 511 | 512 | Face | Face embedding vector |
+| 512 | 516 | 5 | DocQuality | Document quality metrics |
+| 517 | 526 | 10 | OCR | OCR field features |
+| 527 | 542 | 16 | Metadata | Contextual metadata |
+| 543 | 767 | 225 | Padding | Reserved for future use |
+
+## Appendix B: OCR Field Names
+
+```go
+var OCRFieldNames = []string{
+    "name",           // Index 0
+    "date_of_birth",  // Index 1
+    "document_number", // Index 2
+    "expiry_date",    // Index 3
+    "nationality",    // Index 4
+}
+```
+
+## Appendix C: Scope Type Weights
+
+```go
+func ScopeTypeWeight(scopeType ScopeType) uint32 {
+    switch scopeType {
+    case ScopeTypeIDDocument:  return 30
+    case ScopeTypeFaceVideo:   return 25
+    case ScopeTypeSelfie:      return 20
+    case ScopeTypeBiometric:   return 20
+    case ScopeTypeDomainVerify: return 15
+    case ScopeTypeADSSO:       return 12
+    case ScopeTypeEmailProof:  return 10
+    case ScopeTypeSMSProof:    return 10
+    case ScopeTypeSSOMetadata: return 5
+    default:                   return 0
+    }
+}
+```

--- a/x/veid/types/ml_feature_schema.go
+++ b/x/veid/types/ml_feature_schema.go
@@ -1,0 +1,423 @@
+package types
+
+import (
+	"fmt"
+)
+
+// ============================================================================
+// ML Feature Schema Version and Constants
+// ============================================================================
+
+// MLFeatureSchemaVersion defines the current version of the ML feature schema.
+// This version must match between training and inference pipelines.
+const MLFeatureSchemaVersion = "1.0.0"
+
+// MLFeatureSchemaVersionMajor is the major version component
+const MLFeatureSchemaVersionMajor = 1
+
+// MLFeatureSchemaVersionMinor is the minor version component
+const MLFeatureSchemaVersionMinor = 0
+
+// MLFeatureSchemaVersionPatch is the patch version component
+const MLFeatureSchemaVersionPatch = 0
+
+// ============================================================================
+// Feature Dimension Constants
+// ============================================================================
+
+const (
+	// FaceEmbeddingDim is the dimension of face embedding vectors
+	FaceEmbeddingDim = 512
+
+	// DocQualityDim is the dimension of document quality features
+	DocQualityDim = 5
+
+	// OCRFieldCount is the number of OCR fields tracked
+	OCRFieldCount = 5
+
+	// OCRFeaturesDim is the dimension of OCR features (fields * 2)
+	OCRFeaturesDim = OCRFieldCount * 2
+
+	// MetadataFeaturesDim is the dimension of metadata features
+	MetadataFeaturesDim = 16
+
+	// TotalFeatureDim is the total combined feature vector dimension
+	TotalFeatureDim = 768
+
+	// PaddingDim is the reserved padding dimension
+	PaddingDim = TotalFeatureDim - FaceEmbeddingDim - DocQualityDim - OCRFeaturesDim - MetadataFeaturesDim
+)
+
+// Validate dimension constants at compile time
+var _ = [1]struct{}{}[TotalFeatureDim-768]               // TotalFeatureDim must be 768
+var _ = [1]struct{}{}[PaddingDim-225]                    // PaddingDim must be 225
+var _ = [1]struct{}{}[FaceEmbeddingDim+DocQualityDim+OCRFeaturesDim+MetadataFeaturesDim+PaddingDim-768] // Sum must be 768
+
+// ============================================================================
+// Feature Group Definitions
+// ============================================================================
+
+// FeatureGroup represents a group of related ML features
+type FeatureGroup string
+
+const (
+	// FeatureGroupFace contains face embedding and related features
+	FeatureGroupFace FeatureGroup = "face"
+
+	// FeatureGroupDocQuality contains document quality metrics
+	FeatureGroupDocQuality FeatureGroup = "doc_quality"
+
+	// FeatureGroupOCR contains OCR-extracted field features
+	FeatureGroupOCR FeatureGroup = "ocr"
+
+	// FeatureGroupMetadata contains contextual metadata features
+	FeatureGroupMetadata FeatureGroup = "metadata"
+
+	// FeatureGroupPadding contains reserved padding dimensions
+	FeatureGroupPadding FeatureGroup = "padding"
+)
+
+// AllFeatureGroups returns all valid feature groups
+func AllFeatureGroups() []FeatureGroup {
+	return []FeatureGroup{
+		FeatureGroupFace,
+		FeatureGroupDocQuality,
+		FeatureGroupOCR,
+		FeatureGroupMetadata,
+		FeatureGroupPadding,
+	}
+}
+
+// ============================================================================
+// Feature Offset Map
+// ============================================================================
+
+// FeatureOffset defines the offset and size of a feature group in the feature vector
+type FeatureOffset struct {
+	Group      FeatureGroup
+	StartIndex int
+	EndIndex   int
+	Dimension  int
+}
+
+// FeatureOffsets returns the offset map for all feature groups
+func FeatureOffsets() []FeatureOffset {
+	return []FeatureOffset{
+		{Group: FeatureGroupFace, StartIndex: 0, EndIndex: FaceEmbeddingDim - 1, Dimension: FaceEmbeddingDim},
+		{Group: FeatureGroupDocQuality, StartIndex: FaceEmbeddingDim, EndIndex: FaceEmbeddingDim + DocQualityDim - 1, Dimension: DocQualityDim},
+		{Group: FeatureGroupOCR, StartIndex: FaceEmbeddingDim + DocQualityDim, EndIndex: FaceEmbeddingDim + DocQualityDim + OCRFeaturesDim - 1, Dimension: OCRFeaturesDim},
+		{Group: FeatureGroupMetadata, StartIndex: FaceEmbeddingDim + DocQualityDim + OCRFeaturesDim, EndIndex: FaceEmbeddingDim + DocQualityDim + OCRFeaturesDim + MetadataFeaturesDim - 1, Dimension: MetadataFeaturesDim},
+		{Group: FeatureGroupPadding, StartIndex: FaceEmbeddingDim + DocQualityDim + OCRFeaturesDim + MetadataFeaturesDim, EndIndex: TotalFeatureDim - 1, Dimension: PaddingDim},
+	}
+}
+
+// GetFeatureOffset returns the offset for a specific feature group
+func GetFeatureOffset(group FeatureGroup) (FeatureOffset, bool) {
+	for _, offset := range FeatureOffsets() {
+		if offset.Group == group {
+			return offset, true
+		}
+	}
+	return FeatureOffset{}, false
+}
+
+// ============================================================================
+// OCR Field Definitions
+// ============================================================================
+
+// OCRFieldName represents a recognized OCR field
+type OCRFieldName string
+
+const (
+	OCRFieldName_Name           OCRFieldName = "name"
+	OCRFieldName_DateOfBirth    OCRFieldName = "date_of_birth"
+	OCRFieldName_DocumentNumber OCRFieldName = "document_number"
+	OCRFieldName_ExpiryDate     OCRFieldName = "expiry_date"
+	OCRFieldName_Nationality    OCRFieldName = "nationality"
+)
+
+// OCRFieldNames returns all OCR field names in order
+func OCRFieldNames() []OCRFieldName {
+	return []OCRFieldName{
+		OCRFieldName_Name,
+		OCRFieldName_DateOfBirth,
+		OCRFieldName_DocumentNumber,
+		OCRFieldName_ExpiryDate,
+		OCRFieldName_Nationality,
+	}
+}
+
+// OCRFieldIndex returns the index of an OCR field (0-4)
+func OCRFieldIndex(field OCRFieldName) (int, bool) {
+	for i, f := range OCRFieldNames() {
+		if f == field {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// ============================================================================
+// Consent Category Definitions
+// ============================================================================
+
+// ConsentCategory represents a category of consent for feature groups
+type ConsentCategory string
+
+const (
+	// ConsentCategoryBiometricPII requires explicit consent for biometric PII
+	ConsentCategoryBiometricPII ConsentCategory = "biometric_pii"
+
+	// ConsentCategoryBiometric requires explicit consent for biometric data
+	ConsentCategoryBiometric ConsentCategory = "biometric"
+
+	// ConsentCategoryIdentityAttestation has implicit consent via SSO flow
+	ConsentCategoryIdentityAttestation ConsentCategory = "identity_attestation"
+
+	// ConsentCategoryContactVerification has implicit consent via verification
+	ConsentCategoryContactVerification ConsentCategory = "contact_verification"
+
+	// ConsentCategoryDomainOwnership has implicit consent via DNS record
+	ConsentCategoryDomainOwnership ConsentCategory = "domain_ownership"
+
+	// ConsentCategoryEnterpriseIdentity is delegated via enterprise
+	ConsentCategoryEnterpriseIdentity ConsentCategory = "enterprise_identity"
+)
+
+// ScopeTypeToConsentCategory maps scope types to their consent categories
+func ScopeTypeToConsentCategory(scopeType ScopeType) ConsentCategory {
+	switch scopeType {
+	case ScopeTypeIDDocument:
+		return ConsentCategoryBiometricPII
+	case ScopeTypeSelfie, ScopeTypeFaceVideo, ScopeTypeBiometric:
+		return ConsentCategoryBiometric
+	case ScopeTypeSSOMetadata:
+		return ConsentCategoryIdentityAttestation
+	case ScopeTypeEmailProof, ScopeTypeSMSProof:
+		return ConsentCategoryContactVerification
+	case ScopeTypeDomainVerify:
+		return ConsentCategoryDomainOwnership
+	case ScopeTypeADSSO:
+		return ConsentCategoryEnterpriseIdentity
+	default:
+		return ConsentCategoryBiometricPII // Default to most restrictive
+	}
+}
+
+// RequiresExplicitConsent returns true if the consent category requires explicit consent
+func RequiresExplicitConsent(category ConsentCategory) bool {
+	switch category {
+	case ConsentCategoryBiometricPII, ConsentCategoryBiometric:
+		return true
+	default:
+		return false
+	}
+}
+
+// ============================================================================
+// Feature Value Ranges
+// ============================================================================
+
+// FeatureRange defines the valid range for a feature value
+type FeatureRange struct {
+	Name    string
+	Min     float32
+	Max     float32
+	Default float32
+	Unit    string
+}
+
+// DocQualityFeatureRanges returns the valid ranges for document quality features
+func DocQualityFeatureRanges() []FeatureRange {
+	return []FeatureRange{
+		{Name: "sharpness", Min: 0.0, Max: 1.0, Default: 0.5, Unit: "score"},
+		{Name: "brightness", Min: 0.0, Max: 1.0, Default: 0.5, Unit: "score"},
+		{Name: "contrast", Min: 0.0, Max: 1.0, Default: 0.5, Unit: "score"},
+		{Name: "noise_level_inv", Min: 0.0, Max: 1.0, Default: 0.5, Unit: "score"},
+		{Name: "blur_score_inv", Min: 0.0, Max: 1.0, Default: 0.5, Unit: "score"},
+	}
+}
+
+// OCRFeatureRanges returns the valid ranges for OCR features (per field)
+func OCRFeatureRanges() []FeatureRange {
+	return []FeatureRange{
+		{Name: "confidence", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "probability"},
+		{Name: "validated", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "binary"},
+	}
+}
+
+// MetadataFeatureRanges returns the valid ranges for metadata features
+func MetadataFeatureRanges() []FeatureRange {
+	return []FeatureRange{
+		{Name: "scope_count", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "normalized_count"},
+		{Name: "has_id_document", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "binary"},
+		{Name: "has_selfie", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "binary"},
+		{Name: "has_face_video", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "binary"},
+		{Name: "has_biometric", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "binary"},
+		{Name: "has_sso_metadata", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "binary"},
+		{Name: "has_email_proof", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "binary"},
+		{Name: "has_sms_proof", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "binary"},
+		{Name: "has_domain_verify", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "binary"},
+		{Name: "face_confidence", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "probability"},
+		{Name: "block_height_normalized", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "ratio"},
+		{Name: "reserved_11", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "reserved"},
+		{Name: "reserved_12", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "reserved"},
+		{Name: "reserved_13", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "reserved"},
+		{Name: "reserved_14", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "reserved"},
+		{Name: "reserved_15", Min: 0.0, Max: 1.0, Default: 0.0, Unit: "reserved"},
+	}
+}
+
+// ============================================================================
+// Feature Vector Validation
+// ============================================================================
+
+// MLFeatureVector represents a complete ML feature vector
+type MLFeatureVector struct {
+	// SchemaVersion is the schema version used to create this vector
+	SchemaVersion string `json:"schema_version"`
+
+	// Features is the raw feature vector
+	Features []float32 `json:"features"`
+}
+
+// NewMLFeatureVector creates a new feature vector with default values
+func NewMLFeatureVector() *MLFeatureVector {
+	features := make([]float32, TotalFeatureDim)
+
+	// Set default values for doc quality features
+	docQualityOffset, _ := GetFeatureOffset(FeatureGroupDocQuality)
+	for i, r := range DocQualityFeatureRanges() {
+		features[docQualityOffset.StartIndex+i] = r.Default
+	}
+
+	return &MLFeatureVector{
+		SchemaVersion: MLFeatureSchemaVersion,
+		Features:      features,
+	}
+}
+
+// Validate validates the feature vector
+func (v *MLFeatureVector) Validate() error {
+	if v.SchemaVersion == "" {
+		return ErrInvalidParams.Wrap("schema_version cannot be empty")
+	}
+
+	if len(v.Features) != TotalFeatureDim {
+		return ErrInvalidParams.Wrapf("feature vector dimension mismatch: expected %d, got %d", TotalFeatureDim, len(v.Features))
+	}
+
+	// Validate face embedding is normalized (L2 norm should be ~1.0 or 0.0)
+	var sumSquares float64
+	for i := 0; i < FaceEmbeddingDim; i++ {
+		sumSquares += float64(v.Features[i]) * float64(v.Features[i])
+	}
+	if sumSquares > 0.01 { // Non-zero embedding
+		norm := sumSquares
+		if norm < 0.99 || norm > 1.01 {
+			return ErrInvalidParams.Wrapf("face embedding not normalized: L2 norm = %.4f", norm)
+		}
+	}
+
+	// Validate doc quality features are in range
+	docQualityOffset, _ := GetFeatureOffset(FeatureGroupDocQuality)
+	for i, r := range DocQualityFeatureRanges() {
+		val := v.Features[docQualityOffset.StartIndex+i]
+		if val < r.Min || val > r.Max {
+			return ErrInvalidParams.Wrapf("doc quality feature %s out of range [%.2f, %.2f]: %.4f", r.Name, r.Min, r.Max, val)
+		}
+	}
+
+	// Validate OCR features are in range
+	ocrOffset, _ := GetFeatureOffset(FeatureGroupOCR)
+	ocrRanges := OCRFeatureRanges()
+	for i := 0; i < OCRFieldCount; i++ {
+		for j, r := range ocrRanges {
+			idx := ocrOffset.StartIndex + i*2 + j
+			val := v.Features[idx]
+			if val < r.Min || val > r.Max {
+				return ErrInvalidParams.Wrapf("OCR feature %s[%d] out of range [%.2f, %.2f]: %.4f", r.Name, i, r.Min, r.Max, val)
+			}
+		}
+	}
+
+	// Validate metadata features are in range
+	metaOffset, _ := GetFeatureOffset(FeatureGroupMetadata)
+	for i, r := range MetadataFeatureRanges() {
+		val := v.Features[metaOffset.StartIndex+i]
+		if val < r.Min || val > r.Max {
+			return ErrInvalidParams.Wrapf("metadata feature %s out of range [%.2f, %.2f]: %.4f", r.Name, r.Min, r.Max, val)
+		}
+	}
+
+	return nil
+}
+
+// GetFeatureGroup extracts a specific feature group from the vector
+func (v *MLFeatureVector) GetFeatureGroup(group FeatureGroup) ([]float32, error) {
+	offset, found := GetFeatureOffset(group)
+	if !found {
+		return nil, fmt.Errorf("unknown feature group: %s", group)
+	}
+
+	if len(v.Features) < offset.EndIndex+1 {
+		return nil, fmt.Errorf("feature vector too short for group %s", group)
+	}
+
+	return v.Features[offset.StartIndex : offset.EndIndex+1], nil
+}
+
+// SetFeatureGroup sets a specific feature group in the vector
+func (v *MLFeatureVector) SetFeatureGroup(group FeatureGroup, values []float32) error {
+	offset, found := GetFeatureOffset(group)
+	if !found {
+		return fmt.Errorf("unknown feature group: %s", group)
+	}
+
+	if len(values) != offset.Dimension {
+		return fmt.Errorf("dimension mismatch for group %s: expected %d, got %d", group, offset.Dimension, len(values))
+	}
+
+	copy(v.Features[offset.StartIndex:offset.EndIndex+1], values)
+	return nil
+}
+
+// ============================================================================
+// Schema Compatibility
+// ============================================================================
+
+// IsSchemaCompatible checks if two schema versions are compatible
+func IsSchemaCompatible(version1, version2 string) bool {
+	// For now, only exact matches within major version are compatible
+	// Parse version strings to compare major versions
+	var major1, minor1, patch1 int
+	var major2, minor2, patch2 int
+
+	_, err1 := fmt.Sscanf(version1, "%d.%d.%d", &major1, &minor1, &patch1)
+	_, err2 := fmt.Sscanf(version2, "%d.%d.%d", &major2, &minor2, &patch2)
+
+	if err1 != nil || err2 != nil {
+		return version1 == version2 // Fallback to exact match
+	}
+
+	// Same major version = compatible
+	return major1 == major2
+}
+
+// GetSchemaInfo returns information about the current schema
+func GetSchemaInfo() map[string]interface{} {
+	return map[string]interface{}{
+		"version":             MLFeatureSchemaVersion,
+		"major":               MLFeatureSchemaVersionMajor,
+		"minor":               MLFeatureSchemaVersionMinor,
+		"patch":               MLFeatureSchemaVersionPatch,
+		"total_dimension":     TotalFeatureDim,
+		"face_embedding_dim":  FaceEmbeddingDim,
+		"doc_quality_dim":     DocQualityDim,
+		"ocr_features_dim":    OCRFeaturesDim,
+		"metadata_dim":        MetadataFeaturesDim,
+		"padding_dim":         PaddingDim,
+		"ocr_field_count":     OCRFieldCount,
+		"scope_schema_version": ScopeSchemaVersion,
+	}
+}

--- a/x/veid/types/ml_feature_schema_test.go
+++ b/x/veid/types/ml_feature_schema_test.go
@@ -1,0 +1,521 @@
+package types
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMLFeatureSchemaConstants(t *testing.T) {
+	// Verify dimension constants sum correctly
+	t.Run("dimension constants sum to total", func(t *testing.T) {
+		sum := FaceEmbeddingDim + DocQualityDim + OCRFeaturesDim + MetadataFeaturesDim + PaddingDim
+		if sum != TotalFeatureDim {
+			t.Errorf("dimension constants sum to %d, expected %d", sum, TotalFeatureDim)
+		}
+	})
+
+	t.Run("total dimension is 768", func(t *testing.T) {
+		if TotalFeatureDim != 768 {
+			t.Errorf("TotalFeatureDim = %d, expected 768", TotalFeatureDim)
+		}
+	})
+
+	t.Run("face embedding dimension is 512", func(t *testing.T) {
+		if FaceEmbeddingDim != 512 {
+			t.Errorf("FaceEmbeddingDim = %d, expected 512", FaceEmbeddingDim)
+		}
+	})
+
+	t.Run("OCR features dimension is 10", func(t *testing.T) {
+		if OCRFeaturesDim != 10 {
+			t.Errorf("OCRFeaturesDim = %d, expected 10", OCRFeaturesDim)
+		}
+	})
+
+	t.Run("OCR field count is 5", func(t *testing.T) {
+		if OCRFieldCount != 5 {
+			t.Errorf("OCRFieldCount = %d, expected 5", OCRFieldCount)
+		}
+	})
+
+	t.Run("metadata dimension is 16", func(t *testing.T) {
+		if MetadataFeaturesDim != 16 {
+			t.Errorf("MetadataFeaturesDim = %d, expected 16", MetadataFeaturesDim)
+		}
+	})
+
+	t.Run("padding dimension is 225", func(t *testing.T) {
+		if PaddingDim != 225 {
+			t.Errorf("PaddingDim = %d, expected 225", PaddingDim)
+		}
+	})
+}
+
+func TestFeatureOffsets(t *testing.T) {
+	offsets := FeatureOffsets()
+
+	t.Run("has all feature groups", func(t *testing.T) {
+		groups := AllFeatureGroups()
+		if len(offsets) != len(groups) {
+			t.Errorf("got %d offsets, expected %d", len(offsets), len(groups))
+		}
+	})
+
+	t.Run("offsets are contiguous", func(t *testing.T) {
+		expectedStart := 0
+		for _, offset := range offsets {
+			if offset.StartIndex != expectedStart {
+				t.Errorf("group %s starts at %d, expected %d", offset.Group, offset.StartIndex, expectedStart)
+			}
+			expectedStart = offset.EndIndex + 1
+		}
+		if expectedStart != TotalFeatureDim {
+			t.Errorf("final offset ends at %d, expected %d", expectedStart, TotalFeatureDim)
+		}
+	})
+
+	t.Run("face offset is correct", func(t *testing.T) {
+		offset, found := GetFeatureOffset(FeatureGroupFace)
+		if !found {
+			t.Fatal("face feature group not found")
+		}
+		if offset.StartIndex != 0 || offset.EndIndex != 511 || offset.Dimension != 512 {
+			t.Errorf("face offset = %+v, expected start=0, end=511, dim=512", offset)
+		}
+	})
+
+	t.Run("doc quality offset is correct", func(t *testing.T) {
+		offset, found := GetFeatureOffset(FeatureGroupDocQuality)
+		if !found {
+			t.Fatal("doc quality feature group not found")
+		}
+		if offset.StartIndex != 512 || offset.EndIndex != 516 || offset.Dimension != 5 {
+			t.Errorf("doc quality offset = %+v, expected start=512, end=516, dim=5", offset)
+		}
+	})
+
+	t.Run("OCR offset is correct", func(t *testing.T) {
+		offset, found := GetFeatureOffset(FeatureGroupOCR)
+		if !found {
+			t.Fatal("OCR feature group not found")
+		}
+		if offset.StartIndex != 517 || offset.EndIndex != 526 || offset.Dimension != 10 {
+			t.Errorf("OCR offset = %+v, expected start=517, end=526, dim=10", offset)
+		}
+	})
+
+	t.Run("metadata offset is correct", func(t *testing.T) {
+		offset, found := GetFeatureOffset(FeatureGroupMetadata)
+		if !found {
+			t.Fatal("metadata feature group not found")
+		}
+		if offset.StartIndex != 527 || offset.EndIndex != 542 || offset.Dimension != 16 {
+			t.Errorf("metadata offset = %+v, expected start=527, end=542, dim=16", offset)
+		}
+	})
+
+	t.Run("padding offset is correct", func(t *testing.T) {
+		offset, found := GetFeatureOffset(FeatureGroupPadding)
+		if !found {
+			t.Fatal("padding feature group not found")
+		}
+		if offset.StartIndex != 543 || offset.EndIndex != 767 || offset.Dimension != 225 {
+			t.Errorf("padding offset = %+v, expected start=543, end=767, dim=225", offset)
+		}
+	})
+}
+
+func TestOCRFieldNames(t *testing.T) {
+	fields := OCRFieldNames()
+
+	t.Run("has correct field count", func(t *testing.T) {
+		if len(fields) != OCRFieldCount {
+			t.Errorf("got %d OCR fields, expected %d", len(fields), OCRFieldCount)
+		}
+	})
+
+	t.Run("has expected fields", func(t *testing.T) {
+		expected := []OCRFieldName{
+			OCRFieldName_Name,
+			OCRFieldName_DateOfBirth,
+			OCRFieldName_DocumentNumber,
+			OCRFieldName_ExpiryDate,
+			OCRFieldName_Nationality,
+		}
+		for i, f := range expected {
+			if fields[i] != f {
+				t.Errorf("field %d = %s, expected %s", i, fields[i], f)
+			}
+		}
+	})
+
+	t.Run("OCRFieldIndex returns correct indices", func(t *testing.T) {
+		testCases := []struct {
+			field OCRFieldName
+			index int
+		}{
+			{OCRFieldName_Name, 0},
+			{OCRFieldName_DateOfBirth, 1},
+			{OCRFieldName_DocumentNumber, 2},
+			{OCRFieldName_ExpiryDate, 3},
+			{OCRFieldName_Nationality, 4},
+		}
+
+		for _, tc := range testCases {
+			idx, found := OCRFieldIndex(tc.field)
+			if !found {
+				t.Errorf("field %s not found", tc.field)
+				continue
+			}
+			if idx != tc.index {
+				t.Errorf("field %s index = %d, expected %d", tc.field, idx, tc.index)
+			}
+		}
+	})
+
+	t.Run("OCRFieldIndex returns false for unknown field", func(t *testing.T) {
+		_, found := OCRFieldIndex("unknown_field")
+		if found {
+			t.Error("expected false for unknown field")
+		}
+	})
+}
+
+func TestScopeTypeToConsentCategory(t *testing.T) {
+	testCases := []struct {
+		scopeType ScopeType
+		expected  ConsentCategory
+	}{
+		{ScopeTypeIDDocument, ConsentCategoryBiometricPII},
+		{ScopeTypeSelfie, ConsentCategoryBiometric},
+		{ScopeTypeFaceVideo, ConsentCategoryBiometric},
+		{ScopeTypeBiometric, ConsentCategoryBiometric},
+		{ScopeTypeSSOMetadata, ConsentCategoryIdentityAttestation},
+		{ScopeTypeEmailProof, ConsentCategoryContactVerification},
+		{ScopeTypeSMSProof, ConsentCategoryContactVerification},
+		{ScopeTypeDomainVerify, ConsentCategoryDomainOwnership},
+		{ScopeTypeADSSO, ConsentCategoryEnterpriseIdentity},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.scopeType), func(t *testing.T) {
+			result := ScopeTypeToConsentCategory(tc.scopeType)
+			if result != tc.expected {
+				t.Errorf("ScopeTypeToConsentCategory(%s) = %s, expected %s", tc.scopeType, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRequiresExplicitConsent(t *testing.T) {
+	testCases := []struct {
+		category ConsentCategory
+		expected bool
+	}{
+		{ConsentCategoryBiometricPII, true},
+		{ConsentCategoryBiometric, true},
+		{ConsentCategoryIdentityAttestation, false},
+		{ConsentCategoryContactVerification, false},
+		{ConsentCategoryDomainOwnership, false},
+		{ConsentCategoryEnterpriseIdentity, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.category), func(t *testing.T) {
+			result := RequiresExplicitConsent(tc.category)
+			if result != tc.expected {
+				t.Errorf("RequiresExplicitConsent(%s) = %v, expected %v", tc.category, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMLFeatureVector(t *testing.T) {
+	t.Run("NewMLFeatureVector creates correct dimensions", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		if len(v.Features) != TotalFeatureDim {
+			t.Errorf("feature vector length = %d, expected %d", len(v.Features), TotalFeatureDim)
+		}
+	})
+
+	t.Run("NewMLFeatureVector sets schema version", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		if v.SchemaVersion != MLFeatureSchemaVersion {
+			t.Errorf("schema version = %s, expected %s", v.SchemaVersion, MLFeatureSchemaVersion)
+		}
+	})
+
+	t.Run("NewMLFeatureVector sets doc quality defaults", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		offset, _ := GetFeatureOffset(FeatureGroupDocQuality)
+		for i, r := range DocQualityFeatureRanges() {
+			val := v.Features[offset.StartIndex+i]
+			if val != r.Default {
+				t.Errorf("doc quality feature %s default = %.2f, expected %.2f", r.Name, val, r.Default)
+			}
+		}
+	})
+
+	t.Run("Validate accepts valid vector", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		err := v.Validate()
+		if err != nil {
+			t.Errorf("Validate() returned error for valid vector: %v", err)
+		}
+	})
+
+	t.Run("Validate rejects wrong dimension", func(t *testing.T) {
+		v := &MLFeatureVector{
+			SchemaVersion: MLFeatureSchemaVersion,
+			Features:      make([]float32, 100),
+		}
+		err := v.Validate()
+		if err == nil {
+			t.Error("Validate() should reject wrong dimension")
+		}
+	})
+
+	t.Run("Validate rejects empty schema version", func(t *testing.T) {
+		v := &MLFeatureVector{
+			SchemaVersion: "",
+			Features:      make([]float32, TotalFeatureDim),
+		}
+		err := v.Validate()
+		if err == nil {
+			t.Error("Validate() should reject empty schema version")
+		}
+	})
+
+	t.Run("Validate checks face embedding normalization", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		// Set non-zero, non-normalized embedding
+		for i := 0; i < FaceEmbeddingDim; i++ {
+			v.Features[i] = 2.0 // L2 norm will be sqrt(512*4) = ~45.25
+		}
+		err := v.Validate()
+		if err == nil {
+			t.Error("Validate() should reject non-normalized face embedding")
+		}
+	})
+
+	t.Run("Validate accepts normalized face embedding", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		// Set normalized embedding (unit length)
+		norm := float32(math.Sqrt(float64(FaceEmbeddingDim)))
+		for i := 0; i < FaceEmbeddingDim; i++ {
+			v.Features[i] = 1.0 / norm
+		}
+		err := v.Validate()
+		if err != nil {
+			t.Errorf("Validate() rejected normalized face embedding: %v", err)
+		}
+	})
+
+	t.Run("Validate rejects out-of-range doc quality", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		offset, _ := GetFeatureOffset(FeatureGroupDocQuality)
+		v.Features[offset.StartIndex] = 1.5 // Out of range [0, 1]
+		err := v.Validate()
+		if err == nil {
+			t.Error("Validate() should reject out-of-range doc quality")
+		}
+	})
+}
+
+func TestGetSetFeatureGroup(t *testing.T) {
+	t.Run("GetFeatureGroup returns correct slice", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		// Set some values in doc quality
+		offset, _ := GetFeatureOffset(FeatureGroupDocQuality)
+		for i := 0; i < DocQualityDim; i++ {
+			v.Features[offset.StartIndex+i] = float32(i) * 0.1
+		}
+
+		group, err := v.GetFeatureGroup(FeatureGroupDocQuality)
+		if err != nil {
+			t.Fatalf("GetFeatureGroup failed: %v", err)
+		}
+
+		if len(group) != DocQualityDim {
+			t.Errorf("group length = %d, expected %d", len(group), DocQualityDim)
+		}
+
+		for i := 0; i < DocQualityDim; i++ {
+			expected := float32(i) * 0.1
+			if group[i] != expected {
+				t.Errorf("group[%d] = %.2f, expected %.2f", i, group[i], expected)
+			}
+		}
+	})
+
+	t.Run("SetFeatureGroup sets values correctly", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		values := []float32{0.9, 0.8, 0.7, 0.6, 0.5}
+
+		err := v.SetFeatureGroup(FeatureGroupDocQuality, values)
+		if err != nil {
+			t.Fatalf("SetFeatureGroup failed: %v", err)
+		}
+
+		group, _ := v.GetFeatureGroup(FeatureGroupDocQuality)
+		for i, val := range values {
+			if group[i] != val {
+				t.Errorf("group[%d] = %.2f, expected %.2f", i, group[i], val)
+			}
+		}
+	})
+
+	t.Run("SetFeatureGroup rejects wrong dimension", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		values := []float32{0.9, 0.8, 0.7} // Wrong length
+
+		err := v.SetFeatureGroup(FeatureGroupDocQuality, values)
+		if err == nil {
+			t.Error("SetFeatureGroup should reject wrong dimension")
+		}
+	})
+
+	t.Run("GetFeatureGroup rejects unknown group", func(t *testing.T) {
+		v := NewMLFeatureVector()
+		_, err := v.GetFeatureGroup("unknown")
+		if err == nil {
+			t.Error("GetFeatureGroup should reject unknown group")
+		}
+	})
+}
+
+func TestIsSchemaCompatible(t *testing.T) {
+	testCases := []struct {
+		v1       string
+		v2       string
+		expected bool
+	}{
+		{"1.0.0", "1.0.0", true},
+		{"1.0.0", "1.1.0", true},
+		{"1.0.0", "1.2.5", true},
+		{"1.0.0", "2.0.0", false},
+		{"2.0.0", "1.0.0", false},
+		{"invalid", "1.0.0", false},
+		{"1.0.0", "invalid", false},
+		{"invalid", "invalid", true}, // Falls back to exact match
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.v1+"_vs_"+tc.v2, func(t *testing.T) {
+			result := IsSchemaCompatible(tc.v1, tc.v2)
+			if result != tc.expected {
+				t.Errorf("IsSchemaCompatible(%s, %s) = %v, expected %v", tc.v1, tc.v2, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetSchemaInfo(t *testing.T) {
+	info := GetSchemaInfo()
+
+	t.Run("contains version", func(t *testing.T) {
+		if info["version"] != MLFeatureSchemaVersion {
+			t.Errorf("version = %v, expected %s", info["version"], MLFeatureSchemaVersion)
+		}
+	})
+
+	t.Run("contains total_dimension", func(t *testing.T) {
+		if info["total_dimension"] != TotalFeatureDim {
+			t.Errorf("total_dimension = %v, expected %d", info["total_dimension"], TotalFeatureDim)
+		}
+	})
+
+	t.Run("contains all dimension keys", func(t *testing.T) {
+		requiredKeys := []string{
+			"version", "major", "minor", "patch",
+			"total_dimension", "face_embedding_dim", "doc_quality_dim",
+			"ocr_features_dim", "metadata_dim", "padding_dim",
+			"ocr_field_count", "scope_schema_version",
+		}
+
+		for _, key := range requiredKeys {
+			if _, ok := info[key]; !ok {
+				t.Errorf("missing key: %s", key)
+			}
+		}
+	})
+}
+
+func TestFeatureRanges(t *testing.T) {
+	t.Run("doc quality ranges are valid", func(t *testing.T) {
+		ranges := DocQualityFeatureRanges()
+		if len(ranges) != DocQualityDim {
+			t.Errorf("got %d doc quality ranges, expected %d", len(ranges), DocQualityDim)
+		}
+		for _, r := range ranges {
+			if r.Min > r.Max {
+				t.Errorf("range %s has min > max: %.2f > %.2f", r.Name, r.Min, r.Max)
+			}
+			if r.Default < r.Min || r.Default > r.Max {
+				t.Errorf("range %s has default outside range: %.2f not in [%.2f, %.2f]", r.Name, r.Default, r.Min, r.Max)
+			}
+		}
+	})
+
+	t.Run("OCR ranges are valid", func(t *testing.T) {
+		ranges := OCRFeatureRanges()
+		if len(ranges) != 2 { // confidence and validated
+			t.Errorf("got %d OCR ranges, expected 2", len(ranges))
+		}
+		for _, r := range ranges {
+			if r.Min > r.Max {
+				t.Errorf("range %s has min > max: %.2f > %.2f", r.Name, r.Min, r.Max)
+			}
+		}
+	})
+
+	t.Run("metadata ranges are valid", func(t *testing.T) {
+		ranges := MetadataFeatureRanges()
+		if len(ranges) != MetadataFeaturesDim {
+			t.Errorf("got %d metadata ranges, expected %d", len(ranges), MetadataFeaturesDim)
+		}
+		for _, r := range ranges {
+			if r.Min > r.Max {
+				t.Errorf("range %s has min > max: %.2f > %.2f", r.Name, r.Min, r.Max)
+			}
+		}
+	})
+}
+
+// TestFeatureVectorDeterminism verifies that feature vector creation is deterministic
+func TestFeatureVectorDeterminism(t *testing.T) {
+	t.Run("NewMLFeatureVector is deterministic", func(t *testing.T) {
+		v1 := NewMLFeatureVector()
+		v2 := NewMLFeatureVector()
+
+		if len(v1.Features) != len(v2.Features) {
+			t.Fatal("feature vectors have different lengths")
+		}
+
+		for i := range v1.Features {
+			if v1.Features[i] != v2.Features[i] {
+				t.Errorf("feature[%d] differs: %.6f vs %.6f", i, v1.Features[i], v2.Features[i])
+			}
+		}
+	})
+}
+
+// Example test showing how to construct a feature vector
+func ExampleMLFeatureVector() {
+	// Create a new feature vector with defaults
+	v := NewMLFeatureVector()
+
+	// Set document quality features
+	docQuality := []float32{0.85, 0.72, 0.68, 0.88, 0.92}
+	_ = v.SetFeatureGroup(FeatureGroupDocQuality, docQuality)
+
+	// Validate the vector
+	err := v.Validate()
+	if err != nil {
+		panic(err)
+	}
+
+	// Get a specific feature group
+	quality, _ := v.GetFeatureGroup(FeatureGroupDocQuality)
+	_ = quality // Use the quality features
+}


### PR DESCRIPTION
Objective:
Define the canonical VEID ML feature schema and data contract across all scope types.

Needs to be done (A–H):
A. Enumerate all scope types and required features.
B. Define feature names, types, units, and ranges.
C. Specify normalization and missing-data handling rules.
D. Define schema versioning and backward compatibility rules.
E. Map features to training and inference inputs.
F. Define consent/retention constraints for each feature group.
G. Add schema validation tests and examples.
H. Document the data contract and migration policy.

Acceptance criteria:
- Feature schema documented and versioned.
- Normalization rules are deterministic.
- Consent/retention constraints mapped.
- Validation tests added.

How it can be done:
- Align with ml/training pipeline and pkg/inference expectations.
- Capture schema in a single versioned doc.

MCP guidance:
- Use Context7 for ML schema/versioning practices.

Deliverables:
- Feature schema spec, examples, and validation tests.