### PR TITLE
feat(veid): define verification attestation schema + signer

### DIFF
--- a/_docs/protocols/veid-attestation-schema.md
+++ b/_docs/protocols/veid-attestation-schema.md
@@ -1,0 +1,555 @@
+# VEID Verification Attestation Schema
+
+**Task Reference:** VE-1B  
+**Schema Version:** 1.0.0  
+**Status:** Draft  
+**Last Updated:** 2024-01-15
+
+## Overview
+
+This document specifies the verification attestation schema for VEID verification services. Attestations are cryptographically signed statements that assert the result of an identity verification process.
+
+## Table of Contents
+
+1. [Attestation Schema](#attestation-schema)
+2. [Signature Format](#signature-format)
+3. [Canonical Serialization](#canonical-serialization)
+4. [Key Rotation Policy](#key-rotation-policy)
+5. [Replay Protection](#replay-protection)
+6. [On-Chain Linkage](#on-chain-linkage)
+7. [Audit Logging](#audit-logging)
+8. [Signer Service Contract](#signer-service-contract)
+9. [Example Payloads](#example-payloads)
+
+---
+
+## Attestation Schema
+
+### VerificationAttestation
+
+The core attestation structure that represents a signed verification result.
+
+```json
+{
+  "id": "veid:attestation:<issuer_fingerprint_prefix>:<nonce_prefix>",
+  "schema_version": "1.0.0",
+  "type": "facial_verification",
+  "issuer": {
+    "id": "did:virtengine:validator:<address>",
+    "key_fingerprint": "<sha256_hex_64_chars>",
+    "key_id": "validator-key-001",
+    "validator_address": "virtengine1...",
+    "service_endpoint": "https://veid-signer.virtengine.io/v1"
+  },
+  "subject": {
+    "id": "did:virtengine:<account_address>",
+    "account_address": "virtengine1...",
+    "scope_id": "scope-facial-001",
+    "request_id": "req-20240115-001"
+  },
+  "nonce": "<hex_encoded_32_bytes>",
+  "issued_at": "2024-01-15T10:30:00Z",
+  "expires_at": "2024-02-14T10:30:00Z",
+  "verification_proofs": [
+    {
+      "proof_type": "facial_embedding_match",
+      "content_hash": "sha256:abc123...",
+      "score": 94,
+      "passed": true,
+      "threshold": 80,
+      "timestamp": "2024-01-15T10:29:55Z"
+    }
+  ],
+  "score": 92,
+  "confidence": 95,
+  "model_version": "facial-v2.3.0",
+  "metadata": {
+    "pipeline_version": "1.0.0",
+    "validator_consensus": "5/5"
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2024-01-15T10:30:00Z",
+    "verification_method": "did:virtengine:validator:<address>#validator-key-001",
+    "proof_purpose": "assertionMethod",
+    "proof_value": "<base64_signature>",
+    "nonce": "<same_as_attestation_nonce>",
+    "domain": "veid.virtengine.io"
+  }
+}
+```
+
+### Attestation Types
+
+| Type | Description | Validity Period |
+|------|-------------|-----------------|
+| `facial_verification` | Facial recognition match | 30 days |
+| `liveness_check` | Liveness detection | 30 days |
+| `document_verification` | ID document verification | 1 year |
+| `email_verification` | Email ownership proof | 90 days |
+| `sms_verification` | Phone number verification | 90 days |
+| `domain_verification` | Domain ownership proof | 1 year |
+| `sso_verification` | SSO provider verification | 90 days |
+| `biometric_verification` | Biometric data verification | 30 days |
+| `composite_identity` | Combined identity attestation | 30 days |
+
+### Attestation Type to Scope Type Mapping
+
+| Attestation Type | Scope Type |
+|-----------------|------------|
+| `facial_verification` | `selfie` |
+| `liveness_check` | `face_video` |
+| `document_verification` | `id_document` |
+| `email_verification` | `email_proof` |
+| `sms_verification` | `sms_proof` |
+| `domain_verification` | `domain_verify` |
+| `sso_verification` | `sso_metadata` |
+| `biometric_verification` | `biometric` |
+
+---
+
+## Signature Format
+
+### Supported Algorithms
+
+| Algorithm | Type Identifier | Key Size | Usage |
+|-----------|-----------------|----------|-------|
+| Ed25519 | `Ed25519Signature2020` | 256 bits | **Recommended** |
+| secp256k1 | `EcdsaSecp256k1Signature2019` | 256 bits | Cosmos compatible |
+| sr25519 | `Sr25519Signature2020` | 256 bits | Substrate compatible |
+
+### Proof Structure
+
+```json
+{
+  "type": "Ed25519Signature2020",
+  "created": "2024-01-15T10:30:00Z",
+  "verification_method": "<issuer_id>#<key_id>",
+  "proof_purpose": "assertionMethod",
+  "proof_value": "<base64_encoded_signature>",
+  "nonce": "<attestation_nonce_hex>",
+  "domain": "veid.virtengine.io",
+  "challenge": "<optional_challenge>"
+}
+```
+
+### Key Fingerprint
+
+Key fingerprints are computed as SHA256 hash of the raw public key bytes:
+
+```
+fingerprint = hex(SHA256(public_key_bytes))
+```
+
+The fingerprint is a 64-character hex string.
+
+---
+
+## Canonical Serialization
+
+To ensure deterministic signing and verification, attestations are serialized using canonical JSON:
+
+### Canonicalization Rules
+
+1. **Exclude proof field**: The `proof` field is not included in the signed payload
+2. **UTC timestamps**: All timestamps use RFC3339Nano format in UTC
+3. **Sorted keys**: JSON object keys are lexicographically sorted
+4. **No whitespace**: No unnecessary whitespace in serialization
+5. **Sorted metadata**: Metadata map keys are sorted alphabetically
+
+### Canonical Structure
+
+```json
+{
+  "confidence": 95,
+  "expires_at": "2024-02-14T10:30:00.000000000Z",
+  "id": "veid:attestation:1234567890abcdef:a1b2c3d4e5f6a1b2",
+  "issued_at": "2024-01-15T10:30:00.000000000Z",
+  "issuer": { ... },
+  "metadata": { "key1": "value1", "key2": "value2" },
+  "model_version": "facial-v2.3.0",
+  "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  "schema_version": "1.0.0",
+  "score": 92,
+  "subject": { ... },
+  "type": "facial_verification",
+  "verification_proofs": [ ... ]
+}
+```
+
+### Signing Process
+
+1. Serialize attestation to canonical JSON (excluding `proof`)
+2. Compute SHA256 hash of canonical bytes
+3. Sign hash with signer's private key
+4. Base64-encode signature
+5. Attach proof to attestation
+
+---
+
+## Key Rotation Policy
+
+### Default Policy Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `max_key_age_seconds` | 7,776,000 (90 days) | Maximum key lifetime |
+| `rotation_overlap_seconds` | 604,800 (7 days) | Grace period for in-flight attestations |
+| `min_rotation_notice_seconds` | 259,200 (3 days) | Minimum notice before rotation |
+| `max_pending_keys` | 2 | Maximum successor keys |
+| `require_successor_key` | true | Require successor before rotation |
+| `allow_emergency_revocation` | true | Allow immediate revocation |
+| `min_key_strength` | 256 bits | Minimum key strength |
+
+### Key Lifecycle States
+
+```
+┌─────────┐     ┌────────┐     ┌──────────┐     ┌─────────┐
+│ Pending │────▶│ Active │────▶│ Rotating │────▶│ Expired │
+└─────────┘     └────────┘     └──────────┘     └─────────┘
+                     │                              ▲
+                     │         ┌─────────┐          │
+                     └────────▶│ Revoked │◀─────────┘
+                               └─────────┘
+```
+
+| State | Can Sign | Can Verify | Description |
+|-------|----------|------------|-------------|
+| `pending` | No | No | Awaiting activation |
+| `active` | Yes | Yes | Currently valid |
+| `rotating` | Yes | Yes | Transitioning to new key |
+| `revoked` | No | No | Key has been revoked |
+| `expired` | No | No | Key has expired |
+
+### Revocation Reasons
+
+| Reason | Description | Overlap Period |
+|--------|-------------|----------------|
+| `compromised` | Key was compromised | None (immediate) |
+| `rotation` | Normal key rotation | Full overlap |
+| `decommissioned` | Signer is decommissioned | 7 days |
+| `policy_violation` | Policy violation | None (immediate) |
+| `administrative` | Administrative action | 7 days |
+
+### Key Rotation Process
+
+1. **Generate successor key** in `pending` state
+2. **Activate successor** (old key transitions to `rotating`)
+3. **Overlap period** where both keys are valid
+4. **Revoke old key** after overlap period
+
+---
+
+## Replay Protection
+
+### Nonce Requirements
+
+| Parameter | Value |
+|-----------|-------|
+| Minimum length | 16 bytes |
+| Maximum length | 64 bytes |
+| Default length | 32 bytes |
+| Character encoding | Hex |
+
+### Nonce Validity Window
+
+| Parameter | Default | Range |
+|-----------|---------|-------|
+| Window duration | 1 hour | 5 min - 24 hours |
+| Clock skew tolerance | 5 minutes | ≤ window/2 |
+| Max nonces per issuer | 10,000 | N/A |
+
+### Nonce Rules
+
+1. **Uniqueness**: Each nonce must be unique per issuer within the validity window
+2. **Timestamp binding**: Nonces must be used within clock skew of issuance time
+3. **Issuer binding**: Nonces are bound to issuer key fingerprint
+4. **One-time use**: Once used, a nonce cannot be reused
+5. **Expiry**: Unused nonces expire after the validity window
+
+### Weak Nonce Detection
+
+The following nonces are rejected:
+
+- All zeros (e.g., `0000...0000`)
+- All ones (e.g., `ffff...ffff`)
+- Nonces shorter than 16 bytes
+- Nonces longer than 64 bytes
+- Non-hex encoded nonces
+
+---
+
+## On-Chain Linkage
+
+### Store Key Prefixes
+
+| Prefix | Key Format | Value Type |
+|--------|------------|------------|
+| `0x7C` | `attestation_id` | `VerificationAttestation` |
+| `0x7D` | `subject_address \| attestation_id` | `bool` |
+| `0x7E` | `issuer_fingerprint \| attestation_id` | `bool` |
+| `0x7F` | `attestation_type \| attestation_id` | `bool` |
+| `0x80` | `expires_at \| attestation_id` | `bool` |
+| `0x81` | `nonce_hash` | `NonceRecord` |
+| `0x83` | `key_id` | `SignerKeyInfo` |
+| `0x86` | `signer_id` | `SignerRegistryEntry` |
+| `0x87` | `rotation_id` | `KeyRotationRecord` |
+
+### Verification Flow
+
+```
+1. Receive attestation
+2. Validate schema version
+3. Validate attestation type
+4. Validate issuer (registered, active key)
+5. Validate nonce (unique, not expired)
+6. Validate timestamp (within window)
+7. Validate signature
+8. Validate score/confidence bounds
+9. Store attestation
+10. Link to identity scope
+11. Emit events
+```
+
+---
+
+## Audit Logging
+
+### Event Types
+
+| Event | Description | Emitted When |
+|-------|-------------|--------------|
+| `attestation_created` | New attestation created | Attestation stored |
+| `attestation_revoked` | Attestation revoked | Manual revocation |
+| `attestation_expired` | Attestation expired | Expiry cleanup |
+| `signer_key_registered` | New signer key | Key registration |
+| `signer_key_activated` | Key activated | Key activation |
+| `signer_key_revoked` | Key revoked | Key revocation |
+| `signer_key_rotated` | Key rotation complete | Rotation complete |
+| `nonce_used` | Nonce consumed | Attestation created |
+| `attestation_verified` | Signature verified | Verification complete |
+
+### Event Attributes
+
+All attestation events include:
+
+- `block_height`: Block when event occurred
+- `timestamp`: Event timestamp (Unix)
+- `attestation_id`: Attestation identifier
+- `issuer_id`: Issuer DID
+- `subject_address`: Subject account address
+
+---
+
+## Signer Service Contract
+
+### Service Endpoints
+
+#### POST /v1/attestations
+
+Create a new verification attestation.
+
+**Request:**
+
+```json
+{
+  "subject_address": "virtengine1...",
+  "attestation_type": "facial_verification",
+  "scope_id": "scope-123",
+  "request_id": "req-456",
+  "verification_proofs": [...],
+  "score": 92,
+  "confidence": 95,
+  "model_version": "facial-v2.3.0",
+  "validity_duration_seconds": 2592000
+}
+```
+
+**Response:**
+
+```json
+{
+  "attestation": { ... },
+  "attestation_hash": "<sha256_hex>",
+  "created_at": "2024-01-15T10:30:00Z"
+}
+```
+
+#### GET /v1/attestations/{id}
+
+Retrieve an attestation by ID.
+
+#### GET /v1/signers/{signer_id}/keys
+
+List signer keys.
+
+#### POST /v1/signers/{signer_id}/keys/rotate
+
+Initiate key rotation.
+
+### Authentication
+
+All requests must include:
+
+```
+Authorization: Bearer <validator_jwt>
+X-Validator-Address: virtengine1...
+X-Request-Signature: <ed25519_signature>
+```
+
+### Error Codes
+
+| Code | Description |
+|------|-------------|
+| `INVALID_SUBJECT` | Subject address is invalid |
+| `INVALID_TYPE` | Attestation type is invalid |
+| `NONCE_COLLISION` | Nonce already used |
+| `KEY_NOT_FOUND` | Signing key not found |
+| `KEY_REVOKED` | Signing key has been revoked |
+| `KEY_EXPIRED` | Signing key has expired |
+| `SIGNATURE_FAILED` | Signature generation failed |
+| `RATE_LIMITED` | Too many requests |
+
+---
+
+## Example Payloads
+
+### Facial Verification Attestation
+
+```json
+{
+  "id": "veid:attestation:1234567890abcdef:a1b2c3d4e5f6a1b2",
+  "schema_version": "1.0.0",
+  "type": "facial_verification",
+  "issuer": {
+    "id": "did:virtengine:validator:virtengine1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu",
+    "key_fingerprint": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    "key_id": "validator-key-001",
+    "validator_address": "virtengine1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu",
+    "service_endpoint": "https://veid-signer.virtengine.io/v1"
+  },
+  "subject": {
+    "id": "did:virtengine:virtengine1abc123def456ghi789jkl012mno345pqr678stu",
+    "account_address": "virtengine1abc123def456ghi789jkl012mno345pqr678stu",
+    "scope_id": "scope-facial-001",
+    "request_id": "req-20240115-001"
+  },
+  "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  "issued_at": "2024-01-15T10:30:00Z",
+  "expires_at": "2024-02-14T10:30:00Z",
+  "verification_proofs": [
+    {
+      "proof_type": "facial_embedding_match",
+      "content_hash": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+      "score": 94,
+      "passed": true,
+      "threshold": 80,
+      "timestamp": "2024-01-15T10:29:55Z"
+    },
+    {
+      "proof_type": "liveness_score",
+      "content_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "score": 91,
+      "passed": true,
+      "threshold": 85,
+      "timestamp": "2024-01-15T10:29:57Z"
+    }
+  ],
+  "score": 92,
+  "confidence": 95,
+  "model_version": "facial-v2.3.0",
+  "metadata": {
+    "pipeline_version": "1.0.0",
+    "validator_consensus": "5/5"
+  },
+  "proof": {
+    "type": "Ed25519Signature2020",
+    "created": "2024-01-15T10:30:00Z",
+    "verification_method": "did:virtengine:validator:virtengine1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu#validator-key-001",
+    "proof_purpose": "assertionMethod",
+    "proof_value": "z3MvGcY3pFmYBDPKcSQr8TnqNkQu3yqNqwBmJCHuYU2JqcXNLHw2KwgEv7mFdJx2cFmTMxY4JmNvBpQnE9E3Kw7v",
+    "nonce": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "domain": "veid.virtengine.io"
+  }
+}
+```
+
+### Document Verification Attestation
+
+```json
+{
+  "id": "veid:attestation:abcdef1234567890:b2c3d4e5f6a1b2c3",
+  "schema_version": "1.0.0",
+  "type": "document_verification",
+  "issuer": {
+    "id": "did:virtengine:validator:virtengine1validator123456789...",
+    "key_fingerprint": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    "validator_address": "virtengine1validator123456789..."
+  },
+  "subject": {
+    "id": "did:virtengine:virtengine1user456...",
+    "account_address": "virtengine1user456...",
+    "scope_id": "scope-document-001"
+  },
+  "nonce": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+  "issued_at": "2024-01-15T11:00:00Z",
+  "expires_at": "2025-01-15T11:00:00Z",
+  "verification_proofs": [
+    {
+      "proof_type": "document_authenticity",
+      "content_hash": "sha256:doc123...",
+      "score": 90,
+      "passed": true,
+      "threshold": 80,
+      "timestamp": "2024-01-15T10:59:50Z"
+    },
+    {
+      "proof_type": "ocr_extraction",
+      "content_hash": "sha256:ocr456...",
+      "score": 95,
+      "passed": true,
+      "threshold": 90,
+      "timestamp": "2024-01-15T10:59:52Z"
+    },
+    {
+      "proof_type": "document_face_match",
+      "content_hash": "sha256:face789...",
+      "score": 82,
+      "passed": true,
+      "threshold": 75,
+      "timestamp": "2024-01-15T10:59:55Z"
+    }
+  ],
+  "score": 88,
+  "confidence": 85,
+  "proof": {
+    "type": "EcdsaSecp256k1Signature2019",
+    "created": "2024-01-15T11:00:00Z",
+    "verification_method": "did:virtengine:validator:virtengine1validator123456789...#keys-1",
+    "proof_purpose": "assertionMethod",
+    "proof_value": "...",
+    "nonce": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+  }
+}
+```
+
+---
+
+## Security Considerations
+
+1. **Key Storage**: Signer keys must be stored in hardware security modules (HSMs) or secure enclaves
+2. **Nonce Generation**: Nonces must be generated using cryptographically secure random number generators
+3. **Timestamp Validation**: Always validate timestamps to prevent replay attacks
+4. **Key Rotation**: Rotate keys regularly and immediately upon compromise
+5. **Audit Trail**: Maintain complete audit logs for compliance and forensics
+6. **Rate Limiting**: Implement rate limiting to prevent abuse
+7. **Input Validation**: Validate all input parameters before processing
+
+---
+
+## References
+
+- [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model/)
+- [RFC 8017 - PKCS #1: RSA Cryptography Specifications](https://tools.ietf.org/html/rfc8017)
+- [RFC 8032 - Edwards-Curve Digital Signature Algorithm (EdDSA)](https://tools.ietf.org/html/rfc8032)
+- [VirtEngine VEID Flow Specification](_docs/veid-flow-spec.md)

--- a/x/veid/types/attestation.go
+++ b/x/veid/types/attestation.go
@@ -1,0 +1,689 @@
+// Package types provides VEID module types.
+//
+// This file defines verification attestation schema and signer requirements
+// for VEID verification services.
+//
+// Task Reference: VE-1B - Verification Attestation Schema
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// ============================================================================
+// Attestation Schema Version
+// ============================================================================
+
+const (
+	// AttestationSchemaVersion is the current schema version for attestations
+	AttestationSchemaVersion = "1.0.0"
+
+	// AttestationSchemaVersionMajor is the major version number
+	AttestationSchemaVersionMajor = 1
+
+	// AttestationSchemaVersionMinor is the minor version number
+	AttestationSchemaVersionMinor = 0
+
+	// AttestationSchemaVersionPatch is the patch version number
+	AttestationSchemaVersionPatch = 0
+)
+
+// ============================================================================
+// Attestation Types
+// ============================================================================
+
+// AttestationType identifies what kind of verification the attestation represents
+type AttestationType string
+
+const (
+	// AttestationTypeFacialVerification for facial recognition attestations
+	AttestationTypeFacialVerification AttestationType = "facial_verification"
+
+	// AttestationTypeLivenessCheck for liveness detection attestations
+	AttestationTypeLivenessCheck AttestationType = "liveness_check"
+
+	// AttestationTypeDocumentVerification for ID document verification attestations
+	AttestationTypeDocumentVerification AttestationType = "document_verification"
+
+	// AttestationTypeEmailVerification for email verification attestations
+	AttestationTypeEmailVerification AttestationType = "email_verification"
+
+	// AttestationTypeSMSVerification for SMS/phone verification attestations
+	AttestationTypeSMSVerification AttestationType = "sms_verification"
+
+	// AttestationTypeDomainVerification for domain ownership verification
+	AttestationTypeDomainVerification AttestationType = "domain_verification"
+
+	// AttestationTypeSSOVerification for SSO provider verification
+	AttestationTypeSSOVerification AttestationType = "sso_verification"
+
+	// AttestationTypeBiometricVerification for biometric verification
+	AttestationTypeBiometricVerification AttestationType = "biometric_verification"
+
+	// AttestationTypeCompositeIdentity for combined identity attestations
+	AttestationTypeCompositeIdentity AttestationType = "composite_identity"
+)
+
+// AllAttestationTypes returns all valid attestation types
+func AllAttestationTypes() []AttestationType {
+	return []AttestationType{
+		AttestationTypeFacialVerification,
+		AttestationTypeLivenessCheck,
+		AttestationTypeDocumentVerification,
+		AttestationTypeEmailVerification,
+		AttestationTypeSMSVerification,
+		AttestationTypeDomainVerification,
+		AttestationTypeSSOVerification,
+		AttestationTypeBiometricVerification,
+		AttestationTypeCompositeIdentity,
+	}
+}
+
+// IsValidAttestationType checks if the attestation type is valid
+func IsValidAttestationType(t AttestationType) bool {
+	for _, valid := range AllAttestationTypes() {
+		if t == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// ScopeTypeFromAttestationType maps attestation type to scope type for on-chain linkage
+func ScopeTypeFromAttestationType(t AttestationType) ScopeType {
+	switch t {
+	case AttestationTypeFacialVerification:
+		return ScopeTypeSelfie
+	case AttestationTypeLivenessCheck:
+		return ScopeTypeFaceVideo
+	case AttestationTypeDocumentVerification:
+		return ScopeTypeIDDocument
+	case AttestationTypeEmailVerification:
+		return ScopeTypeEmailProof
+	case AttestationTypeSMSVerification:
+		return ScopeTypeSMSProof
+	case AttestationTypeDomainVerification:
+		return ScopeTypeDomainVerify
+	case AttestationTypeSSOVerification:
+		return ScopeTypeSSOMetadata
+	case AttestationTypeBiometricVerification:
+		return ScopeTypeBiometric
+	case AttestationTypeCompositeIdentity:
+		return ScopeTypeIDDocument // Default to ID document for composite
+	default:
+		return ScopeTypeIDDocument
+	}
+}
+
+// ============================================================================
+// Attestation Proof Types
+// ============================================================================
+
+// AttestationProofType identifies the cryptographic signature algorithm used
+type AttestationProofType string
+
+const (
+	// ProofTypeEd25519 uses Ed25519 signatures (recommended)
+	ProofTypeEd25519 AttestationProofType = "Ed25519Signature2020"
+
+	// ProofTypeSecp256k1 uses secp256k1 ECDSA signatures (Cosmos compatible)
+	ProofTypeSecp256k1 AttestationProofType = "EcdsaSecp256k1Signature2019"
+
+	// ProofTypeSr25519 uses sr25519 signatures (Substrate compatible)
+	ProofTypeSr25519 AttestationProofType = "Sr25519Signature2020"
+)
+
+// AllProofTypes returns all valid proof types
+func AllProofTypes() []AttestationProofType {
+	return []AttestationProofType{
+		ProofTypeEd25519,
+		ProofTypeSecp256k1,
+		ProofTypeSr25519,
+	}
+}
+
+// IsValidProofType checks if the proof type is valid
+func IsValidProofType(t AttestationProofType) bool {
+	for _, valid := range AllProofTypes() {
+		if t == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// Verification Attestation
+// ============================================================================
+
+// VerificationAttestation represents a cryptographically signed attestation
+// of a verification result from a VEID verification service.
+//
+// The attestation follows a simplified W3C Verifiable Credential structure
+// optimized for on-chain storage and verification.
+type VerificationAttestation struct {
+	// ID is the unique identifier for this attestation
+	// Format: "veid:attestation:<issuer_fingerprint>:<nonce_hex>"
+	ID string `json:"id"`
+
+	// SchemaVersion identifies the attestation schema version
+	SchemaVersion string `json:"schema_version"`
+
+	// Type identifies what kind of verification this attestation represents
+	Type AttestationType `json:"type"`
+
+	// Issuer contains information about the signer that created this attestation
+	Issuer AttestationIssuer `json:"issuer"`
+
+	// Subject identifies the identity being attested
+	Subject AttestationSubject `json:"subject"`
+
+	// Nonce is a unique value for replay protection (32 bytes, hex-encoded)
+	Nonce string `json:"nonce"`
+
+	// IssuedAt is when the attestation was created (RFC3339 timestamp)
+	IssuedAt time.Time `json:"issued_at"`
+
+	// ExpiresAt is when the attestation expires (RFC3339 timestamp)
+	ExpiresAt time.Time `json:"expires_at"`
+
+	// VerificationProofs contains evidence from the verification process
+	VerificationProofs []VerificationProofDetail `json:"verification_proofs"`
+
+	// Score is the verification score (0-100)
+	Score uint32 `json:"score"`
+
+	// Confidence is the confidence level of the verification (0-100)
+	Confidence uint32 `json:"confidence"`
+
+	// ModelVersion identifies the ML model version used for verification
+	ModelVersion string `json:"model_version,omitempty"`
+
+	// Metadata contains additional attestation-specific data
+	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Proof contains the cryptographic signature
+	Proof AttestationProof `json:"proof"`
+}
+
+// AttestationIssuer identifies the signer that created the attestation
+type AttestationIssuer struct {
+	// ID is the DID or identifier of the issuer
+	// Format: "did:virtengine:validator:<address>" or "did:virtengine:signer:<fingerprint>"
+	ID string `json:"id"`
+
+	// KeyFingerprint is the SHA256 fingerprint of the signing key (hex-encoded)
+	KeyFingerprint string `json:"key_fingerprint"`
+
+	// KeyID is an optional key identifier for key rotation support
+	KeyID string `json:"key_id,omitempty"`
+
+	// ValidatorAddress is the on-chain validator address (if applicable)
+	ValidatorAddress string `json:"validator_address,omitempty"`
+
+	// ServiceEndpoint is an optional endpoint for the signer service
+	ServiceEndpoint string `json:"service_endpoint,omitempty"`
+}
+
+// AttestationSubject identifies the identity being attested
+type AttestationSubject struct {
+	// ID is the DID of the subject
+	// Format: "did:virtengine:<account_address>"
+	ID string `json:"id"`
+
+	// AccountAddress is the blockchain address of the subject
+	AccountAddress string `json:"account_address"`
+
+	// ScopeID is the identity scope this attestation relates to (if applicable)
+	ScopeID string `json:"scope_id,omitempty"`
+
+	// RequestID links to the original verification request
+	RequestID string `json:"request_id,omitempty"`
+}
+
+// VerificationProofDetail contains evidence from the verification process
+type VerificationProofDetail struct {
+	// ProofType identifies the type of proof (e.g., "facial_match", "liveness_score")
+	ProofType string `json:"proof_type"`
+
+	// ContentHash is the hash of the verified content (without revealing content)
+	ContentHash string `json:"content_hash"`
+
+	// Score is the individual proof score (0-100)
+	Score uint32 `json:"score"`
+
+	// Passed indicates if this proof passed the threshold
+	Passed bool `json:"passed"`
+
+	// Threshold is the required threshold for this proof
+	Threshold uint32 `json:"threshold,omitempty"`
+
+	// Timestamp is when this proof was computed
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// AttestationProof contains the cryptographic signature for the attestation
+type AttestationProof struct {
+	// Type identifies the signature algorithm
+	Type AttestationProofType `json:"type"`
+
+	// Created is when the signature was created
+	Created time.Time `json:"created"`
+
+	// VerificationMethod identifies the key used for signing
+	// Format: "<issuer_id>#<key_id>" or "<issuer_id>#keys-1"
+	VerificationMethod string `json:"verification_method"`
+
+	// ProofPurpose is always "assertionMethod" for attestations
+	ProofPurpose string `json:"proof_purpose"`
+
+	// ProofValue is the base64-encoded signature
+	ProofValue string `json:"proof_value"`
+
+	// Nonce binds the proof to the attestation nonce (prevents proof reuse)
+	Nonce string `json:"nonce"`
+
+	// Domain is an optional domain binding for the signature
+	Domain string `json:"domain,omitempty"`
+
+	// Challenge is an optional challenge that was signed
+	Challenge string `json:"challenge,omitempty"`
+}
+
+// ============================================================================
+// Constructor Functions
+// ============================================================================
+
+// NewVerificationAttestation creates a new verification attestation
+func NewVerificationAttestation(
+	issuer AttestationIssuer,
+	subject AttestationSubject,
+	attestationType AttestationType,
+	nonce []byte,
+	issuedAt time.Time,
+	validityDuration time.Duration,
+	score uint32,
+	confidence uint32,
+) *VerificationAttestation {
+	nonceHex := hex.EncodeToString(nonce)
+	attestationID := fmt.Sprintf("veid:attestation:%s:%s", issuer.KeyFingerprint[:16], nonceHex[:16])
+
+	return &VerificationAttestation{
+		ID:                 attestationID,
+		SchemaVersion:      AttestationSchemaVersion,
+		Type:               attestationType,
+		Issuer:             issuer,
+		Subject:            subject,
+		Nonce:              nonceHex,
+		IssuedAt:           issuedAt,
+		ExpiresAt:          issuedAt.Add(validityDuration),
+		VerificationProofs: make([]VerificationProofDetail, 0),
+		Score:              score,
+		Confidence:         confidence,
+		Metadata:           make(map[string]string),
+	}
+}
+
+// NewAttestationIssuer creates a new attestation issuer
+func NewAttestationIssuer(keyFingerprint string, validatorAddress string) AttestationIssuer {
+	var issuerID string
+	if validatorAddress != "" {
+		issuerID = fmt.Sprintf("did:virtengine:validator:%s", validatorAddress)
+	} else {
+		issuerID = fmt.Sprintf("did:virtengine:signer:%s", keyFingerprint[:16])
+	}
+
+	return AttestationIssuer{
+		ID:               issuerID,
+		KeyFingerprint:   keyFingerprint,
+		ValidatorAddress: validatorAddress,
+	}
+}
+
+// NewAttestationSubject creates a new attestation subject
+func NewAttestationSubject(accountAddress string) AttestationSubject {
+	return AttestationSubject{
+		ID:             fmt.Sprintf("did:virtengine:%s", accountAddress),
+		AccountAddress: accountAddress,
+	}
+}
+
+// NewVerificationProofDetail creates a new verification proof detail
+func NewVerificationProofDetail(
+	proofType string,
+	contentHash string,
+	score uint32,
+	threshold uint32,
+	timestamp time.Time,
+) VerificationProofDetail {
+	return VerificationProofDetail{
+		ProofType:   proofType,
+		ContentHash: contentHash,
+		Score:       score,
+		Passed:      score >= threshold,
+		Threshold:   threshold,
+		Timestamp:   timestamp,
+	}
+}
+
+// NewAttestationProof creates a new attestation proof
+func NewAttestationProof(
+	proofType AttestationProofType,
+	created time.Time,
+	verificationMethod string,
+	signature []byte,
+	nonce string,
+) AttestationProof {
+	return AttestationProof{
+		Type:               proofType,
+		Created:            created,
+		VerificationMethod: verificationMethod,
+		ProofPurpose:       "assertionMethod",
+		ProofValue:         base64.StdEncoding.EncodeToString(signature),
+		Nonce:              nonce,
+	}
+}
+
+// ============================================================================
+// Validation Methods
+// ============================================================================
+
+// Validate validates the verification attestation
+func (a *VerificationAttestation) Validate() error {
+	if a.ID == "" {
+		return ErrInvalidAttestation.Wrap("attestation ID is required")
+	}
+
+	if a.SchemaVersion == "" {
+		return ErrInvalidAttestation.Wrap("schema version is required")
+	}
+
+	if !IsValidAttestationType(a.Type) {
+		return ErrInvalidAttestation.Wrapf("invalid attestation type: %s", a.Type)
+	}
+
+	if err := a.Issuer.Validate(); err != nil {
+		return ErrInvalidAttestation.Wrapf("invalid issuer: %v", err)
+	}
+
+	if err := a.Subject.Validate(); err != nil {
+		return ErrInvalidAttestation.Wrapf("invalid subject: %v", err)
+	}
+
+	if len(a.Nonce) < 32 {
+		return ErrInvalidAttestation.Wrap("nonce must be at least 32 hex characters (16 bytes)")
+	}
+
+	if _, err := hex.DecodeString(a.Nonce); err != nil {
+		return ErrInvalidAttestation.Wrap("nonce must be valid hex encoding")
+	}
+
+	if a.IssuedAt.IsZero() {
+		return ErrInvalidAttestation.Wrap("issued_at is required")
+	}
+
+	if a.ExpiresAt.IsZero() {
+		return ErrInvalidAttestation.Wrap("expires_at is required")
+	}
+
+	if !a.ExpiresAt.After(a.IssuedAt) {
+		return ErrInvalidAttestation.Wrap("expires_at must be after issued_at")
+	}
+
+	if a.Score > 100 {
+		return ErrInvalidAttestation.Wrap("score cannot exceed 100")
+	}
+
+	if a.Confidence > 100 {
+		return ErrInvalidAttestation.Wrap("confidence cannot exceed 100")
+	}
+
+	for i, proof := range a.VerificationProofs {
+		if err := proof.Validate(); err != nil {
+			return ErrInvalidAttestation.Wrapf("invalid verification proof at index %d: %v", i, err)
+		}
+	}
+
+	if err := a.Proof.Validate(); err != nil {
+		return ErrInvalidAttestation.Wrapf("invalid proof: %v", err)
+	}
+
+	return nil
+}
+
+// Validate validates the attestation issuer
+func (i AttestationIssuer) Validate() error {
+	if i.ID == "" {
+		return fmt.Errorf("issuer ID is required")
+	}
+
+	if i.KeyFingerprint == "" {
+		return fmt.Errorf("key fingerprint is required")
+	}
+
+	if len(i.KeyFingerprint) < 32 {
+		return fmt.Errorf("key fingerprint must be at least 32 hex characters")
+	}
+
+	if _, err := hex.DecodeString(i.KeyFingerprint); err != nil {
+		return fmt.Errorf("key fingerprint must be valid hex encoding")
+	}
+
+	return nil
+}
+
+// Validate validates the attestation subject
+func (s AttestationSubject) Validate() error {
+	if s.ID == "" {
+		return fmt.Errorf("subject ID is required")
+	}
+
+	if s.AccountAddress == "" {
+		return fmt.Errorf("account address is required")
+	}
+
+	return nil
+}
+
+// Validate validates the verification proof detail
+func (p VerificationProofDetail) Validate() error {
+	if p.ProofType == "" {
+		return fmt.Errorf("proof type is required")
+	}
+
+	if p.ContentHash == "" {
+		return fmt.Errorf("content hash is required")
+	}
+
+	if p.Score > 100 {
+		return fmt.Errorf("score cannot exceed 100")
+	}
+
+	if p.Timestamp.IsZero() {
+		return fmt.Errorf("timestamp is required")
+	}
+
+	return nil
+}
+
+// Validate validates the attestation proof
+func (p AttestationProof) Validate() error {
+	if !IsValidProofType(p.Type) {
+		return ErrInvalidProof.Wrapf("invalid proof type: %s", p.Type)
+	}
+
+	if p.Created.IsZero() {
+		return ErrInvalidProof.Wrap("proof created timestamp is required")
+	}
+
+	if p.VerificationMethod == "" {
+		return ErrInvalidProof.Wrap("verification method is required")
+	}
+
+	if p.ProofPurpose == "" {
+		return ErrInvalidProof.Wrap("proof purpose is required")
+	}
+
+	if p.ProofValue == "" {
+		return ErrInvalidProof.Wrap("proof value is required")
+	}
+
+	// Verify base64 encoding
+	if _, err := base64.StdEncoding.DecodeString(p.ProofValue); err != nil {
+		return ErrInvalidProof.Wrap("proof value must be valid base64 encoding")
+	}
+
+	if p.Nonce == "" {
+		return ErrInvalidProof.Wrap("proof nonce is required")
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Canonical Serialization
+// ============================================================================
+
+// CanonicalBytes returns the canonical byte representation for signing.
+// The canonical form excludes the proof field and uses deterministic JSON encoding.
+func (a *VerificationAttestation) CanonicalBytes() ([]byte, error) {
+	// Create a copy without the proof for signing
+	canonical := struct {
+		ID                 string                    `json:"id"`
+		SchemaVersion      string                    `json:"schema_version"`
+		Type               AttestationType           `json:"type"`
+		Issuer             AttestationIssuer         `json:"issuer"`
+		Subject            AttestationSubject        `json:"subject"`
+		Nonce              string                    `json:"nonce"`
+		IssuedAt           string                    `json:"issued_at"`
+		ExpiresAt          string                    `json:"expires_at"`
+		VerificationProofs []VerificationProofDetail `json:"verification_proofs"`
+		Score              uint32                    `json:"score"`
+		Confidence         uint32                    `json:"confidence"`
+		ModelVersion       string                    `json:"model_version,omitempty"`
+		Metadata           map[string]string         `json:"metadata,omitempty"`
+	}{
+		ID:                 a.ID,
+		SchemaVersion:      a.SchemaVersion,
+		Type:               a.Type,
+		Issuer:             a.Issuer,
+		Subject:            a.Subject,
+		Nonce:              a.Nonce,
+		IssuedAt:           a.IssuedAt.UTC().Format(time.RFC3339Nano),
+		ExpiresAt:          a.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		VerificationProofs: a.VerificationProofs,
+		Score:              a.Score,
+		Confidence:         a.Confidence,
+		ModelVersion:       a.ModelVersion,
+		Metadata:           a.sortedMetadata(),
+	}
+
+	return json.Marshal(canonical)
+}
+
+// Hash computes the SHA256 hash of the canonical representation
+func (a *VerificationAttestation) Hash() ([]byte, error) {
+	canonicalBytes, err := a.CanonicalBytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute canonical bytes: %w", err)
+	}
+
+	hash := sha256.Sum256(canonicalBytes)
+	return hash[:], nil
+}
+
+// HashHex returns the hex-encoded SHA256 hash
+func (a *VerificationAttestation) HashHex() (string, error) {
+	hash, err := a.Hash()
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash), nil
+}
+
+// sortedMetadata returns metadata with keys sorted for deterministic serialization
+func (a *VerificationAttestation) sortedMetadata() map[string]string {
+	if len(a.Metadata) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(a.Metadata))
+	for k := range a.Metadata {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	sorted := make(map[string]string, len(a.Metadata))
+	for _, k := range keys {
+		sorted[k] = a.Metadata[k]
+	}
+	return sorted
+}
+
+// ToJSON serializes the attestation to JSON
+func (a *VerificationAttestation) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(a, "", "  ")
+}
+
+// AttestationFromJSON deserializes an attestation from JSON
+func AttestationFromJSON(data []byte) (*VerificationAttestation, error) {
+	var a VerificationAttestation
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal attestation: %w", err)
+	}
+	return &a, nil
+}
+
+// ============================================================================
+// Utility Methods
+// ============================================================================
+
+// IsExpired checks if the attestation has expired
+func (a *VerificationAttestation) IsExpired(now time.Time) bool {
+	return now.After(a.ExpiresAt)
+}
+
+// IsValid checks if the attestation is currently valid (not expired and after issuance)
+func (a *VerificationAttestation) IsValid(now time.Time) bool {
+	return now.After(a.IssuedAt) && now.Before(a.ExpiresAt)
+}
+
+// AddVerificationProof adds a verification proof detail
+func (a *VerificationAttestation) AddVerificationProof(proof VerificationProofDetail) {
+	a.VerificationProofs = append(a.VerificationProofs, proof)
+}
+
+// SetProof sets the cryptographic proof on the attestation
+func (a *VerificationAttestation) SetProof(proof AttestationProof) {
+	a.Proof = proof
+}
+
+// SetMetadata sets a metadata key-value pair
+func (a *VerificationAttestation) SetMetadata(key, value string) {
+	if a.Metadata == nil {
+		a.Metadata = make(map[string]string)
+	}
+	a.Metadata[key] = value
+}
+
+// GetProofBytes returns the decoded signature bytes from the proof
+func (a *VerificationAttestation) GetProofBytes() ([]byte, error) {
+	return base64.StdEncoding.DecodeString(a.Proof.ProofValue)
+}
+
+// ToScopeType returns the corresponding scope type for on-chain linkage
+func (a *VerificationAttestation) ToScopeType() ScopeType {
+	return ScopeTypeFromAttestationType(a.Type)
+}
+
+// String returns a string representation of the attestation
+func (a *VerificationAttestation) String() string {
+	return fmt.Sprintf("VerificationAttestation{ID: %s, Type: %s, Subject: %s, Score: %d}",
+		a.ID, a.Type, a.Subject.AccountAddress, a.Score)
+}

--- a/x/veid/types/attestation_keys.go
+++ b/x/veid/types/attestation_keys.go
@@ -1,0 +1,666 @@
+// Package types provides VEID module types.
+//
+// This file defines signer key management, rotation policy, and revocation
+// requirements for VEID verification attestation signers.
+//
+// Task Reference: VE-1B - Verification Attestation Schema
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// ============================================================================
+// Key State Constants
+// ============================================================================
+
+// SignerKeyState represents the lifecycle state of a signer key
+type SignerKeyState string
+
+const (
+	// SignerKeyStateActive indicates the key is currently valid for signing
+	SignerKeyStateActive SignerKeyState = "active"
+
+	// SignerKeyStatePending indicates the key is awaiting activation
+	// Used during key rotation to pre-register successor keys
+	SignerKeyStatePending SignerKeyState = "pending"
+
+	// SignerKeyStateRotating indicates the key is in rotation transition
+	// Both old and new keys are valid during this period
+	SignerKeyStateRotating SignerKeyState = "rotating"
+
+	// SignerKeyStateRevoked indicates the key has been revoked
+	// Attestations signed with revoked keys should be rejected
+	SignerKeyStateRevoked SignerKeyState = "revoked"
+
+	// SignerKeyStateExpired indicates the key has expired naturally
+	SignerKeyStateExpired SignerKeyState = "expired"
+)
+
+// AllSignerKeyStates returns all valid key states
+func AllSignerKeyStates() []SignerKeyState {
+	return []SignerKeyState{
+		SignerKeyStateActive,
+		SignerKeyStatePending,
+		SignerKeyStateRotating,
+		SignerKeyStateRevoked,
+		SignerKeyStateExpired,
+	}
+}
+
+// IsValidSignerKeyState checks if the key state is valid
+func IsValidSignerKeyState(s SignerKeyState) bool {
+	for _, valid := range AllSignerKeyStates() {
+		if s == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// CanSign returns true if keys in this state can create valid signatures
+func (s SignerKeyState) CanSign() bool {
+	return s == SignerKeyStateActive || s == SignerKeyStateRotating
+}
+
+// CanVerify returns true if signatures from keys in this state should be verified
+func (s SignerKeyState) CanVerify() bool {
+	return s == SignerKeyStateActive || s == SignerKeyStateRotating
+}
+
+// ============================================================================
+// Revocation Reason Constants
+// ============================================================================
+
+// KeyRevocationReason indicates why a key was revoked
+type KeyRevocationReason string
+
+const (
+	// RevocationReasonCompromised indicates the key was compromised
+	RevocationReasonCompromised KeyRevocationReason = "compromised"
+
+	// RevocationReasonRotation indicates normal key rotation
+	RevocationReasonRotation KeyRevocationReason = "rotation"
+
+	// RevocationReasonDecommissioned indicates the signer is decommissioned
+	RevocationReasonDecommissioned KeyRevocationReason = "decommissioned"
+
+	// RevocationReasonPolicyViolation indicates policy violation by the signer
+	RevocationReasonPolicyViolation KeyRevocationReason = "policy_violation"
+
+	// RevocationReasonAdministrative indicates administrative revocation
+	RevocationReasonAdministrative KeyRevocationReason = "administrative"
+)
+
+// AllRevocationReasons returns all valid revocation reasons
+func AllRevocationReasons() []KeyRevocationReason {
+	return []KeyRevocationReason{
+		RevocationReasonCompromised,
+		RevocationReasonRotation,
+		RevocationReasonDecommissioned,
+		RevocationReasonPolicyViolation,
+		RevocationReasonAdministrative,
+	}
+}
+
+// IsValidRevocationReason checks if the revocation reason is valid
+func IsValidRevocationReason(r KeyRevocationReason) bool {
+	for _, valid := range AllRevocationReasons() {
+		if r == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// Key Rotation Policy
+// ============================================================================
+
+// SignerKeyPolicy defines the key rotation and management policy
+type SignerKeyPolicy struct {
+	// MaxKeyAgeSeconds is the maximum age of a key before rotation is required
+	// Default: 7776000 (90 days)
+	MaxKeyAgeSeconds int64 `json:"max_key_age_seconds"`
+
+	// RotationOverlapSeconds is how long old and new keys are both valid
+	// This allows attestations in-flight to complete verification
+	// Default: 604800 (7 days)
+	RotationOverlapSeconds int64 `json:"rotation_overlap_seconds"`
+
+	// MinRotationNoticeSeconds is the minimum notice before key rotation
+	// Default: 259200 (3 days)
+	MinRotationNoticeSeconds int64 `json:"min_rotation_notice_seconds"`
+
+	// MaxPendingKeys is the maximum number of pending keys allowed
+	// Default: 2
+	MaxPendingKeys int `json:"max_pending_keys"`
+
+	// RequireSuccessorKey requires a successor key before rotation
+	// Default: true
+	RequireSuccessorKey bool `json:"require_successor_key"`
+
+	// AllowEmergencyRevocation allows immediate revocation without overlap
+	// Default: true (for compromised keys)
+	AllowEmergencyRevocation bool `json:"allow_emergency_revocation"`
+
+	// KeyAlgorithms is the list of allowed key algorithms
+	KeyAlgorithms []AttestationProofType `json:"key_algorithms"`
+
+	// MinKeyStrength is the minimum key strength in bits
+	// Default: 256 for Ed25519
+	MinKeyStrength int `json:"min_key_strength"`
+}
+
+// DefaultSignerKeyPolicy returns the default key rotation policy
+func DefaultSignerKeyPolicy() SignerKeyPolicy {
+	return SignerKeyPolicy{
+		MaxKeyAgeSeconds:         7776000,  // 90 days
+		RotationOverlapSeconds:   604800,   // 7 days
+		MinRotationNoticeSeconds: 259200,   // 3 days
+		MaxPendingKeys:           2,
+		RequireSuccessorKey:      true,
+		AllowEmergencyRevocation: true,
+		KeyAlgorithms: []AttestationProofType{
+			ProofTypeEd25519,
+			ProofTypeSecp256k1,
+		},
+		MinKeyStrength: 256,
+	}
+}
+
+// Validate validates the signer key policy
+func (p SignerKeyPolicy) Validate() error {
+	if p.MaxKeyAgeSeconds <= 0 {
+		return fmt.Errorf("max_key_age_seconds must be positive")
+	}
+
+	if p.RotationOverlapSeconds < 0 {
+		return fmt.Errorf("rotation_overlap_seconds cannot be negative")
+	}
+
+	if p.RotationOverlapSeconds >= p.MaxKeyAgeSeconds {
+		return fmt.Errorf("rotation_overlap_seconds must be less than max_key_age_seconds")
+	}
+
+	if p.MinRotationNoticeSeconds < 0 {
+		return fmt.Errorf("min_rotation_notice_seconds cannot be negative")
+	}
+
+	if p.MaxPendingKeys < 0 {
+		return fmt.Errorf("max_pending_keys cannot be negative")
+	}
+
+	if len(p.KeyAlgorithms) == 0 {
+		return fmt.Errorf("at least one key algorithm must be specified")
+	}
+
+	for _, alg := range p.KeyAlgorithms {
+		if !IsValidProofType(alg) {
+			return fmt.Errorf("invalid key algorithm: %s", alg)
+		}
+	}
+
+	if p.MinKeyStrength < 128 {
+		return fmt.Errorf("min_key_strength must be at least 128 bits")
+	}
+
+	return nil
+}
+
+// IsAlgorithmAllowed checks if a key algorithm is allowed by the policy
+func (p SignerKeyPolicy) IsAlgorithmAllowed(alg AttestationProofType) bool {
+	for _, allowed := range p.KeyAlgorithms {
+		if allowed == alg {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// Signer Key Info
+// ============================================================================
+
+// SignerKeyInfo represents a signer's key with metadata for rotation tracking
+type SignerKeyInfo struct {
+	// KeyID is the unique identifier for this key
+	// Format: "<signer_id>:<sequence_number>" or "<fingerprint_prefix>"
+	KeyID string `json:"key_id"`
+
+	// Fingerprint is the SHA256 fingerprint of the public key (hex-encoded)
+	Fingerprint string `json:"fingerprint"`
+
+	// PublicKey is the raw public key bytes (base64 or hex encoded based on algorithm)
+	PublicKey []byte `json:"public_key"`
+
+	// Algorithm is the key/signature algorithm
+	Algorithm AttestationProofType `json:"algorithm"`
+
+	// State is the current lifecycle state of the key
+	State SignerKeyState `json:"state"`
+
+	// SignerID identifies the signer/validator that owns this key
+	SignerID string `json:"signer_id"`
+
+	// SequenceNumber is the key sequence for this signer (1, 2, 3...)
+	SequenceNumber uint64 `json:"sequence_number"`
+
+	// CreatedAt is when this key was created/registered
+	CreatedAt time.Time `json:"created_at"`
+
+	// ActivatedAt is when this key became active (nil if pending)
+	ActivatedAt *time.Time `json:"activated_at,omitempty"`
+
+	// ExpiresAt is when this key is scheduled to expire
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+
+	// RevokedAt is when this key was revoked (nil if not revoked)
+	RevokedAt *time.Time `json:"revoked_at,omitempty"`
+
+	// RevocationReason is why the key was revoked
+	RevocationReason KeyRevocationReason `json:"revocation_reason,omitempty"`
+
+	// SuccessorKeyID is the ID of the key that replaced this one
+	SuccessorKeyID string `json:"successor_key_id,omitempty"`
+
+	// PredecessorKeyID is the ID of the key this one replaced
+	PredecessorKeyID string `json:"predecessor_key_id,omitempty"`
+
+	// Metadata contains additional key metadata
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// NewSignerKeyInfo creates a new signer key info
+func NewSignerKeyInfo(
+	signerID string,
+	publicKey []byte,
+	algorithm AttestationProofType,
+	sequenceNumber uint64,
+	createdAt time.Time,
+) *SignerKeyInfo {
+	fingerprint := ComputeKeyFingerprint(publicKey)
+	keyID := fmt.Sprintf("%s:%d", signerID, sequenceNumber)
+
+	return &SignerKeyInfo{
+		KeyID:          keyID,
+		Fingerprint:    fingerprint,
+		PublicKey:      publicKey,
+		Algorithm:      algorithm,
+		State:          SignerKeyStatePending,
+		SignerID:       signerID,
+		SequenceNumber: sequenceNumber,
+		CreatedAt:      createdAt,
+		Metadata:       make(map[string]string),
+	}
+}
+
+// ComputeKeyFingerprint computes the SHA256 fingerprint of a public key
+func ComputeKeyFingerprint(publicKey []byte) string {
+	hash := sha256.Sum256(publicKey)
+	return hex.EncodeToString(hash[:])
+}
+
+// Validate validates the signer key info
+func (k *SignerKeyInfo) Validate() error {
+	if k.KeyID == "" {
+		return ErrInvalidSignerKey.Wrap("key_id is required")
+	}
+
+	if k.Fingerprint == "" {
+		return ErrInvalidSignerKey.Wrap("fingerprint is required")
+	}
+
+	if len(k.Fingerprint) != 64 {
+		return ErrInvalidSignerKey.Wrap("fingerprint must be 64 hex characters (SHA256)")
+	}
+
+	if _, err := hex.DecodeString(k.Fingerprint); err != nil {
+		return ErrInvalidSignerKey.Wrap("fingerprint must be valid hex encoding")
+	}
+
+	if len(k.PublicKey) == 0 {
+		return ErrInvalidSignerKey.Wrap("public_key is required")
+	}
+
+	if !IsValidProofType(k.Algorithm) {
+		return ErrInvalidSignerKey.Wrapf("invalid algorithm: %s", k.Algorithm)
+	}
+
+	if !IsValidSignerKeyState(k.State) {
+		return ErrInvalidSignerKey.Wrapf("invalid state: %s", k.State)
+	}
+
+	if k.SignerID == "" {
+		return ErrInvalidSignerKey.Wrap("signer_id is required")
+	}
+
+	if k.CreatedAt.IsZero() {
+		return ErrInvalidSignerKey.Wrap("created_at is required")
+	}
+
+	// Verify fingerprint matches public key
+	expectedFingerprint := ComputeKeyFingerprint(k.PublicKey)
+	if k.Fingerprint != expectedFingerprint {
+		return ErrInvalidSignerKey.Wrap("fingerprint does not match public key")
+	}
+
+	return nil
+}
+
+// Activate activates the key
+func (k *SignerKeyInfo) Activate(activatedAt time.Time, expiresAt time.Time) error {
+	if k.State != SignerKeyStatePending {
+		return fmt.Errorf("can only activate pending keys, current state: %s", k.State)
+	}
+
+	k.State = SignerKeyStateActive
+	k.ActivatedAt = &activatedAt
+	k.ExpiresAt = &expiresAt
+	return nil
+}
+
+// StartRotation marks the key as rotating
+func (k *SignerKeyInfo) StartRotation(successorKeyID string) error {
+	if k.State != SignerKeyStateActive {
+		return fmt.Errorf("can only rotate active keys, current state: %s", k.State)
+	}
+
+	k.State = SignerKeyStateRotating
+	k.SuccessorKeyID = successorKeyID
+	return nil
+}
+
+// Revoke revokes the key
+func (k *SignerKeyInfo) Revoke(revokedAt time.Time, reason KeyRevocationReason) error {
+	if k.State == SignerKeyStateRevoked {
+		return fmt.Errorf("key is already revoked")
+	}
+
+	k.State = SignerKeyStateRevoked
+	k.RevokedAt = &revokedAt
+	k.RevocationReason = reason
+	return nil
+}
+
+// Expire marks the key as expired
+func (k *SignerKeyInfo) Expire() error {
+	if k.State == SignerKeyStateRevoked {
+		return fmt.Errorf("cannot expire revoked key")
+	}
+
+	k.State = SignerKeyStateExpired
+	return nil
+}
+
+// IsActive returns true if the key is currently active for signing
+func (k *SignerKeyInfo) IsActive() bool {
+	return k.State.CanSign()
+}
+
+// IsExpired returns true if the key has expired
+func (k *SignerKeyInfo) IsExpired(now time.Time) bool {
+	if k.ExpiresAt == nil {
+		return false
+	}
+	return now.After(*k.ExpiresAt)
+}
+
+// ShouldRotate returns true if the key should be rotated based on the policy
+func (k *SignerKeyInfo) ShouldRotate(now time.Time, policy SignerKeyPolicy) bool {
+	if k.State != SignerKeyStateActive {
+		return false
+	}
+
+	if k.ActivatedAt == nil {
+		return false
+	}
+
+	keyAge := now.Sub(*k.ActivatedAt).Seconds()
+	return keyAge >= float64(policy.MaxKeyAgeSeconds-policy.MinRotationNoticeSeconds)
+}
+
+// ============================================================================
+// Key Rotation Record
+// ============================================================================
+
+// KeyRotationRecord tracks a key rotation event for audit purposes
+type KeyRotationRecord struct {
+	// RotationID is the unique identifier for this rotation event
+	RotationID string `json:"rotation_id"`
+
+	// SignerID identifies the signer
+	SignerID string `json:"signer_id"`
+
+	// OldKeyID is the key being rotated from
+	OldKeyID string `json:"old_key_id"`
+
+	// OldKeyFingerprint is the fingerprint of the old key
+	OldKeyFingerprint string `json:"old_key_fingerprint"`
+
+	// NewKeyID is the key being rotated to
+	NewKeyID string `json:"new_key_id"`
+
+	// NewKeyFingerprint is the fingerprint of the new key
+	NewKeyFingerprint string `json:"new_key_fingerprint"`
+
+	// InitiatedAt is when the rotation was initiated
+	InitiatedAt time.Time `json:"initiated_at"`
+
+	// CompletedAt is when the rotation was completed (nil if in progress)
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+
+	// OverlapEndsAt is when the overlap period ends
+	OverlapEndsAt time.Time `json:"overlap_ends_at"`
+
+	// Status indicates the rotation status
+	Status KeyRotationStatus `json:"status"`
+
+	// Reason indicates why the rotation was performed
+	Reason KeyRevocationReason `json:"reason"`
+
+	// InitiatedBy indicates who initiated the rotation
+	InitiatedBy string `json:"initiated_by"`
+
+	// BlockHeight is the block height when rotation was initiated
+	BlockHeight int64 `json:"block_height"`
+
+	// Notes contains optional notes about the rotation
+	Notes string `json:"notes,omitempty"`
+}
+
+// KeyRotationStatus represents the status of a key rotation
+type KeyRotationStatus string
+
+const (
+	// RotationStatusPending indicates rotation is pending
+	RotationStatusPending KeyRotationStatus = "pending"
+
+	// RotationStatusInProgress indicates rotation is in progress
+	RotationStatusInProgress KeyRotationStatus = "in_progress"
+
+	// RotationStatusCompleted indicates rotation completed successfully
+	RotationStatusCompleted KeyRotationStatus = "completed"
+
+	// RotationStatusFailed indicates rotation failed
+	RotationStatusFailed KeyRotationStatus = "failed"
+
+	// RotationStatusCancelled indicates rotation was cancelled
+	RotationStatusCancelled KeyRotationStatus = "cancelled"
+)
+
+// NewKeyRotationRecord creates a new key rotation record
+func NewKeyRotationRecord(
+	rotationID string,
+	signerID string,
+	oldKey *SignerKeyInfo,
+	newKey *SignerKeyInfo,
+	initiatedAt time.Time,
+	overlapSeconds int64,
+	reason KeyRevocationReason,
+	initiatedBy string,
+	blockHeight int64,
+) *KeyRotationRecord {
+	return &KeyRotationRecord{
+		RotationID:        rotationID,
+		SignerID:          signerID,
+		OldKeyID:          oldKey.KeyID,
+		OldKeyFingerprint: oldKey.Fingerprint,
+		NewKeyID:          newKey.KeyID,
+		NewKeyFingerprint: newKey.Fingerprint,
+		InitiatedAt:       initiatedAt,
+		OverlapEndsAt:     initiatedAt.Add(time.Duration(overlapSeconds) * time.Second),
+		Status:            RotationStatusInProgress,
+		Reason:            reason,
+		InitiatedBy:       initiatedBy,
+		BlockHeight:       blockHeight,
+	}
+}
+
+// Validate validates the key rotation record
+func (r *KeyRotationRecord) Validate() error {
+	if r.RotationID == "" {
+		return fmt.Errorf("rotation_id is required")
+	}
+
+	if r.SignerID == "" {
+		return fmt.Errorf("signer_id is required")
+	}
+
+	if r.OldKeyID == "" {
+		return fmt.Errorf("old_key_id is required")
+	}
+
+	if r.NewKeyID == "" {
+		return fmt.Errorf("new_key_id is required")
+	}
+
+	if r.InitiatedAt.IsZero() {
+		return fmt.Errorf("initiated_at is required")
+	}
+
+	if r.OverlapEndsAt.IsZero() {
+		return fmt.Errorf("overlap_ends_at is required")
+	}
+
+	return nil
+}
+
+// Complete marks the rotation as completed
+func (r *KeyRotationRecord) Complete(completedAt time.Time) {
+	r.CompletedAt = &completedAt
+	r.Status = RotationStatusCompleted
+}
+
+// Fail marks the rotation as failed
+func (r *KeyRotationRecord) Fail(reason string) {
+	r.Status = RotationStatusFailed
+	r.Notes = reason
+}
+
+// IsOverlapPeriodActive returns true if the overlap period is still active
+func (r *KeyRotationRecord) IsOverlapPeriodActive(now time.Time) bool {
+	return now.Before(r.OverlapEndsAt) && r.Status == RotationStatusInProgress
+}
+
+// ============================================================================
+// Signer Registry Entry
+// ============================================================================
+
+// SignerRegistryEntry represents a registered attestation signer
+type SignerRegistryEntry struct {
+	// SignerID is the unique identifier for the signer
+	SignerID string `json:"signer_id"`
+
+	// Name is the human-readable name of the signer
+	Name string `json:"name"`
+
+	// ValidatorAddress is the associated validator address (if applicable)
+	ValidatorAddress string `json:"validator_address,omitempty"`
+
+	// ActiveKeyID is the currently active key ID
+	ActiveKeyID string `json:"active_key_id"`
+
+	// KeyHistory contains IDs of all keys ever used by this signer
+	KeyHistory []string `json:"key_history"`
+
+	// Policy is the key management policy for this signer
+	Policy SignerKeyPolicy `json:"policy"`
+
+	// RegisteredAt is when the signer was registered
+	RegisteredAt time.Time `json:"registered_at"`
+
+	// LastRotationAt is when the last key rotation occurred
+	LastRotationAt *time.Time `json:"last_rotation_at,omitempty"`
+
+	// Active indicates if the signer is currently active
+	Active bool `json:"active"`
+
+	// DeactivatedAt is when the signer was deactivated
+	DeactivatedAt *time.Time `json:"deactivated_at,omitempty"`
+
+	// Metadata contains additional signer metadata
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// NewSignerRegistryEntry creates a new signer registry entry
+func NewSignerRegistryEntry(
+	signerID string,
+	name string,
+	validatorAddress string,
+	initialKeyID string,
+	registeredAt time.Time,
+) *SignerRegistryEntry {
+	return &SignerRegistryEntry{
+		SignerID:         signerID,
+		Name:             name,
+		ValidatorAddress: validatorAddress,
+		ActiveKeyID:      initialKeyID,
+		KeyHistory:       []string{initialKeyID},
+		Policy:           DefaultSignerKeyPolicy(),
+		RegisteredAt:     registeredAt,
+		Active:           true,
+		Metadata:         make(map[string]string),
+	}
+}
+
+// Validate validates the signer registry entry
+func (e *SignerRegistryEntry) Validate() error {
+	if e.SignerID == "" {
+		return ErrInvalidSignerKey.Wrap("signer_id is required")
+	}
+
+	if e.Name == "" {
+		return ErrInvalidSignerKey.Wrap("name is required")
+	}
+
+	if e.ActiveKeyID == "" && e.Active {
+		return ErrInvalidSignerKey.Wrap("active signer must have an active_key_id")
+	}
+
+	if e.RegisteredAt.IsZero() {
+		return ErrInvalidSignerKey.Wrap("registered_at is required")
+	}
+
+	if err := e.Policy.Validate(); err != nil {
+		return ErrInvalidSignerKey.Wrapf("invalid policy: %v", err)
+	}
+
+	return nil
+}
+
+// RotateKey updates the signer to use a new key
+func (e *SignerRegistryEntry) RotateKey(newKeyID string, rotatedAt time.Time) {
+	e.KeyHistory = append(e.KeyHistory, newKeyID)
+	e.ActiveKeyID = newKeyID
+	e.LastRotationAt = &rotatedAt
+}
+
+// Deactivate deactivates the signer
+func (e *SignerRegistryEntry) Deactivate(deactivatedAt time.Time) {
+	e.Active = false
+	e.DeactivatedAt = &deactivatedAt
+}

--- a/x/veid/types/attestation_keys_test.go
+++ b/x/veid/types/attestation_keys_test.go
@@ -1,0 +1,558 @@
+package types
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+// ============================================================================
+// SignerKeyPolicy Tests
+// ============================================================================
+
+func TestDefaultSignerKeyPolicy(t *testing.T) {
+	policy := DefaultSignerKeyPolicy()
+
+	err := policy.Validate()
+	if err != nil {
+		t.Errorf("default policy should be valid: %v", err)
+	}
+
+	if policy.MaxKeyAgeSeconds != 7776000 {
+		t.Errorf("expected max key age 7776000, got %d", policy.MaxKeyAgeSeconds)
+	}
+
+	if policy.RotationOverlapSeconds != 604800 {
+		t.Errorf("expected rotation overlap 604800, got %d", policy.RotationOverlapSeconds)
+	}
+
+	if !policy.RequireSuccessorKey {
+		t.Error("expected require_successor_key to be true by default")
+	}
+}
+
+func TestSignerKeyPolicy_Validate_Invalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		modify func(*SignerKeyPolicy)
+	}{
+		{
+			name:   "negative max key age",
+			modify: func(p *SignerKeyPolicy) { p.MaxKeyAgeSeconds = -1 },
+		},
+		{
+			name:   "negative overlap",
+			modify: func(p *SignerKeyPolicy) { p.RotationOverlapSeconds = -1 },
+		},
+		{
+			name:   "overlap exceeds max age",
+			modify: func(p *SignerKeyPolicy) { p.RotationOverlapSeconds = p.MaxKeyAgeSeconds + 1 },
+		},
+		{
+			name:   "no key algorithms",
+			modify: func(p *SignerKeyPolicy) { p.KeyAlgorithms = nil },
+		},
+		{
+			name:   "invalid algorithm",
+			modify: func(p *SignerKeyPolicy) { p.KeyAlgorithms = []AttestationProofType{"invalid"} },
+		},
+		{
+			name:   "weak key strength",
+			modify: func(p *SignerKeyPolicy) { p.MinKeyStrength = 64 },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := DefaultSignerKeyPolicy()
+			tc.modify(&policy)
+
+			err := policy.Validate()
+			if err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
+func TestSignerKeyPolicy_IsAlgorithmAllowed(t *testing.T) {
+	policy := DefaultSignerKeyPolicy()
+
+	if !policy.IsAlgorithmAllowed(ProofTypeEd25519) {
+		t.Error("Ed25519 should be allowed by default")
+	}
+
+	if !policy.IsAlgorithmAllowed(ProofTypeSecp256k1) {
+		t.Error("Secp256k1 should be allowed by default")
+	}
+
+	if policy.IsAlgorithmAllowed(ProofTypeSr25519) {
+		t.Error("Sr25519 should not be allowed by default")
+	}
+}
+
+// ============================================================================
+// SignerKeyInfo Tests
+// ============================================================================
+
+func TestSignerKeyInfo_Create(t *testing.T) {
+	now := time.Now().UTC()
+	publicKey := make([]byte, 32)
+	rand.Read(publicKey)
+
+	keyInfo := NewSignerKeyInfo(
+		"validator-001",
+		publicKey,
+		ProofTypeEd25519,
+		1,
+		now,
+	)
+
+	if keyInfo.State != SignerKeyStatePending {
+		t.Errorf("new key should be in pending state, got %s", keyInfo.State)
+	}
+
+	if keyInfo.KeyID != "validator-001:1" {
+		t.Errorf("unexpected key ID: %s", keyInfo.KeyID)
+	}
+
+	if len(keyInfo.Fingerprint) != 64 {
+		t.Errorf("expected 64-char fingerprint, got %d", len(keyInfo.Fingerprint))
+	}
+}
+
+func TestSignerKeyInfo_Validate_Valid(t *testing.T) {
+	now := time.Now().UTC()
+	publicKey := make([]byte, 32)
+	rand.Read(publicKey)
+
+	keyInfo := NewSignerKeyInfo(
+		"validator-001",
+		publicKey,
+		ProofTypeEd25519,
+		1,
+		now,
+	)
+
+	err := keyInfo.Validate()
+	if err != nil {
+		t.Errorf("expected valid key info: %v", err)
+	}
+}
+
+func TestSignerKeyInfo_Validate_FingerprintMismatch(t *testing.T) {
+	now := time.Now().UTC()
+	publicKey := make([]byte, 32)
+	rand.Read(publicKey)
+
+	keyInfo := NewSignerKeyInfo(
+		"validator-001",
+		publicKey,
+		ProofTypeEd25519,
+		1,
+		now,
+	)
+
+	// Corrupt the fingerprint
+	keyInfo.Fingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
+
+	err := keyInfo.Validate()
+	if err == nil {
+		t.Error("expected error for fingerprint mismatch")
+	}
+}
+
+func TestSignerKeyInfo_Lifecycle(t *testing.T) {
+	now := time.Now().UTC()
+	publicKey := make([]byte, 32)
+	rand.Read(publicKey)
+
+	keyInfo := NewSignerKeyInfo(
+		"validator-001",
+		publicKey,
+		ProofTypeEd25519,
+		1,
+		now,
+	)
+
+	// Initial state
+	if keyInfo.IsActive() {
+		t.Error("pending key should not be active")
+	}
+
+	// Activate
+	expiresAt := now.Add(90 * 24 * time.Hour)
+	err := keyInfo.Activate(now, expiresAt)
+	if err != nil {
+		t.Fatalf("failed to activate: %v", err)
+	}
+
+	if keyInfo.State != SignerKeyStateActive {
+		t.Errorf("expected active state, got %s", keyInfo.State)
+	}
+
+	if !keyInfo.IsActive() {
+		t.Error("active key should be active")
+	}
+
+	// Cannot activate again
+	err = keyInfo.Activate(now, expiresAt)
+	if err == nil {
+		t.Error("should not be able to activate non-pending key")
+	}
+
+	// Start rotation
+	err = keyInfo.StartRotation("validator-001:2")
+	if err != nil {
+		t.Fatalf("failed to start rotation: %v", err)
+	}
+
+	if keyInfo.State != SignerKeyStateRotating {
+		t.Errorf("expected rotating state, got %s", keyInfo.State)
+	}
+
+	// Still active during rotation
+	if !keyInfo.IsActive() {
+		t.Error("rotating key should still be active")
+	}
+
+	// Revoke
+	err = keyInfo.Revoke(now, RevocationReasonRotation)
+	if err != nil {
+		t.Fatalf("failed to revoke: %v", err)
+	}
+
+	if keyInfo.State != SignerKeyStateRevoked {
+		t.Errorf("expected revoked state, got %s", keyInfo.State)
+	}
+
+	if keyInfo.IsActive() {
+		t.Error("revoked key should not be active")
+	}
+
+	// Cannot revoke again
+	err = keyInfo.Revoke(now, RevocationReasonCompromised)
+	if err == nil {
+		t.Error("should not be able to revoke already revoked key")
+	}
+}
+
+func TestSignerKeyInfo_ShouldRotate(t *testing.T) {
+	now := time.Now().UTC()
+	publicKey := make([]byte, 32)
+	rand.Read(publicKey)
+
+	keyInfo := NewSignerKeyInfo(
+		"validator-001",
+		publicKey,
+		ProofTypeEd25519,
+		1,
+		now,
+	)
+
+	policy := DefaultSignerKeyPolicy()
+
+	// Pending key should not rotate
+	if keyInfo.ShouldRotate(now, policy) {
+		t.Error("pending key should not need rotation")
+	}
+
+	// Activate key
+	expiresAt := now.Add(90 * 24 * time.Hour)
+	keyInfo.Activate(now, expiresAt)
+
+	// Recently activated key should not need rotation
+	if keyInfo.ShouldRotate(now.Add(1*time.Hour), policy) {
+		t.Error("recently activated key should not need rotation")
+	}
+
+	// Key approaching expiry should need rotation
+	// policy.MaxKeyAgeSeconds - policy.MinRotationNoticeSeconds = 87 days
+	nearExpiry := now.Add(88 * 24 * time.Hour)
+	if !keyInfo.ShouldRotate(nearExpiry, policy) {
+		t.Error("key approaching expiry should need rotation")
+	}
+}
+
+func TestSignerKeyInfo_IsExpired(t *testing.T) {
+	now := time.Now().UTC()
+	publicKey := make([]byte, 32)
+	rand.Read(publicKey)
+
+	keyInfo := NewSignerKeyInfo(
+		"validator-001",
+		publicKey,
+		ProofTypeEd25519,
+		1,
+		now,
+	)
+
+	// No expiry set
+	if keyInfo.IsExpired(now.Add(100 * 365 * 24 * time.Hour)) {
+		t.Error("key without expiry should not be expired")
+	}
+
+	// Set expiry
+	expiresAt := now.Add(24 * time.Hour)
+	keyInfo.Activate(now, expiresAt)
+
+	if keyInfo.IsExpired(now) {
+		t.Error("key should not be expired before expiry")
+	}
+
+	if !keyInfo.IsExpired(now.Add(25 * time.Hour)) {
+		t.Error("key should be expired after expiry")
+	}
+}
+
+// ============================================================================
+// SignerKeyState Tests
+// ============================================================================
+
+func TestSignerKeyState_CanSign(t *testing.T) {
+	tests := []struct {
+		state   SignerKeyState
+		canSign bool
+	}{
+		{SignerKeyStateActive, true},
+		{SignerKeyStateRotating, true},
+		{SignerKeyStatePending, false},
+		{SignerKeyStateRevoked, false},
+		{SignerKeyStateExpired, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.state), func(t *testing.T) {
+			if tc.state.CanSign() != tc.canSign {
+				t.Errorf("expected CanSign=%v for state %s", tc.canSign, tc.state)
+			}
+		})
+	}
+}
+
+func TestSignerKeyState_CanVerify(t *testing.T) {
+	tests := []struct {
+		state     SignerKeyState
+		canVerify bool
+	}{
+		{SignerKeyStateActive, true},
+		{SignerKeyStateRotating, true},
+		{SignerKeyStatePending, false},
+		{SignerKeyStateRevoked, false},
+		{SignerKeyStateExpired, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.state), func(t *testing.T) {
+			if tc.state.CanVerify() != tc.canVerify {
+				t.Errorf("expected CanVerify=%v for state %s", tc.canVerify, tc.state)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// KeyRotationRecord Tests
+// ============================================================================
+
+func TestKeyRotationRecord_Create(t *testing.T) {
+	now := time.Now().UTC()
+	publicKey1 := make([]byte, 32)
+	publicKey2 := make([]byte, 32)
+	rand.Read(publicKey1)
+	rand.Read(publicKey2)
+
+	oldKey := NewSignerKeyInfo("validator-001", publicKey1, ProofTypeEd25519, 1, now.Add(-90*24*time.Hour))
+	newKey := NewSignerKeyInfo("validator-001", publicKey2, ProofTypeEd25519, 2, now)
+
+	record := NewKeyRotationRecord(
+		"rotation-001",
+		"validator-001",
+		oldKey,
+		newKey,
+		now,
+		604800, // 7 days overlap
+		RevocationReasonRotation,
+		"admin",
+		12345,
+	)
+
+	if record.Status != RotationStatusInProgress {
+		t.Errorf("expected in_progress status, got %s", record.Status)
+	}
+
+	expectedOverlapEnd := now.Add(7 * 24 * time.Hour)
+	if !record.OverlapEndsAt.Equal(expectedOverlapEnd) {
+		t.Errorf("unexpected overlap end time: %v", record.OverlapEndsAt)
+	}
+}
+
+func TestKeyRotationRecord_IsOverlapPeriodActive(t *testing.T) {
+	now := time.Now().UTC()
+	publicKey1 := make([]byte, 32)
+	publicKey2 := make([]byte, 32)
+	rand.Read(publicKey1)
+	rand.Read(publicKey2)
+
+	oldKey := NewSignerKeyInfo("validator-001", publicKey1, ProofTypeEd25519, 1, now)
+	newKey := NewSignerKeyInfo("validator-001", publicKey2, ProofTypeEd25519, 2, now)
+
+	record := NewKeyRotationRecord(
+		"rotation-001",
+		"validator-001",
+		oldKey,
+		newKey,
+		now,
+		3600, // 1 hour overlap
+		RevocationReasonRotation,
+		"admin",
+		12345,
+	)
+
+	// During overlap
+	if !record.IsOverlapPeriodActive(now.Add(30 * time.Minute)) {
+		t.Error("overlap should be active during overlap period")
+	}
+
+	// After overlap
+	if record.IsOverlapPeriodActive(now.Add(2 * time.Hour)) {
+		t.Error("overlap should not be active after overlap period")
+	}
+
+	// After completion
+	record.Complete(now.Add(30 * time.Minute))
+	if record.IsOverlapPeriodActive(now.Add(30 * time.Minute)) {
+		t.Error("overlap should not be active after completion")
+	}
+}
+
+// ============================================================================
+// SignerRegistryEntry Tests
+// ============================================================================
+
+func TestSignerRegistryEntry_Create(t *testing.T) {
+	now := time.Now().UTC()
+
+	entry := NewSignerRegistryEntry(
+		"signer-001",
+		"Test Validator",
+		"virtengine1validator...",
+		"signer-001:1",
+		now,
+	)
+
+	if !entry.Active {
+		t.Error("new signer should be active")
+	}
+
+	if len(entry.KeyHistory) != 1 {
+		t.Errorf("expected 1 key in history, got %d", len(entry.KeyHistory))
+	}
+
+	if entry.ActiveKeyID != "signer-001:1" {
+		t.Errorf("unexpected active key ID: %s", entry.ActiveKeyID)
+	}
+}
+
+func TestSignerRegistryEntry_RotateKey(t *testing.T) {
+	now := time.Now().UTC()
+
+	entry := NewSignerRegistryEntry(
+		"signer-001",
+		"Test Validator",
+		"virtengine1validator...",
+		"signer-001:1",
+		now,
+	)
+
+	rotatedAt := now.Add(30 * 24 * time.Hour)
+	entry.RotateKey("signer-001:2", rotatedAt)
+
+	if entry.ActiveKeyID != "signer-001:2" {
+		t.Errorf("expected new active key, got %s", entry.ActiveKeyID)
+	}
+
+	if len(entry.KeyHistory) != 2 {
+		t.Errorf("expected 2 keys in history, got %d", len(entry.KeyHistory))
+	}
+
+	if entry.LastRotationAt == nil || !entry.LastRotationAt.Equal(rotatedAt) {
+		t.Error("last rotation time not updated")
+	}
+}
+
+func TestSignerRegistryEntry_Deactivate(t *testing.T) {
+	now := time.Now().UTC()
+
+	entry := NewSignerRegistryEntry(
+		"signer-001",
+		"Test Validator",
+		"virtengine1validator...",
+		"signer-001:1",
+		now,
+	)
+
+	deactivatedAt := now.Add(24 * time.Hour)
+	entry.Deactivate(deactivatedAt)
+
+	if entry.Active {
+		t.Error("signer should be inactive after deactivation")
+	}
+
+	if entry.DeactivatedAt == nil || !entry.DeactivatedAt.Equal(deactivatedAt) {
+		t.Error("deactivated time not set")
+	}
+}
+
+// ============================================================================
+// Revocation Reason Tests
+// ============================================================================
+
+func TestIsValidRevocationReason(t *testing.T) {
+	validReasons := AllRevocationReasons()
+	for _, r := range validReasons {
+		if !IsValidRevocationReason(r) {
+			t.Errorf("expected %s to be valid", r)
+		}
+	}
+
+	if IsValidRevocationReason(KeyRevocationReason("invalid")) {
+		t.Error("expected invalid reason to be invalid")
+	}
+}
+
+// ============================================================================
+// ComputeKeyFingerprint Tests
+// ============================================================================
+
+func TestComputeKeyFingerprint(t *testing.T) {
+	publicKey := make([]byte, 32)
+	rand.Read(publicKey)
+
+	fp := ComputeKeyFingerprint(publicKey)
+
+	if len(fp) != 64 {
+		t.Errorf("expected 64-char fingerprint, got %d", len(fp))
+	}
+
+	// Verify it's valid hex
+	_, err := hex.DecodeString(fp)
+	if err != nil {
+		t.Errorf("fingerprint should be valid hex: %v", err)
+	}
+
+	// Same input should produce same output
+	fp2 := ComputeKeyFingerprint(publicKey)
+	if fp != fp2 {
+		t.Error("fingerprint should be deterministic")
+	}
+
+	// Different input should produce different output
+	publicKey2 := make([]byte, 32)
+	rand.Read(publicKey2)
+	fp3 := ComputeKeyFingerprint(publicKey2)
+	if fp == fp3 {
+		t.Error("different keys should have different fingerprints")
+	}
+}

--- a/x/veid/types/attestation_nonce.go
+++ b/x/veid/types/attestation_nonce.go
@@ -1,0 +1,457 @@
+// Package types provides VEID module types.
+//
+// This file defines replay protection and nonce tracking for VEID attestations.
+//
+// Task Reference: VE-1B - Verification Attestation Schema
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// ============================================================================
+// Nonce Constants
+// ============================================================================
+
+const (
+	// NonceMinLength is the minimum nonce length in bytes
+	NonceMinLength = 16
+
+	// NonceMaxLength is the maximum nonce length in bytes
+	NonceMaxLength = 64
+
+	// NonceDefaultLength is the default nonce length in bytes
+	NonceDefaultLength = 32
+
+	// NonceWindowDefaultSeconds is the default nonce validity window
+	NonceWindowDefaultSeconds int64 = 3600 // 1 hour
+
+	// NonceWindowMaxSeconds is the maximum nonce validity window
+	NonceWindowMaxSeconds int64 = 86400 // 24 hours
+
+	// NonceWindowMinSeconds is the minimum nonce validity window
+	NonceWindowMinSeconds int64 = 300 // 5 minutes
+
+	// DefaultMaxNoncesPerIssuer is the default max tracked nonces per issuer
+	DefaultMaxNoncesPerIssuer = 10000
+
+	// NonceCleanupBatchSize is the batch size for nonce cleanup operations
+	NonceCleanupBatchSize = 1000
+)
+
+// ============================================================================
+// Nonce Status
+// ============================================================================
+
+// NonceStatus represents the usage status of a nonce
+type NonceStatus string
+
+const (
+	// NonceStatusUnused indicates the nonce has not been used
+	NonceStatusUnused NonceStatus = "unused"
+
+	// NonceStatusUsed indicates the nonce has been used
+	NonceStatusUsed NonceStatus = "used"
+
+	// NonceStatusExpired indicates the nonce has expired without use
+	NonceStatusExpired NonceStatus = "expired"
+
+	// NonceStatusInvalid indicates the nonce is invalid
+	NonceStatusInvalid NonceStatus = "invalid"
+)
+
+// ============================================================================
+// Replay Protection Policy
+// ============================================================================
+
+// ReplayProtectionPolicy defines the replay protection requirements
+type ReplayProtectionPolicy struct {
+	// NonceWindowSeconds is how long a nonce is valid
+	NonceWindowSeconds int64 `json:"nonce_window_seconds"`
+
+	// RequireTimestampBinding requires nonces to be bound to timestamps
+	RequireTimestampBinding bool `json:"require_timestamp_binding"`
+
+	// MaxClockSkewSeconds is the maximum allowed clock skew
+	MaxClockSkewSeconds int64 `json:"max_clock_skew_seconds"`
+
+	// MaxNoncesPerIssuer is the maximum tracked nonces per issuer
+	MaxNoncesPerIssuer int `json:"max_nonces_per_issuer"`
+
+	// RequireIssuerBinding requires nonces to be bound to issuers
+	RequireIssuerBinding bool `json:"require_issuer_binding"`
+
+	// RequireSubjectBinding requires nonces to be bound to subjects
+	RequireSubjectBinding bool `json:"require_subject_binding"`
+
+	// AllowNonceReuse allows nonce reuse after expiry (not recommended)
+	AllowNonceReuse bool `json:"allow_nonce_reuse"`
+
+	// TrackNonceHistory keeps history of used nonces (for audit)
+	TrackNonceHistory bool `json:"track_nonce_history"`
+}
+
+// DefaultReplayProtectionPolicy returns the default replay protection policy
+func DefaultReplayProtectionPolicy() ReplayProtectionPolicy {
+	return ReplayProtectionPolicy{
+		NonceWindowSeconds:      NonceWindowDefaultSeconds,
+		RequireTimestampBinding: true,
+		MaxClockSkewSeconds:     300, // 5 minutes
+		MaxNoncesPerIssuer:      DefaultMaxNoncesPerIssuer,
+		RequireIssuerBinding:    true,
+		RequireSubjectBinding:   false, // Optional for batch attestations
+		AllowNonceReuse:         false,
+		TrackNonceHistory:       true,
+	}
+}
+
+// Validate validates the replay protection policy
+func (p ReplayProtectionPolicy) Validate() error {
+	if p.NonceWindowSeconds < NonceWindowMinSeconds {
+		return fmt.Errorf("nonce_window_seconds must be at least %d", NonceWindowMinSeconds)
+	}
+
+	if p.NonceWindowSeconds > NonceWindowMaxSeconds {
+		return fmt.Errorf("nonce_window_seconds cannot exceed %d", NonceWindowMaxSeconds)
+	}
+
+	if p.MaxClockSkewSeconds < 0 {
+		return fmt.Errorf("max_clock_skew_seconds cannot be negative")
+	}
+
+	if p.MaxClockSkewSeconds > p.NonceWindowSeconds/2 {
+		return fmt.Errorf("max_clock_skew_seconds should not exceed half of nonce_window_seconds")
+	}
+
+	if p.MaxNoncesPerIssuer <= 0 {
+		return fmt.Errorf("max_nonces_per_issuer must be positive")
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Nonce Record
+// ============================================================================
+
+// NonceRecord tracks the usage of an attestation nonce
+type NonceRecord struct {
+	// NonceHash is the SHA256 hash of the nonce (for efficient lookup)
+	NonceHash string `json:"nonce_hash"`
+
+	// IssuerFingerprint is the issuer key fingerprint (for issuer binding)
+	IssuerFingerprint string `json:"issuer_fingerprint"`
+
+	// SubjectAddress is the subject address (for subject binding, optional)
+	SubjectAddress string `json:"subject_address,omitempty"`
+
+	// AttestationType is the type of attestation this nonce was used for
+	AttestationType AttestationType `json:"attestation_type"`
+
+	// Status is the current status of the nonce
+	Status NonceStatus `json:"status"`
+
+	// CreatedAt is when the nonce record was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// UsedAt is when the nonce was used (nil if unused)
+	UsedAt *time.Time `json:"used_at,omitempty"`
+
+	// ExpiresAt is when the nonce expires
+	ExpiresAt time.Time `json:"expires_at"`
+
+	// AttestationID is the ID of the attestation that used this nonce
+	AttestationID string `json:"attestation_id,omitempty"`
+
+	// BlockHeight is the block height when the nonce was used
+	BlockHeight int64 `json:"block_height,omitempty"`
+}
+
+// NewNonceRecord creates a new nonce record
+func NewNonceRecord(
+	nonce []byte,
+	issuerFingerprint string,
+	attestationType AttestationType,
+	createdAt time.Time,
+	windowSeconds int64,
+) *NonceRecord {
+	return &NonceRecord{
+		NonceHash:         ComputeNonceHash(nonce),
+		IssuerFingerprint: issuerFingerprint,
+		AttestationType:   attestationType,
+		Status:            NonceStatusUnused,
+		CreatedAt:         createdAt,
+		ExpiresAt:         createdAt.Add(time.Duration(windowSeconds) * time.Second),
+	}
+}
+
+// ComputeNonceHash computes the SHA256 hash of a nonce
+func ComputeNonceHash(nonce []byte) string {
+	hash := sha256.Sum256(nonce)
+	return hex.EncodeToString(hash[:])
+}
+
+// Validate validates the nonce record
+func (r *NonceRecord) Validate() error {
+	if r.NonceHash == "" {
+		return ErrInvalidNonce.Wrap("nonce_hash is required")
+	}
+
+	if len(r.NonceHash) != 64 {
+		return ErrInvalidNonce.Wrap("nonce_hash must be 64 hex characters (SHA256)")
+	}
+
+	if _, err := hex.DecodeString(r.NonceHash); err != nil {
+		return ErrInvalidNonce.Wrap("nonce_hash must be valid hex encoding")
+	}
+
+	if r.IssuerFingerprint == "" {
+		return ErrInvalidNonce.Wrap("issuer_fingerprint is required")
+	}
+
+	if !IsValidAttestationType(r.AttestationType) {
+		return ErrInvalidNonce.Wrapf("invalid attestation_type: %s", r.AttestationType)
+	}
+
+	if r.CreatedAt.IsZero() {
+		return ErrInvalidNonce.Wrap("created_at is required")
+	}
+
+	if r.ExpiresAt.IsZero() {
+		return ErrInvalidNonce.Wrap("expires_at is required")
+	}
+
+	if !r.ExpiresAt.After(r.CreatedAt) {
+		return ErrInvalidNonce.Wrap("expires_at must be after created_at")
+	}
+
+	return nil
+}
+
+// MarkUsed marks the nonce as used
+func (r *NonceRecord) MarkUsed(usedAt time.Time, attestationID string, blockHeight int64) error {
+	if r.Status == NonceStatusUsed {
+		return ErrNonceAlreadyUsed.Wrap("nonce has already been used")
+	}
+
+	if r.Status == NonceStatusExpired {
+		return ErrNonceExpired.Wrap("nonce has expired")
+	}
+
+	if usedAt.After(r.ExpiresAt) {
+		return ErrNonceExpired.Wrap("nonce has expired at time of use")
+	}
+
+	r.Status = NonceStatusUsed
+	r.UsedAt = &usedAt
+	r.AttestationID = attestationID
+	r.BlockHeight = blockHeight
+	return nil
+}
+
+// MarkExpired marks the nonce as expired
+func (r *NonceRecord) MarkExpired() {
+	if r.Status == NonceStatusUnused {
+		r.Status = NonceStatusExpired
+	}
+}
+
+// IsExpired checks if the nonce has expired
+func (r *NonceRecord) IsExpired(now time.Time) bool {
+	return now.After(r.ExpiresAt)
+}
+
+// IsUsed checks if the nonce has been used
+func (r *NonceRecord) IsUsed() bool {
+	return r.Status == NonceStatusUsed
+}
+
+// CanBeUsed checks if the nonce can be used
+func (r *NonceRecord) CanBeUsed(now time.Time) bool {
+	return r.Status == NonceStatusUnused && !r.IsExpired(now)
+}
+
+// ============================================================================
+// Nonce Validation
+// ============================================================================
+
+// NonceValidationRequest contains parameters for nonce validation
+type NonceValidationRequest struct {
+	// Nonce is the raw nonce bytes
+	Nonce []byte `json:"nonce"`
+
+	// IssuerFingerprint is the expected issuer fingerprint
+	IssuerFingerprint string `json:"issuer_fingerprint"`
+
+	// SubjectAddress is the expected subject address (optional)
+	SubjectAddress string `json:"subject_address,omitempty"`
+
+	// AttestationType is the attestation type
+	AttestationType AttestationType `json:"attestation_type"`
+
+	// Timestamp is the attestation timestamp
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// ValidateNonce validates a nonce for replay protection
+// This function validates the nonce format; actual uniqueness checking
+// requires querying the nonce store.
+func ValidateNonce(nonce []byte) error {
+	if len(nonce) < NonceMinLength {
+		return ErrInvalidNonce.Wrapf("nonce must be at least %d bytes", NonceMinLength)
+	}
+
+	if len(nonce) > NonceMaxLength {
+		return ErrInvalidNonce.Wrapf("nonce cannot exceed %d bytes", NonceMaxLength)
+	}
+
+	// Check for weak nonces (all zeros or all ones)
+	allZero := true
+	allOne := true
+	for _, b := range nonce {
+		if b != 0 {
+			allZero = false
+		}
+		if b != 0xFF {
+			allOne = false
+		}
+	}
+
+	if allZero {
+		return ErrInvalidNonce.Wrap("nonce cannot be all zeros")
+	}
+
+	if allOne {
+		return ErrInvalidNonce.Wrap("nonce cannot be all ones")
+	}
+
+	return nil
+}
+
+// ValidateNonceHex validates a hex-encoded nonce
+func ValidateNonceHex(nonceHex string) error {
+	nonce, err := hex.DecodeString(nonceHex)
+	if err != nil {
+		return ErrInvalidNonce.Wrap("nonce must be valid hex encoding")
+	}
+
+	return ValidateNonce(nonce)
+}
+
+// ============================================================================
+// Nonce Validation Result
+// ============================================================================
+
+// NonceValidationResult contains the result of nonce validation
+type NonceValidationResult struct {
+	// Valid indicates if the nonce is valid for use
+	Valid bool `json:"valid"`
+
+	// NonceHash is the computed nonce hash
+	NonceHash string `json:"nonce_hash"`
+
+	// Error contains the error message if validation failed
+	Error string `json:"error,omitempty"`
+
+	// ExistingRecord contains the existing record if nonce was already used
+	ExistingRecord *NonceRecord `json:"existing_record,omitempty"`
+
+	// TimestampValid indicates if the timestamp is within bounds
+	TimestampValid bool `json:"timestamp_valid"`
+
+	// IssuerBindingValid indicates if issuer binding is valid
+	IssuerBindingValid bool `json:"issuer_binding_valid"`
+}
+
+// NewNonceValidationResultSuccess creates a successful validation result
+func NewNonceValidationResultSuccess(nonceHash string) *NonceValidationResult {
+	return &NonceValidationResult{
+		Valid:              true,
+		NonceHash:          nonceHash,
+		TimestampValid:     true,
+		IssuerBindingValid: true,
+	}
+}
+
+// NewNonceValidationResultFailure creates a failed validation result
+func NewNonceValidationResultFailure(nonceHash string, err string) *NonceValidationResult {
+	return &NonceValidationResult{
+		Valid:     false,
+		NonceHash: nonceHash,
+		Error:     err,
+	}
+}
+
+// ============================================================================
+// Timestamp Validation
+// ============================================================================
+
+// ValidateTimestamp validates an attestation timestamp
+func ValidateTimestamp(
+	timestamp time.Time,
+	now time.Time,
+	policy ReplayProtectionPolicy,
+) error {
+	if !policy.RequireTimestampBinding {
+		return nil
+	}
+
+	// Check if timestamp is in the future (with clock skew allowance)
+	maxFuture := now.Add(time.Duration(policy.MaxClockSkewSeconds) * time.Second)
+	if timestamp.After(maxFuture) {
+		return ErrInvalidTimestamp.Wrap("timestamp is too far in the future")
+	}
+
+	// Check if timestamp is too old (within nonce window + clock skew)
+	minPast := now.Add(-time.Duration(policy.NonceWindowSeconds+policy.MaxClockSkewSeconds) * time.Second)
+	if timestamp.Before(minPast) {
+		return ErrInvalidTimestamp.Wrap("timestamp is too far in the past")
+	}
+
+	return nil
+}
+
+// ============================================================================
+// Nonce History Entry
+// ============================================================================
+
+// NonceHistoryEntry is a compact entry for nonce usage history (for audit)
+type NonceHistoryEntry struct {
+	// NonceHash is the SHA256 hash of the nonce
+	NonceHash string `json:"nonce_hash"`
+
+	// IssuerFingerprint is the issuer key fingerprint (first 16 chars)
+	IssuerFingerprint string `json:"issuer_fingerprint"`
+
+	// AttestationID is the attestation that used this nonce
+	AttestationID string `json:"attestation_id"`
+
+	// UsedAt is when the nonce was used
+	UsedAt time.Time `json:"used_at"`
+
+	// BlockHeight is the block height
+	BlockHeight int64 `json:"block_height"`
+}
+
+// NewNonceHistoryEntry creates a new nonce history entry from a nonce record
+func NewNonceHistoryEntry(record *NonceRecord) *NonceHistoryEntry {
+	if record.UsedAt == nil {
+		return nil
+	}
+
+	issuerFP := record.IssuerFingerprint
+	if len(issuerFP) > 16 {
+		issuerFP = issuerFP[:16]
+	}
+
+	return &NonceHistoryEntry{
+		NonceHash:         record.NonceHash,
+		IssuerFingerprint: issuerFP,
+		AttestationID:     record.AttestationID,
+		UsedAt:            *record.UsedAt,
+		BlockHeight:       record.BlockHeight,
+	}
+}

--- a/x/veid/types/attestation_nonce_test.go
+++ b/x/veid/types/attestation_nonce_test.go
@@ -1,0 +1,538 @@
+package types
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+// ============================================================================
+// NonceRecord Tests
+// ============================================================================
+
+func TestNonceRecord_Create(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	now := time.Now().UTC()
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	record := NewNonceRecord(
+		nonce,
+		fingerprint,
+		AttestationTypeFacialVerification,
+		now,
+		3600, // 1 hour window
+	)
+
+	if record.Status != NonceStatusUnused {
+		t.Errorf("expected unused status, got %s", record.Status)
+	}
+
+	if len(record.NonceHash) != 64 {
+		t.Errorf("expected 64-char hash, got %d", len(record.NonceHash))
+	}
+
+	expectedExpiry := now.Add(1 * time.Hour)
+	if !record.ExpiresAt.Equal(expectedExpiry) {
+		t.Errorf("unexpected expiry time: %v", record.ExpiresAt)
+	}
+}
+
+func TestNonceRecord_Validate_Valid(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	now := time.Now().UTC()
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	record := NewNonceRecord(nonce, fingerprint, AttestationTypeFacialVerification, now, 3600)
+
+	err := record.Validate()
+	if err != nil {
+		t.Errorf("expected valid record: %v", err)
+	}
+}
+
+func TestNonceRecord_Validate_Invalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		modify func(*NonceRecord)
+	}{
+		{
+			name:   "empty nonce hash",
+			modify: func(r *NonceRecord) { r.NonceHash = "" },
+		},
+		{
+			name:   "short nonce hash",
+			modify: func(r *NonceRecord) { r.NonceHash = "abc123" },
+		},
+		{
+			name:   "invalid hex hash",
+			modify: func(r *NonceRecord) { r.NonceHash = "ghij" + r.NonceHash[4:] },
+		},
+		{
+			name:   "empty issuer fingerprint",
+			modify: func(r *NonceRecord) { r.IssuerFingerprint = "" },
+		},
+		{
+			name:   "invalid attestation type",
+			modify: func(r *NonceRecord) { r.AttestationType = AttestationType("invalid") },
+		},
+		{
+			name:   "zero created_at",
+			modify: func(r *NonceRecord) { r.CreatedAt = time.Time{} },
+		},
+		{
+			name:   "zero expires_at",
+			modify: func(r *NonceRecord) { r.ExpiresAt = time.Time{} },
+		},
+		{
+			name:   "expires before created",
+			modify: func(r *NonceRecord) { r.ExpiresAt = r.CreatedAt.Add(-1 * time.Hour) },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nonce := make([]byte, 32)
+			rand.Read(nonce)
+			now := time.Now().UTC()
+			fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+			record := NewNonceRecord(nonce, fingerprint, AttestationTypeFacialVerification, now, 3600)
+			tc.modify(record)
+
+			err := record.Validate()
+			if err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
+func TestNonceRecord_MarkUsed(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	now := time.Now().UTC()
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	record := NewNonceRecord(nonce, fingerprint, AttestationTypeFacialVerification, now, 3600)
+
+	// Can be used initially
+	if !record.CanBeUsed(now.Add(30 * time.Minute)) {
+		t.Error("nonce should be usable within window")
+	}
+
+	// Mark as used
+	usedAt := now.Add(10 * time.Minute)
+	err := record.MarkUsed(usedAt, "attestation-001", 12345)
+	if err != nil {
+		t.Fatalf("failed to mark used: %v", err)
+	}
+
+	if record.Status != NonceStatusUsed {
+		t.Errorf("expected used status, got %s", record.Status)
+	}
+
+	if record.UsedAt == nil || !record.UsedAt.Equal(usedAt) {
+		t.Error("used_at not set correctly")
+	}
+
+	if record.AttestationID != "attestation-001" {
+		t.Errorf("unexpected attestation ID: %s", record.AttestationID)
+	}
+
+	// Cannot be used again
+	if record.CanBeUsed(now.Add(15 * time.Minute)) {
+		t.Error("used nonce should not be usable")
+	}
+
+	err = record.MarkUsed(now.Add(15*time.Minute), "attestation-002", 12346)
+	if err == nil {
+		t.Error("should not be able to mark used nonce as used again")
+	}
+}
+
+func TestNonceRecord_MarkUsed_Expired(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	now := time.Now().UTC()
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	record := NewNonceRecord(nonce, fingerprint, AttestationTypeFacialVerification, now, 3600)
+
+	// Try to use after expiry
+	err := record.MarkUsed(now.Add(2*time.Hour), "attestation-001", 12345)
+	if err == nil {
+		t.Error("should not be able to use expired nonce")
+	}
+}
+
+func TestNonceRecord_MarkUsed_AlreadyExpired(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	now := time.Now().UTC()
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	record := NewNonceRecord(nonce, fingerprint, AttestationTypeFacialVerification, now, 3600)
+	record.MarkExpired()
+
+	err := record.MarkUsed(now.Add(30*time.Minute), "attestation-001", 12345)
+	if err == nil {
+		t.Error("should not be able to use already expired nonce")
+	}
+}
+
+func TestNonceRecord_IsExpired(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	now := time.Now().UTC()
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	record := NewNonceRecord(nonce, fingerprint, AttestationTypeFacialVerification, now, 3600)
+
+	// Not expired within window
+	if record.IsExpired(now.Add(30 * time.Minute)) {
+		t.Error("nonce should not be expired within window")
+	}
+
+	// Expired after window
+	if !record.IsExpired(now.Add(2 * time.Hour)) {
+		t.Error("nonce should be expired after window")
+	}
+}
+
+func TestNonceRecord_CanBeUsed(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	now := time.Now().UTC()
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	record := NewNonceRecord(nonce, fingerprint, AttestationTypeFacialVerification, now, 3600)
+
+	// Can be used within window
+	if !record.CanBeUsed(now.Add(30 * time.Minute)) {
+		t.Error("unused nonce within window should be usable")
+	}
+
+	// Cannot be used after expiry
+	if record.CanBeUsed(now.Add(2 * time.Hour)) {
+		t.Error("expired nonce should not be usable")
+	}
+}
+
+// ============================================================================
+// ReplayProtectionPolicy Tests
+// ============================================================================
+
+func TestDefaultReplayProtectionPolicy(t *testing.T) {
+	policy := DefaultReplayProtectionPolicy()
+
+	err := policy.Validate()
+	if err != nil {
+		t.Errorf("default policy should be valid: %v", err)
+	}
+
+	if policy.NonceWindowSeconds != NonceWindowDefaultSeconds {
+		t.Errorf("unexpected nonce window: %d", policy.NonceWindowSeconds)
+	}
+
+	if !policy.RequireTimestampBinding {
+		t.Error("timestamp binding should be required by default")
+	}
+
+	if !policy.RequireIssuerBinding {
+		t.Error("issuer binding should be required by default")
+	}
+}
+
+func TestReplayProtectionPolicy_Validate_Invalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		modify func(*ReplayProtectionPolicy)
+	}{
+		{
+			name:   "window too short",
+			modify: func(p *ReplayProtectionPolicy) { p.NonceWindowSeconds = 60 },
+		},
+		{
+			name:   "window too long",
+			modify: func(p *ReplayProtectionPolicy) { p.NonceWindowSeconds = 100000 },
+		},
+		{
+			name:   "negative clock skew",
+			modify: func(p *ReplayProtectionPolicy) { p.MaxClockSkewSeconds = -1 },
+		},
+		{
+			name:   "clock skew too large",
+			modify: func(p *ReplayProtectionPolicy) { p.MaxClockSkewSeconds = p.NonceWindowSeconds },
+		},
+		{
+			name:   "zero max nonces",
+			modify: func(p *ReplayProtectionPolicy) { p.MaxNoncesPerIssuer = 0 },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := DefaultReplayProtectionPolicy()
+			tc.modify(&policy)
+
+			err := policy.Validate()
+			if err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
+// ============================================================================
+// ValidateNonce Tests
+// ============================================================================
+
+func TestValidateNonce_Valid(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+
+	err := ValidateNonce(nonce)
+	if err != nil {
+		t.Errorf("expected valid nonce: %v", err)
+	}
+}
+
+func TestValidateNonce_TooShort(t *testing.T) {
+	nonce := make([]byte, 8)
+	rand.Read(nonce)
+
+	err := ValidateNonce(nonce)
+	if err == nil {
+		t.Error("expected error for short nonce")
+	}
+}
+
+func TestValidateNonce_TooLong(t *testing.T) {
+	nonce := make([]byte, 128)
+	rand.Read(nonce)
+
+	err := ValidateNonce(nonce)
+	if err == nil {
+		t.Error("expected error for long nonce")
+	}
+}
+
+func TestValidateNonce_AllZeros(t *testing.T) {
+	nonce := make([]byte, 32) // All zeros
+
+	err := ValidateNonce(nonce)
+	if err == nil {
+		t.Error("expected error for all-zeros nonce")
+	}
+}
+
+func TestValidateNonce_AllOnes(t *testing.T) {
+	nonce := make([]byte, 32)
+	for i := range nonce {
+		nonce[i] = 0xFF
+	}
+
+	err := ValidateNonce(nonce)
+	if err == nil {
+		t.Error("expected error for all-ones nonce")
+	}
+}
+
+func TestValidateNonceHex_Valid(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	nonceHex := hex.EncodeToString(nonce)
+
+	err := ValidateNonceHex(nonceHex)
+	if err != nil {
+		t.Errorf("expected valid hex nonce: %v", err)
+	}
+}
+
+func TestValidateNonceHex_InvalidHex(t *testing.T) {
+	err := ValidateNonceHex("not-valid-hex!!!")
+	if err == nil {
+		t.Error("expected error for invalid hex")
+	}
+}
+
+// ============================================================================
+// ValidateTimestamp Tests
+// ============================================================================
+
+func TestValidateTimestamp_Valid(t *testing.T) {
+	now := time.Now().UTC()
+	policy := DefaultReplayProtectionPolicy()
+
+	// Timestamp at now is valid
+	err := ValidateTimestamp(now, now, policy)
+	if err != nil {
+		t.Errorf("current timestamp should be valid: %v", err)
+	}
+
+	// Slight past is valid
+	err = ValidateTimestamp(now.Add(-30*time.Minute), now, policy)
+	if err != nil {
+		t.Errorf("recent past timestamp should be valid: %v", err)
+	}
+
+	// Slight future (within clock skew) is valid
+	err = ValidateTimestamp(now.Add(1*time.Minute), now, policy)
+	if err != nil {
+		t.Errorf("near future timestamp should be valid: %v", err)
+	}
+}
+
+func TestValidateTimestamp_TooFuture(t *testing.T) {
+	now := time.Now().UTC()
+	policy := DefaultReplayProtectionPolicy()
+
+	err := ValidateTimestamp(now.Add(10*time.Minute), now, policy)
+	if err == nil {
+		t.Error("expected error for far future timestamp")
+	}
+}
+
+func TestValidateTimestamp_TooPast(t *testing.T) {
+	now := time.Now().UTC()
+	policy := DefaultReplayProtectionPolicy()
+
+	err := ValidateTimestamp(now.Add(-2*time.Hour), now, policy)
+	if err == nil {
+		t.Error("expected error for far past timestamp")
+	}
+}
+
+func TestValidateTimestamp_BindingDisabled(t *testing.T) {
+	now := time.Now().UTC()
+	policy := DefaultReplayProtectionPolicy()
+	policy.RequireTimestampBinding = false
+
+	// Any timestamp is valid when binding is disabled
+	err := ValidateTimestamp(now.Add(-100*time.Hour), now, policy)
+	if err != nil {
+		t.Error("timestamp should be valid when binding is disabled")
+	}
+}
+
+// ============================================================================
+// ComputeNonceHash Tests
+// ============================================================================
+
+func TestComputeNonceHash(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+
+	hash := ComputeNonceHash(nonce)
+
+	if len(hash) != 64 {
+		t.Errorf("expected 64-char hash, got %d", len(hash))
+	}
+
+	// Verify it's valid hex
+	_, err := hex.DecodeString(hash)
+	if err != nil {
+		t.Errorf("hash should be valid hex: %v", err)
+	}
+
+	// Deterministic
+	hash2 := ComputeNonceHash(nonce)
+	if hash != hash2 {
+		t.Error("hash should be deterministic")
+	}
+
+	// Different input produces different output
+	nonce2 := make([]byte, 32)
+	rand.Read(nonce2)
+	hash3 := ComputeNonceHash(nonce2)
+	if hash == hash3 {
+		t.Error("different nonces should have different hashes")
+	}
+}
+
+// ============================================================================
+// NonceHistoryEntry Tests
+// ============================================================================
+
+func TestNewNonceHistoryEntry(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	now := time.Now().UTC()
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	record := NewNonceRecord(nonce, fingerprint, AttestationTypeFacialVerification, now, 3600)
+	record.MarkUsed(now.Add(10*time.Minute), "attestation-001", 12345)
+
+	entry := NewNonceHistoryEntry(record)
+
+	if entry == nil {
+		t.Fatal("expected non-nil entry for used nonce")
+	}
+
+	if entry.NonceHash != record.NonceHash {
+		t.Error("nonce hash mismatch")
+	}
+
+	if entry.AttestationID != "attestation-001" {
+		t.Errorf("unexpected attestation ID: %s", entry.AttestationID)
+	}
+
+	if entry.BlockHeight != 12345 {
+		t.Errorf("unexpected block height: %d", entry.BlockHeight)
+	}
+
+	// Fingerprint should be truncated
+	if len(entry.IssuerFingerprint) > 16 {
+		t.Errorf("fingerprint should be truncated to 16 chars, got %d", len(entry.IssuerFingerprint))
+	}
+}
+
+func TestNewNonceHistoryEntry_UnusedNonce(t *testing.T) {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	now := time.Now().UTC()
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	record := NewNonceRecord(nonce, fingerprint, AttestationTypeFacialVerification, now, 3600)
+
+	entry := NewNonceHistoryEntry(record)
+
+	if entry != nil {
+		t.Error("expected nil entry for unused nonce")
+	}
+}
+
+// ============================================================================
+// NonceValidationResult Tests
+// ============================================================================
+
+func TestNonceValidationResult_Success(t *testing.T) {
+	result := NewNonceValidationResultSuccess("abc123...")
+
+	if !result.Valid {
+		t.Error("success result should be valid")
+	}
+
+	if result.Error != "" {
+		t.Error("success result should have no error")
+	}
+
+	if !result.TimestampValid {
+		t.Error("timestamp should be valid in success result")
+	}
+}
+
+func TestNonceValidationResult_Failure(t *testing.T) {
+	result := NewNonceValidationResultFailure("abc123...", "nonce already used")
+
+	if result.Valid {
+		t.Error("failure result should not be valid")
+	}
+
+	if result.Error == "" {
+		t.Error("failure result should have error message")
+	}
+}

--- a/x/veid/types/attestation_test.go
+++ b/x/veid/types/attestation_test.go
@@ -1,0 +1,719 @@
+package types
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+func generateTestNonce(t *testing.T, length int) []byte {
+	t.Helper()
+	nonce := make([]byte, length)
+	_, err := rand.Read(nonce)
+	if err != nil {
+		t.Fatalf("failed to generate nonce: %v", err)
+	}
+	return nonce
+}
+
+func generateTestFingerprint(t *testing.T) string {
+	t.Helper()
+	fp := make([]byte, 32)
+	_, err := rand.Read(fp)
+	if err != nil {
+		t.Fatalf("failed to generate fingerprint: %v", err)
+	}
+	return hex.EncodeToString(fp)
+}
+
+// ============================================================================
+// VerificationAttestation Tests
+// ============================================================================
+
+func TestVerificationAttestation_Validate_Valid(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+	fingerprint := generateTestFingerprint(t)
+
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1validator...")
+	subject := NewAttestationSubject("virtengine1account...")
+
+	attestation := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationTypeFacialVerification,
+		nonce,
+		now,
+		24*time.Hour,
+		85,
+		90,
+	)
+
+	// Add a proof
+	proof := NewAttestationProof(
+		ProofTypeEd25519,
+		now,
+		issuer.ID+"#keys-1",
+		[]byte("test-signature-bytes"),
+		hex.EncodeToString(nonce),
+	)
+	attestation.SetProof(proof)
+
+	err := attestation.Validate()
+	if err != nil {
+		t.Errorf("expected valid attestation, got error: %v", err)
+	}
+}
+
+func TestVerificationAttestation_Validate_InvalidType(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+	fingerprint := generateTestFingerprint(t)
+
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1validator...")
+	subject := NewAttestationSubject("virtengine1account...")
+
+	attestation := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationType("invalid_type"),
+		nonce,
+		now,
+		24*time.Hour,
+		85,
+		90,
+	)
+
+	proof := NewAttestationProof(
+		ProofTypeEd25519,
+		now,
+		issuer.ID+"#keys-1",
+		[]byte("test-signature-bytes"),
+		hex.EncodeToString(nonce),
+	)
+	attestation.SetProof(proof)
+
+	err := attestation.Validate()
+	if err == nil {
+		t.Error("expected error for invalid attestation type")
+	}
+}
+
+func TestVerificationAttestation_Validate_ExpiredBeforeIssued(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+	fingerprint := generateTestFingerprint(t)
+
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1validator...")
+	subject := NewAttestationSubject("virtengine1account...")
+
+	attestation := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationTypeFacialVerification,
+		nonce,
+		now,
+		24*time.Hour,
+		85,
+		90,
+	)
+
+	// Set expires before issued
+	attestation.ExpiresAt = now.Add(-1 * time.Hour)
+
+	proof := NewAttestationProof(
+		ProofTypeEd25519,
+		now,
+		issuer.ID+"#keys-1",
+		[]byte("test-signature-bytes"),
+		hex.EncodeToString(nonce),
+	)
+	attestation.SetProof(proof)
+
+	err := attestation.Validate()
+	if err == nil {
+		t.Error("expected error for expires_at before issued_at")
+	}
+}
+
+func TestVerificationAttestation_Validate_ScoreExceeds100(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+	fingerprint := generateTestFingerprint(t)
+
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1validator...")
+	subject := NewAttestationSubject("virtengine1account...")
+
+	attestation := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationTypeFacialVerification,
+		nonce,
+		now,
+		24*time.Hour,
+		150, // Invalid score
+		90,
+	)
+
+	proof := NewAttestationProof(
+		ProofTypeEd25519,
+		now,
+		issuer.ID+"#keys-1",
+		[]byte("test-signature-bytes"),
+		hex.EncodeToString(nonce),
+	)
+	attestation.SetProof(proof)
+
+	err := attestation.Validate()
+	if err == nil {
+		t.Error("expected error for score exceeding 100")
+	}
+}
+
+func TestVerificationAttestation_CanonicalBytes(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+	fingerprint := generateTestFingerprint(t)
+
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1validator...")
+	subject := NewAttestationSubject("virtengine1account...")
+
+	attestation := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationTypeFacialVerification,
+		nonce,
+		now,
+		24*time.Hour,
+		85,
+		90,
+	)
+
+	// Canonical bytes should be deterministic
+	bytes1, err := attestation.CanonicalBytes()
+	if err != nil {
+		t.Fatalf("failed to get canonical bytes: %v", err)
+	}
+
+	bytes2, err := attestation.CanonicalBytes()
+	if err != nil {
+		t.Fatalf("failed to get canonical bytes: %v", err)
+	}
+
+	if string(bytes1) != string(bytes2) {
+		t.Error("canonical bytes should be deterministic")
+	}
+}
+
+func TestVerificationAttestation_Hash(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+	fingerprint := generateTestFingerprint(t)
+
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1validator...")
+	subject := NewAttestationSubject("virtengine1account...")
+
+	attestation := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationTypeFacialVerification,
+		nonce,
+		now,
+		24*time.Hour,
+		85,
+		90,
+	)
+
+	hash, err := attestation.Hash()
+	if err != nil {
+		t.Fatalf("failed to compute hash: %v", err)
+	}
+
+	if len(hash) != 32 {
+		t.Errorf("expected SHA256 hash length 32, got %d", len(hash))
+	}
+
+	// Hash should be deterministic
+	hash2, err := attestation.Hash()
+	if err != nil {
+		t.Fatalf("failed to compute hash: %v", err)
+	}
+
+	if string(hash) != string(hash2) {
+		t.Error("hash should be deterministic")
+	}
+}
+
+func TestVerificationAttestation_IsExpired(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+	fingerprint := generateTestFingerprint(t)
+
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1validator...")
+	subject := NewAttestationSubject("virtengine1account...")
+
+	attestation := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationTypeFacialVerification,
+		nonce,
+		now,
+		1*time.Hour,
+		85,
+		90,
+	)
+
+	// Should not be expired immediately
+	if attestation.IsExpired(now) {
+		t.Error("attestation should not be expired at issuance time")
+	}
+
+	// Should be expired after expiry
+	if !attestation.IsExpired(now.Add(2 * time.Hour)) {
+		t.Error("attestation should be expired after expiry time")
+	}
+}
+
+func TestVerificationAttestation_ToScopeType(t *testing.T) {
+	tests := []struct {
+		attestationType AttestationType
+		expectedScope   ScopeType
+	}{
+		{AttestationTypeFacialVerification, ScopeTypeSelfie},
+		{AttestationTypeLivenessCheck, ScopeTypeFaceVideo},
+		{AttestationTypeDocumentVerification, ScopeTypeIDDocument},
+		{AttestationTypeEmailVerification, ScopeTypeEmailProof},
+		{AttestationTypeSMSVerification, ScopeTypeSMSProof},
+		{AttestationTypeDomainVerification, ScopeTypeDomainVerify},
+		{AttestationTypeSSOVerification, ScopeTypeSSOMetadata},
+		{AttestationTypeBiometricVerification, ScopeTypeBiometric},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.attestationType), func(t *testing.T) {
+			now := time.Now().UTC()
+			nonce := generateTestNonce(t, 32)
+			fingerprint := generateTestFingerprint(t)
+
+			issuer := NewAttestationIssuer(fingerprint, "")
+			subject := NewAttestationSubject("virtengine1account...")
+
+			attestation := NewVerificationAttestation(
+				issuer,
+				subject,
+				tc.attestationType,
+				nonce,
+				now,
+				24*time.Hour,
+				85,
+				90,
+			)
+
+			if attestation.ToScopeType() != tc.expectedScope {
+				t.Errorf("expected scope type %s, got %s", tc.expectedScope, attestation.ToScopeType())
+			}
+		})
+	}
+}
+
+// ============================================================================
+// AttestationIssuer Tests
+// ============================================================================
+
+func TestAttestationIssuer_Validate_Valid(t *testing.T) {
+	fingerprint := generateTestFingerprint(t)
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1validator...")
+
+	err := issuer.Validate()
+	if err != nil {
+		t.Errorf("expected valid issuer, got error: %v", err)
+	}
+}
+
+func TestAttestationIssuer_Validate_EmptyFingerprint(t *testing.T) {
+	issuer := AttestationIssuer{
+		ID:             "did:virtengine:validator:test",
+		KeyFingerprint: "",
+	}
+
+	err := issuer.Validate()
+	if err == nil {
+		t.Error("expected error for empty fingerprint")
+	}
+}
+
+func TestAttestationIssuer_Validate_ShortFingerprint(t *testing.T) {
+	issuer := AttestationIssuer{
+		ID:             "did:virtengine:validator:test",
+		KeyFingerprint: "abcd1234", // Too short
+	}
+
+	err := issuer.Validate()
+	if err == nil {
+		t.Error("expected error for short fingerprint")
+	}
+}
+
+func TestAttestationIssuer_Validate_InvalidHex(t *testing.T) {
+	issuer := AttestationIssuer{
+		ID:             "did:virtengine:validator:test",
+		KeyFingerprint: "ghij" + generateTestFingerprint(t)[4:], // Invalid hex chars
+	}
+
+	err := issuer.Validate()
+	if err == nil {
+		t.Error("expected error for invalid hex fingerprint")
+	}
+}
+
+// ============================================================================
+// AttestationSubject Tests
+// ============================================================================
+
+func TestAttestationSubject_Validate_Valid(t *testing.T) {
+	subject := NewAttestationSubject("virtengine1account...")
+
+	err := subject.Validate()
+	if err != nil {
+		t.Errorf("expected valid subject, got error: %v", err)
+	}
+}
+
+func TestAttestationSubject_Validate_EmptyAddress(t *testing.T) {
+	subject := AttestationSubject{
+		ID:             "did:virtengine:test",
+		AccountAddress: "",
+	}
+
+	err := subject.Validate()
+	if err == nil {
+		t.Error("expected error for empty account address")
+	}
+}
+
+// ============================================================================
+// VerificationProofDetail Tests
+// ============================================================================
+
+func TestVerificationProofDetail_Validate_Valid(t *testing.T) {
+	proof := NewVerificationProofDetail(
+		"facial_match",
+		"abc123...",
+		85,
+		70,
+		time.Now().UTC(),
+	)
+
+	err := proof.Validate()
+	if err != nil {
+		t.Errorf("expected valid proof detail, got error: %v", err)
+	}
+
+	if !proof.Passed {
+		t.Error("proof should pass when score >= threshold")
+	}
+}
+
+func TestVerificationProofDetail_Validate_ScoreExceeds100(t *testing.T) {
+	proof := NewVerificationProofDetail(
+		"facial_match",
+		"abc123...",
+		150, // Invalid
+		70,
+		time.Now().UTC(),
+	)
+
+	err := proof.Validate()
+	if err == nil {
+		t.Error("expected error for score exceeding 100")
+	}
+}
+
+func TestVerificationProofDetail_Passed(t *testing.T) {
+	// Score below threshold
+	proofFail := NewVerificationProofDetail("test", "hash", 50, 70, time.Now())
+	if proofFail.Passed {
+		t.Error("proof should not pass when score < threshold")
+	}
+
+	// Score equals threshold
+	proofEqual := NewVerificationProofDetail("test", "hash", 70, 70, time.Now())
+	if !proofEqual.Passed {
+		t.Error("proof should pass when score == threshold")
+	}
+
+	// Score above threshold
+	proofPass := NewVerificationProofDetail("test", "hash", 90, 70, time.Now())
+	if !proofPass.Passed {
+		t.Error("proof should pass when score > threshold")
+	}
+}
+
+// ============================================================================
+// AttestationProof Tests
+// ============================================================================
+
+func TestAttestationProof_Validate_Valid(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+
+	proof := NewAttestationProof(
+		ProofTypeEd25519,
+		now,
+		"did:virtengine:validator:test#keys-1",
+		[]byte("signature-bytes"),
+		hex.EncodeToString(nonce),
+	)
+
+	err := proof.Validate()
+	if err != nil {
+		t.Errorf("expected valid proof, got error: %v", err)
+	}
+}
+
+func TestAttestationProof_Validate_InvalidType(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+
+	proof := AttestationProof{
+		Type:               AttestationProofType("invalid"),
+		Created:            now,
+		VerificationMethod: "did:virtengine:test#keys-1",
+		ProofPurpose:       "assertionMethod",
+		ProofValue:         "dGVzdA==", // base64 "test"
+		Nonce:              hex.EncodeToString(nonce),
+	}
+
+	err := proof.Validate()
+	if err == nil {
+		t.Error("expected error for invalid proof type")
+	}
+}
+
+func TestAttestationProof_Validate_EmptyProofValue(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+
+	proof := AttestationProof{
+		Type:               ProofTypeEd25519,
+		Created:            now,
+		VerificationMethod: "did:virtengine:test#keys-1",
+		ProofPurpose:       "assertionMethod",
+		ProofValue:         "",
+		Nonce:              hex.EncodeToString(nonce),
+	}
+
+	err := proof.Validate()
+	if err == nil {
+		t.Error("expected error for empty proof value")
+	}
+}
+
+func TestAttestationProof_Validate_InvalidBase64(t *testing.T) {
+	now := time.Now().UTC()
+	nonce := generateTestNonce(t, 32)
+
+	proof := AttestationProof{
+		Type:               ProofTypeEd25519,
+		Created:            now,
+		VerificationMethod: "did:virtengine:test#keys-1",
+		ProofPurpose:       "assertionMethod",
+		ProofValue:         "not-valid-base64!!!",
+		Nonce:              hex.EncodeToString(nonce),
+	}
+
+	err := proof.Validate()
+	if err == nil {
+		t.Error("expected error for invalid base64 proof value")
+	}
+}
+
+// ============================================================================
+// Attestation Type Tests
+// ============================================================================
+
+func TestIsValidAttestationType(t *testing.T) {
+	validTypes := AllAttestationTypes()
+	for _, at := range validTypes {
+		if !IsValidAttestationType(at) {
+			t.Errorf("expected %s to be valid", at)
+		}
+	}
+
+	if IsValidAttestationType(AttestationType("invalid")) {
+		t.Error("expected invalid type to be invalid")
+	}
+}
+
+func TestAllProofTypes(t *testing.T) {
+	proofTypes := AllProofTypes()
+	if len(proofTypes) == 0 {
+		t.Error("expected at least one proof type")
+	}
+
+	for _, pt := range proofTypes {
+		if !IsValidProofType(pt) {
+			t.Errorf("expected %s to be valid", pt)
+		}
+	}
+}
+
+// ============================================================================
+// Example Attestation Fixtures
+// ============================================================================
+
+func TestExampleFacialVerificationAttestation(t *testing.T) {
+	// This test demonstrates a complete facial verification attestation
+	now := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	nonce, _ := hex.DecodeString("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+	fingerprint := "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5lzv7xu")
+	issuer.KeyID = "validator-key-001"
+	issuer.ServiceEndpoint = "https://veid-signer.virtengine.io/v1"
+
+	subject := NewAttestationSubject("virtengine1abc123def456ghi789jkl012mno345pqr678stu")
+	subject.ScopeID = "scope-facial-001"
+	subject.RequestID = "req-20240115-001"
+
+	attestation := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationTypeFacialVerification,
+		nonce,
+		now,
+		30*24*time.Hour, // 30 days validity
+		92,              // High score
+		95,              // High confidence
+	)
+
+	attestation.ModelVersion = "facial-v2.3.0"
+	attestation.SetMetadata("pipeline_version", "1.0.0")
+	attestation.SetMetadata("validator_consensus", "5/5")
+
+	// Add verification proofs
+	attestation.AddVerificationProof(NewVerificationProofDetail(
+		"facial_embedding_match",
+		"sha256:abc123...",
+		94,
+		80,
+		now,
+	))
+	attestation.AddVerificationProof(NewVerificationProofDetail(
+		"liveness_score",
+		"sha256:def456...",
+		91,
+		85,
+		now,
+	))
+
+	// Add proof signature
+	proof := NewAttestationProof(
+		ProofTypeEd25519,
+		now,
+		issuer.ID+"#"+issuer.KeyID,
+		[]byte("example-ed25519-signature-64-bytes-padded-for-test-purposes!!"),
+		hex.EncodeToString(nonce),
+	)
+	proof.Domain = "veid.virtengine.io"
+	attestation.SetProof(proof)
+
+	// Validate
+	err := attestation.Validate()
+	if err != nil {
+		t.Errorf("example attestation should be valid: %v", err)
+	}
+
+	// Test JSON serialization
+	jsonBytes, err := attestation.ToJSON()
+	if err != nil {
+		t.Fatalf("failed to serialize to JSON: %v", err)
+	}
+
+	// Deserialize and validate
+	parsed, err := AttestationFromJSON(jsonBytes)
+	if err != nil {
+		t.Fatalf("failed to deserialize from JSON: %v", err)
+	}
+
+	if parsed.ID != attestation.ID {
+		t.Error("parsed attestation ID mismatch")
+	}
+
+	if parsed.Score != attestation.Score {
+		t.Error("parsed attestation score mismatch")
+	}
+
+	if len(parsed.VerificationProofs) != 2 {
+		t.Errorf("expected 2 verification proofs, got %d", len(parsed.VerificationProofs))
+	}
+
+	t.Logf("Example attestation JSON:\n%s", string(jsonBytes))
+}
+
+func TestExampleDocumentVerificationAttestation(t *testing.T) {
+	// Document verification attestation example
+	now := time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC)
+	nonce, _ := hex.DecodeString("b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3")
+	fingerprint := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	issuer := NewAttestationIssuer(fingerprint, "virtengine1validator123...")
+	subject := NewAttestationSubject("virtengine1user456...")
+
+	attestation := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationTypeDocumentVerification,
+		nonce,
+		now,
+		365*24*time.Hour, // 1 year validity for document verification
+		88,
+		85,
+	)
+
+	attestation.AddVerificationProof(NewVerificationProofDetail(
+		"document_authenticity",
+		"sha256:doc123...",
+		90,
+		80,
+		now,
+	))
+	attestation.AddVerificationProof(NewVerificationProofDetail(
+		"ocr_extraction",
+		"sha256:ocr456...",
+		95,
+		90,
+		now,
+	))
+	attestation.AddVerificationProof(NewVerificationProofDetail(
+		"document_face_match",
+		"sha256:face789...",
+		82,
+		75,
+		now,
+	))
+
+	proof := NewAttestationProof(
+		ProofTypeSecp256k1,
+		now,
+		issuer.ID+"#keys-1",
+		[]byte("example-secp256k1-signature"),
+		hex.EncodeToString(nonce),
+	)
+	attestation.SetProof(proof)
+
+	err := attestation.Validate()
+	if err != nil {
+		t.Errorf("example document attestation should be valid: %v", err)
+	}
+
+	// Verify scope type mapping
+	if attestation.ToScopeType() != ScopeTypeIDDocument {
+		t.Error("document attestation should map to id_document scope")
+	}
+}

--- a/x/veid/types/errors.go
+++ b/x/veid/types/errors.go
@@ -643,4 +643,56 @@ var (
 
 	// ErrBorderlineFallbackFailed is returned when borderline fallback fails
 	ErrBorderlineFallbackFailed = veidv1.ErrBorderlineFallbackFailed
+
+	// ============================================================================
+	// Verification Attestation Errors (VE-1B)
+	// Error codes: 1240-1259
+	// ============================================================================
+
+	// ErrInvalidAttestation is returned when an attestation is malformed or invalid
+	ErrInvalidAttestation = errorsmod.Register(ModuleName, 1240, "invalid verification attestation")
+
+	// ErrAttestationNotFound is returned when an attestation is not found
+	ErrAttestationNotFound = errorsmod.Register(ModuleName, 1241, "attestation not found")
+
+	// ErrAttestationExpired is returned when an attestation has expired
+	ErrAttestationExpired = errorsmod.Register(ModuleName, 1242, "attestation has expired")
+
+	// ErrAttestationRevoked is returned when an attestation has been revoked
+	ErrAttestationRevoked = errorsmod.Register(ModuleName, 1243, "attestation has been revoked")
+
+	// ErrInvalidSignerKey is returned when a signer key is invalid
+	ErrInvalidSignerKey = errorsmod.Register(ModuleName, 1244, "invalid signer key")
+
+	// ErrSignerKeyNotFound is returned when a signer key is not found
+	ErrSignerKeyNotFound = errorsmod.Register(ModuleName, 1245, "signer key not found")
+
+	// ErrSignerKeyRevoked is returned when a signer key has been revoked
+	ErrSignerKeyRevoked = errorsmod.Register(ModuleName, 1246, "signer key has been revoked")
+
+	// ErrSignerKeyExpired is returned when a signer key has expired
+	ErrSignerKeyExpired = errorsmod.Register(ModuleName, 1247, "signer key has expired")
+
+	// Note: ErrNonceAlreadyUsed already defined at code 1089
+
+	// ErrNonceExpired is returned when an attestation nonce has expired
+	ErrNonceExpired = errorsmod.Register(ModuleName, 1249, "nonce has expired")
+
+	// ErrInvalidTimestamp is returned when an attestation timestamp is invalid
+	ErrInvalidTimestamp = errorsmod.Register(ModuleName, 1250, "invalid attestation timestamp")
+
+	// ErrSignerNotRegistered is returned when the signer is not registered
+	ErrSignerNotRegistered = errorsmod.Register(ModuleName, 1251, "signer is not registered")
+
+	// ErrKeyRotationInProgress is returned when key rotation is already in progress
+	ErrKeyRotationInProgress = errorsmod.Register(ModuleName, 1252, "key rotation already in progress")
+
+	// ErrKeyRotationFailed is returned when key rotation fails
+	ErrKeyRotationFailed = errorsmod.Register(ModuleName, 1253, "key rotation failed")
+
+	// ErrAttestationSignatureInvalid is returned when attestation signature verification fails
+	ErrAttestationSignatureInvalid = errorsmod.Register(ModuleName, 1254, "attestation signature verification failed")
+
+	// ErrMaxAttestationsExceeded is returned when maximum attestations limit is exceeded
+	ErrMaxAttestationsExceeded = errorsmod.Register(ModuleName, 1255, "maximum attestations exceeded")
 )

--- a/x/veid/types/events.go
+++ b/x/veid/types/events.go
@@ -310,3 +310,179 @@ func (m *EventAuthorizationConsumed) String() string { return fmt.Sprintf("%+v",
 func (*EventAuthorizationExpired) ProtoMessage()     {}
 func (m *EventAuthorizationExpired) Reset()          { *m = EventAuthorizationExpired{} }
 func (m *EventAuthorizationExpired) String() string  { return fmt.Sprintf("%+v", *m) }
+
+// ============================================================================
+// Verification Attestation Events (VE-1B)
+// ============================================================================
+
+// Attestation event types
+const (
+	EventTypeAttestationCreated     = "attestation_created"
+	EventTypeAttestationRevoked     = "attestation_revoked"
+	EventTypeAttestationExpired     = "attestation_expired"
+	EventTypeSignerKeyRegistered    = "signer_key_registered"
+	EventTypeSignerKeyActivated     = "signer_key_activated"
+	EventTypeSignerKeyRevoked       = "signer_key_revoked"
+	EventTypeSignerKeyRotated       = "signer_key_rotated"
+	EventTypeNonceUsed              = "nonce_used"
+	EventTypeAttestationVerified    = "attestation_verified"
+)
+
+// Attestation event attribute keys
+const (
+	AttributeKeyAttestationID     = "attestation_id"
+	AttributeKeyAttestationType   = "attestation_type"
+	AttributeKeyIssuerID          = "issuer_id"
+	AttributeKeyIssuerFingerprint = "issuer_fingerprint"
+	AttributeKeySubjectAddress    = "subject_address"
+	AttributeKeyNonceHash         = "nonce_hash"
+	// Note: AttributeKeyExpiresAt already defined in borderline_events.go
+	AttributeKeyKeyID             = "key_id"
+	AttributeKeyKeyFingerprint    = "key_fingerprint"
+	AttributeKeyKeyState          = "key_state"
+	AttributeKeySignerID          = "signer_id"
+	AttributeKeyRotationID        = "rotation_id"
+	AttributeKeyOldKeyID          = "old_key_id"
+	AttributeKeyNewKeyID          = "new_key_id"
+	AttributeKeyRevocationReason  = "revocation_reason"
+	AttributeKeyConfidence        = "confidence"
+)
+
+// EventAttestationCreated is emitted when a verification attestation is created
+type EventAttestationCreated struct {
+	AttestationID   string `json:"attestation_id"`
+	AttestationType string `json:"attestation_type"`
+	IssuerID        string `json:"issuer_id"`
+	IssuerFP        string `json:"issuer_fingerprint"`
+	SubjectAddress  string `json:"subject_address"`
+	Score           uint32 `json:"score"`
+	Confidence      uint32 `json:"confidence"`
+	ExpiresAt       int64  `json:"expires_at"`
+	BlockHeight     int64  `json:"block_height"`
+	Timestamp       int64  `json:"timestamp"`
+}
+
+// EventAttestationRevoked is emitted when an attestation is revoked
+type EventAttestationRevoked struct {
+	AttestationID  string `json:"attestation_id"`
+	IssuerID       string `json:"issuer_id"`
+	SubjectAddress string `json:"subject_address"`
+	Reason         string `json:"reason"`
+	RevokedBy      string `json:"revoked_by"`
+	BlockHeight    int64  `json:"block_height"`
+	Timestamp      int64  `json:"timestamp"`
+}
+
+// EventAttestationExpired is emitted when an attestation expires
+type EventAttestationExpired struct {
+	AttestationID  string `json:"attestation_id"`
+	IssuerID       string `json:"issuer_id"`
+	SubjectAddress string `json:"subject_address"`
+	CreatedAt      int64  `json:"created_at"`
+	ExpiredAt      int64  `json:"expired_at"`
+	BlockHeight    int64  `json:"block_height"`
+}
+
+// EventSignerKeyRegistered is emitted when a new signer key is registered
+type EventSignerKeyRegistered struct {
+	KeyID       string `json:"key_id"`
+	SignerID    string `json:"signer_id"`
+	Fingerprint string `json:"fingerprint"`
+	Algorithm   string `json:"algorithm"`
+	State       string `json:"state"`
+	BlockHeight int64  `json:"block_height"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// EventSignerKeyActivated is emitted when a signer key becomes active
+type EventSignerKeyActivated struct {
+	KeyID       string `json:"key_id"`
+	SignerID    string `json:"signer_id"`
+	Fingerprint string `json:"fingerprint"`
+	ExpiresAt   int64  `json:"expires_at"`
+	BlockHeight int64  `json:"block_height"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// EventSignerKeyRevoked is emitted when a signer key is revoked
+type EventSignerKeyRevoked struct {
+	KeyID       string `json:"key_id"`
+	SignerID    string `json:"signer_id"`
+	Fingerprint string `json:"fingerprint"`
+	Reason      string `json:"reason"`
+	RevokedBy   string `json:"revoked_by"`
+	BlockHeight int64  `json:"block_height"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// EventSignerKeyRotated is emitted when a signer key rotation completes
+type EventSignerKeyRotated struct {
+	RotationID        string `json:"rotation_id"`
+	SignerID          string `json:"signer_id"`
+	OldKeyID          string `json:"old_key_id"`
+	OldKeyFingerprint string `json:"old_key_fingerprint"`
+	NewKeyID          string `json:"new_key_id"`
+	NewKeyFingerprint string `json:"new_key_fingerprint"`
+	Reason            string `json:"reason"`
+	BlockHeight       int64  `json:"block_height"`
+	Timestamp         int64  `json:"timestamp"`
+}
+
+// EventNonceUsed is emitted when an attestation nonce is consumed
+type EventNonceUsed struct {
+	NonceHash       string `json:"nonce_hash"`
+	IssuerFP        string `json:"issuer_fingerprint"`
+	AttestationID   string `json:"attestation_id"`
+	AttestationType string `json:"attestation_type"`
+	BlockHeight     int64  `json:"block_height"`
+	Timestamp       int64  `json:"timestamp"`
+}
+
+// EventAttestationVerified is emitted when an attestation signature is verified
+type EventAttestationVerified struct {
+	AttestationID  string `json:"attestation_id"`
+	IssuerID       string `json:"issuer_id"`
+	SubjectAddress string `json:"subject_address"`
+	KeyID          string `json:"key_id"`
+	Valid          bool   `json:"valid"`
+	BlockHeight    int64  `json:"block_height"`
+	Timestamp      int64  `json:"timestamp"`
+}
+
+// Proto stubs for attestation events
+
+func (*EventAttestationCreated) ProtoMessage()       {}
+func (m *EventAttestationCreated) Reset()            { *m = EventAttestationCreated{} }
+func (m *EventAttestationCreated) String() string    { return fmt.Sprintf("%+v", *m) }
+
+func (*EventAttestationRevoked) ProtoMessage()       {}
+func (m *EventAttestationRevoked) Reset()            { *m = EventAttestationRevoked{} }
+func (m *EventAttestationRevoked) String() string    { return fmt.Sprintf("%+v", *m) }
+
+func (*EventAttestationExpired) ProtoMessage()       {}
+func (m *EventAttestationExpired) Reset()            { *m = EventAttestationExpired{} }
+func (m *EventAttestationExpired) String() string    { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSignerKeyRegistered) ProtoMessage()      {}
+func (m *EventSignerKeyRegistered) Reset()           { *m = EventSignerKeyRegistered{} }
+func (m *EventSignerKeyRegistered) String() string   { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSignerKeyActivated) ProtoMessage()       {}
+func (m *EventSignerKeyActivated) Reset()            { *m = EventSignerKeyActivated{} }
+func (m *EventSignerKeyActivated) String() string    { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSignerKeyRevoked) ProtoMessage()         {}
+func (m *EventSignerKeyRevoked) Reset()              { *m = EventSignerKeyRevoked{} }
+func (m *EventSignerKeyRevoked) String() string      { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSignerKeyRotated) ProtoMessage()         {}
+func (m *EventSignerKeyRotated) Reset()              { *m = EventSignerKeyRotated{} }
+func (m *EventSignerKeyRotated) String() string      { return fmt.Sprintf("%+v", *m) }
+
+func (*EventNonceUsed) ProtoMessage()                {}
+func (m *EventNonceUsed) Reset()                     { *m = EventNonceUsed{} }
+func (m *EventNonceUsed) String() string             { return fmt.Sprintf("%+v", *m) }
+
+func (*EventAttestationVerified) ProtoMessage()      {}
+func (m *EventAttestationVerified) Reset()           { *m = EventAttestationVerified{} }
+func (m *EventAttestationVerified) String() string   { return fmt.Sprintf("%+v", *m) }

--- a/x/veid/types/keys.go
+++ b/x/veid/types/keys.go
@@ -609,6 +609,70 @@ var (
 	// PrefixValidatorStatsHistory is the prefix for validator stats history by epoch
 	// Key: PrefixValidatorStatsHistory | validator_address | epoch -> ValidatorStatsHistoryEntry
 	PrefixValidatorStatsHistory = []byte{0x7B}
+
+	// ============================================================================
+	// Verification Attestation Keys (VE-1B: Attestation Schema)
+	// ============================================================================
+
+	// PrefixAttestation is the prefix for verification attestation storage
+	// Key: PrefixAttestation | attestation_id -> VerificationAttestation
+	PrefixAttestation = []byte{0x7C}
+
+	// PrefixAttestationBySubject is the prefix for attestation lookup by subject
+	// Key: PrefixAttestationBySubject | subject_address | attestation_id -> bool
+	PrefixAttestationBySubject = []byte{0x7D}
+
+	// PrefixAttestationByIssuer is the prefix for attestation lookup by issuer
+	// Key: PrefixAttestationByIssuer | issuer_fingerprint | attestation_id -> bool
+	PrefixAttestationByIssuer = []byte{0x7E}
+
+	// PrefixAttestationByType is the prefix for attestation lookup by type
+	// Key: PrefixAttestationByType | attestation_type | attestation_id -> bool
+	PrefixAttestationByType = []byte{0x7F}
+
+	// PrefixAttestationExpiry is the prefix for attestation expiry index
+	// Key: PrefixAttestationExpiry | expires_at | attestation_id -> bool
+	PrefixAttestationExpiry = []byte{0x80}
+
+	// PrefixAttestationNonce is the prefix for attestation nonce tracking
+	// Key: PrefixAttestationNonce | nonce_hash -> NonceRecord
+	PrefixAttestationNonce = []byte{0x81}
+
+	// PrefixAttestationNonceByIssuer is the prefix for nonce lookup by issuer
+	// Key: PrefixAttestationNonceByIssuer | issuer_fingerprint | nonce_hash -> bool
+	PrefixAttestationNonceByIssuer = []byte{0x82}
+
+	// PrefixSignerKey is the prefix for signer key storage
+	// Key: PrefixSignerKey | key_id -> SignerKeyInfo
+	PrefixSignerKey = []byte{0x83}
+
+	// PrefixSignerKeyByFingerprint is the prefix for signer key lookup by fingerprint
+	// Key: PrefixSignerKeyByFingerprint | fingerprint -> key_id
+	PrefixSignerKeyByFingerprint = []byte{0x84}
+
+	// PrefixSignerKeyBySigner is the prefix for signer key lookup by signer
+	// Key: PrefixSignerKeyBySigner | signer_id | key_id -> bool
+	PrefixSignerKeyBySigner = []byte{0x85}
+
+	// PrefixSignerRegistry is the prefix for signer registry
+	// Key: PrefixSignerRegistry | signer_id -> SignerRegistryEntry
+	PrefixSignerRegistry = []byte{0x86}
+
+	// PrefixKeyRotation is the prefix for key rotation records
+	// Key: PrefixKeyRotation | rotation_id -> KeyRotationRecord
+	PrefixKeyRotation = []byte{0x87}
+
+	// PrefixKeyRotationBySigner is the prefix for key rotation lookup by signer
+	// Key: PrefixKeyRotationBySigner | signer_id | rotation_id -> bool
+	PrefixKeyRotationBySigner = []byte{0x88}
+
+	// PrefixNonceHistory is the prefix for nonce usage history (audit trail)
+	// Key: PrefixNonceHistory | used_at | nonce_hash -> NonceHistoryEntry
+	PrefixNonceHistory = []byte{0x89}
+
+	// PrefixAttestationParams is the prefix for attestation module parameters
+	// Key: PrefixAttestationParams -> AttestationParams
+	PrefixAttestationParams = []byte{0x8A}
 )
 
 // IdentityRecordKey returns the store key for an identity record


### PR DESCRIPTION
Objective:
Define verification attestation payloads and signer/key rotation requirements for VEID verification services.

Needs to be done (A–H):
A. Define attestation schema (issuer, subject, nonce, expiry, proofs).
B. Define signature format and canonical serialization.
C. Specify key rotation and revocation policy.
D. Define replay protection and nonce tracking rules.
E. Map attestation fields to on-chain linkage types.
F. Define audit logging requirements.
G. Add example attestations and validation tests.
H. Document signer service contract.

Acceptance criteria:
- Attestation schema versioned and documented.
- Key rotation policy defined.
- Replay protection requirements specified.
- Example payloads validated.

How it can be done:
- Align schema with existing x/veid linkage types.
- Draft contract in docs with test fixtures.

MCP guidance:
- Use Context7 for crypto serialization patterns.

Deliverables:
- Attestation schema spec, example payloads, and tests.