### PR TITLE
feat(app): define support ticket schema + encryption/retention 

### DIFF
--- a/docs/support/SUPPORT_TICKET_SCHEMA.md
+++ b/docs/support/SUPPORT_TICKET_SCHEMA.md
@@ -1,0 +1,844 @@
+# VirtEngine Support Ticket Schema Specification
+
+**Version:** 1.0.0  
+**Date:** 2026-01-30  
+**Status:** Draft  
+**Schema:** `docs/support/schemas/support_ticket.schema.json`
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Ticket States and Transitions](#ticket-states-and-transitions)
+3. [Role Permissions](#role-permissions)
+4. [Payload Schema](#payload-schema)
+5. [Encryption Policy](#encryption-policy)
+6. [Retention and PII Policy](#retention-and-pii-policy)
+7. [Audit Logging Requirements](#audit-logging-requirements)
+8. [Access Control Mapping](#access-control-mapping)
+9. [Examples](#examples)
+10. [Validation](#validation)
+
+---
+
+## Overview
+
+This document defines the data model for VirtEngine support tickets, including:
+
+- **Ticket lifecycle** with defined states and transitions
+- **Payload fields** for orders, providers, timestamps, and attachments
+- **Encryption envelope policy** for PII and sensitive data
+- **Retention/deletion rules** by jurisdiction (GDPR, CCPA, HIPAA)
+- **Audit logging** for compliance and security
+- **Access control** integration with `x/roles` module
+
+### Design Principles
+
+1. **Sensitive data is encrypted at rest** using the `x/encryption` envelope format
+2. **PII follows data minimization** - only collect what's necessary
+3. **Retention is jurisdiction-aware** with automatic deletion
+4. **All access is logged** for audit and compliance
+5. **Role-based access control** via `x/roles` module
+
+### Classification Level
+
+Support tickets are classified as **C2 (Confidential)** to **C3 (Restricted)** depending on content:
+
+| Field Type | Classification | Encrypted |
+|------------|---------------|-----------|
+| Ticket ID, status, timestamps | C0 (Public) | No |
+| Order/Provider references | C2 (Confidential) | No |
+| Message content | C2-C3 (Confidential-Restricted) | Yes |
+| Attachments (screenshots, logs) | C3 (Restricted) | Yes |
+| PII (email, phone, names) | C3 (Restricted) | Yes |
+
+---
+
+## Ticket States and Transitions
+
+### State Definitions
+
+| State | Description | Terminal |
+|-------|-------------|----------|
+| `OPEN` | Newly created ticket, awaiting triage | No |
+| `ASSIGNED` | Assigned to a support agent | No |
+| `IN_PROGRESS` | Agent actively working on ticket | No |
+| `AWAITING_CUSTOMER` | Waiting for customer response | No |
+| `AWAITING_PROVIDER` | Waiting for provider response | No |
+| `ESCALATED` | Escalated to senior support/admin | No |
+| `ON_HOLD` | Temporarily paused (customer request) | No |
+| `RESOLVED` | Issue resolved, pending confirmation | No |
+| `CLOSED` | Ticket closed, no further action | Yes |
+| `CANCELLED` | Ticket cancelled by customer | Yes |
+
+### State Transition Matrix
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                        Support Ticket State Machine                           │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                               │
+│   ┌──────┐                                                                    │
+│   │ OPEN │ ─────────────┬─────────────────────────────────────────────────┐  │
+│   └──┬───┘              │                                                 │  │
+│      │                  │ cancel                                          │  │
+│      │ assign           ▼                                                 │  │
+│      │            ┌───────────┐                                           │  │
+│      ▼            │ CANCELLED │ (terminal)                                │  │
+│   ┌──────────┐    └───────────┘                                           │  │
+│   │ ASSIGNED │                                                            │  │
+│   └────┬─────┘                                                            │  │
+│        │ start_work                                                       │  │
+│        ▼                                                                  │  │
+│   ┌─────────────┐                                                         │  │
+│   │ IN_PROGRESS │◄────────────────────────────────────┐                   │  │
+│   └──────┬──────┘                                     │                   │  │
+│          │                                            │                   │  │
+│     ┌────┼────┬────────────┬───────────────┐         │                   │  │
+│     │    │    │            │               │         │                   │  │
+│     ▼    │    ▼            ▼               ▼         │                   │  │
+│ ┌────────┴─┐ ┌───────────────┐ ┌───────────────┐ ┌─────────┐            │  │
+│ │AWAIT_CUST│ │ AWAIT_PROVIDER│ │   ESCALATED   │ │ ON_HOLD │            │  │
+│ └────┬─────┘ └───────┬───────┘ └───────┬───────┘ └────┬────┘            │  │
+│      │               │                 │              │                  │  │
+│      │ respond       │ respond         │ resolve      │ resume           │  │
+│      └───────────────┴─────────────────┴──────────────┴──────────────────┘  │
+│                                        │                                     │
+│                                        │ resolve                             │
+│                                        ▼                                     │
+│                                   ┌──────────┐                               │
+│                                   │ RESOLVED │                               │
+│                                   └────┬─────┘                               │
+│                                        │                                     │
+│                           ┌────────────┼────────────┐                        │
+│                           │ confirm    │ reopen     │                        │
+│                           ▼            │            ▼                        │
+│                      ┌────────┐        │       ┌─────────────┐               │
+│                      │ CLOSED │        │       │ IN_PROGRESS │               │
+│                      └────────┘        │       └─────────────┘               │
+│                      (terminal)        │                                     │
+│                                        └──► back to IN_PROGRESS              │
+│                                                                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Allowed Transitions by Role
+
+| Current State | Target State | Allowed Roles |
+|---------------|--------------|---------------|
+| `OPEN` | `ASSIGNED` | `support_agent`, `moderator`, `administrator` |
+| `OPEN` | `CANCELLED` | `customer` (owner), `administrator` |
+| `ASSIGNED` | `IN_PROGRESS` | `support_agent` (assigned), `moderator`, `administrator` |
+| `IN_PROGRESS` | `AWAITING_CUSTOMER` | `support_agent`, `moderator`, `administrator` |
+| `IN_PROGRESS` | `AWAITING_PROVIDER` | `support_agent`, `moderator`, `administrator` |
+| `IN_PROGRESS` | `ESCALATED` | `support_agent`, `moderator`, `administrator` |
+| `IN_PROGRESS` | `ON_HOLD` | `support_agent`, `moderator`, `administrator` |
+| `IN_PROGRESS` | `RESOLVED` | `support_agent`, `moderator`, `administrator` |
+| `AWAITING_CUSTOMER` | `IN_PROGRESS` | `customer` (owner), `support_agent`, `administrator` |
+| `AWAITING_PROVIDER` | `IN_PROGRESS` | `service_provider`, `support_agent`, `administrator` |
+| `ESCALATED` | `IN_PROGRESS` | `moderator`, `administrator` |
+| `ESCALATED` | `RESOLVED` | `moderator`, `administrator` |
+| `ON_HOLD` | `IN_PROGRESS` | `customer` (owner), `support_agent`, `administrator` |
+| `RESOLVED` | `CLOSED` | `customer` (owner), `support_agent`, `administrator` |
+| `RESOLVED` | `IN_PROGRESS` | `customer` (owner) |
+
+### Automatic Transitions
+
+| Condition | Transition | Timeout |
+|-----------|------------|---------|
+| `AWAITING_CUSTOMER` with no response | `RESOLVED` | 7 days |
+| `RESOLVED` with no confirmation | `CLOSED` | 3 days |
+| `OPEN` with no assignment | Alert | 24 hours |
+
+---
+
+## Role Permissions
+
+### Ticket-Specific Permissions
+
+| Permission | Description |
+|------------|-------------|
+| `ticket:create` | Create new support tickets |
+| `ticket:read` | View ticket details (own or assigned) |
+| `ticket:read_all` | View all tickets (administrative) |
+| `ticket:update` | Update ticket fields |
+| `ticket:assign` | Assign tickets to agents |
+| `ticket:escalate` | Escalate tickets |
+| `ticket:close` | Close/cancel tickets |
+| `ticket:delete` | Delete tickets (admin only) |
+| `ticket:export` | Export ticket data |
+| `ticket:attachment:upload` | Upload attachments |
+| `ticket:attachment:download` | Download attachments |
+| `ticket:message:read` | Read ticket messages |
+| `ticket:message:create` | Create ticket messages |
+| `ticket:pii:view` | View decrypted PII fields |
+
+### Role-Permission Matrix
+
+| Role | Permissions |
+|------|-------------|
+| `customer` | `ticket:create`, `ticket:read` (own), `ticket:update` (own), `ticket:close` (own), `ticket:attachment:upload`, `ticket:attachment:download` (own), `ticket:message:read` (own), `ticket:message:create` (own) |
+| `service_provider` | `ticket:read` (related), `ticket:message:read` (related), `ticket:message:create` (related) |
+| `support_agent` | `ticket:read`, `ticket:update`, `ticket:assign`, `ticket:close`, `ticket:attachment:*`, `ticket:message:*`, `ticket:pii:view` |
+| `moderator` | All `support_agent` permissions + `ticket:escalate`, `ticket:read_all` |
+| `administrator` | All permissions including `ticket:delete`, `ticket:export` |
+| `genesis_account` | All permissions |
+| `validator` | None (tickets not validator-related) |
+
+---
+
+## Payload Schema
+
+### SupportTicket Structure
+
+```go
+// SupportTicket represents a customer support ticket
+type SupportTicket struct {
+    // Identification
+    TicketID    string `json:"ticket_id"`    // Unique identifier (UUID v7)
+    Version     uint32 `json:"version"`      // Schema version (1)
+    
+    // Classification
+    Category    TicketCategory `json:"category"`    // billing, technical, identity, marketplace, other
+    Priority    TicketPriority `json:"priority"`    // low, medium, high, critical
+    Tags        []string       `json:"tags,omitempty"`
+    
+    // Lifecycle
+    Status      TicketStatus `json:"status"`      // Current state
+    CreatedAt   int64        `json:"created_at"`  // Unix timestamp (seconds)
+    UpdatedAt   int64        `json:"updated_at"`  // Unix timestamp (seconds)
+    ClosedAt    int64        `json:"closed_at,omitempty"` // Unix timestamp when closed
+    
+    // Parties
+    CustomerAddress   string `json:"customer_address"`   // VirtEngine address
+    AssignedAgentAddr string `json:"assigned_agent_addr,omitempty"` // Support agent address
+    
+    // References
+    OrderRef       *OrderReference    `json:"order_ref,omitempty"`
+    ProviderRef    *ProviderReference `json:"provider_ref,omitempty"`
+    DeploymentRef  *DeploymentRef     `json:"deployment_ref,omitempty"`
+    RelatedTickets []string           `json:"related_tickets,omitempty"`
+    
+    // Content (encrypted)
+    Subject         string                    `json:"subject"`
+    DescriptionEnvelope *EncryptedPayloadEnvelope `json:"description_envelope"`
+    
+    // Messages (encrypted)
+    Messages []TicketMessage `json:"messages,omitempty"`
+    
+    // Attachments (encrypted, stored off-chain)
+    Attachments []AttachmentRef `json:"attachments,omitempty"`
+    
+    // Contact Info (encrypted)
+    ContactEnvelope *EncryptedPayloadEnvelope `json:"contact_envelope,omitempty"`
+    
+    // Retention
+    RetentionPolicy   RetentionPolicyRef `json:"retention_policy"`
+    JurisdictionCode  string             `json:"jurisdiction_code"` // ISO 3166-1 alpha-2
+    ConsentRecordID   string             `json:"consent_record_id,omitempty"`
+    
+    // Metadata
+    Metadata map[string]string `json:"metadata,omitempty"`
+}
+```
+
+### Reference Types
+
+```go
+// OrderReference links ticket to a marketplace order
+type OrderReference struct {
+    OrderID    string `json:"order_id"`
+    OwnerAddr  string `json:"owner_addr"`
+    DSeq       uint64 `json:"dseq"`       // Deployment sequence
+    GSeq       uint32 `json:"gseq"`       // Group sequence
+    OSeq       uint32 `json:"oseq"`       // Order sequence
+}
+
+// ProviderReference links ticket to a service provider
+type ProviderReference struct {
+    ProviderAddr string `json:"provider_addr"`
+    ProviderName string `json:"provider_name,omitempty"`
+    LeaseID      string `json:"lease_id,omitempty"`
+}
+
+// DeploymentRef links ticket to a deployment
+type DeploymentRef struct {
+    DeploymentID string `json:"deployment_id"`
+    OwnerAddr    string `json:"owner_addr"`
+    DSeq         uint64 `json:"dseq"`
+}
+
+// TicketMessage represents a message in the ticket thread
+type TicketMessage struct {
+    MessageID       string                    `json:"message_id"` // UUID v7
+    SenderAddr      string                    `json:"sender_addr"`
+    SenderRole      string                    `json:"sender_role"` // customer, support_agent, etc.
+    CreatedAt       int64                     `json:"created_at"`
+    ContentEnvelope *EncryptedPayloadEnvelope `json:"content_envelope"`
+    IsInternal      bool                      `json:"is_internal"` // Internal notes (not visible to customer)
+}
+
+// AttachmentRef references an encrypted attachment stored off-chain
+type AttachmentRef struct {
+    AttachmentID    string `json:"attachment_id"`    // UUID v7
+    FileName        string `json:"file_name"`        // Original filename
+    ContentType     string `json:"content_type"`     // MIME type
+    SizeBytes       int64  `json:"size_bytes"`       // File size
+    StorageLocation string `json:"storage_location"` // IPFS CID or storage path
+    UploadedAt      int64  `json:"uploaded_at"`
+    UploadedBy      string `json:"uploaded_by"`      // Uploader address
+    ChecksumSHA256  string `json:"checksum_sha256"`  // Integrity verification
+    
+    // Encryption envelope for the attachment encryption key
+    KeyEnvelope *EncryptedPayloadEnvelope `json:"key_envelope"`
+}
+
+// RetentionPolicyRef references the applicable retention policy
+type RetentionPolicyRef struct {
+    PolicyID          string `json:"policy_id"`
+    RetentionDays     int    `json:"retention_days"`
+    DeleteAfterClosed bool   `json:"delete_after_closed"`
+    ArchiveAfterDays  int    `json:"archive_after_days,omitempty"`
+}
+```
+
+### Enumerations
+
+```go
+type TicketStatus string
+
+const (
+    TicketStatusOpen             TicketStatus = "OPEN"
+    TicketStatusAssigned         TicketStatus = "ASSIGNED"
+    TicketStatusInProgress       TicketStatus = "IN_PROGRESS"
+    TicketStatusAwaitingCustomer TicketStatus = "AWAITING_CUSTOMER"
+    TicketStatusAwaitingProvider TicketStatus = "AWAITING_PROVIDER"
+    TicketStatusEscalated        TicketStatus = "ESCALATED"
+    TicketStatusOnHold           TicketStatus = "ON_HOLD"
+    TicketStatusResolved         TicketStatus = "RESOLVED"
+    TicketStatusClosed           TicketStatus = "CLOSED"
+    TicketStatusCancelled        TicketStatus = "CANCELLED"
+)
+
+type TicketCategory string
+
+const (
+    TicketCategoryBilling     TicketCategory = "billing"
+    TicketCategoryTechnical   TicketCategory = "technical"
+    TicketCategoryIdentity    TicketCategory = "identity"
+    TicketCategoryMarketplace TicketCategory = "marketplace"
+    TicketCategorySecurity    TicketCategory = "security"
+    TicketCategoryOther       TicketCategory = "other"
+)
+
+type TicketPriority string
+
+const (
+    TicketPriorityLow      TicketPriority = "low"
+    TicketPriorityMedium   TicketPriority = "medium"
+    TicketPriorityHigh     TicketPriority = "high"
+    TicketPriorityCritical TicketPriority = "critical"
+)
+```
+
+### Timestamp Fields
+
+All timestamps use Unix epoch seconds (int64) for deterministic consensus:
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| `created_at` | Ticket creation time | Yes |
+| `updated_at` | Last modification time | Yes |
+| `closed_at` | Time when ticket reached terminal state | No |
+
+---
+
+## Encryption Policy
+
+### Encrypted Fields
+
+The following fields contain sensitive data and **MUST** be encrypted:
+
+| Field | Content Type | Recipients |
+|-------|--------------|------------|
+| `description_envelope` | Initial ticket description | Customer + Assigned Agent + Support Team |
+| `contact_envelope` | PII (email, phone, etc.) | Customer + Assigned Agent |
+| `messages[].content_envelope` | Message content | Customer + Participants |
+| `attachments[].key_envelope` | Attachment encryption key | Customer + Assigned Agent |
+
+### Envelope Format
+
+All encrypted fields use the VirtEngine `EncryptedPayloadEnvelope` format from `x/encryption`:
+
+```go
+type EncryptedPayloadEnvelope struct {
+    Version          uint32            `json:"version"`           // Envelope version (1)
+    AlgorithmID      string            `json:"algorithm_id"`      // "X25519-XSALSA20-POLY1305"
+    AlgorithmVersion uint32            `json:"algorithm_version"` // Algorithm version
+    RecipientKeyIDs  []string          `json:"recipient_key_ids"` // Key fingerprints
+    WrappedKeys      []WrappedKeyEntry `json:"wrapped_keys"`      // Per-recipient DEKs
+    Nonce            []byte            `json:"nonce"`             // Unique per encryption
+    Ciphertext       []byte            `json:"ciphertext"`        // Encrypted data
+    SenderSignature  []byte            `json:"sender_signature"`  // Authenticity
+    SenderPubKey     []byte            `json:"sender_pub_key"`    // Sender's public key
+    Metadata         map[string]string `json:"metadata,omitempty"`
+}
+```
+
+### Recipient Selection
+
+| Ticket Type | Encryption Recipients |
+|-------------|----------------------|
+| New ticket | Customer + Support Team Key (role-based) |
+| Assigned ticket | Customer + Assigned Agent |
+| Provider-related | Customer + Assigned Agent + Provider (for relevant fields) |
+| Escalated | Customer + Assigned Agent + Escalation Team Key |
+
+### Support Team Key
+
+A **role-based encryption key** allows any authorized support agent to decrypt tickets:
+
+```go
+// Support team uses a shared key registered to the support_agent role
+// This allows ticket reassignment without re-encryption
+type RoleEncryptionKey struct {
+    RoleID        string `json:"role_id"`        // "support_agent"
+    PublicKey     []byte `json:"public_key"`     // X25519 public key
+    KeyFingerprint string `json:"key_fingerprint"`
+    RegisteredAt  int64  `json:"registered_at"`
+    // Private key is managed by HSM accessible to role holders
+}
+```
+
+### Key Rotation Strategy
+
+| Key Type | Rotation Frequency | Procedure |
+|----------|-------------------|-----------|
+| Customer keys | User-controlled | Standard x/encryption key rotation |
+| Support team role key | Annual or on compromise | Re-encrypt active tickets, archive old key |
+| Agent individual keys | Annual | Re-encrypt assigned tickets on agent departure |
+| Attachment DEKs | Per-upload (unique) | No rotation needed |
+
+#### Role Key Rotation Procedure
+
+1. **Generate new role key** in HSM
+2. **Register new key** with `x/encryption` module
+3. **Re-encrypt active tickets** (status != CLOSED, CANCELLED)
+   - Decrypt with old key
+   - Re-encrypt with new key + existing recipients
+4. **Archive old key** for historical ticket access (read-only)
+5. **Update key ID** in role configuration
+
+```bash
+# Key rotation command (governance-gated)
+virtengine tx support rotate-role-key \
+    --role support_agent \
+    --new-key-file /path/to/new-key.pub \
+    --from admin
+```
+
+### Attachment Encryption
+
+Attachments use a separate encryption layer:
+
+1. **Generate unique DEK** (AES-256-GCM) per attachment
+2. **Encrypt file** with DEK
+3. **Store encrypted file** off-chain (IPFS/S3)
+4. **Encrypt DEK** using ticket envelope format
+5. **Store `key_envelope`** in attachment reference
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Attachment Encryption Flow                    │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│   ┌────────────┐    AES-256-GCM    ┌──────────────────────────┐ │
+│   │ Attachment │ ───────────────► │ Encrypted File           │ │
+│   │ (plaintext)│      DEK          │ (stored off-chain)       │ │
+│   └────────────┘                   └──────────────────────────┘ │
+│                                                                  │
+│   ┌────────────┐   X25519 Envelope ┌──────────────────────────┐ │
+│   │    DEK     │ ───────────────► │ key_envelope             │ │
+│   │ (256-bit)  │    Recipients     │ (stored on-chain)        │ │
+│   └────────────┘                   └──────────────────────────┘ │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Retention and PII Policy
+
+### Retention by Jurisdiction
+
+| Jurisdiction | Regulation | Default Retention | Max Retention | Deletion Trigger |
+|--------------|------------|-------------------|---------------|------------------|
+| EU (GDPR) | GDPR Art. 5(1)(e) | 2 years | 6 years (legal hold) | Ticket closed + retention |
+| California (US) | CCPA | 3 years | 7 years (legal hold) | Ticket closed + retention |
+| US (General) | N/A | 5 years | 7 years | Ticket closed + retention |
+| UK | UK GDPR | 2 years | 6 years (legal hold) | Ticket closed + retention |
+| Global Default | N/A | 3 years | 7 years | Ticket closed + retention |
+
+### Retention Policy Types
+
+```go
+const (
+    // RetentionPolicyGDPR - EU GDPR compliance (2 years)
+    RetentionPolicyGDPR = "gdpr"
+    
+    // RetentionPolicyCCPA - California CCPA compliance (3 years)
+    RetentionPolicyCCPA = "ccpa"
+    
+    // RetentionPolicyUSGeneral - US general (5 years)
+    RetentionPolicyUSGeneral = "us_general"
+    
+    // RetentionPolicyUKGDPR - UK GDPR (2 years)
+    RetentionPolicyUKGDPR = "uk_gdpr"
+    
+    // RetentionPolicyGlobal - Global default (3 years)
+    RetentionPolicyGlobal = "global"
+    
+    // RetentionPolicyLegalHold - Indefinite (litigation)
+    RetentionPolicyLegalHold = "legal_hold"
+)
+```
+
+### Jurisdiction Mapping
+
+| Country Code | Policy | Retention Days |
+|--------------|--------|----------------|
+| AT, BE, BG, HR, CY, CZ, DK, EE, FI, FR, DE, GR, HU, IE, IT, LV, LT, LU, MT, NL, PL, PT, RO, SK, SI, ES, SE | `gdpr` | 730 |
+| GB | `uk_gdpr` | 730 |
+| US-CA | `ccpa` | 1095 |
+| US-* | `us_general` | 1825 |
+| * | `global` | 1095 |
+
+### PII Field Inventory
+
+| Field | Classification | PII Type | Encrypted | Deletion on Request |
+|-------|---------------|----------|-----------|---------------------|
+| `contact_envelope` | C3 | Email, Phone | Yes | Yes |
+| `description_envelope` | C2-C3 | Varies | Yes | Pseudonymized |
+| `messages[].content_envelope` | C2-C3 | Varies | Yes | Pseudonymized |
+| `attachments[]` | C3 | Screenshots, logs | Yes | Yes |
+| `customer_address` | C2 | Blockchain address | No | No (pseudonymous) |
+
+### Data Subject Rights
+
+#### Right to Access (GDPR Art. 15)
+
+```bash
+# Export all ticket data for a customer
+virtengine query support export-customer-data \
+    --customer-address virtengine1abc... \
+    --format json
+```
+
+#### Right to Erasure (GDPR Art. 17)
+
+```bash
+# Request data deletion (requires consent verification)
+virtengine tx support request-deletion \
+    --ticket-id abc123... \
+    --reason "customer_request" \
+    --from customer-key
+```
+
+**Deletion Workflow:**
+
+1. **Verify identity** - Confirm requester owns the ticket
+2. **Check legal holds** - Cannot delete if under legal hold
+3. **Anonymize references** - Replace PII with pseudonyms
+4. **Delete encrypted content** - Remove `description_envelope`, `contact_envelope`
+5. **Delete attachments** - Remove from off-chain storage
+6. **Retain metadata** - Keep anonymized ticket shell for audit
+
+#### Right to Rectification (GDPR Art. 16)
+
+```bash
+# Update PII (re-encrypts with new data)
+virtengine tx support update-contact-info \
+    --ticket-id abc123... \
+    --contact-file updated-contact.json \
+    --from customer-key
+```
+
+### Automatic Deletion Process
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Retention Deletion Flow                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│   1. Daily Cron Job                                             │
+│   ┌──────────────────────────────────────────────────────────┐  │
+│   │ SELECT tickets WHERE                                      │  │
+│   │   status IN (CLOSED, CANCELLED) AND                       │  │
+│   │   closed_at + retention_days < NOW() AND                  │  │
+│   │   legal_hold = false                                      │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                          │                                      │
+│                          ▼                                      │
+│   2. For each eligible ticket:                                 │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │ a. Delete encrypted envelopes (description, contact)    │  │
+│   │ b. Delete message content envelopes                     │  │
+│   │ c. Delete attachments from off-chain storage            │  │
+│   │ d. Delete attachment key envelopes                      │  │
+│   │ e. Anonymize customer address → hash                    │  │
+│   │ f. Set deletion_timestamp                               │  │
+│   │ g. Emit TicketDataDeleted event                         │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                                                                  │
+│   3. Retained (for audit):                                      │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │ - ticket_id                                              │  │
+│   │ - category, priority, status                             │  │
+│   │ - created_at, closed_at, deletion_timestamp              │  │
+│   │ - anonymized_customer_hash                               │  │
+│   │ - retention_policy reference                             │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Legal Hold
+
+Tickets can be placed under legal hold to prevent deletion:
+
+```bash
+# Place legal hold (admin only)
+virtengine tx support set-legal-hold \
+    --ticket-id abc123... \
+    --reason "Litigation case #12345" \
+    --from admin-key
+```
+
+Legal hold prevents:
+- Automatic retention deletion
+- Customer deletion requests
+- Attachment purging
+
+---
+
+## Audit Logging Requirements
+
+### Audit Events
+
+| Event Type | Description | Logged Fields |
+|------------|-------------|---------------|
+| `TICKET_CREATED` | New ticket created | ticket_id, customer_addr, category, priority |
+| `TICKET_VIEWED` | Ticket details accessed | ticket_id, viewer_addr, viewer_role, fields_accessed |
+| `TICKET_UPDATED` | Ticket fields modified | ticket_id, modifier_addr, changed_fields |
+| `TICKET_STATUS_CHANGED` | State transition | ticket_id, old_status, new_status, changed_by |
+| `TICKET_ASSIGNED` | Agent assignment | ticket_id, agent_addr, assigned_by |
+| `TICKET_ESCALATED` | Escalation event | ticket_id, escalated_by, escalation_reason |
+| `MESSAGE_CREATED` | New message added | ticket_id, message_id, sender_addr, is_internal |
+| `MESSAGE_VIEWED` | Message decrypted/read | ticket_id, message_id, viewer_addr |
+| `ATTACHMENT_UPLOADED` | File attached | ticket_id, attachment_id, uploader_addr, size_bytes |
+| `ATTACHMENT_DOWNLOADED` | File downloaded | ticket_id, attachment_id, downloader_addr |
+| `ATTACHMENT_DELETED` | File removed | ticket_id, attachment_id, deleted_by |
+| `PII_ACCESSED` | Contact info decrypted | ticket_id, accessor_addr, accessor_role, pii_fields |
+| `TICKET_EXPORTED` | Data export requested | ticket_id, exporter_addr, export_format |
+| `TICKET_DELETED` | Data deletion (GDPR) | ticket_id, deletion_reason, deleted_by |
+| `LEGAL_HOLD_SET` | Legal hold applied | ticket_id, set_by, reason |
+| `LEGAL_HOLD_REMOVED` | Legal hold lifted | ticket_id, removed_by, reason |
+
+### Audit Log Entry Structure
+
+```go
+type SupportAuditEntry struct {
+    EntryID        string            `json:"entry_id"`        // UUID v7
+    Timestamp      int64             `json:"timestamp"`       // Unix seconds
+    EventType      string            `json:"event_type"`      // From enum above
+    TicketID       string            `json:"ticket_id"`
+    ActorAddress   string            `json:"actor_address"`   // Who performed action
+    ActorRole      string            `json:"actor_role"`      // Role at time of action
+    ClientIP       string            `json:"client_ip"`       // Anonymized after 30 days
+    UserAgent      string            `json:"user_agent,omitempty"`
+    SessionID      string            `json:"session_id,omitempty"`
+    
+    // Event-specific details
+    Details        map[string]interface{} `json:"details"`
+    
+    // Integrity
+    PreviousHash   string            `json:"previous_hash"`   // Hash chain
+    EntryHash      string            `json:"entry_hash"`      // SHA256 of entry
+}
+```
+
+### Audit Log Retention
+
+| Log Type | Retention | Archive |
+|----------|-----------|---------|
+| Access logs (`*_VIEWED`, `*_ACCESSED`) | 2 years | 5 years (cold) |
+| Modification logs (`*_CREATED`, `*_UPDATED`) | 5 years | 10 years (cold) |
+| Deletion logs (`*_DELETED`) | 10 years | Indefinite |
+| Security events (`LEGAL_HOLD_*`) | 10 years | Indefinite |
+
+### Audit Query Examples
+
+```bash
+# View audit trail for a ticket
+virtengine query support audit-log \
+    --ticket-id abc123... \
+    --from-timestamp 1704067200 \
+    --limit 100
+
+# View PII access for compliance report
+virtengine query support audit-log \
+    --event-type PII_ACCESSED \
+    --actor-role support_agent \
+    --from-timestamp 1704067200
+
+# Verify audit log integrity
+virtengine query support verify-audit-integrity \
+    --from-entry entry123... \
+    --to-entry entry456...
+```
+
+---
+
+## Access Control Mapping
+
+### Integration with x/roles
+
+The support ticket system integrates with the `x/roles` module for access control:
+
+```go
+// From x/roles/types/roles.go
+const (
+    RoleCustomer       Role = 6  // End users (ticket creators)
+    RoleSupportAgent   Role = 7  // Customer support
+    RoleModerator      Role = 4  // Escalation handling
+    RoleAdministrator  Role = 2  // Full access
+    RoleServiceProvider Role = 5 // Provider-related tickets
+)
+```
+
+### Permission Checks
+
+```go
+// Check if actor can perform action on ticket
+func (k Keeper) CanAccessTicket(ctx sdk.Context, actorAddr, ticketID string, permission Permission) error {
+    // Get actor's role
+    role, err := k.rolesKeeper.GetRole(ctx, actorAddr)
+    if err != nil {
+        return ErrUnauthorized
+    }
+    
+    // Get ticket
+    ticket, found := k.GetTicket(ctx, ticketID)
+    if !found {
+        return ErrTicketNotFound
+    }
+    
+    // Check ownership
+    isOwner := ticket.CustomerAddress == actorAddr
+    isAssigned := ticket.AssignedAgentAddr == actorAddr
+    isRelatedProvider := k.isProviderRelated(ctx, ticket, actorAddr)
+    
+    switch permission {
+    case PermissionTicketRead:
+        if isOwner || isAssigned || isRelatedProvider {
+            return nil
+        }
+        if role == RoleSupportAgent || role == RoleModerator || role == RoleAdministrator {
+            return nil
+        }
+        
+    case PermissionTicketUpdate:
+        if isOwner && ticket.Status == TicketStatusOpen {
+            return nil
+        }
+        if isAssigned || role == RoleModerator || role == RoleAdministrator {
+            return nil
+        }
+        
+    case PermissionPIIView:
+        // Only assigned agent or higher can view PII
+        if isAssigned || role == RoleModerator || role == RoleAdministrator {
+            return nil
+        }
+        
+    case PermissionTicketDelete:
+        // Admin only
+        if role == RoleAdministrator || role == RoleGenesisAccount {
+            return nil
+        }
+    }
+    
+    return ErrUnauthorized
+}
+```
+
+### Trust Level Requirements
+
+| Operation | Minimum Trust Level | Roles |
+|-----------|---------------------|-------|
+| Create ticket | 50 | `customer`, `support_agent`, `administrator` |
+| View own ticket | 50 | `customer` |
+| View any ticket | 60 | `support_agent`, `moderator`, `administrator` |
+| Assign ticket | 60 | `support_agent`, `moderator`, `administrator` |
+| Escalate | 70 | `moderator`, `administrator` |
+| View PII | 60 | `support_agent` (assigned), `moderator`, `administrator` |
+| Delete ticket | 90 | `administrator` |
+| Export all | 90 | `administrator` |
+
+---
+
+## Examples
+
+### Example 1: Basic Support Ticket
+
+See: `docs/support/examples/basic_ticket.json`
+
+### Example 2: Marketplace Order Issue
+
+See: `docs/support/examples/marketplace_ticket.json`
+
+### Example 3: Identity Verification Issue
+
+See: `docs/support/examples/identity_ticket.json`
+
+---
+
+## Validation
+
+### JSON Schema
+
+The JSON Schema for validation is located at:
+`docs/support/schemas/support_ticket.schema.json`
+
+### Validation Rules
+
+1. **TicketID**: Must be valid UUID v7 format
+2. **Status**: Must be valid enum value
+3. **Transitions**: Must follow allowed transition matrix
+4. **Timestamps**: Must be valid Unix timestamps, `updated_at >= created_at`
+5. **Addresses**: Must be valid VirtEngine bech32 addresses
+6. **Envelopes**: Must pass `x/encryption` envelope validation
+7. **Attachments**: Size must not exceed 50MB, allowed types only
+8. **Retention**: Must have valid retention policy for jurisdiction
+
+### Test Coverage
+
+Tests are located at: `tests/support_ticket_schema_test.go`
+
+- Schema validation tests
+- State transition tests
+- Encryption envelope tests
+- Retention policy tests
+- Access control tests
+
+---
+
+## Changelog
+
+- **2026-01-30**: Initial specification (v1.0.0)
+  - Defined ticket states and transitions
+  - Defined payload schema with encryption
+  - Defined retention policies by jurisdiction
+  - Defined audit logging requirements
+  - Mapped to x/roles access control

--- a/docs/support/examples/basic_ticket.json
+++ b/docs/support/examples/basic_ticket.json
@@ -1,0 +1,54 @@
+{
+  "ticket_id": "019479b8-7c3d-7000-8000-000000000001",
+  "version": 1,
+  "category": "technical",
+  "priority": "medium",
+  "tags": ["deployment", "connectivity"],
+  "status": "OPEN",
+  "created_at": 1706620800,
+  "updated_at": 1706620800,
+  "customer_address": "virtengine1abc123def456ghi789jkl012mno345pq",
+  "subject": "Unable to access deployed application",
+  "description_envelope": {
+    "version": 1,
+    "algorithm_id": "X25519-XSALSA20-POLY1305",
+    "algorithm_version": 1,
+    "recipient_key_ids": [
+      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      "f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5"
+    ],
+    "wrapped_keys": [
+      {
+        "recipient_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        "wrapped_key": "base64EncodedWrappedKey1==",
+        "algorithm": "X25519-XSALSA20-POLY1305"
+      },
+      {
+        "recipient_id": "f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5",
+        "wrapped_key": "base64EncodedWrappedKey2==",
+        "algorithm": "X25519-XSALSA20-POLY1305"
+      }
+    ],
+    "nonce": "dW5pcXVlTm9uY2VWYWx1ZTEyMzQ1Ng==",
+    "ciphertext": "ZW5jcnlwdGVkRGVzY3JpcHRpb25Db250ZW50SGVyZQ==",
+    "sender_signature": "c2lnbmF0dXJlT2ZUaGVFbnZlbG9wZUNvbnRlbnRz",
+    "sender_pub_key": "c2VuZGVyUHVibGljS2V5Qnl0ZXM=",
+    "metadata": {
+      "content_type": "text/plain",
+      "_schema_version": "1.0.0"
+    }
+  },
+  "messages": [],
+  "attachments": [],
+  "retention_policy": {
+    "policy_id": "global",
+    "retention_days": 1095,
+    "delete_after_closed": true,
+    "archive_after_days": 90
+  },
+  "jurisdiction_code": "US",
+  "metadata": {
+    "source": "web_portal",
+    "browser": "Chrome/120.0"
+  }
+}

--- a/docs/support/examples/identity_ticket.json
+++ b/docs/support/examples/identity_ticket.json
@@ -1,0 +1,184 @@
+{
+  "ticket_id": "019479b8-7c3d-7000-8002-000000000003",
+  "version": 1,
+  "category": "identity",
+  "priority": "critical",
+  "tags": ["veid", "verification", "ml-score"],
+  "status": "ESCALATED",
+  "created_at": 1706620800,
+  "updated_at": 1706631600,
+  "customer_address": "virtengine1veidcust0789abc123def456ghi78901",
+  "assigned_agent_addr": "virtengine1moderator0xyz789abc123def4567890",
+  "subject": "Identity verification rejected with high-quality documents",
+  "description_envelope": {
+    "version": 1,
+    "algorithm_id": "X25519-XSALSA20-POLY1305",
+    "algorithm_version": 1,
+    "recipient_key_ids": [
+      "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+      "escalation_team_key_fingerprint12345678901"
+    ],
+    "wrapped_keys": [
+      {
+        "recipient_id": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+        "wrapped_key": "aWRlbnRpdHlDdXN0b21lcktleQ==",
+        "algorithm": "X25519-XSALSA20-POLY1305"
+      },
+      {
+        "recipient_id": "escalation_team_key_fingerprint12345678901",
+        "wrapped_key": "ZXNjYWxhdGlvblRlYW1LZXk=",
+        "algorithm": "X25519-XSALSA20-POLY1305"
+      }
+    ],
+    "nonce": "aWRlbnRpdHlOb25jZTEyMzQ1",
+    "ciphertext": "TXkgaWRlbnRpdHkgdmVyaWZpY2F0aW9uIHdhcyByZWplY3RlZCB3aXRoIGEgc2NvcmUgb2YgNDUvMTAwLiBJIHN1Ym1pdHRlZCBhIHZhbGlkIHBhc3Nwb3J0IGFuZCBhIGNsZWFyIHNlbGZpZS4gVGhlIHJlamVjdGlvbiByZWFzb24gc2F5cyAiZmFjZSBtaXNtYXRjaCIgYnV0IEkgYmVsaWV2ZSB0aGlzIGlzIGFuIGVycm9yLiBQbGVhc2UgcmV2aWV3IG15IHN1Ym1pc3Npb24u",
+    "sender_signature": "aWRlbnRpdHlTaWduYXR1cmU=",
+    "sender_pub_key": "dmVpZEN1c3RvbWVyUHViS2V5",
+    "metadata": {
+      "content_type": "text/plain",
+      "veid_submission_id": "veid-sub-2024-01-30-xyz789",
+      "ml_model_version": "facial_verification_v2.3.1",
+      "ml_score": "45"
+    }
+  },
+  "messages": [
+    {
+      "message_id": "019479b8-7c3d-7003-8000-000000000001",
+      "sender_addr": "virtengine1agent0000xyz012abc345def678ghi901",
+      "sender_role": "support_agent",
+      "created_at": 1706624400,
+      "content_envelope": {
+        "version": 1,
+        "algorithm_id": "X25519-XSALSA20-POLY1305",
+        "algorithm_version": 1,
+        "recipient_key_ids": [
+          "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+          "1234567890abcdef1234567890abcdef12345678"
+        ],
+        "wrapped_keys": [
+          {
+            "recipient_id": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+            "wrapped_key": "bXNnMUN1c3RvbWVyS2V5"
+          },
+          {
+            "recipient_id": "1234567890abcdef1234567890abcdef12345678",
+            "wrapped_key": "bXNnMUFnZW50S2V5"
+          }
+        ],
+        "nonce": "bXNnMU5vbmNlVmVpZA==",
+        "ciphertext": "VGhhbmsgeW91IGZvciBjb250YWN0aW5nIHN1cHBvcnQuIEkndmUgcmV2aWV3ZWQgeW91ciBzdWJtaXNzaW9uIElEIGFuZCBjYW4gc2VlIHRoZSBNTCBtb2RlbCBmbGFnZ2VkIGEgbG93IGNvbmZpZGVuY2Ugc2NvcmUuIEknbSBlc2NhbGF0aW5nIHRoaXMgdG8gb3VyIGlkZW50aXR5IHZlcmlmaWNhdGlvbiB0ZWFtIGZvciBtYW51YWwgcmV2aWV3Lg==",
+        "sender_signature": "YWdlbnRWZWlkTXNnU2ln",
+        "sender_pub_key": "YWdlbnRQdWJLZXk="
+      },
+      "is_internal": false
+    },
+    {
+      "message_id": "019479b8-7c3d-7003-8000-000000000002",
+      "sender_addr": "virtengine1agent0000xyz012abc345def678ghi901",
+      "sender_role": "support_agent",
+      "created_at": 1706624500,
+      "content_envelope": {
+        "version": 1,
+        "algorithm_id": "X25519-XSALSA20-POLY1305",
+        "algorithm_version": 1,
+        "recipient_key_ids": [
+          "1234567890abcdef1234567890abcdef12345678",
+          "support_team_role_key_fingerprint1234567",
+          "escalation_team_key_fingerprint12345678901"
+        ],
+        "wrapped_keys": [
+          {
+            "recipient_id": "1234567890abcdef1234567890abcdef12345678",
+            "wrapped_key": "aW50ZXJuYWxBZ2VudEtleQ=="
+          },
+          {
+            "recipient_id": "support_team_role_key_fingerprint1234567",
+            "wrapped_key": "aW50ZXJuYWxUZWFtS2V5"
+          },
+          {
+            "recipient_id": "escalation_team_key_fingerprint12345678901",
+            "wrapped_key": "ZXNjYWxhdGlvbktleQ=="
+          }
+        ],
+        "nonce": "aW50ZXJuYWxWZWlkTm9uY2U=",
+        "ciphertext": "SU5URVJOQUw6IE1MIG1vZGVsIHYyLjMuMSBoYXMga25vd24gaXNzdWVzIHdpdGggY2VydGFpbiBsaWdodGluZyBjb25kaXRpb25zLiBSZWNvbW1lbmQgbWFudWFsIHJldmlldyBieSBWRUlEIHRlYW0uIFN1Ym1pc3Npb24gZG9jdW1lbnRzIGFwcGVhciB2YWxpZCBvbiBwcmVsaW1pbmFyeSBjaGVjay4=",
+        "sender_signature": "aW50ZXJuYWxWZWlkU2ln",
+        "sender_pub_key": "YWdlbnRQdWJLZXk="
+      },
+      "is_internal": true
+    },
+    {
+      "message_id": "019479b8-7c3d-7003-8000-000000000003",
+      "sender_addr": "virtengine1moderator0xyz789abc123def4567890",
+      "sender_role": "moderator",
+      "created_at": 1706631600,
+      "content_envelope": {
+        "version": 1,
+        "algorithm_id": "X25519-XSALSA20-POLY1305",
+        "algorithm_version": 1,
+        "recipient_key_ids": [
+          "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+          "escalation_team_key_fingerprint12345678901"
+        ],
+        "wrapped_keys": [
+          {
+            "recipient_id": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+            "wrapped_key": "bW9kTXNnQ3VzdG9tZXJLZXk="
+          },
+          {
+            "recipient_id": "escalation_team_key_fingerprint12345678901",
+            "wrapped_key": "bW9kTXNnRXNjYWxhdGlvbktleQ=="
+          }
+        ],
+        "nonce": "bW9kZXJhdG9yTm9uY2U=",
+        "ciphertext": "SSd2ZSBjb21wbGV0ZWQgYSBtYW51YWwgcmV2aWV3IG9mIHlvdXIgaWRlbnRpdHkgc3VibWlzc2lvbi4gVGhlIGRvY3VtZW50cyBhcmUgdmFsaWQgYW5kIHRoZSBmYWNlIG1hdGNoIGlzIGNvbmZpcm1lZC4gSSdtIGFwcHJvdmluZyB5b3VyIHZlcmlmaWNhdGlvbiB3aXRoIGFuIG92ZXJyaWRlIHNjb3JlIG9mIDg1LzEwMC4gWW91ciBWRUlEIHN0YXR1cyB3aWxsIGJlIHVwZGF0ZWQgd2l0aGluIHRoZSBuZXh0IGJsb2NrLg==",
+        "sender_signature": "bW9kZXJhdG9yU2ln",
+        "sender_pub_key": "bW9kZXJhdG9yUHViS2V5"
+      },
+      "is_internal": false
+    }
+  ],
+  "attachments": [],
+  "contact_envelope": {
+    "version": 1,
+    "algorithm_id": "X25519-XSALSA20-POLY1305",
+    "algorithm_version": 1,
+    "recipient_key_ids": [
+      "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+      "escalation_team_key_fingerprint12345678901"
+    ],
+    "wrapped_keys": [
+      {
+        "recipient_id": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+        "wrapped_key": "Y29udGFjdEN1c3RvbWVyS2V5Vg=="
+      },
+      {
+        "recipient_id": "escalation_team_key_fingerprint12345678901",
+        "wrapped_key": "Y29udGFjdEVzY2FsYXRpb25LZXk="
+      }
+    ],
+    "nonce": "Y29udGFjdFZlaWROb25jZQ==",
+    "ciphertext": "eyJlbWFpbCI6ICJ2ZWlkLnVzZXJAZXhhbXBsZS5jb20ifQ==",
+    "sender_signature": "Y29udGFjdFZlaWRTaWc=",
+    "sender_pub_key": "dmVpZEN1c3RvbWVyUHViS2V5",
+    "metadata": {
+      "content_type": "application/json",
+      "pii_fields": "email"
+    }
+  },
+  "retention_policy": {
+    "policy_id": "gdpr",
+    "retention_days": 730,
+    "delete_after_closed": true,
+    "archive_after_days": 90
+  },
+  "jurisdiction_code": "DE",
+  "consent_record_id": "consent-2024-01-30-veid-de-123",
+  "metadata": {
+    "source": "veid_portal",
+    "veid_submission_id": "veid-sub-2024-01-30-xyz789",
+    "original_ml_score": "45",
+    "override_ml_score": "85",
+    "override_reason": "manual_review_approved"
+  }
+}

--- a/docs/support/examples/marketplace_ticket.json
+++ b/docs/support/examples/marketplace_ticket.json
@@ -1,0 +1,195 @@
+{
+  "ticket_id": "019479b8-7c3d-7000-8001-000000000002",
+  "version": 1,
+  "category": "marketplace",
+  "priority": "high",
+  "tags": ["order", "billing", "provider"],
+  "status": "ASSIGNED",
+  "created_at": 1706620800,
+  "updated_at": 1706624400,
+  "customer_address": "virtengine1customer0abc123def456ghi789jkl012m",
+  "assigned_agent_addr": "virtengine1agent0000xyz012abc345def678ghi901",
+  "order_ref": {
+    "order_id": "order-12345-abcde",
+    "owner_addr": "virtengine1customer0abc123def456ghi789jkl012m",
+    "dseq": 1234567,
+    "gseq": 1,
+    "oseq": 1
+  },
+  "provider_ref": {
+    "provider_addr": "virtengine1provider0def789ghi012jkl345mno678",
+    "provider_name": "CloudProvider Inc.",
+    "lease_id": "lease-98765-fghij"
+  },
+  "deployment_ref": {
+    "deployment_id": "deploy-11111-aaaaa",
+    "owner_addr": "virtengine1customer0abc123def456ghi789jkl012m",
+    "dseq": 1234567
+  },
+  "subject": "Unexpected charges on marketplace order #12345",
+  "description_envelope": {
+    "version": 1,
+    "algorithm_id": "X25519-XSALSA20-POLY1305",
+    "algorithm_version": 1,
+    "recipient_key_ids": [
+      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      "1234567890abcdef1234567890abcdef12345678"
+    ],
+    "wrapped_keys": [
+      {
+        "recipient_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        "wrapped_key": "Y3VzdG9tZXJXcmFwcGVkS2V5RGF0YQ==",
+        "algorithm": "X25519-XSALSA20-POLY1305"
+      },
+      {
+        "recipient_id": "1234567890abcdef1234567890abcdef12345678",
+        "wrapped_key": "YWdlbnRXcmFwcGVkS2V5RGF0YQ==",
+        "algorithm": "X25519-XSALSA20-POLY1305"
+      }
+    ],
+    "nonce": "bWFya2V0cGxhY2VOb25jZTEyMzQ1",
+    "ciphertext": "RW5jcnlwdGVkOiBJIHdhcyBjaGFyZ2VkIDEwMCBWRSBidXQgdGhlIHF1b3RlIHNhaWQgNTAgVkUuIFRoZSBwcm92aWRlciBzYXlzIHRoZXkgY2hhcmdlZCB0aGUgY29ycmVjdCBhbW91bnQgYnV0IG15IGJpbGwgc2hvd3Mgb3RoZXJ3aXNlLg==",
+    "sender_signature": "bWFya2V0cGxhY2VTaWduYXR1cmU=",
+    "sender_pub_key": "Y3VzdG9tZXJQdWJLZXk=",
+    "metadata": {
+      "content_type": "text/plain"
+    }
+  },
+  "messages": [
+    {
+      "message_id": "019479b8-7c3d-7001-8000-000000000001",
+      "sender_addr": "virtengine1agent0000xyz012abc345def678ghi901",
+      "sender_role": "support_agent",
+      "created_at": 1706624400,
+      "content_envelope": {
+        "version": 1,
+        "algorithm_id": "X25519-XSALSA20-POLY1305",
+        "algorithm_version": 1,
+        "recipient_key_ids": [
+          "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+          "1234567890abcdef1234567890abcdef12345678"
+        ],
+        "wrapped_keys": [
+          {
+            "recipient_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "wrapped_key": "bWVzc2FnZUN1c3RvbWVyS2V5"
+          },
+          {
+            "recipient_id": "1234567890abcdef1234567890abcdef12345678",
+            "wrapped_key": "bWVzc2FnZUFnZW50S2V5"
+          }
+        ],
+        "nonce": "bXNnMU5vbmNlVmFsdWU=",
+        "ciphertext": "SGkgdGhhbmtzIGZvciBjb250YWN0aW5nIHN1cHBvcnQuIEkndmUgYXNzaWduZWQgdGhpcyB0aWNrZXQgdG8gbXlzZWxmIGFuZCB3aWxsIGludmVzdGlnYXRlIHRoZSBiaWxsaW5nIGRpc2NyZXBhbmN5Lg==",
+        "sender_signature": "YWdlbnRNc2dTaWduYXR1cmU=",
+        "sender_pub_key": "YWdlbnRQdWJLZXk="
+      },
+      "is_internal": false
+    },
+    {
+      "message_id": "019479b8-7c3d-7001-8000-000000000002",
+      "sender_addr": "virtengine1agent0000xyz012abc345def678ghi901",
+      "sender_role": "support_agent",
+      "created_at": 1706624500,
+      "content_envelope": {
+        "version": 1,
+        "algorithm_id": "X25519-XSALSA20-POLY1305",
+        "algorithm_version": 1,
+        "recipient_key_ids": [
+          "1234567890abcdef1234567890abcdef12345678",
+          "support_team_role_key_fingerprint1234567"
+        ],
+        "wrapped_keys": [
+          {
+            "recipient_id": "1234567890abcdef1234567890abcdef12345678",
+            "wrapped_key": "aW50ZXJuYWxBZ2VudEtleQ=="
+          },
+          {
+            "recipient_id": "support_team_role_key_fingerprint1234567",
+            "wrapped_key": "aW50ZXJuYWxUZWFtS2V5"
+          }
+        ],
+        "nonce": "aW50ZXJuYWxOb25jZQ==",
+        "ciphertext": "SW50ZXJuYWwgbm90ZTogQ2hlY2sgZXNjcm93IG1vZHVsZSBmb3IgdHJhbnNhY3Rpb24gaGlzdG9yeS4gTWF5IG5lZWQgdG8gZXNjYWxhdGUgdG8gYmlsbGluZyB0ZWFtLg==",
+        "sender_signature": "aW50ZXJuYWxTaWc=",
+        "sender_pub_key": "YWdlbnRQdWJLZXk="
+      },
+      "is_internal": true
+    }
+  ],
+  "attachments": [
+    {
+      "attachment_id": "019479b8-7c3d-7002-8000-000000000001",
+      "file_name": "billing_screenshot.png",
+      "content_type": "image/png",
+      "size_bytes": 245760,
+      "storage_location": "ipfs://QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco",
+      "uploaded_at": 1706620800,
+      "uploaded_by": "virtengine1customer0abc123def456ghi789jkl012m",
+      "checksum_sha256": "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
+      "key_envelope": {
+        "version": 1,
+        "algorithm_id": "X25519-XSALSA20-POLY1305",
+        "algorithm_version": 1,
+        "recipient_key_ids": [
+          "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+          "1234567890abcdef1234567890abcdef12345678"
+        ],
+        "wrapped_keys": [
+          {
+            "recipient_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "wrapped_key": "YXR0YWNobWVudERFS0N1c3RvbWVy"
+          },
+          {
+            "recipient_id": "1234567890abcdef1234567890abcdef12345678",
+            "wrapped_key": "YXR0YWNobWVudERFS0FnZW50"
+          }
+        ],
+        "nonce": "YXR0YWNobWVudE5vbmNl",
+        "ciphertext": "QUVTLTI1Ni1HQ00gREVLIGZvciB0aGUgYXR0YWNobWVudA==",
+        "sender_signature": "YXR0YWNobWVudFNpZw==",
+        "sender_pub_key": "Y3VzdG9tZXJQdWJLZXk="
+      }
+    }
+  ],
+  "contact_envelope": {
+    "version": 1,
+    "algorithm_id": "X25519-XSALSA20-POLY1305",
+    "algorithm_version": 1,
+    "recipient_key_ids": [
+      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      "1234567890abcdef1234567890abcdef12345678"
+    ],
+    "wrapped_keys": [
+      {
+        "recipient_id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        "wrapped_key": "Y29udGFjdEN1c3RvbWVyS2V5"
+      },
+      {
+        "recipient_id": "1234567890abcdef1234567890abcdef12345678",
+        "wrapped_key": "Y29udGFjdEFnZW50S2V5"
+      }
+    ],
+    "nonce": "Y29udGFjdE5vbmNl",
+    "ciphertext": "eyJlbWFpbCI6ICJjdXN0b21lckBleGFtcGxlLmNvbSIsICJwaG9uZSI6ICIrMS01NTUtMTIzNDU2NyJ9",
+    "sender_signature": "Y29udGFjdFNpZw==",
+    "sender_pub_key": "Y3VzdG9tZXJQdWJLZXk=",
+    "metadata": {
+      "content_type": "application/json",
+      "pii_fields": "email,phone"
+    }
+  },
+  "retention_policy": {
+    "policy_id": "us_general",
+    "retention_days": 1825,
+    "delete_after_closed": true,
+    "archive_after_days": 90
+  },
+  "jurisdiction_code": "US-NY",
+  "consent_record_id": "consent-2024-01-30-abc123",
+  "metadata": {
+    "source": "mobile_app",
+    "app_version": "2.5.0",
+    "dispute_amount": "50 VE"
+  }
+}

--- a/docs/support/schemas/support_ticket.schema.json
+++ b/docs/support/schemas/support_ticket.schema.json
@@ -1,0 +1,528 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://virtengine.network/schemas/support/ticket.schema.json",
+  "title": "VirtEngine Support Ticket",
+  "description": "Schema for VirtEngine support tickets with encryption and retention policies",
+  "type": "object",
+  "required": [
+    "ticket_id",
+    "version",
+    "category",
+    "priority",
+    "status",
+    "created_at",
+    "updated_at",
+    "customer_address",
+    "subject",
+    "description_envelope",
+    "retention_policy",
+    "jurisdiction_code"
+  ],
+  "properties": {
+    "ticket_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "Unique ticket identifier (UUID v7)"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1,
+      "description": "Schema version number"
+    },
+    "category": {
+      "$ref": "#/$defs/ticketCategory"
+    },
+    "priority": {
+      "$ref": "#/$defs/ticketPriority"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 50
+      },
+      "maxItems": 10,
+      "uniqueItems": true,
+      "description": "Optional tags for categorization"
+    },
+    "status": {
+      "$ref": "#/$defs/ticketStatus"
+    },
+    "created_at": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Unix timestamp (seconds) when ticket was created"
+    },
+    "updated_at": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Unix timestamp (seconds) of last update"
+    },
+    "closed_at": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Unix timestamp (seconds) when ticket was closed"
+    },
+    "customer_address": {
+      "$ref": "#/$defs/virtengineAddress"
+    },
+    "assigned_agent_addr": {
+      "$ref": "#/$defs/virtengineAddress"
+    },
+    "order_ref": {
+      "$ref": "#/$defs/orderReference"
+    },
+    "provider_ref": {
+      "$ref": "#/$defs/providerReference"
+    },
+    "deployment_ref": {
+      "$ref": "#/$defs/deploymentReference"
+    },
+    "related_tickets": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      },
+      "maxItems": 20,
+      "uniqueItems": true,
+      "description": "Related ticket IDs"
+    },
+    "subject": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 200,
+      "description": "Ticket subject line (not encrypted)"
+    },
+    "description_envelope": {
+      "$ref": "#/$defs/encryptedPayloadEnvelope"
+    },
+    "messages": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ticketMessage"
+      },
+      "maxItems": 500,
+      "description": "Thread of messages"
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/attachmentRef"
+      },
+      "maxItems": 50,
+      "description": "Attached files"
+    },
+    "contact_envelope": {
+      "$ref": "#/$defs/encryptedPayloadEnvelope"
+    },
+    "retention_policy": {
+      "$ref": "#/$defs/retentionPolicyRef"
+    },
+    "jurisdiction_code": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}(-[A-Z0-9]{1,3})?$",
+      "description": "ISO 3166-1 alpha-2 country code with optional subdivision"
+    },
+    "consent_record_id": {
+      "type": "string",
+      "description": "Reference to consent record for PII processing"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "maxLength": 1000
+      },
+      "maxProperties": 20,
+      "description": "Additional key-value metadata"
+    }
+  },
+  "$defs": {
+    "ticketStatus": {
+      "type": "string",
+      "enum": [
+        "OPEN",
+        "ASSIGNED",
+        "IN_PROGRESS",
+        "AWAITING_CUSTOMER",
+        "AWAITING_PROVIDER",
+        "ESCALATED",
+        "ON_HOLD",
+        "RESOLVED",
+        "CLOSED",
+        "CANCELLED"
+      ],
+      "description": "Current ticket status"
+    },
+    "ticketCategory": {
+      "type": "string",
+      "enum": [
+        "billing",
+        "technical",
+        "identity",
+        "marketplace",
+        "security",
+        "other"
+      ],
+      "description": "Ticket category"
+    },
+    "ticketPriority": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ],
+      "description": "Ticket priority level"
+    },
+    "virtengineAddress": {
+      "type": "string",
+      "pattern": "^virtengine1[a-z0-9]{32,58}$",
+      "description": "VirtEngine bech32 address"
+    },
+    "orderReference": {
+      "type": "object",
+      "required": ["order_id", "owner_addr", "dseq", "gseq", "oseq"],
+      "properties": {
+        "order_id": {
+          "type": "string",
+          "description": "Unique order identifier"
+        },
+        "owner_addr": {
+          "$ref": "#/$defs/virtengineAddress"
+        },
+        "dseq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Deployment sequence"
+        },
+        "gseq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Group sequence"
+        },
+        "oseq": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Order sequence"
+        }
+      },
+      "additionalProperties": false
+    },
+    "providerReference": {
+      "type": "object",
+      "required": ["provider_addr"],
+      "properties": {
+        "provider_addr": {
+          "$ref": "#/$defs/virtengineAddress"
+        },
+        "provider_name": {
+          "type": "string",
+          "maxLength": 100
+        },
+        "lease_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "deploymentReference": {
+      "type": "object",
+      "required": ["deployment_id", "owner_addr", "dseq"],
+      "properties": {
+        "deployment_id": {
+          "type": "string"
+        },
+        "owner_addr": {
+          "$ref": "#/$defs/virtengineAddress"
+        },
+        "dseq": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "encryptedPayloadEnvelope": {
+      "type": "object",
+      "required": [
+        "version",
+        "algorithm_id",
+        "algorithm_version",
+        "recipient_key_ids",
+        "nonce",
+        "ciphertext",
+        "sender_signature",
+        "sender_pub_key"
+      ],
+      "properties": {
+        "version": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1,
+          "description": "Envelope format version"
+        },
+        "algorithm_id": {
+          "type": "string",
+          "enum": [
+            "X25519-XSALSA20-POLY1305",
+            "AGE-X25519"
+          ],
+          "description": "Encryption algorithm identifier"
+        },
+        "algorithm_version": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Algorithm version"
+        },
+        "recipient_key_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{40}$"
+          },
+          "minItems": 1,
+          "maxItems": 10,
+          "uniqueItems": true,
+          "description": "Key fingerprints of recipients"
+        },
+        "recipient_public_keys": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "description": "Optional recipient public keys"
+        },
+        "encrypted_keys": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "description": "Per-recipient encrypted data keys"
+        },
+        "wrapped_keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/wrappedKeyEntry"
+          },
+          "description": "Wrapped DEKs per recipient"
+        },
+        "nonce": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "Unique nonce for encryption"
+        },
+        "ciphertext": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "Encrypted payload data"
+        },
+        "sender_signature": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "Signature for authenticity"
+        },
+        "sender_pub_key": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "Sender's public key"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Optional metadata"
+        }
+      },
+      "additionalProperties": false
+    },
+    "wrappedKeyEntry": {
+      "type": "object",
+      "required": ["recipient_id", "wrapped_key"],
+      "properties": {
+        "recipient_id": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "wrapped_key": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "algorithm": {
+          "type": "string"
+        },
+        "ephemeral_pub_key": {
+          "type": "string",
+          "contentEncoding": "base64"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ticketMessage": {
+      "type": "object",
+      "required": [
+        "message_id",
+        "sender_addr",
+        "sender_role",
+        "created_at",
+        "content_envelope"
+      ],
+      "properties": {
+        "message_id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "sender_addr": {
+          "$ref": "#/$defs/virtengineAddress"
+        },
+        "sender_role": {
+          "type": "string",
+          "enum": [
+            "customer",
+            "support_agent",
+            "moderator",
+            "administrator",
+            "service_provider",
+            "system"
+          ]
+        },
+        "created_at": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "content_envelope": {
+          "$ref": "#/$defs/encryptedPayloadEnvelope"
+        },
+        "is_internal": {
+          "type": "boolean",
+          "default": false,
+          "description": "Internal notes not visible to customer"
+        }
+      },
+      "additionalProperties": false
+    },
+    "attachmentRef": {
+      "type": "object",
+      "required": [
+        "attachment_id",
+        "file_name",
+        "content_type",
+        "size_bytes",
+        "storage_location",
+        "uploaded_at",
+        "uploaded_by",
+        "checksum_sha256",
+        "key_envelope"
+      ],
+      "properties": {
+        "attachment_id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "file_name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 255,
+          "pattern": "^[^\\\\/:*?\"<>|]+$"
+        },
+        "content_type": {
+          "type": "string",
+          "enum": [
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp",
+            "application/pdf",
+            "text/plain",
+            "text/csv",
+            "application/json",
+            "application/zip",
+            "application/gzip",
+            "video/mp4",
+            "video/webm"
+          ],
+          "description": "Allowed MIME types"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 52428800,
+          "description": "File size (max 50MB)"
+        },
+        "storage_location": {
+          "type": "string",
+          "description": "IPFS CID or storage path"
+        },
+        "uploaded_at": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "uploaded_by": {
+          "$ref": "#/$defs/virtengineAddress"
+        },
+        "checksum_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "key_envelope": {
+          "$ref": "#/$defs/encryptedPayloadEnvelope"
+        }
+      },
+      "additionalProperties": false
+    },
+    "retentionPolicyRef": {
+      "type": "object",
+      "required": ["policy_id", "retention_days", "delete_after_closed"],
+      "properties": {
+        "policy_id": {
+          "type": "string",
+          "enum": [
+            "gdpr",
+            "ccpa",
+            "us_general",
+            "uk_gdpr",
+            "global",
+            "legal_hold"
+          ]
+        },
+        "retention_days": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3650,
+          "description": "Days to retain after closure (0 for indefinite)"
+        },
+        "delete_after_closed": {
+          "type": "boolean",
+          "description": "Whether to delete after retention period"
+        },
+        "archive_after_days": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Days before archiving to cold storage"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "enum": ["CLOSED", "CANCELLED"]
+          }
+        }
+      },
+      "then": {
+        "required": ["closed_at"]
+      }
+    }
+  ]
+}

--- a/tests/support_ticket_schema_test.go
+++ b/tests/support_ticket_schema_test.go
@@ -1,0 +1,772 @@
+package tests
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// SupportTicket represents a customer support ticket
+type SupportTicket struct {
+	TicketID           string                    `json:"ticket_id"`
+	Version            uint32                    `json:"version"`
+	Category           string                    `json:"category"`
+	Priority           string                    `json:"priority"`
+	Tags               []string                  `json:"tags,omitempty"`
+	Status             string                    `json:"status"`
+	CreatedAt          int64                     `json:"created_at"`
+	UpdatedAt          int64                     `json:"updated_at"`
+	ClosedAt           int64                     `json:"closed_at,omitempty"`
+	CustomerAddress    string                    `json:"customer_address"`
+	AssignedAgentAddr  string                    `json:"assigned_agent_addr,omitempty"`
+	OrderRef           *OrderReference           `json:"order_ref,omitempty"`
+	ProviderRef        *ProviderReference        `json:"provider_ref,omitempty"`
+	DeploymentRef      *DeploymentReference      `json:"deployment_ref,omitempty"`
+	RelatedTickets     []string                  `json:"related_tickets,omitempty"`
+	Subject            string                    `json:"subject"`
+	DescriptionEnvelope *EncryptedPayloadEnvelope `json:"description_envelope"`
+	Messages           []TicketMessage           `json:"messages,omitempty"`
+	Attachments        []AttachmentRef           `json:"attachments,omitempty"`
+	ContactEnvelope    *EncryptedPayloadEnvelope `json:"contact_envelope,omitempty"`
+	RetentionPolicy    RetentionPolicyRef        `json:"retention_policy"`
+	JurisdictionCode   string                    `json:"jurisdiction_code"`
+	ConsentRecordID    string                    `json:"consent_record_id,omitempty"`
+	Metadata           map[string]string         `json:"metadata,omitempty"`
+}
+
+type OrderReference struct {
+	OrderID   string `json:"order_id"`
+	OwnerAddr string `json:"owner_addr"`
+	DSeq      uint64 `json:"dseq"`
+	GSeq      uint32 `json:"gseq"`
+	OSeq      uint32 `json:"oseq"`
+}
+
+type ProviderReference struct {
+	ProviderAddr string `json:"provider_addr"`
+	ProviderName string `json:"provider_name,omitempty"`
+	LeaseID      string `json:"lease_id,omitempty"`
+}
+
+type DeploymentReference struct {
+	DeploymentID string `json:"deployment_id"`
+	OwnerAddr    string `json:"owner_addr"`
+	DSeq         uint64 `json:"dseq"`
+}
+
+type EncryptedPayloadEnvelope struct {
+	Version             uint32            `json:"version"`
+	AlgorithmID         string            `json:"algorithm_id"`
+	AlgorithmVersion    uint32            `json:"algorithm_version"`
+	RecipientKeyIDs     []string          `json:"recipient_key_ids"`
+	RecipientPublicKeys []string          `json:"recipient_public_keys,omitempty"`
+	EncryptedKeys       []string          `json:"encrypted_keys,omitempty"`
+	WrappedKeys         []WrappedKeyEntry `json:"wrapped_keys,omitempty"`
+	Nonce               string            `json:"nonce"`
+	Ciphertext          string            `json:"ciphertext"`
+	SenderSignature     string            `json:"sender_signature"`
+	SenderPubKey        string            `json:"sender_pub_key"`
+	Metadata            map[string]string `json:"metadata,omitempty"`
+}
+
+type WrappedKeyEntry struct {
+	RecipientID     string `json:"recipient_id"`
+	WrappedKey      string `json:"wrapped_key"`
+	Algorithm       string `json:"algorithm,omitempty"`
+	EphemeralPubKey string `json:"ephemeral_pub_key,omitempty"`
+}
+
+type TicketMessage struct {
+	MessageID       string                    `json:"message_id"`
+	SenderAddr      string                    `json:"sender_addr"`
+	SenderRole      string                    `json:"sender_role"`
+	CreatedAt       int64                     `json:"created_at"`
+	ContentEnvelope *EncryptedPayloadEnvelope `json:"content_envelope"`
+	IsInternal      bool                      `json:"is_internal"`
+}
+
+type AttachmentRef struct {
+	AttachmentID    string                    `json:"attachment_id"`
+	FileName        string                    `json:"file_name"`
+	ContentType     string                    `json:"content_type"`
+	SizeBytes       int64                     `json:"size_bytes"`
+	StorageLocation string                    `json:"storage_location"`
+	UploadedAt      int64                     `json:"uploaded_at"`
+	UploadedBy      string                    `json:"uploaded_by"`
+	ChecksumSHA256  string                    `json:"checksum_sha256"`
+	KeyEnvelope     *EncryptedPayloadEnvelope `json:"key_envelope"`
+}
+
+type RetentionPolicyRef struct {
+	PolicyID         string `json:"policy_id"`
+	RetentionDays    int    `json:"retention_days"`
+	DeleteAfterClosed bool   `json:"delete_after_closed"`
+	ArchiveAfterDays int    `json:"archive_after_days,omitempty"`
+}
+
+// Valid values
+var validStatuses = []string{
+	"OPEN", "ASSIGNED", "IN_PROGRESS", "AWAITING_CUSTOMER",
+	"AWAITING_PROVIDER", "ESCALATED", "ON_HOLD", "RESOLVED",
+	"CLOSED", "CANCELLED",
+}
+
+var validCategories = []string{
+	"billing", "technical", "identity", "marketplace", "security", "other",
+}
+
+var validPriorities = []string{
+	"low", "medium", "high", "critical",
+}
+
+var validSenderRoles = []string{
+	"customer", "support_agent", "moderator", "administrator", "service_provider", "system",
+}
+
+var validPolicyIDs = []string{
+	"gdpr", "ccpa", "us_general", "uk_gdpr", "global", "legal_hold",
+}
+
+var validAlgorithms = []string{
+	"X25519-XSALSA20-POLY1305", "AGE-X25519",
+}
+
+var validContentTypes = []string{
+	"image/png", "image/jpeg", "image/gif", "image/webp",
+	"application/pdf", "text/plain", "text/csv", "application/json",
+	"application/zip", "application/gzip", "video/mp4", "video/webm",
+}
+
+// State transition rules
+var allowedTransitions = map[string][]string{
+	"OPEN":              {"ASSIGNED", "CANCELLED"},
+	"ASSIGNED":          {"IN_PROGRESS"},
+	"IN_PROGRESS":       {"AWAITING_CUSTOMER", "AWAITING_PROVIDER", "ESCALATED", "ON_HOLD", "RESOLVED"},
+	"AWAITING_CUSTOMER": {"IN_PROGRESS"},
+	"AWAITING_PROVIDER": {"IN_PROGRESS"},
+	"ESCALATED":         {"IN_PROGRESS", "RESOLVED"},
+	"ON_HOLD":           {"IN_PROGRESS"},
+	"RESOLVED":          {"CLOSED", "IN_PROGRESS"},
+	"CLOSED":            {},
+	"CANCELLED":         {},
+}
+
+// Regex patterns
+var uuidV7Pattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+var virtengineAddrPattern = regexp.MustCompile(`^virtengine1[a-z0-9]{32,58}$`)
+var keyFingerprintPattern = regexp.MustCompile(`^[a-f0-9]{40}$`)
+var sha256Pattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
+var jurisdictionPattern = regexp.MustCompile(`^[A-Z]{2}(-[A-Z0-9]{1,3})?$`)
+
+// contains checks if a slice contains a string
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateTicket validates a support ticket against the schema
+func ValidateTicket(t *SupportTicket) []string {
+	var errors []string
+
+	// Required field validations
+	if t.TicketID == "" {
+		errors = append(errors, "ticket_id is required")
+	} else if !uuidV7Pattern.MatchString(t.TicketID) {
+		errors = append(errors, "ticket_id must be a valid UUID v7")
+	}
+
+	if t.Version != 1 {
+		errors = append(errors, "version must be 1")
+	}
+
+	if !contains(validCategories, t.Category) {
+		errors = append(errors, "invalid category: "+t.Category)
+	}
+
+	if !contains(validPriorities, t.Priority) {
+		errors = append(errors, "invalid priority: "+t.Priority)
+	}
+
+	if !contains(validStatuses, t.Status) {
+		errors = append(errors, "invalid status: "+t.Status)
+	}
+
+	if t.CreatedAt <= 0 {
+		errors = append(errors, "created_at must be a positive Unix timestamp")
+	}
+
+	if t.UpdatedAt <= 0 {
+		errors = append(errors, "updated_at must be a positive Unix timestamp")
+	}
+
+	if t.UpdatedAt < t.CreatedAt {
+		errors = append(errors, "updated_at must be >= created_at")
+	}
+
+	// Terminal states require closed_at
+	if t.Status == "CLOSED" || t.Status == "CANCELLED" {
+		if t.ClosedAt <= 0 {
+			errors = append(errors, "closed_at is required for terminal states")
+		}
+	}
+
+	if t.CustomerAddress == "" {
+		errors = append(errors, "customer_address is required")
+	} else if !virtengineAddrPattern.MatchString(t.CustomerAddress) {
+		errors = append(errors, "customer_address must be a valid VirtEngine address")
+	}
+
+	if t.AssignedAgentAddr != "" && !virtengineAddrPattern.MatchString(t.AssignedAgentAddr) {
+		errors = append(errors, "assigned_agent_addr must be a valid VirtEngine address")
+	}
+
+	if t.Subject == "" {
+		errors = append(errors, "subject is required")
+	} else if len(t.Subject) < 5 {
+		errors = append(errors, "subject must be at least 5 characters")
+	} else if len(t.Subject) > 200 {
+		errors = append(errors, "subject must not exceed 200 characters")
+	}
+
+	if t.DescriptionEnvelope == nil {
+		errors = append(errors, "description_envelope is required")
+	} else {
+		envErrors := validateEnvelope(t.DescriptionEnvelope, "description_envelope")
+		errors = append(errors, envErrors...)
+	}
+
+	// Validate retention policy
+	if t.RetentionPolicy.PolicyID == "" {
+		errors = append(errors, "retention_policy.policy_id is required")
+	} else if !contains(validPolicyIDs, t.RetentionPolicy.PolicyID) {
+		errors = append(errors, "invalid retention_policy.policy_id: "+t.RetentionPolicy.PolicyID)
+	}
+
+	if t.RetentionPolicy.RetentionDays < 0 || t.RetentionPolicy.RetentionDays > 3650 {
+		errors = append(errors, "retention_policy.retention_days must be between 0 and 3650")
+	}
+
+	// Validate jurisdiction code
+	if t.JurisdictionCode == "" {
+		errors = append(errors, "jurisdiction_code is required")
+	} else if !jurisdictionPattern.MatchString(t.JurisdictionCode) {
+		errors = append(errors, "jurisdiction_code must be a valid ISO 3166-1 alpha-2 code")
+	}
+
+	// Validate messages
+	for i, msg := range t.Messages {
+		msgErrors := validateMessage(&msg, i)
+		errors = append(errors, msgErrors...)
+	}
+
+	// Validate attachments
+	for i, att := range t.Attachments {
+		attErrors := validateAttachment(&att, i)
+		errors = append(errors, attErrors...)
+	}
+
+	// Validate contact envelope if present
+	if t.ContactEnvelope != nil {
+		envErrors := validateEnvelope(t.ContactEnvelope, "contact_envelope")
+		errors = append(errors, envErrors...)
+	}
+
+	// Validate tags
+	if len(t.Tags) > 10 {
+		errors = append(errors, "tags must not exceed 10 items")
+	}
+	for i, tag := range t.Tags {
+		if len(tag) == 0 || len(tag) > 50 {
+			errors = append(errors, "tags["+string(rune('0'+i))+"] must be 1-50 characters")
+		}
+	}
+
+	// Validate related tickets
+	if len(t.RelatedTickets) > 20 {
+		errors = append(errors, "related_tickets must not exceed 20 items")
+	}
+	for i, rt := range t.RelatedTickets {
+		if !uuidV7Pattern.MatchString(rt) {
+			errors = append(errors, "related_tickets["+string(rune('0'+i))+"] must be a valid UUID v7")
+		}
+	}
+
+	return errors
+}
+
+func validateEnvelope(e *EncryptedPayloadEnvelope, prefix string) []string {
+	var errors []string
+
+	if e.Version != 1 {
+		errors = append(errors, prefix+".version must be 1")
+	}
+
+	if !contains(validAlgorithms, e.AlgorithmID) {
+		errors = append(errors, prefix+".algorithm_id must be a supported algorithm")
+	}
+
+	if e.AlgorithmVersion < 1 {
+		errors = append(errors, prefix+".algorithm_version must be >= 1")
+	}
+
+	if len(e.RecipientKeyIDs) == 0 {
+		errors = append(errors, prefix+".recipient_key_ids must have at least one entry")
+	}
+
+	if len(e.RecipientKeyIDs) > 10 {
+		errors = append(errors, prefix+".recipient_key_ids must not exceed 10 entries")
+	}
+
+	if e.Nonce == "" {
+		errors = append(errors, prefix+".nonce is required")
+	}
+
+	if e.Ciphertext == "" {
+		errors = append(errors, prefix+".ciphertext is required")
+	}
+
+	if e.SenderSignature == "" {
+		errors = append(errors, prefix+".sender_signature is required")
+	}
+
+	if e.SenderPubKey == "" {
+		errors = append(errors, prefix+".sender_pub_key is required")
+	}
+
+	return errors
+}
+
+func validateMessage(m *TicketMessage, index int) []string {
+	var errors []string
+	prefix := "messages[" + string(rune('0'+index)) + "]"
+
+	if !uuidV7Pattern.MatchString(m.MessageID) {
+		errors = append(errors, prefix+".message_id must be a valid UUID v7")
+	}
+
+	if !virtengineAddrPattern.MatchString(m.SenderAddr) {
+		errors = append(errors, prefix+".sender_addr must be a valid VirtEngine address")
+	}
+
+	if !contains(validSenderRoles, m.SenderRole) {
+		errors = append(errors, prefix+".sender_role is invalid: "+m.SenderRole)
+	}
+
+	if m.CreatedAt <= 0 {
+		errors = append(errors, prefix+".created_at must be a positive Unix timestamp")
+	}
+
+	if m.ContentEnvelope == nil {
+		errors = append(errors, prefix+".content_envelope is required")
+	} else {
+		envErrors := validateEnvelope(m.ContentEnvelope, prefix+".content_envelope")
+		errors = append(errors, envErrors...)
+	}
+
+	return errors
+}
+
+func validateAttachment(a *AttachmentRef, index int) []string {
+	var errors []string
+	prefix := "attachments[" + string(rune('0'+index)) + "]"
+
+	if !uuidV7Pattern.MatchString(a.AttachmentID) {
+		errors = append(errors, prefix+".attachment_id must be a valid UUID v7")
+	}
+
+	if a.FileName == "" || len(a.FileName) > 255 {
+		errors = append(errors, prefix+".file_name must be 1-255 characters")
+	}
+
+	if !contains(validContentTypes, a.ContentType) {
+		errors = append(errors, prefix+".content_type is not allowed: "+a.ContentType)
+	}
+
+	if a.SizeBytes < 1 || a.SizeBytes > 52428800 {
+		errors = append(errors, prefix+".size_bytes must be 1-52428800 (50MB)")
+	}
+
+	if a.StorageLocation == "" {
+		errors = append(errors, prefix+".storage_location is required")
+	}
+
+	if a.UploadedAt <= 0 {
+		errors = append(errors, prefix+".uploaded_at must be a positive Unix timestamp")
+	}
+
+	if !virtengineAddrPattern.MatchString(a.UploadedBy) {
+		errors = append(errors, prefix+".uploaded_by must be a valid VirtEngine address")
+	}
+
+	if !sha256Pattern.MatchString(a.ChecksumSHA256) {
+		errors = append(errors, prefix+".checksum_sha256 must be a valid SHA-256 hash")
+	}
+
+	if a.KeyEnvelope == nil {
+		errors = append(errors, prefix+".key_envelope is required")
+	} else {
+		envErrors := validateEnvelope(a.KeyEnvelope, prefix+".key_envelope")
+		errors = append(errors, envErrors...)
+	}
+
+	return errors
+}
+
+// IsValidTransition checks if a state transition is allowed
+func IsValidTransition(from, to string) bool {
+	allowed, ok := allowedTransitions[from]
+	if !ok {
+		return false
+	}
+	return contains(allowed, to)
+}
+
+// GetRetentionDaysForJurisdiction returns the default retention days for a jurisdiction
+func GetRetentionDaysForJurisdiction(code string) int {
+	// GDPR countries
+	gdprCountries := []string{
+		"AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR",
+		"DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL",
+		"PL", "PT", "RO", "SK", "SI", "ES", "SE",
+	}
+
+	// Extract country code (first 2 chars)
+	if len(code) >= 2 {
+		countryCode := code[:2]
+
+		if countryCode == "GB" {
+			return 730 // UK GDPR
+		}
+
+		for _, c := range gdprCountries {
+			if c == countryCode {
+				return 730 // GDPR - 2 years
+			}
+		}
+
+		if countryCode == "US" {
+			if len(code) > 2 && code[2:] == "-CA" {
+				return 1095 // CCPA - 3 years
+			}
+			return 1825 // US General - 5 years
+		}
+	}
+
+	return 1095 // Global default - 3 years
+}
+
+// Tests
+
+func TestValidateBasicTicket(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "docs", "support", "examples", "basic_ticket.json"))
+	if err != nil {
+		t.Skipf("Example file not found: %v", err)
+	}
+
+	var ticket SupportTicket
+	if err := json.Unmarshal(data, &ticket); err != nil {
+		t.Fatalf("Failed to unmarshal basic_ticket.json: %v", err)
+	}
+
+	errors := ValidateTicket(&ticket)
+	if len(errors) > 0 {
+		t.Errorf("basic_ticket.json validation failed:\n%v", errors)
+	}
+}
+
+func TestValidateMarketplaceTicket(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "docs", "support", "examples", "marketplace_ticket.json"))
+	if err != nil {
+		t.Skipf("Example file not found: %v", err)
+	}
+
+	var ticket SupportTicket
+	if err := json.Unmarshal(data, &ticket); err != nil {
+		t.Fatalf("Failed to unmarshal marketplace_ticket.json: %v", err)
+	}
+
+	errors := ValidateTicket(&ticket)
+	if len(errors) > 0 {
+		t.Errorf("marketplace_ticket.json validation failed:\n%v", errors)
+	}
+}
+
+func TestValidateIdentityTicket(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "docs", "support", "examples", "identity_ticket.json"))
+	if err != nil {
+		t.Skipf("Example file not found: %v", err)
+	}
+
+	var ticket SupportTicket
+	if err := json.Unmarshal(data, &ticket); err != nil {
+		t.Fatalf("Failed to unmarshal identity_ticket.json: %v", err)
+	}
+
+	errors := ValidateTicket(&ticket)
+	if len(errors) > 0 {
+		t.Errorf("identity_ticket.json validation failed:\n%v", errors)
+	}
+}
+
+func TestTicketIDFormat(t *testing.T) {
+	testCases := []struct {
+		id      string
+		isValid bool
+	}{
+		{"019479b8-7c3d-7000-8000-000000000001", true},  // Valid UUID v7
+		{"019479b8-7c3d-7000-9000-000000000001", true},  // Valid UUID v7 (variant 9)
+		{"019479b8-7c3d-7000-a000-000000000001", true},  // Valid UUID v7 (variant a)
+		{"019479b8-7c3d-7000-b000-000000000001", true},  // Valid UUID v7 (variant b)
+		{"019479b8-7c3d-4000-8000-000000000001", false}, // UUID v4, not v7
+		{"not-a-uuid", false},
+		{"", false},
+		{"019479b8-7c3d-7000-c000-000000000001", false}, // Invalid variant
+	}
+
+	for _, tc := range testCases {
+		result := uuidV7Pattern.MatchString(tc.id)
+		if result != tc.isValid {
+			t.Errorf("UUID v7 validation for %q: got %v, want %v", tc.id, result, tc.isValid)
+		}
+	}
+}
+
+func TestVirtEngineAddressFormat(t *testing.T) {
+	testCases := []struct {
+		addr    string
+		isValid bool
+	}{
+		{"virtengine1abc123def456ghi789jkl012mno345pq", true},  // 32 chars after prefix
+		{"virtengine1abcdefghijklmnopqrstuvwxyz012345", true},    // 32 chars after prefix
+		{"virtengine1abc123def456ghi789jkl012mno345pqrstuvwxyz01234567", true}, // 50 chars
+		{"cosmos1abc123def456ghi789jkl012mno345pqr678st", false}, // Wrong prefix
+		{"virtengine1ABC", false}, // Uppercase not allowed
+		{"", false},
+	}
+
+	for _, tc := range testCases {
+		result := virtengineAddrPattern.MatchString(tc.addr)
+		if result != tc.isValid {
+			t.Errorf("VirtEngine address validation for %q: got %v, want %v", tc.addr, result, tc.isValid)
+		}
+	}
+}
+
+func TestStateTransitions(t *testing.T) {
+	testCases := []struct {
+		from    string
+		to      string
+		allowed bool
+	}{
+		{"OPEN", "ASSIGNED", true},
+		{"OPEN", "CANCELLED", true},
+		{"OPEN", "CLOSED", false},
+		{"ASSIGNED", "IN_PROGRESS", true},
+		{"ASSIGNED", "CLOSED", false},
+		{"IN_PROGRESS", "AWAITING_CUSTOMER", true},
+		{"IN_PROGRESS", "RESOLVED", true},
+		{"RESOLVED", "CLOSED", true},
+		{"RESOLVED", "IN_PROGRESS", true}, // Reopen
+		{"CLOSED", "OPEN", false},         // Terminal state
+		{"CANCELLED", "OPEN", false},      // Terminal state
+	}
+
+	for _, tc := range testCases {
+		result := IsValidTransition(tc.from, tc.to)
+		if result != tc.allowed {
+			t.Errorf("Transition %s -> %s: got %v, want %v", tc.from, tc.to, result, tc.allowed)
+		}
+	}
+}
+
+func TestRetentionPolicyByJurisdiction(t *testing.T) {
+	testCases := []struct {
+		code     string
+		expected int
+	}{
+		{"DE", 730},    // Germany - GDPR
+		{"FR", 730},    // France - GDPR
+		{"GB", 730},    // UK - UK GDPR
+		{"US-CA", 1095}, // California - CCPA
+		{"US-NY", 1825}, // New York - US General
+		{"US", 1825},    // US General
+		{"AU", 1095},    // Australia - Global default
+		{"JP", 1095},    // Japan - Global default
+	}
+
+	for _, tc := range testCases {
+		result := GetRetentionDaysForJurisdiction(tc.code)
+		if result != tc.expected {
+			t.Errorf("Retention for %s: got %d, want %d", tc.code, result, tc.expected)
+		}
+	}
+}
+
+func TestTerminalStatesRequireClosedAt(t *testing.T) {
+	ticket := &SupportTicket{
+		TicketID:        "019479b8-7c3d-7000-8000-000000000001",
+		Version:         1,
+		Category:        "technical",
+		Priority:        "medium",
+		Status:          "CLOSED",
+		CreatedAt:       time.Now().Unix(),
+		UpdatedAt:       time.Now().Unix(),
+		CustomerAddress: "virtengine1abc123def456ghi789jkl012mno345pqr678",
+		Subject:         "Test ticket",
+		DescriptionEnvelope: &EncryptedPayloadEnvelope{
+			Version:          1,
+			AlgorithmID:      "X25519-XSALSA20-POLY1305",
+			AlgorithmVersion: 1,
+			RecipientKeyIDs:  []string{"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"},
+			Nonce:            "dGVzdE5vbmNl",
+			Ciphertext:       "dGVzdENpcGhlcnRleHQ=",
+			SenderSignature:  "dGVzdFNpZw==",
+			SenderPubKey:     "dGVzdFB1YktleQ==",
+		},
+		RetentionPolicy: RetentionPolicyRef{
+			PolicyID:         "global",
+			RetentionDays:    1095,
+			DeleteAfterClosed: true,
+		},
+		JurisdictionCode: "US",
+		// Note: ClosedAt is missing
+	}
+
+	errors := ValidateTicket(ticket)
+	found := false
+	for _, e := range errors {
+		if e == "closed_at is required for terminal states" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("Expected validation error for missing closed_at in CLOSED state")
+	}
+}
+
+func TestEnvelopeValidation(t *testing.T) {
+	// Test empty envelope
+	emptyEnv := &EncryptedPayloadEnvelope{}
+	errors := validateEnvelope(emptyEnv, "test")
+	if len(errors) == 0 {
+		t.Error("Expected validation errors for empty envelope")
+	}
+
+	// Test valid envelope
+	validEnv := &EncryptedPayloadEnvelope{
+		Version:          1,
+		AlgorithmID:      "X25519-XSALSA20-POLY1305",
+		AlgorithmVersion: 1,
+		RecipientKeyIDs:  []string{"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"},
+		Nonce:            "dGVzdE5vbmNl",
+		Ciphertext:       "dGVzdENpcGhlcnRleHQ=",
+		SenderSignature:  "dGVzdFNpZw==",
+		SenderPubKey:     "dGVzdFB1YktleQ==",
+	}
+	errors = validateEnvelope(validEnv, "test")
+	if len(errors) != 0 {
+		t.Errorf("Expected no validation errors for valid envelope, got: %v", errors)
+	}
+
+	// Test invalid algorithm
+	invalidAlgEnv := &EncryptedPayloadEnvelope{
+		Version:          1,
+		AlgorithmID:      "INVALID-ALGORITHM",
+		AlgorithmVersion: 1,
+		RecipientKeyIDs:  []string{"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"},
+		Nonce:            "dGVzdE5vbmNl",
+		Ciphertext:       "dGVzdENpcGhlcnRleHQ=",
+		SenderSignature:  "dGVzdFNpZw==",
+		SenderPubKey:     "dGVzdFB1YktleQ==",
+	}
+	errors = validateEnvelope(invalidAlgEnv, "test")
+	found := false
+	for _, e := range errors {
+		if e == "test.algorithm_id must be a supported algorithm" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected validation error for invalid algorithm")
+	}
+}
+
+func TestAttachmentSizeLimit(t *testing.T) {
+	attachment := &AttachmentRef{
+		AttachmentID:    "019479b8-7c3d-7002-8000-000000000001",
+		FileName:        "large_file.zip",
+		ContentType:     "application/zip",
+		SizeBytes:       60 * 1024 * 1024, // 60MB - exceeds 50MB limit
+		StorageLocation: "ipfs://Qm...",
+		UploadedAt:      time.Now().Unix(),
+		UploadedBy:      "virtengine1abc123def456ghi789jkl012mno345pqr678",
+		ChecksumSHA256:  "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
+		KeyEnvelope: &EncryptedPayloadEnvelope{
+			Version:          1,
+			AlgorithmID:      "X25519-XSALSA20-POLY1305",
+			AlgorithmVersion: 1,
+			RecipientKeyIDs:  []string{"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"},
+			Nonce:            "dGVzdE5vbmNl",
+			Ciphertext:       "dGVzdENpcGhlcnRleHQ=",
+			SenderSignature:  "dGVzdFNpZw==",
+			SenderPubKey:     "dGVzdFB1YktleQ==",
+		},
+	}
+
+	errors := validateAttachment(attachment, 0)
+	found := false
+	for _, e := range errors {
+		if e == "attachments[0].size_bytes must be 1-52428800 (50MB)" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected validation error for oversized attachment")
+	}
+}
+
+func TestInvalidContentType(t *testing.T) {
+	attachment := &AttachmentRef{
+		AttachmentID:    "019479b8-7c3d-7002-8000-000000000001",
+		FileName:        "malware.exe",
+		ContentType:     "application/x-msdownload", // Executable - not allowed
+		SizeBytes:       1024,
+		StorageLocation: "ipfs://Qm...",
+		UploadedAt:      time.Now().Unix(),
+		UploadedBy:      "virtengine1abc123def456ghi789jkl012mno345pqr678",
+		ChecksumSHA256:  "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
+		KeyEnvelope: &EncryptedPayloadEnvelope{
+			Version:          1,
+			AlgorithmID:      "X25519-XSALSA20-POLY1305",
+			AlgorithmVersion: 1,
+			RecipientKeyIDs:  []string{"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"},
+			Nonce:            "dGVzdE5vbmNl",
+			Ciphertext:       "dGVzdENpcGhlcnRleHQ=",
+			SenderSignature:  "dGVzdFNpZw==",
+			SenderPubKey:     "dGVzdFB1YktleQ==",
+		},
+	}
+
+	errors := validateAttachment(attachment, 0)
+	found := false
+	for _, e := range errors {
+		if e == "attachments[0].content_type is not allowed: application/x-msdownload" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected validation error for disallowed content type")
+	}
+}


### PR DESCRIPTION
Objective:
Define the support ticket data model, encryption envelope policy, and retention/PII handling rules.

Needs to be done (A–H):
A. Enumerate ticket states, roles, and allowed transitions.
B. Define payload fields (order refs, provider refs, timestamps, attachments).
C. Specify encryption recipients and key rotation strategy.
D. Define retention and deletion policy by jurisdiction.
E. Define audit logging requirements for ticket access.
F. Map schema to x/roles access control rules.
G. Add schema validation tests and examples.
H. Document the support data contract.

Acceptance criteria:
- Ticket schema documented and versioned.
- Encryption policy defines recipients and rotation.
- Retention/PII policy approved.
- Validation tests included.

How it can be done:
- Create a markdown spec and JSON schema in docs.
- Align with x/encryption and x/roles capabilities.

MCP guidance:
- Use Context7 for Cosmos SDK schema conventions if needed.

Deliverables:
- Support ticket schema spec, examples, and validation tests.