### PR TITLE
feat(market): automate offering sync from chain to Waldur

### DIFF
--- a/_docs/operations/offering-sync-guide.md
+++ b/_docs/operations/offering-sync-guide.md
@@ -1,0 +1,300 @@
+# Offering Sync Guide
+
+This document describes the automatic offering synchronization feature that syncs on-chain marketplace offerings to Waldur.
+
+## Overview
+
+The offering sync feature (VE-2D) eliminates manual mapping between VirtEngine on-chain offerings and Waldur marketplace offerings. When enabled, the provider daemon automatically:
+
+1. Subscribes to on-chain offering events (create/update/terminate)
+2. Synchronizes offerings to Waldur with the correct field mappings
+3. Tracks sync state including checksums, versions, and errors
+4. Handles retries with exponential backoff
+5. Dead-letters persistently failing offerings
+6. Runs periodic reconciliation to detect and fix drift
+
+## Configuration
+
+### CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--waldur-offering-sync-enabled` | `false` | Enable automatic offering sync |
+| `--waldur-offering-sync-state-file` | `data/offering_sync_state.json` | Path for sync state persistence |
+| `--waldur-customer-uuid` | (required) | Waldur customer/organization UUID |
+| `--waldur-category-map` | (optional) | Path to JSON file mapping categories to Waldur category UUIDs |
+| `--waldur-offering-sync-interval` | `300` | Reconciliation interval in seconds |
+| `--waldur-offering-sync-max-retries` | `5` | Max retries before dead-lettering |
+
+### Environment Variables
+
+All flags can be set via environment variables with the prefix `VIRTENGINE_`:
+
+```bash
+export VIRTENGINE_WALDUR_OFFERING_SYNC_ENABLED=true
+export VIRTENGINE_WALDUR_CUSTOMER_UUID=<your-customer-uuid>
+export VIRTENGINE_WALDUR_OFFERING_SYNC_INTERVAL=300
+```
+
+### Category Map JSON
+
+Create a JSON file mapping VirtEngine offering categories to Waldur category UUIDs:
+
+```json
+{
+  "compute": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "storage": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy",
+  "hpc": "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"
+}
+```
+
+## Migration from Manual Mapping
+
+If you were previously using `--waldur-offering-map`:
+
+1. The flag is now **deprecated** but still works for backward compatibility
+2. When `--waldur-offering-sync-enabled=true`, the manual map is ignored
+3. Existing offerings will be auto-discovered via Waldur `backend_id` lookup
+4. New offerings will be created automatically
+
+### Migration Steps
+
+1. Ensure Waldur offerings have correct `backend_id` values (VirtEngine offering IDs)
+2. Set `--waldur-offering-sync-enabled=true`
+3. Provide `--waldur-customer-uuid` for new offering creation
+4. Optionally provide `--waldur-category-map` for category mappings
+5. Remove `--waldur-offering-map` after confirming sync works
+
+## Field Mappings
+
+On-chain offering fields are mapped to Waldur as follows:
+
+| VirtEngine Field | Waldur Field | Notes |
+|------------------|--------------|-------|
+| `ID` | `backend_id` | Used for cross-reference |
+| `Name` | `name` | Truncated to 255 chars |
+| `Description` | `description` | Full description |
+| `Category` | `type` | Mapped via category map |
+| `State` | state action | `Active→activate`, `Paused→pause`, `Archived→archive` |
+| `BasePrice` | `unit_price` | Divided by currency denominator |
+| `EncryptedSecrets` | (excluded) | Never synced to Waldur |
+
+## Sync States
+
+Each offering can be in one of these sync states:
+
+| State | Description |
+|-------|-------------|
+| `pending` | Initial state, never synced |
+| `synced` | Successfully synced to Waldur |
+| `out_of_sync` | Drift detected, needs re-sync |
+| `failed` | Sync attempt failed |
+| `retrying` | Waiting for retry attempt |
+| `dead_lettered` | Failed after max retries |
+
+## Retry Behavior
+
+Failed syncs are retried with exponential backoff:
+
+- Base backoff: 30 seconds
+- Max backoff: 1 hour
+- Max retries: 5 (configurable)
+- Backoff formula: `min(base * 2^(attempt-1), max)`
+
+Example retry schedule:
+1. First retry: 30s
+2. Second retry: 60s
+3. Third retry: 120s
+4. Fourth retry: 240s
+5. Fifth retry: 480s
+6. After 5 failures: Dead-lettered
+
+## Dead Letter Queue
+
+Offerings that fail after max retries are moved to the dead letter queue:
+
+- Dead-lettered offerings are not automatically retried
+- Use the reprocess command to retry dead-lettered items
+- Dead letter entries include: offering ID, error message, attempt count, timestamp
+
+### Reprocessing Dead Letters
+
+```bash
+# View dead-lettered offerings
+virtengine provider-daemon dead-letter list
+
+# Reprocess a specific offering
+virtengine provider-daemon dead-letter reprocess <offering-id>
+
+# Reprocess all dead-lettered offerings
+virtengine provider-daemon dead-letter reprocess --all
+```
+
+## Reconciliation
+
+The reconciliation job runs periodically to:
+
+1. Detect offerings that are out of sync (checksum mismatch)
+2. Find offerings missing from Waldur
+3. Queue sync tasks for drifted offerings
+
+Reconciliation interval is controlled by `--waldur-offering-sync-interval` (default: 5 minutes).
+
+### Manual Reconciliation
+
+Trigger immediate reconciliation via the admin API:
+
+```bash
+curl -X POST http://localhost:8080/admin/offering-sync/reconcile
+```
+
+## Monitoring
+
+### Metrics
+
+The sync worker exposes Prometheus-compatible metrics:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `offering_sync_total` | Counter | Total sync operations |
+| `offering_sync_successful` | Counter | Successful syncs |
+| `offering_sync_failed` | Counter | Failed syncs |
+| `offering_sync_dead_lettered` | Counter | Dead-lettered items |
+| `offering_sync_drift_detected` | Counter | Drift detections |
+| `offering_sync_reconciliations` | Counter | Reconciliation runs |
+| `offering_sync_queue_depth` | Gauge | Current queue depth |
+| `offering_sync_active_syncs` | Gauge | Active sync operations |
+| `offering_sync_dead_letter_size` | Gauge | Dead letter queue size |
+| `offering_sync_duration_seconds` | Histogram | Sync operation duration |
+| `offering_sync_events_received` | Counter | Events received from chain |
+| `offering_sync_events_processed` | Counter | Events successfully processed |
+| `offering_sync_events_dropped` | Counter | Events dropped (queue full) |
+
+### Audit Logs
+
+The sync worker logs structured JSON audit entries for:
+
+- **Sync attempts**: Every create/update/disable operation
+- **Reconciliation runs**: Periodic drift checks
+- **Dead letter events**: Items dead-lettered or reprocessed
+
+Audit log format:
+
+```json
+{
+  "timestamp": "2024-01-15T10:30:00Z",
+  "offering_id": "ve1abc123...",
+  "waldur_uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "action": "update",
+  "success": true,
+  "duration_ns": 1234567890,
+  "retry_count": 0,
+  "provider_address": "virtengine1...",
+  "checksum": "sha256:abc123..."
+}
+```
+
+## Troubleshooting
+
+### Offering Not Syncing
+
+1. Check sync state: `virtengine provider-daemon offering-sync status <offering-id>`
+2. Verify provider address matches
+3. Check Waldur API connectivity
+4. Review audit logs for errors
+
+### High Failure Rate
+
+1. Check Waldur API health
+2. Verify customer UUID is correct
+3. Check category mappings
+4. Review rate limiting (Waldur may be throttling)
+
+### Drift Keeps Occurring
+
+1. Check if external changes are made in Waldur
+2. Verify checksum calculation is stable
+3. Consider increasing reconciliation interval
+
+### Dead Letter Queue Growing
+
+1. Review error messages in dead-lettered items
+2. Fix underlying issues (API errors, invalid data)
+3. Reprocess after fixes
+
+## Recovery Procedures
+
+### State File Corruption
+
+If the state file is corrupted:
+
+1. Stop the provider daemon
+2. Back up the corrupted file
+3. Delete or rename the state file
+4. Restart the daemon
+5. Run manual reconciliation to rebuild state
+
+```bash
+mv data/offering_sync_state.json data/offering_sync_state.json.bak
+virtengine provider-daemon start
+curl -X POST http://localhost:8080/admin/offering-sync/reconcile
+```
+
+### Full Resync
+
+To force a complete resync of all offerings:
+
+1. Stop the provider daemon
+2. Delete the state file
+3. Restart with `--waldur-offering-sync-enabled=true`
+4. The reconciliation job will sync all offerings
+
+### Waldur API Recovery
+
+If Waldur API was down and offerings are out of sync:
+
+1. Wait for Waldur API to recover
+2. Trigger manual reconciliation
+3. Monitor dead letter queue for any permanent failures
+4. Reprocess dead-lettered items after investigation
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Provider Daemon                              │
+│                                                                 │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐      │
+│  │   CometBFT   │───▶│    Event     │───▶│    Sync      │      │
+│  │ Subscription │    │    Loop      │    │   Queue      │      │
+│  └──────────────┘    └──────────────┘    └──────────────┘      │
+│                                                   │              │
+│                                                   ▼              │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐      │
+│  │    State     │◀───│    Sync      │───▶│   Waldur     │      │
+│  │    Store     │    │   Worker     │    │    API       │      │
+│  └──────────────┘    └──────────────┘    └──────────────┘      │
+│         │                    │                                   │
+│         ▼                    ▼                                   │
+│  ┌──────────────┐    ┌──────────────┐                          │
+│  │  State File  │    │ Audit Logs / │                          │
+│  │    (JSON)    │    │   Metrics    │                          │
+│  └──────────────┘    └──────────────┘                          │
+│                                                                 │
+│  ┌──────────────┐                                               │
+│  │ Reconcile    │ (runs every sync_interval)                    │
+│  │    Loop      │                                               │
+│  └──────────────┘                                               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Security Considerations
+
+- **Encrypted secrets are never synced**: The `EncryptedSecrets` field is excluded from Waldur sync
+- **API tokens**: Waldur API token should be stored securely (env var, not CLI flag)
+- **State file**: Contains offering IDs and Waldur UUIDs, protect accordingly
+- **Audit logs**: May contain sensitive information, configure log retention
+
+## Changelog
+
+- **VE-2D**: Initial implementation of automatic offering sync

--- a/cmd/provider-daemon/main.go
+++ b/cmd/provider-daemon/main.go
@@ -125,6 +125,25 @@ const (
 
 	// FlagCometWS is the CometBFT websocket endpoint
 	FlagCometWS = "comet-ws"
+
+	// VE-2D: Automatic offering sync flags
+	// FlagWaldurOfferingSyncEnabled enables automatic offering sync
+	FlagWaldurOfferingSyncEnabled = "waldur-offering-sync-enabled"
+
+	// FlagWaldurOfferingSyncStateFile is the path for offering sync state
+	FlagWaldurOfferingSyncStateFile = "waldur-offering-sync-state-file"
+
+	// FlagWaldurCustomerUUID is the Waldur customer/org UUID for offerings
+	FlagWaldurCustomerUUID = "waldur-customer-uuid"
+
+	// FlagWaldurCategoryMap is path to category map JSON
+	FlagWaldurCategoryMap = "waldur-category-map"
+
+	// FlagWaldurOfferingSyncInterval is the reconciliation interval in seconds
+	FlagWaldurOfferingSyncInterval = "waldur-offering-sync-interval"
+
+	// FlagWaldurOfferingSyncMaxRetries is max retries before dead-letter
+	FlagWaldurOfferingSyncMaxRetries = "waldur-offering-sync-max-retries"
 )
 
 var (
@@ -166,7 +185,7 @@ func init() {
 	rootCmd.PersistentFlags().String(FlagWaldurBaseURL, "", "Waldur API base URL")
 	rootCmd.PersistentFlags().String(FlagWaldurToken, "", "Waldur API token")
 	rootCmd.PersistentFlags().String(FlagWaldurProjectUUID, "", "Waldur project UUID")
-	rootCmd.PersistentFlags().String(FlagWaldurOfferingMap, "", "Path to Waldur offering map JSON")
+	rootCmd.PersistentFlags().String(FlagWaldurOfferingMap, "", "Path to Waldur offering map JSON (DEPRECATED: use --waldur-offering-sync-enabled)")
 	rootCmd.PersistentFlags().String(FlagWaldurCallbackSinkDir, "data/callbacks", "Directory for Waldur callback files")
 	rootCmd.PersistentFlags().String(FlagWaldurStateFile, "data/waldur_bridge_state.json", "Waldur bridge state file path")
 	rootCmd.PersistentFlags().String(FlagWaldurCheckpointFile, "data/marketplace_checkpoint.json", "Marketplace checkpoint file path")
@@ -184,6 +203,14 @@ func init() {
 	rootCmd.PersistentFlags().Duration(FlagWaldurChainBroadcastTimeout, 30*time.Second, "Broadcast timeout for on-chain callback submissions")
 	rootCmd.PersistentFlags().String(FlagMarketplaceEventQuery, "", "Marketplace event query for CometBFT subscription")
 	rootCmd.PersistentFlags().String(FlagCometWS, "/websocket", "CometBFT websocket endpoint path")
+
+	// VE-2D: Automatic offering sync flags
+	rootCmd.PersistentFlags().Bool(FlagWaldurOfferingSyncEnabled, false, "Enable automatic offering sync from chain to Waldur (replaces manual offering map)")
+	rootCmd.PersistentFlags().String(FlagWaldurOfferingSyncStateFile, "data/offering_sync_state.json", "Path for offering sync state file")
+	rootCmd.PersistentFlags().String(FlagWaldurCustomerUUID, "", "Waldur customer/organization UUID for creating offerings")
+	rootCmd.PersistentFlags().String(FlagWaldurCategoryMap, "", "Path to JSON file mapping offering categories to Waldur category UUIDs")
+	rootCmd.PersistentFlags().Int64(FlagWaldurOfferingSyncInterval, 300, "Offering sync reconciliation interval in seconds")
+	rootCmd.PersistentFlags().Int(FlagWaldurOfferingSyncMaxRetries, 5, "Max sync retries before dead-lettering")
 
 	// Bind to viper
 	_ = viper.BindPFlag(FlagChainID, rootCmd.PersistentFlags().Lookup(FlagChainID))
@@ -214,6 +241,14 @@ func init() {
 	_ = viper.BindPFlag(FlagWaldurChainBroadcastTimeout, rootCmd.PersistentFlags().Lookup(FlagWaldurChainBroadcastTimeout))
 	_ = viper.BindPFlag(FlagMarketplaceEventQuery, rootCmd.PersistentFlags().Lookup(FlagMarketplaceEventQuery))
 	_ = viper.BindPFlag(FlagCometWS, rootCmd.PersistentFlags().Lookup(FlagCometWS))
+
+	// VE-2D: Bind offering sync flags
+	_ = viper.BindPFlag(FlagWaldurOfferingSyncEnabled, rootCmd.PersistentFlags().Lookup(FlagWaldurOfferingSyncEnabled))
+	_ = viper.BindPFlag(FlagWaldurOfferingSyncStateFile, rootCmd.PersistentFlags().Lookup(FlagWaldurOfferingSyncStateFile))
+	_ = viper.BindPFlag(FlagWaldurCustomerUUID, rootCmd.PersistentFlags().Lookup(FlagWaldurCustomerUUID))
+	_ = viper.BindPFlag(FlagWaldurCategoryMap, rootCmd.PersistentFlags().Lookup(FlagWaldurCategoryMap))
+	_ = viper.BindPFlag(FlagWaldurOfferingSyncInterval, rootCmd.PersistentFlags().Lookup(FlagWaldurOfferingSyncInterval))
+	_ = viper.BindPFlag(FlagWaldurOfferingSyncMaxRetries, rootCmd.PersistentFlags().Lookup(FlagWaldurOfferingSyncMaxRetries))
 
 	// Add commands
 	rootCmd.AddCommand(startCmd())

--- a/pkg/provider_daemon/offering_sync_state.go
+++ b/pkg/provider_daemon/offering_sync_state.go
@@ -1,0 +1,412 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-2D: Offering sync state persistence for chain-to-Waldur synchronization.
+// This file manages the sync state including checksum tracking, version history,
+// error recording, and dead-letter queue handling.
+package provider_daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// OfferingSyncState tracks sync state for all offerings managed by this provider.
+type OfferingSyncState struct {
+	// ProviderAddress is the provider this state belongs to.
+	ProviderAddress string `json:"provider_address"`
+
+	// Records maps offering IDs to their sync records.
+	Records map[string]*OfferingSyncRecord `json:"records"`
+
+	// DeadLetterQueue contains offerings that failed max retries.
+	DeadLetterQueue []*DeadLetterItem `json:"dead_letter_queue,omitempty"`
+
+	// LastReconcileAt is when the last reconciliation ran.
+	LastReconcileAt *time.Time `json:"last_reconcile_at,omitempty"`
+
+	// Metrics tracks sync operation metrics.
+	Metrics *SyncMetrics `json:"metrics"`
+
+	// UpdatedAt is when this state was last modified.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// OfferingSyncRecord tracks sync state for a single offering.
+type OfferingSyncRecord struct {
+	// OfferingID is the on-chain offering ID.
+	OfferingID string `json:"offering_id"`
+
+	// WaldurUUID is the corresponding Waldur offering UUID.
+	WaldurUUID string `json:"waldur_uuid,omitempty"`
+
+	// State is the current sync state.
+	State SyncState `json:"state"`
+
+	// ChainVersion is the current on-chain version.
+	ChainVersion uint64 `json:"chain_version"`
+
+	// SyncedVersion is the version that was last synced to Waldur.
+	SyncedVersion uint64 `json:"synced_version"`
+
+	// Checksum is the hash of the synced data.
+	Checksum string `json:"checksum"`
+
+	// LastSyncedAt is when the offering was last successfully synced.
+	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
+
+	// LastAttemptAt is when sync was last attempted.
+	LastAttemptAt *time.Time `json:"last_attempt_at,omitempty"`
+
+	// LastError is the most recent error message.
+	LastError string `json:"last_error,omitempty"`
+
+	// RetryCount is the number of consecutive retry attempts.
+	RetryCount int `json:"retry_count"`
+
+	// NextRetryAt is when the next retry should be attempted.
+	NextRetryAt *time.Time `json:"next_retry_at,omitempty"`
+
+	// CreatedAt is when this record was first created.
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// SyncState represents the sync state of an offering.
+type SyncState string
+
+const (
+	// SyncStatePending indicates sync is pending.
+	SyncStatePending SyncState = "pending"
+
+	// SyncStateSynced indicates offering is in sync with Waldur.
+	SyncStateSynced SyncState = "synced"
+
+	// SyncStateFailed indicates last sync attempt failed.
+	SyncStateFailed SyncState = "failed"
+
+	// SyncStateRetrying indicates sync is being retried.
+	SyncStateRetrying SyncState = "retrying"
+
+	// SyncStateDeadLettered indicates sync failed permanently.
+	SyncStateDeadLettered SyncState = "dead_lettered"
+
+	// SyncStateOutOfSync indicates chain version > synced version.
+	SyncStateOutOfSync SyncState = "out_of_sync"
+)
+
+// DeadLetterItem represents an offering that failed to sync after max retries.
+type DeadLetterItem struct {
+	// OfferingID is the offering that failed.
+	OfferingID string `json:"offering_id"`
+
+	// Action is the action that failed (create, update, disable).
+	Action string `json:"action"`
+
+	// LastError is the final error.
+	LastError string `json:"last_error"`
+
+	// RetryCount is the number of attempts made.
+	RetryCount int `json:"retry_count"`
+
+	// FirstAttemptAt is when the first attempt was made.
+	FirstAttemptAt time.Time `json:"first_attempt_at"`
+
+	// DeadLetteredAt is when the item was dead-lettered.
+	DeadLetteredAt time.Time `json:"dead_lettered_at"`
+
+	// Checksum is the offering checksum at time of failure.
+	Checksum string `json:"checksum"`
+
+	// ChainVersion is the chain version that failed to sync.
+	ChainVersion uint64 `json:"chain_version"`
+}
+
+// SyncMetrics tracks aggregate sync metrics.
+type SyncMetrics struct {
+	// TotalSyncs is the total number of sync operations.
+	TotalSyncs int64 `json:"total_syncs"`
+
+	// SuccessfulSyncs is the count of successful syncs.
+	SuccessfulSyncs int64 `json:"successful_syncs"`
+
+	// FailedSyncs is the count of failed sync attempts.
+	FailedSyncs int64 `json:"failed_syncs"`
+
+	// DeadLettered is the count of dead-lettered offerings.
+	DeadLettered int64 `json:"dead_lettered"`
+
+	// DriftDetections is the count of drift detections.
+	DriftDetections int64 `json:"drift_detections"`
+
+	// ReconciliationsRun is the count of reconciliation cycles.
+	ReconciliationsRun int64 `json:"reconciliations_run"`
+
+	// LastSyncDurationMs is the duration of the last sync in milliseconds.
+	LastSyncDurationMs int64 `json:"last_sync_duration_ms"`
+
+	// AverageSyncDurationMs is the rolling average sync duration.
+	AverageSyncDurationMs float64 `json:"average_sync_duration_ms"`
+}
+
+// NewOfferingSyncState creates a new sync state for a provider.
+func NewOfferingSyncState(providerAddress string) *OfferingSyncState {
+	return &OfferingSyncState{
+		ProviderAddress: providerAddress,
+		Records:         make(map[string]*OfferingSyncRecord),
+		DeadLetterQueue: make([]*DeadLetterItem, 0),
+		Metrics:         &SyncMetrics{},
+		UpdatedAt:       time.Now().UTC(),
+	}
+}
+
+// GetRecord retrieves a sync record by offering ID.
+func (s *OfferingSyncState) GetRecord(offeringID string) *OfferingSyncRecord {
+	return s.Records[offeringID]
+}
+
+// GetOrCreateRecord retrieves or creates a sync record for an offering.
+func (s *OfferingSyncState) GetOrCreateRecord(offeringID string) *OfferingSyncRecord {
+	if record, exists := s.Records[offeringID]; exists {
+		return record
+	}
+	record := &OfferingSyncRecord{
+		OfferingID:   offeringID,
+		State:        SyncStatePending,
+		ChainVersion: 1,
+		CreatedAt:    time.Now().UTC(),
+	}
+	s.Records[offeringID] = record
+	return record
+}
+
+// MarkSynced marks an offering as successfully synced.
+func (s *OfferingSyncState) MarkSynced(offeringID, waldurUUID, checksum string, version uint64) {
+	record := s.GetOrCreateRecord(offeringID)
+	now := time.Now().UTC()
+	record.WaldurUUID = waldurUUID
+	record.State = SyncStateSynced
+	record.SyncedVersion = version
+	record.ChainVersion = version
+	record.Checksum = checksum
+	record.LastSyncedAt = &now
+	record.LastError = ""
+	record.RetryCount = 0
+	record.NextRetryAt = nil
+	s.UpdatedAt = now
+	s.Metrics.SuccessfulSyncs++
+	s.Metrics.TotalSyncs++
+}
+
+// MarkFailed marks an offering sync as failed. Returns true if the item was dead-lettered.
+func (s *OfferingSyncState) MarkFailed(offeringID, errorMsg string, maxRetries int, baseBackoff, maxBackoff time.Duration) bool {
+	record := s.GetOrCreateRecord(offeringID)
+	now := time.Now().UTC()
+	record.State = SyncStateFailed
+	record.LastAttemptAt = &now
+	record.LastError = errorMsg
+	record.RetryCount++
+
+	deadLettered := false
+
+	// Calculate next retry with exponential backoff
+	if record.RetryCount <= maxRetries {
+		record.State = SyncStateRetrying
+		backoff := baseBackoff * time.Duration(1<<uint(record.RetryCount-1))
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+		nextRetry := now.Add(backoff)
+		record.NextRetryAt = &nextRetry
+	} else {
+		// Move to dead letter queue
+		s.DeadLetter(offeringID, "update", record.Checksum, record.ChainVersion)
+		deadLettered = true
+	}
+
+	s.UpdatedAt = now
+	s.Metrics.FailedSyncs++
+	s.Metrics.TotalSyncs++
+	return deadLettered
+}
+
+// MarkOutOfSync marks an offering as out of sync with chain.
+func (s *OfferingSyncState) MarkOutOfSync(offeringID string, chainVersion uint64, checksum string) {
+	record := s.GetOrCreateRecord(offeringID)
+	record.State = SyncStateOutOfSync
+	record.ChainVersion = chainVersion
+	record.Checksum = checksum
+	s.UpdatedAt = time.Now().UTC()
+	s.Metrics.DriftDetections++
+}
+
+// DeadLetter moves an offering to the dead letter queue.
+func (s *OfferingSyncState) DeadLetter(offeringID, action, checksum string, chainVersion uint64) {
+	record := s.GetRecord(offeringID)
+	if record == nil {
+		return
+	}
+
+	now := time.Now().UTC()
+	item := &DeadLetterItem{
+		OfferingID:     offeringID,
+		Action:         action,
+		LastError:      record.LastError,
+		RetryCount:     record.RetryCount,
+		FirstAttemptAt: record.CreatedAt,
+		DeadLetteredAt: now,
+		Checksum:       checksum,
+		ChainVersion:   chainVersion,
+	}
+
+	s.DeadLetterQueue = append(s.DeadLetterQueue, item)
+	record.State = SyncStateDeadLettered
+	s.UpdatedAt = now
+	s.Metrics.DeadLettered++
+}
+
+// NeedsSyncOfferings returns offering IDs that need syncing.
+func (s *OfferingSyncState) NeedsSyncOfferings() []string {
+	var ids []string
+	now := time.Now().UTC()
+
+	for id, record := range s.Records {
+		switch record.State {
+		case SyncStatePending, SyncStateOutOfSync:
+			ids = append(ids, id)
+		case SyncStateRetrying:
+			if record.NextRetryAt != nil && now.After(*record.NextRetryAt) {
+				ids = append(ids, id)
+			}
+		case SyncStateFailed:
+			if record.NextRetryAt != nil && now.After(*record.NextRetryAt) {
+				ids = append(ids, id)
+			}
+		}
+	}
+
+	return ids
+}
+
+// ReprocessDeadLetter attempts to reprocess a dead-lettered offering.
+func (s *OfferingSyncState) ReprocessDeadLetter(offeringID string) bool {
+	// Find and remove from dead letter queue
+	for i, item := range s.DeadLetterQueue {
+		if item.OfferingID == offeringID {
+			s.DeadLetterQueue = append(s.DeadLetterQueue[:i], s.DeadLetterQueue[i+1:]...)
+			break
+		}
+	}
+
+	// Reset the record for retry
+	record := s.GetRecord(offeringID)
+	if record != nil {
+		record.State = SyncStatePending
+		record.RetryCount = 0
+		record.LastError = ""
+		record.NextRetryAt = nil
+		s.UpdatedAt = time.Now().UTC()
+		return true
+	}
+
+	return false
+}
+
+// RecordReconciliation records that a reconciliation cycle ran.
+func (s *OfferingSyncState) RecordReconciliation() {
+	now := time.Now().UTC()
+	s.LastReconcileAt = &now
+	s.Metrics.ReconciliationsRun++
+	s.UpdatedAt = now
+}
+
+// OfferingSyncStateStore persists offering sync state to disk.
+type OfferingSyncStateStore struct {
+	path string
+	mu   sync.RWMutex
+}
+
+// NewOfferingSyncStateStore creates a new state store.
+func NewOfferingSyncStateStore(path string) *OfferingSyncStateStore {
+	return &OfferingSyncStateStore{path: path}
+}
+
+// Load reads state from disk or returns a new state.
+func (s *OfferingSyncStateStore) Load(providerAddress string) (*OfferingSyncState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return NewOfferingSyncState(providerAddress), nil
+		}
+		return nil, fmt.Errorf("read offering sync state: %w", err)
+	}
+
+	var state OfferingSyncState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("decode offering sync state: %w", err)
+	}
+
+	// Initialize maps if nil
+	if state.Records == nil {
+		state.Records = make(map[string]*OfferingSyncRecord)
+	}
+	if state.DeadLetterQueue == nil {
+		state.DeadLetterQueue = make([]*DeadLetterItem, 0)
+	}
+	if state.Metrics == nil {
+		state.Metrics = &SyncMetrics{}
+	}
+
+	return &state, nil
+}
+
+// Save writes state to disk atomically.
+func (s *OfferingSyncStateStore) Save(state *OfferingSyncState) error {
+	if state == nil {
+		return fmt.Errorf("state is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state.UpdatedAt = time.Now().UTC()
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode offering sync state: %w", err)
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+
+	// Atomic write via temp file
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write state tmp: %w", err)
+	}
+
+	if err := os.Rename(tmp, s.path); err != nil {
+		return fmt.Errorf("replace state: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes the state file.
+func (s *OfferingSyncStateStore) Delete() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete state: %w", err)
+	}
+	return nil
+}

--- a/pkg/provider_daemon/offering_sync_worker.go
+++ b/pkg/provider_daemon/offering_sync_worker.go
@@ -1,0 +1,917 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-2D: Offering sync worker for automatic chain-to-Waldur synchronization.
+// This file implements the sync worker that listens to offering events and
+// synchronizes them to Waldur, with retry/backoff and reconciliation.
+package provider_daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	tmtypes "github.com/cometbft/cometbft/types"
+
+	"github.com/virtengine/virtengine/pkg/waldur"
+	"github.com/virtengine/virtengine/x/market/types/marketplace"
+)
+
+// OfferingSyncAuditLogger defines the interface for audit logging.
+// Implementations can log to files, databases, or external services.
+type OfferingSyncAuditLogger interface {
+	// LogSyncAttempt logs a sync operation attempt
+	LogSyncAttempt(entry OfferingSyncAuditEntry)
+	// LogReconciliation logs a reconciliation run
+	LogReconciliation(entry ReconciliationAuditEntry)
+	// LogDeadLetter logs a dead-letter event
+	LogDeadLetter(entry DeadLetterAuditEntry)
+}
+
+// OfferingSyncAuditEntry represents an audit log entry for a sync operation.
+type OfferingSyncAuditEntry struct {
+	Timestamp       time.Time              `json:"timestamp"`
+	OfferingID      string                 `json:"offering_id"`
+	WaldurUUID      string                 `json:"waldur_uuid,omitempty"`
+	Action          SyncAction             `json:"action"`
+	Success         bool                   `json:"success"`
+	Duration        time.Duration          `json:"duration_ns"`
+	Error           string                 `json:"error,omitempty"`
+	RetryCount      int                    `json:"retry_count"`
+	ProviderAddress string                 `json:"provider_address"`
+	Checksum        string                 `json:"checksum,omitempty"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// ReconciliationAuditEntry represents an audit log entry for reconciliation.
+type ReconciliationAuditEntry struct {
+	Timestamp        time.Time `json:"timestamp"`
+	ProviderAddress  string    `json:"provider_address"`
+	OfferingsChecked int       `json:"offerings_checked"`
+	DriftDetected    int       `json:"drift_detected"`
+	OfferingsQueued  int       `json:"offerings_queued"`
+	Duration         time.Duration `json:"duration_ns"`
+	Error            string    `json:"error,omitempty"`
+}
+
+// DeadLetterAuditEntry represents an audit log entry for dead-letter events.
+type DeadLetterAuditEntry struct {
+	Timestamp       time.Time `json:"timestamp"`
+	OfferingID      string    `json:"offering_id"`
+	ProviderAddress string    `json:"provider_address"`
+	TotalAttempts   int       `json:"total_attempts"`
+	LastError       string    `json:"last_error"`
+	Action          string    `json:"action"` // "dead_lettered" or "reprocessed"
+}
+
+// DefaultAuditLogger is a structured JSON audit logger that writes to standard log.
+type DefaultAuditLogger struct {
+	prefix string
+}
+
+// NewDefaultAuditLogger creates a new default audit logger.
+func NewDefaultAuditLogger(prefix string) *DefaultAuditLogger {
+	if prefix == "" {
+		prefix = "[offering-sync-audit]"
+	}
+	return &DefaultAuditLogger{prefix: prefix}
+}
+
+// LogSyncAttempt logs a sync operation to the standard logger as JSON.
+func (l *DefaultAuditLogger) LogSyncAttempt(entry OfferingSyncAuditEntry) {
+	data, _ := json.Marshal(entry)
+	log.Printf("%s sync: %s", l.prefix, string(data))
+}
+
+// LogReconciliation logs a reconciliation run to the standard logger as JSON.
+func (l *DefaultAuditLogger) LogReconciliation(entry ReconciliationAuditEntry) {
+	data, _ := json.Marshal(entry)
+	log.Printf("%s reconcile: %s", l.prefix, string(data))
+}
+
+// LogDeadLetter logs a dead-letter event to the standard logger as JSON.
+func (l *DefaultAuditLogger) LogDeadLetter(entry DeadLetterAuditEntry) {
+	data, _ := json.Marshal(entry)
+	log.Printf("%s dead_letter: %s", l.prefix, string(data))
+}
+
+// OfferingSyncPrometheusMetrics provides Prometheus-compatible metric counters.
+// These can be registered with prometheus.MustRegister() in the main application.
+type OfferingSyncPrometheusMetrics struct {
+	// Sync operation counters
+	SyncsTotal        atomic.Int64
+	SyncsSuccessful   atomic.Int64
+	SyncsFailed       atomic.Int64
+	SyncsDeadLettered atomic.Int64
+
+	// Event counters
+	EventsReceived  atomic.Int64
+	EventsProcessed atomic.Int64
+	EventsDropped   atomic.Int64
+
+	// Reconciliation counters
+	ReconciliationsRun atomic.Int64
+	DriftDetected      atomic.Int64
+
+	// Timing histograms (simplified - in production use prometheus.Histogram)
+	SyncDurationSum   atomic.Int64
+	SyncDurationCount atomic.Int64
+
+	// Current state
+	QueueDepth     atomic.Int64
+	ActiveSyncs    atomic.Int64
+	DeadLetterSize atomic.Int64
+}
+
+// OfferingSyncWorkerConfig configures the offering sync worker.
+type OfferingSyncWorkerConfig struct {
+	// Enabled toggles the sync worker.
+	Enabled bool
+
+	// ProviderAddress is the provider's on-chain address.
+	ProviderAddress string
+
+	// CometRPC is the CometBFT RPC endpoint.
+	CometRPC string
+
+	// CometWS is the CometBFT WebSocket path.
+	CometWS string
+
+	// SubscriberID identifies this subscriber.
+	SubscriberID string
+
+	// EventBuffer is the event channel buffer size.
+	EventBuffer int
+
+	// SyncIntervalSeconds is how often to run reconciliation.
+	SyncIntervalSeconds int64
+
+	// ReconcileOnStartup triggers full reconciliation on start.
+	ReconcileOnStartup bool
+
+	// MaxRetries is the max retry attempts before dead-lettering.
+	MaxRetries int
+
+	// RetryBackoffSeconds is the base backoff duration.
+	RetryBackoffSeconds int64
+
+	// MaxBackoffSeconds is the maximum backoff duration.
+	MaxBackoffSeconds int64
+
+	// StateFilePath is the path to persist sync state.
+	StateFilePath string
+
+	// WaldurCustomerUUID is the Waldur customer/organization UUID.
+	WaldurCustomerUUID string
+
+	// WaldurCategoryMap maps offering categories to Waldur category UUIDs.
+	WaldurCategoryMap map[string]string
+
+	// CurrencyDenominator for price normalization.
+	CurrencyDenominator uint64
+
+	// OperationTimeout for Waldur API calls.
+	OperationTimeout time.Duration
+}
+
+// DefaultOfferingSyncWorkerConfig returns sensible defaults.
+func DefaultOfferingSyncWorkerConfig() OfferingSyncWorkerConfig {
+	return OfferingSyncWorkerConfig{
+		EventBuffer:         100,
+		SyncIntervalSeconds: 300,
+		ReconcileOnStartup:  true,
+		MaxRetries:          5,
+		RetryBackoffSeconds: 30,
+		MaxBackoffSeconds:   3600,
+		CurrencyDenominator: 1000000,
+		OperationTimeout:    45 * time.Second,
+		CometWS:             "/websocket",
+		StateFilePath:       "data/offering_sync_state.json",
+	}
+}
+
+// OfferingSyncWorker synchronizes on-chain offerings to Waldur.
+type OfferingSyncWorker struct {
+	cfg         OfferingSyncWorkerConfig
+	syncConfig  marketplace.OfferingSyncConfig
+	marketplace *waldur.MarketplaceClient
+	stateStore  *OfferingSyncStateStore
+	state       *OfferingSyncState
+	rpcClient   *rpchttp.HTTP
+
+	mu            sync.RWMutex
+	running       bool
+	stopCh        chan struct{}
+	doneCh        chan struct{}
+	syncQueue     chan *OfferingSyncTask
+	metrics       *OfferingSyncWorkerMetrics
+	auditLogger   OfferingSyncAuditLogger
+	promMetrics   *OfferingSyncPrometheusMetrics
+}
+
+// OfferingSyncTask represents a sync task to execute.
+type OfferingSyncTask struct {
+	OfferingID string
+	Action     SyncAction
+	Offering   *marketplace.Offering
+	Timestamp  time.Time
+}
+
+// SyncAction represents the sync action to perform.
+type SyncAction string
+
+const (
+	SyncActionCreate  SyncAction = "create"
+	SyncActionUpdate  SyncAction = "update"
+	SyncActionDisable SyncAction = "disable"
+)
+
+// OfferingSyncWorkerMetrics tracks worker metrics.
+type OfferingSyncWorkerMetrics struct {
+	mu                  sync.RWMutex
+	SyncsTotal          int64
+	SyncsSuccessful     int64
+	SyncsFailed         int64
+	SyncsDeadLettered   int64
+	DriftDetections     int64
+	ReconciliationsRun  int64
+	LastSyncTime        time.Time
+	LastSuccessTime     time.Time
+	LastReconcileTime   time.Time
+	WorkerUptime        time.Time
+	EventsReceived      int64
+	EventsProcessed     int64
+	QueueDepth          int
+	AverageSyncDuration time.Duration
+}
+
+// OfferingEventPayload represents an offering event from the chain.
+type OfferingEventPayload struct {
+	OfferingID      string `json:"offering_id"`
+	ProviderAddress string `json:"provider_address"`
+	Name            string `json:"name,omitempty"`
+	Category        string `json:"category,omitempty"`
+	State           string `json:"state,omitempty"`
+	Version         uint64 `json:"version"`
+}
+
+// NewOfferingSyncWorker creates a new offering sync worker.
+func NewOfferingSyncWorker(
+	cfg OfferingSyncWorkerConfig,
+	marketplaceClient *waldur.MarketplaceClient,
+) (*OfferingSyncWorker, error) {
+	return NewOfferingSyncWorkerWithLogger(cfg, marketplaceClient, nil)
+}
+
+// NewOfferingSyncWorkerWithLogger creates a new offering sync worker with a custom audit logger.
+func NewOfferingSyncWorkerWithLogger(
+	cfg OfferingSyncWorkerConfig,
+	marketplaceClient *waldur.MarketplaceClient,
+	auditLogger OfferingSyncAuditLogger,
+) (*OfferingSyncWorker, error) {
+	if marketplaceClient == nil {
+		return nil, fmt.Errorf("marketplace client is required")
+	}
+
+	// Use default audit logger if none provided
+	if auditLogger == nil {
+		auditLogger = NewDefaultAuditLogger("[offering-sync-audit]")
+	}
+
+	// Build sync config from worker config
+	syncConfig := marketplace.DefaultOfferingSyncConfig()
+	syncConfig.Enabled = cfg.Enabled
+	syncConfig.SyncIntervalSeconds = cfg.SyncIntervalSeconds
+	syncConfig.ReconcileOnStartup = cfg.ReconcileOnStartup
+	syncConfig.MaxRetries = cfg.MaxRetries
+	syncConfig.RetryBackoffSeconds = cfg.RetryBackoffSeconds
+	syncConfig.MaxBackoffSeconds = cfg.MaxBackoffSeconds
+	syncConfig.WaldurCustomerUUID = cfg.WaldurCustomerUUID
+	syncConfig.WaldurCategoryMap = cfg.WaldurCategoryMap
+	syncConfig.CurrencyDenominator = cfg.CurrencyDenominator
+
+	stateStore := NewOfferingSyncStateStore(cfg.StateFilePath)
+
+	return &OfferingSyncWorker{
+		cfg:         cfg,
+		syncConfig:  syncConfig,
+		marketplace: marketplaceClient,
+		stateStore:  stateStore,
+		stopCh:      make(chan struct{}),
+		doneCh:      make(chan struct{}),
+		syncQueue:   make(chan *OfferingSyncTask, cfg.EventBuffer),
+		metrics: &OfferingSyncWorkerMetrics{
+			WorkerUptime: time.Now().UTC(),
+		},
+		auditLogger: auditLogger,
+		promMetrics: &OfferingSyncPrometheusMetrics{},
+	}, nil
+}
+
+// Start starts the offering sync worker.
+func (w *OfferingSyncWorker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return fmt.Errorf("worker already running")
+	}
+	w.running = true
+	w.mu.Unlock()
+
+	// Load persisted state
+	state, err := w.stateStore.Load(w.cfg.ProviderAddress)
+	if err != nil {
+		return fmt.Errorf("load sync state: %w", err)
+	}
+	w.state = state
+
+	// Connect to CometBFT
+	if w.cfg.CometRPC != "" {
+		rpc, err := rpchttp.New(w.cfg.CometRPC, w.cfg.CometWS)
+		if err != nil {
+			return fmt.Errorf("create rpc client: %w", err)
+		}
+		if err := rpc.Start(); err != nil {
+			return fmt.Errorf("start rpc client: %w", err)
+		}
+		w.rpcClient = rpc
+	}
+
+	log.Printf("[offering-sync] started for provider %s", w.cfg.ProviderAddress)
+
+	// Start background goroutines
+	go w.eventLoop(ctx)
+	go w.syncLoop(ctx)
+	go w.reconcileLoop(ctx)
+
+	// Initial reconciliation if enabled
+	if w.cfg.ReconcileOnStartup {
+		go func() {
+			time.Sleep(5 * time.Second) // Wait for system to stabilize
+			if err := w.Reconcile(ctx); err != nil {
+				log.Printf("[offering-sync] initial reconcile failed: %v", err)
+			}
+		}()
+	}
+
+	return nil
+}
+
+// Stop stops the offering sync worker.
+func (w *OfferingSyncWorker) Stop() error {
+	w.mu.Lock()
+	if !w.running {
+		w.mu.Unlock()
+		return nil
+	}
+	w.running = false
+	w.mu.Unlock()
+
+	close(w.stopCh)
+
+	// Wait for goroutines to finish with timeout
+	select {
+	case <-w.doneCh:
+	case <-time.After(10 * time.Second):
+		log.Printf("[offering-sync] shutdown timeout")
+	}
+
+	// Stop RPC client
+	if w.rpcClient != nil {
+		if err := w.rpcClient.Stop(); err != nil {
+			log.Printf("[offering-sync] rpc client stop error: %v", err)
+		}
+	}
+
+	// Save final state
+	if err := w.stateStore.Save(w.state); err != nil {
+		log.Printf("[offering-sync] failed to save final state: %v", err)
+	}
+
+	log.Printf("[offering-sync] stopped")
+	return nil
+}
+
+// eventLoop subscribes to offering events from the chain.
+func (w *OfferingSyncWorker) eventLoop(ctx context.Context) {
+	if w.rpcClient == nil {
+		log.Printf("[offering-sync] no RPC client, skipping event subscription")
+		return
+	}
+
+	query := w.buildOfferingEventQuery()
+	subscriberID := w.cfg.SubscriberID
+	if subscriberID == "" {
+		subscriberID = fmt.Sprintf("offering-sync-%d", time.Now().UnixNano())
+	}
+
+	sub, err := w.rpcClient.Subscribe(ctx, subscriberID, query, w.cfg.EventBuffer)
+	if err != nil {
+		log.Printf("[offering-sync] subscribe failed: %v", err)
+		return
+	}
+
+	log.Printf("[offering-sync] subscribed to offering events with query: %s", query)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case msg := <-sub:
+			w.metrics.mu.Lock()
+			w.metrics.EventsReceived++
+			w.metrics.mu.Unlock()
+			w.promMetrics.EventsReceived.Add(1)
+
+			data, ok := msg.Data.(tmtypes.EventDataTx)
+			if !ok {
+				continue
+			}
+
+			w.processChainEvents(ctx, data)
+		}
+	}
+}
+
+// buildOfferingEventQuery builds the CometBFT subscription query for offering events.
+func (w *OfferingSyncWorker) buildOfferingEventQuery() string {
+	eventTypes := []string{
+		string(marketplace.EventOfferingCreated),
+		string(marketplace.EventOfferingUpdated),
+		string(marketplace.EventOfferingTerminated),
+	}
+
+	parts := make([]string, 0, len(eventTypes))
+	for _, eventType := range eventTypes {
+		parts = append(parts, fmt.Sprintf("marketplace_event.event_type='%s'", eventType))
+	}
+
+	return fmt.Sprintf("tm.event='Tx' AND (%s)", strings.Join(parts, " OR "))
+}
+
+// processChainEvents extracts and queues offering events from a transaction.
+func (w *OfferingSyncWorker) processChainEvents(ctx context.Context, data tmtypes.EventDataTx) {
+	envelopes, err := ExtractMarketplaceEvents(data.Result.Events)
+	if err != nil {
+		log.Printf("[offering-sync] extract events error: %v", err)
+		return
+	}
+
+	for _, envelope := range envelopes {
+		// Filter to offering events for this provider
+		switch marketplace.MarketplaceEventType(envelope.EventType) {
+		case marketplace.EventOfferingCreated,
+			marketplace.EventOfferingUpdated,
+			marketplace.EventOfferingTerminated:
+
+			var payload OfferingEventPayload
+			if err := json.Unmarshal([]byte(envelope.PayloadJSON), &payload); err != nil {
+				log.Printf("[offering-sync] decode payload error: %v", err)
+				continue
+			}
+
+			// Only process events for this provider
+			if !strings.EqualFold(payload.ProviderAddress, w.cfg.ProviderAddress) {
+				continue
+			}
+
+			// Queue the sync task
+			action := w.eventTypeToAction(marketplace.MarketplaceEventType(envelope.EventType))
+			task := &OfferingSyncTask{
+				OfferingID: payload.OfferingID,
+				Action:     action,
+				Timestamp:  time.Now().UTC(),
+			}
+
+			select {
+			case w.syncQueue <- task:
+				w.metrics.mu.Lock()
+				w.metrics.EventsProcessed++
+				w.metrics.mu.Unlock()
+				w.promMetrics.EventsProcessed.Add(1)
+				log.Printf("[offering-sync] queued %s for offering %s", action, payload.OfferingID)
+			default:
+				w.promMetrics.EventsDropped.Add(1)
+				log.Printf("[offering-sync] queue full, dropping event for %s", payload.OfferingID)
+			}
+		}
+	}
+}
+
+// eventTypeToAction converts an event type to a sync action.
+func (w *OfferingSyncWorker) eventTypeToAction(eventType marketplace.MarketplaceEventType) SyncAction {
+	switch eventType {
+	case marketplace.EventOfferingCreated:
+		return SyncActionCreate
+	case marketplace.EventOfferingUpdated:
+		return SyncActionUpdate
+	case marketplace.EventOfferingTerminated:
+		return SyncActionDisable
+	default:
+		return SyncActionUpdate
+	}
+}
+
+// syncLoop processes sync tasks from the queue.
+func (w *OfferingSyncWorker) syncLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			close(w.doneCh)
+			return
+		case <-w.stopCh:
+			close(w.doneCh)
+			return
+		case task := <-w.syncQueue:
+			w.processTask(ctx, task)
+		}
+	}
+}
+
+// processTask executes a sync task.
+func (w *OfferingSyncWorker) processTask(ctx context.Context, task *OfferingSyncTask) {
+	startTime := time.Now()
+
+	w.metrics.mu.Lock()
+	w.metrics.SyncsTotal++
+	w.metrics.LastSyncTime = startTime
+	w.metrics.mu.Unlock()
+
+	// Update prometheus metrics
+	w.promMetrics.SyncsTotal.Add(1)
+	w.promMetrics.ActiveSyncs.Add(1)
+	defer w.promMetrics.ActiveSyncs.Add(-1)
+
+	var err error
+	var waldurUUID string
+	var retryCount int
+
+	// Get current retry count from state
+	record := w.state.GetRecord(task.OfferingID)
+	if record != nil {
+		retryCount = record.RetryCount
+	}
+
+	opCtx, cancel := context.WithTimeout(ctx, w.cfg.OperationTimeout)
+	defer cancel()
+
+	switch task.Action {
+	case SyncActionCreate:
+		waldurUUID, err = w.syncCreate(opCtx, task)
+	case SyncActionUpdate:
+		waldurUUID, err = w.syncUpdate(opCtx, task)
+	case SyncActionDisable:
+		err = w.syncDisable(opCtx, task)
+	}
+
+	duration := time.Since(startTime)
+
+	// Update prometheus timing metrics
+	w.promMetrics.SyncDurationSum.Add(int64(duration))
+	w.promMetrics.SyncDurationCount.Add(1)
+
+	// Prepare checksum for audit entry
+	checksum := ""
+	if task.Offering != nil {
+		checksum = task.Offering.SyncChecksum()
+	}
+
+	// Create audit entry
+	auditEntry := OfferingSyncAuditEntry{
+		Timestamp:       startTime,
+		OfferingID:      task.OfferingID,
+		WaldurUUID:      waldurUUID,
+		Action:          task.Action,
+		Success:         err == nil,
+		Duration:        duration,
+		RetryCount:      retryCount,
+		ProviderAddress: w.cfg.ProviderAddress,
+		Checksum:        checksum,
+	}
+
+	if err != nil {
+		auditEntry.Error = err.Error()
+		log.Printf("[offering-sync] %s failed for %s: %v", task.Action, task.OfferingID, err)
+
+		deadLettered := w.state.MarkFailed(
+			task.OfferingID,
+			err.Error(),
+			w.cfg.MaxRetries,
+			time.Duration(w.cfg.RetryBackoffSeconds)*time.Second,
+			time.Duration(w.cfg.MaxBackoffSeconds)*time.Second,
+		)
+
+		w.metrics.mu.Lock()
+		w.metrics.SyncsFailed++
+		w.metrics.mu.Unlock()
+
+		w.promMetrics.SyncsFailed.Add(1)
+
+		// Log dead-letter event if this pushed it to dead-letter
+		if deadLettered {
+			w.metrics.mu.Lock()
+			w.metrics.SyncsDeadLettered++
+			w.metrics.mu.Unlock()
+
+			w.promMetrics.SyncsDeadLettered.Add(1)
+			w.promMetrics.DeadLetterSize.Add(1)
+
+			w.auditLogger.LogDeadLetter(DeadLetterAuditEntry{
+				Timestamp:       time.Now().UTC(),
+				OfferingID:      task.OfferingID,
+				ProviderAddress: w.cfg.ProviderAddress,
+				TotalAttempts:   retryCount + 1,
+				LastError:       err.Error(),
+				Action:          "dead_lettered",
+			})
+		}
+	} else {
+		version := uint64(1)
+		w.state.MarkSynced(task.OfferingID, waldurUUID, checksum, version)
+		log.Printf("[offering-sync] %s succeeded for %s → %s (took %v)",
+			task.Action, task.OfferingID, waldurUUID, duration)
+
+		w.metrics.mu.Lock()
+		w.metrics.SyncsSuccessful++
+		w.metrics.LastSuccessTime = time.Now().UTC()
+		w.metrics.mu.Unlock()
+
+		w.promMetrics.SyncsSuccessful.Add(1)
+	}
+
+	// Log audit entry
+	w.auditLogger.LogSyncAttempt(auditEntry)
+
+	// Persist state after each sync
+	if saveErr := w.stateStore.Save(w.state); saveErr != nil {
+		log.Printf("[offering-sync] failed to save state: %v", saveErr)
+	}
+}
+
+// syncCreate creates a new offering in Waldur.
+func (w *OfferingSyncWorker) syncCreate(ctx context.Context, task *OfferingSyncTask) (string, error) {
+	if task.Offering == nil {
+		return "", fmt.Errorf("offering data required for create")
+	}
+
+	// Check if offering already exists in Waldur
+	existing, err := w.marketplace.GetOfferingByBackendID(ctx, task.OfferingID)
+	if err == nil && existing != nil {
+		// Already exists, update instead
+		return existing.UUID, w.syncUpdateExisting(ctx, task, existing.UUID)
+	}
+	if err != nil && !errors.Is(err, waldur.ErrNotFound) {
+		return "", fmt.Errorf("check existing: %w", err)
+	}
+
+	// Convert to Waldur create request
+	createReq := task.Offering.ToWaldurCreate(w.syncConfig)
+
+	offering, err := w.marketplace.CreateOffering(ctx, waldur.CreateOfferingRequest{
+		Name:         createReq.Name,
+		Description:  createReq.Description,
+		Type:         createReq.Type,
+		State:        createReq.State,
+		CategoryUUID: createReq.CategoryUUID,
+		CustomerUUID: createReq.CustomerUUID,
+		Shared:       createReq.Shared,
+		Billable:     createReq.Billable,
+		BackendID:    createReq.BackendID,
+		Attributes:   createReq.Attributes,
+	})
+	if err != nil {
+		return "", fmt.Errorf("create offering: %w", err)
+	}
+
+	return offering.UUID, nil
+}
+
+// syncUpdate updates an existing offering in Waldur.
+func (w *OfferingSyncWorker) syncUpdate(ctx context.Context, task *OfferingSyncTask) (string, error) {
+	// Get the Waldur UUID from state
+	record := w.state.GetRecord(task.OfferingID)
+	if record == nil || record.WaldurUUID == "" {
+		// Try to find by backend ID
+		existing, err := w.marketplace.GetOfferingByBackendID(ctx, task.OfferingID)
+		if err != nil {
+			if errors.Is(err, waldur.ErrNotFound) {
+				// Doesn't exist, create instead
+				return w.syncCreate(ctx, task)
+			}
+			return "", fmt.Errorf("lookup offering: %w", err)
+		}
+		return existing.UUID, w.syncUpdateExisting(ctx, task, existing.UUID)
+	}
+
+	return record.WaldurUUID, w.syncUpdateExisting(ctx, task, record.WaldurUUID)
+}
+
+// syncUpdateExisting updates an offering with a known Waldur UUID.
+func (w *OfferingSyncWorker) syncUpdateExisting(ctx context.Context, task *OfferingSyncTask, waldurUUID string) error {
+	if task.Offering == nil {
+		return fmt.Errorf("offering data required for update")
+	}
+
+	updateReq := task.Offering.ToWaldurUpdate(w.syncConfig)
+
+	_, err := w.marketplace.UpdateOffering(ctx, waldurUUID, waldur.UpdateOfferingRequest{
+		Name:        updateReq.Name,
+		Description: updateReq.Description,
+		Attributes:  updateReq.Attributes,
+	})
+	if err != nil {
+		return fmt.Errorf("update offering: %w", err)
+	}
+
+	// Handle state changes
+	waldurState := marketplace.WaldurOfferingState[task.Offering.State]
+	if waldurState != "" {
+		action := w.stateToAction(waldurState)
+		if action != "" {
+			if err := w.marketplace.SetOfferingState(ctx, waldurUUID, action); err != nil {
+				log.Printf("[offering-sync] set state %s failed: %v", action, err)
+				// Don't fail the whole update for state change failure
+			}
+		}
+	}
+
+	return nil
+}
+
+// stateToAction converts a Waldur state to an action.
+func (w *OfferingSyncWorker) stateToAction(state string) string {
+	switch state {
+	case "Active":
+		return "activate"
+	case "Paused":
+		return "pause"
+	case "Archived":
+		return "archive"
+	default:
+		return ""
+	}
+}
+
+// syncDisable disables an offering in Waldur.
+func (w *OfferingSyncWorker) syncDisable(ctx context.Context, task *OfferingSyncTask) error {
+	record := w.state.GetRecord(task.OfferingID)
+	if record == nil || record.WaldurUUID == "" {
+		// Try to find by backend ID
+		existing, err := w.marketplace.GetOfferingByBackendID(ctx, task.OfferingID)
+		if err != nil {
+			if errors.Is(err, waldur.ErrNotFound) {
+				return nil // Already gone, nothing to do
+			}
+			return fmt.Errorf("lookup offering: %w", err)
+		}
+		return w.marketplace.SetOfferingState(ctx, existing.UUID, "archive")
+	}
+
+	return w.marketplace.SetOfferingState(ctx, record.WaldurUUID, "archive")
+}
+
+// reconcileLoop runs periodic reconciliation.
+func (w *OfferingSyncWorker) reconcileLoop(ctx context.Context) {
+	if w.cfg.SyncIntervalSeconds <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(time.Duration(w.cfg.SyncIntervalSeconds) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			if err := w.Reconcile(ctx); err != nil {
+				log.Printf("[offering-sync] reconcile error: %v", err)
+			}
+		}
+	}
+}
+
+// Reconcile performs full reconciliation between chain and Waldur.
+func (w *OfferingSyncWorker) Reconcile(ctx context.Context) error {
+	log.Printf("[offering-sync] starting reconciliation")
+	startTime := time.Now()
+
+	// Get offerings that need syncing
+	needsSync := w.state.NeedsSyncOfferings()
+	offeringsQueued := 0
+
+	for _, offeringID := range needsSync {
+		task := &OfferingSyncTask{
+			OfferingID: offeringID,
+			Action:     SyncActionUpdate,
+			Timestamp:  time.Now().UTC(),
+		}
+
+		select {
+		case w.syncQueue <- task:
+			offeringsQueued++
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			log.Printf("[offering-sync] reconcile queue full, skipping %s", offeringID)
+		}
+	}
+
+	duration := time.Since(startTime)
+
+	w.state.RecordReconciliation()
+	w.metrics.mu.Lock()
+	w.metrics.ReconciliationsRun++
+	w.metrics.LastReconcileTime = time.Now().UTC()
+	w.metrics.mu.Unlock()
+
+	// Update prometheus metrics
+	w.promMetrics.ReconciliationsRun.Add(1)
+	w.promMetrics.DriftDetected.Add(int64(len(needsSync)))
+	w.promMetrics.QueueDepth.Store(int64(len(w.syncQueue)))
+
+	// Log reconciliation audit entry
+	w.auditLogger.LogReconciliation(ReconciliationAuditEntry{
+		Timestamp:        startTime,
+		ProviderAddress:  w.cfg.ProviderAddress,
+		OfferingsChecked: len(w.state.Records),
+		DriftDetected:    len(needsSync),
+		OfferingsQueued:  offeringsQueued,
+		Duration:         duration,
+	})
+
+	log.Printf("[offering-sync] reconciliation queued %d offerings (took %v)",
+		len(needsSync), duration)
+
+	return nil
+}
+
+// QueueSync manually queues a sync task.
+func (w *OfferingSyncWorker) QueueSync(offeringID string, action SyncAction, offering *marketplace.Offering) error {
+	task := &OfferingSyncTask{
+		OfferingID: offeringID,
+		Action:     action,
+		Offering:   offering,
+		Timestamp:  time.Now().UTC(),
+	}
+
+	select {
+	case w.syncQueue <- task:
+		return nil
+	default:
+		return fmt.Errorf("sync queue full")
+	}
+}
+
+// Metrics returns current worker metrics.
+func (w *OfferingSyncWorker) Metrics() OfferingSyncWorkerMetrics {
+	w.metrics.mu.RLock()
+	defer w.metrics.mu.RUnlock()
+
+	m := *w.metrics
+	m.QueueDepth = len(w.syncQueue)
+	return m
+}
+
+// State returns the current sync state.
+func (w *OfferingSyncWorker) State() *OfferingSyncState {
+	return w.state
+}
+
+// ReprocessDeadLetter attempts to reprocess a dead-lettered offering.
+func (w *OfferingSyncWorker) ReprocessDeadLetter(offeringID string) error {
+	if w.state.ReprocessDeadLetter(offeringID) {
+		w.promMetrics.DeadLetterSize.Add(-1)
+
+		// Log the reprocess event
+		w.auditLogger.LogDeadLetter(DeadLetterAuditEntry{
+			Timestamp:       time.Now().UTC(),
+			OfferingID:      offeringID,
+			ProviderAddress: w.cfg.ProviderAddress,
+			Action:          "reprocessed",
+		})
+
+		return w.QueueSync(offeringID, SyncActionUpdate, nil)
+	}
+	return fmt.Errorf("offering %s not found in dead letter queue", offeringID)
+}
+
+// PrometheusMetrics returns the prometheus-compatible metrics for this worker.
+func (w *OfferingSyncWorker) PrometheusMetrics() *OfferingSyncPrometheusMetrics {
+	return w.promMetrics
+}
+
+// SetAuditLogger allows replacing the audit logger.
+func (w *OfferingSyncWorker) SetAuditLogger(logger OfferingSyncAuditLogger) {
+	w.auditLogger = logger
+}

--- a/x/market/types/marketplace/offering_sync.go
+++ b/x/market/types/marketplace/offering_sync.go
@@ -1,0 +1,482 @@
+// Package marketplace provides types for the marketplace on-chain module.
+//
+// VE-2D: Offering sync types for automatic chain-to-Waldur synchronization.
+// This file defines the canonical mapping from on-chain offerings to Waldur offerings.
+package marketplace
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// WaldurOfferingType maps VirtEngine offering categories to Waldur offering types.
+var WaldurOfferingType = map[OfferingCategory]string{
+	OfferingCategoryCompute: "VirtEngine.Compute",
+	OfferingCategoryStorage: "VirtEngine.Storage",
+	OfferingCategoryNetwork: "VirtEngine.Network",
+	OfferingCategoryHPC:     "VirtEngine.HPC",
+	OfferingCategoryGPU:     "VirtEngine.GPU",
+	OfferingCategoryML:      "VirtEngine.ML",
+	OfferingCategoryOther:   "VirtEngine.Generic",
+}
+
+// WaldurOfferingState maps VirtEngine offering states to Waldur states.
+var WaldurOfferingState = map[OfferingState]string{
+	OfferingStateActive:     "Active",
+	OfferingStatePaused:     "Paused",
+	OfferingStateSuspended:  "Archived",
+	OfferingStateDeprecated: "Paused",
+	OfferingStateTerminated: "Archived",
+}
+
+// WaldurOfferingCreate contains parameters for creating a Waldur offering.
+type WaldurOfferingCreate struct {
+	// Name is the offering name (max 255 chars).
+	Name string `json:"name"`
+
+	// Description is the offering description (markdown supported).
+	Description string `json:"description,omitempty"`
+
+	// Type is the Waldur offering type (e.g., "VirtEngine.Compute").
+	Type string `json:"type"`
+
+	// State is the initial state (Active, Paused, Archived).
+	State string `json:"state"`
+
+	// CategoryUUID is the Waldur category UUID.
+	CategoryUUID string `json:"category_uuid,omitempty"`
+
+	// CustomerUUID is the Waldur customer/organization UUID (provider).
+	CustomerUUID string `json:"customer_uuid"`
+
+	// Shared indicates if the offering is publicly visible.
+	Shared bool `json:"shared"`
+
+	// Billable indicates if the offering is billable.
+	Billable bool `json:"billable"`
+
+	// BackendID is the on-chain offering ID for cross-reference.
+	BackendID string `json:"backend_id"`
+
+	// Attributes contains additional offering attributes.
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+
+	// Components contains pricing components.
+	Components []WaldurPricingComponent `json:"components,omitempty"`
+}
+
+// WaldurOfferingUpdate contains parameters for updating a Waldur offering.
+type WaldurOfferingUpdate struct {
+	// Name is the updated offering name.
+	Name string `json:"name,omitempty"`
+
+	// Description is the updated description.
+	Description string `json:"description,omitempty"`
+
+	// State is the updated state.
+	State string `json:"state,omitempty"`
+
+	// Attributes contains updated attributes.
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+
+	// Components contains updated pricing components.
+	Components []WaldurPricingComponent `json:"components,omitempty"`
+}
+
+// WaldurPricingComponent represents a Waldur pricing component.
+type WaldurPricingComponent struct {
+	// Type is the component type (usage, fixed, one_time).
+	Type string `json:"type"`
+
+	// Name is the component name.
+	Name string `json:"name"`
+
+	// MeasuredUnit is the unit of measurement.
+	MeasuredUnit string `json:"measured_unit,omitempty"`
+
+	// BillingType is how billing is calculated.
+	BillingType string `json:"billing_type,omitempty"`
+
+	// Price is the price per unit.
+	Price string `json:"price"`
+
+	// MinValue is the minimum value.
+	MinValue int64 `json:"min_value,omitempty"`
+
+	// MaxValue is the maximum value.
+	MaxValue int64 `json:"max_value,omitempty"`
+}
+
+// OfferingSyncConfig configures offering synchronization behavior.
+type OfferingSyncConfig struct {
+	// Enabled toggles automatic offering sync.
+	Enabled bool `json:"enabled"`
+
+	// SyncInterval is how often to check for drift (seconds).
+	SyncIntervalSeconds int64 `json:"sync_interval_seconds"`
+
+	// ReconcileOnStartup triggers full reconciliation on worker start.
+	ReconcileOnStartup bool `json:"reconcile_on_startup"`
+
+	// MaxRetries is the maximum sync retry attempts before dead-lettering.
+	MaxRetries int `json:"max_retries"`
+
+	// RetryBackoffSeconds is the base backoff between retries.
+	RetryBackoffSeconds int64 `json:"retry_backoff_seconds"`
+
+	// MaxBackoffSeconds is the maximum backoff time.
+	MaxBackoffSeconds int64 `json:"max_backoff_seconds"`
+
+	// WaldurCustomerUUID is the Waldur customer UUID for offerings.
+	WaldurCustomerUUID string `json:"waldur_customer_uuid"`
+
+	// WaldurCategoryMap maps offering categories to Waldur category UUIDs.
+	WaldurCategoryMap map[string]string `json:"waldur_category_map,omitempty"`
+
+	// DefaultRegionMap maps VirtEngine region codes to Waldur location UUIDs.
+	DefaultRegionMap map[string]string `json:"default_region_map,omitempty"`
+
+	// CurrencyDenominator is the denominator for price conversion (e.g., 1000000 for utoken).
+	CurrencyDenominator uint64 `json:"currency_denominator"`
+}
+
+// DefaultOfferingSyncConfig returns sensible defaults for offering sync.
+func DefaultOfferingSyncConfig() OfferingSyncConfig {
+	return OfferingSyncConfig{
+		Enabled:             false,
+		SyncIntervalSeconds: 300, // 5 minutes
+		ReconcileOnStartup:  true,
+		MaxRetries:          5,
+		RetryBackoffSeconds: 30,
+		MaxBackoffSeconds:   3600, // 1 hour
+		CurrencyDenominator: 1000000,
+		WaldurCategoryMap:   make(map[string]string),
+		DefaultRegionMap:    make(map[string]string),
+	}
+}
+
+// OfferingSyncResult represents the result of an offering sync operation.
+type OfferingSyncResult struct {
+	// OfferingID is the on-chain offering ID.
+	OfferingID string `json:"offering_id"`
+
+	// WaldurUUID is the Waldur offering UUID (on success).
+	WaldurUUID string `json:"waldur_uuid,omitempty"`
+
+	// Action is the sync action performed (create, update, disable).
+	Action string `json:"action"`
+
+	// Success indicates if the sync succeeded.
+	Success bool `json:"success"`
+
+	// Error is the error message on failure.
+	Error string `json:"error,omitempty"`
+
+	// Checksum is the data checksum after sync.
+	Checksum string `json:"checksum,omitempty"`
+
+	// Version is the on-chain version that was synced.
+	Version uint64 `json:"version"`
+
+	// Timestamp is when the sync completed.
+	Timestamp time.Time `json:"timestamp"`
+
+	// RetryCount is the number of retries attempted.
+	RetryCount int `json:"retry_count"`
+}
+
+// OfferingSyncMetrics tracks sync operation metrics.
+type OfferingSyncMetrics struct {
+	// TotalSyncs is the total sync attempts.
+	TotalSyncs int64 `json:"total_syncs"`
+
+	// SuccessfulSyncs is the count of successful syncs.
+	SuccessfulSyncs int64 `json:"successful_syncs"`
+
+	// FailedSyncs is the count of failed syncs.
+	FailedSyncs int64 `json:"failed_syncs"`
+
+	// DeadLetteredSyncs is the count of dead-lettered syncs.
+	DeadLetteredSyncs int64 `json:"dead_lettered_syncs"`
+
+	// DriftDetections is the count of drift detections.
+	DriftDetections int64 `json:"drift_detections"`
+
+	// ReconciliationsRun is the count of reconciliation runs.
+	ReconciliationsRun int64 `json:"reconciliations_run"`
+
+	// LastSyncTime is the timestamp of the last sync attempt.
+	LastSyncTime time.Time `json:"last_sync_time"`
+
+	// LastSuccessTime is the timestamp of the last successful sync.
+	LastSuccessTime time.Time `json:"last_success_time"`
+
+	// LastReconcileTime is the timestamp of the last reconciliation.
+	LastReconcileTime time.Time `json:"last_reconcile_time"`
+
+	// AverageSyncDurationMs is the average sync duration in milliseconds.
+	AverageSyncDurationMs float64 `json:"average_sync_duration_ms"`
+}
+
+// ToWaldurCreate converts an on-chain offering to Waldur creation parameters.
+func (o *Offering) ToWaldurCreate(cfg OfferingSyncConfig) WaldurOfferingCreate {
+	// Truncate name to Waldur's 255 char limit
+	name := o.Name
+	if len(name) > 255 {
+		name = name[:252] + "..."
+	}
+
+	// Map category to Waldur type
+	offeringType := WaldurOfferingType[o.Category]
+	if offeringType == "" {
+		offeringType = "VirtEngine.Generic"
+	}
+
+	// Map state
+	state := WaldurOfferingState[o.State]
+	if state == "" {
+		state = "Paused"
+	}
+
+	// Build attributes
+	attrs := make(map[string]interface{})
+
+	// Core VirtEngine attributes
+	attrs["ve_offering_id"] = o.ID.String()
+	attrs["ve_provider"] = o.ID.ProviderAddress
+	attrs["ve_category"] = string(o.Category)
+	attrs["ve_version"] = o.Version
+	attrs["ve_min_identity_score"] = o.IdentityRequirement.MinScore
+	attrs["ve_require_mfa"] = o.RequireMFAForOrders
+	attrs["ve_max_concurrent_orders"] = o.MaxConcurrentOrders
+
+	// Tags
+	if len(o.Tags) > 0 {
+		attrs["tags"] = o.Tags
+	}
+
+	// Regions
+	if len(o.Regions) > 0 {
+		attrs["regions"] = o.Regions
+	}
+
+	// Specifications
+	for k, v := range o.Specifications {
+		attrs["spec_"+k] = v
+	}
+
+	// Public metadata with ve_ prefix
+	for k, v := range o.PublicMetadata {
+		attrs["ve_"+k] = v
+	}
+
+	// Build pricing components
+	var components []WaldurPricingComponent
+	components = append(components, WaldurPricingComponent{
+		Type:         "usage",
+		Name:         "base",
+		MeasuredUnit: string(o.Pricing.Model),
+		BillingType:  mapPricingModel(o.Pricing.Model),
+		Price:        normalizePrice(o.Pricing.BasePrice, cfg.CurrencyDenominator),
+	})
+
+	// Add usage rate components
+	for name, rate := range o.Pricing.UsageRates {
+		components = append(components, WaldurPricingComponent{
+			Type:         "usage",
+			Name:         name,
+			MeasuredUnit: name,
+			BillingType:  "usage",
+			Price:        normalizePrice(rate, cfg.CurrencyDenominator),
+		})
+	}
+
+	// Resolve category UUID
+	categoryUUID := cfg.WaldurCategoryMap[string(o.Category)]
+
+	return WaldurOfferingCreate{
+		Name:         name,
+		Description:  o.Description,
+		Type:         offeringType,
+		State:        state,
+		CategoryUUID: categoryUUID,
+		CustomerUUID: cfg.WaldurCustomerUUID,
+		Shared:       true, // VirtEngine offerings are public marketplace offerings
+		Billable:     true,
+		BackendID:    o.ID.String(),
+		Attributes:   attrs,
+		Components:   components,
+	}
+}
+
+// ToWaldurUpdate converts offering changes to Waldur update parameters.
+func (o *Offering) ToWaldurUpdate(cfg OfferingSyncConfig) WaldurOfferingUpdate {
+	// Truncate name
+	name := o.Name
+	if len(name) > 255 {
+		name = name[:252] + "..."
+	}
+
+	// Map state
+	state := WaldurOfferingState[o.State]
+	if state == "" {
+		state = "Paused"
+	}
+
+	// Build attributes (same as create)
+	attrs := make(map[string]interface{})
+	attrs["ve_offering_id"] = o.ID.String()
+	attrs["ve_provider"] = o.ID.ProviderAddress
+	attrs["ve_category"] = string(o.Category)
+	attrs["ve_version"] = o.Version
+	attrs["ve_min_identity_score"] = o.IdentityRequirement.MinScore
+	attrs["ve_require_mfa"] = o.RequireMFAForOrders
+	attrs["ve_max_concurrent_orders"] = o.MaxConcurrentOrders
+
+	if len(o.Tags) > 0 {
+		attrs["tags"] = o.Tags
+	}
+	if len(o.Regions) > 0 {
+		attrs["regions"] = o.Regions
+	}
+	for k, v := range o.Specifications {
+		attrs["spec_"+k] = v
+	}
+	for k, v := range o.PublicMetadata {
+		attrs["ve_"+k] = v
+	}
+
+	// Build pricing components
+	var components []WaldurPricingComponent
+	components = append(components, WaldurPricingComponent{
+		Type:         "usage",
+		Name:         "base",
+		MeasuredUnit: string(o.Pricing.Model),
+		BillingType:  mapPricingModel(o.Pricing.Model),
+		Price:        normalizePrice(o.Pricing.BasePrice, cfg.CurrencyDenominator),
+	})
+	for name, rate := range o.Pricing.UsageRates {
+		components = append(components, WaldurPricingComponent{
+			Type:         "usage",
+			Name:         name,
+			MeasuredUnit: name,
+			BillingType:  "usage",
+			Price:        normalizePrice(rate, cfg.CurrencyDenominator),
+		})
+	}
+
+	return WaldurOfferingUpdate{
+		Name:        name,
+		Description: o.Description,
+		State:       state,
+		Attributes:  attrs,
+		Components:  components,
+	}
+}
+
+// SyncChecksum computes a deterministic checksum of the offering for drift detection.
+func (o *Offering) SyncChecksum() string {
+	h := sha256.New()
+
+	// Include all sync-relevant fields in a deterministic order
+	h.Write([]byte(o.ID.String()))
+	h.Write([]byte(o.Name))
+	h.Write([]byte(o.Description))
+	h.Write([]byte(o.Category))
+	h.Write([]byte(o.Version))
+	h.Write([]byte(fmt.Sprintf("%d", o.State)))
+	h.Write([]byte(o.Pricing.Model))
+	h.Write([]byte(fmt.Sprintf("%d", o.Pricing.BasePrice)))
+	h.Write([]byte(o.Pricing.Currency))
+	h.Write([]byte(fmt.Sprintf("%d", o.IdentityRequirement.MinScore)))
+	h.Write([]byte(fmt.Sprintf("%t", o.RequireMFAForOrders)))
+	h.Write([]byte(fmt.Sprintf("%d", o.MaxConcurrentOrders)))
+	h.Write([]byte(fmt.Sprintf("%d", o.UpdatedAt.Unix())))
+
+	// Include tags in sorted order
+	for _, tag := range o.Tags {
+		h.Write([]byte(tag))
+	}
+
+	// Include regions in sorted order
+	for _, region := range o.Regions {
+		h.Write([]byte(region))
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// mapPricingModel converts VirtEngine pricing model to Waldur billing type.
+func mapPricingModel(model PricingModel) string {
+	switch model {
+	case PricingModelHourly:
+		return "usage"
+	case PricingModelDaily:
+		return "usage"
+	case PricingModelMonthly:
+		return "monthly"
+	case PricingModelUsageBased:
+		return "usage"
+	case PricingModelFixed:
+		return "fixed"
+	default:
+		return "usage"
+	}
+}
+
+// normalizePrice converts smallest token denomination to decimal string.
+func normalizePrice(amount uint64, denominator uint64) string {
+	if denominator == 0 {
+		denominator = 1000000 // default: micro-units
+	}
+	intPart := amount / denominator
+	fracPart := amount % denominator
+	return fmt.Sprintf("%d.%06d", intPart, fracPart)
+}
+
+// OfferingEventData contains data for offering sync events.
+type OfferingEventData struct {
+	// OfferingID is the on-chain offering ID.
+	OfferingID string `json:"offering_id"`
+
+	// ProviderAddress is the provider's address.
+	ProviderAddress string `json:"provider_address"`
+
+	// EventType is the event type (created, updated, terminated).
+	EventType string `json:"event_type"`
+
+	// Version is the current on-chain version.
+	Version uint64 `json:"version"`
+
+	// Checksum is the offering data checksum.
+	Checksum string `json:"checksum"`
+
+	// Timestamp is when the event occurred.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// DeadLetterEntry represents a failed sync that exceeded retry limits.
+type DeadLetterEntry struct {
+	// OfferingID is the offering that failed to sync.
+	OfferingID string `json:"offering_id"`
+
+	// Action is the action that failed (create, update, disable).
+	Action string `json:"action"`
+
+	// LastError is the last error encountered.
+	LastError string `json:"last_error"`
+
+	// RetryCount is the number of retries attempted.
+	RetryCount int `json:"retry_count"`
+
+	// FirstAttempt is when the first sync was attempted.
+	FirstAttempt time.Time `json:"first_attempt"`
+
+	// LastAttempt is when the last sync was attempted.
+	LastAttempt time.Time `json:"last_attempt"`
+
+	// OfferingChecksum is the checksum at time of failure.
+	OfferingChecksum string `json:"offering_checksum"`
+}


### PR DESCRIPTION
Objective:
Eliminate manual mapping by automatically syncing on-chain offerings to Waldur marketplace.

Prerequisites:
- 1D feat(market): define chain<->Waldur mapping + policy spec

Needs to be done (A–I):
A. Define canonical mapping from x/market offering fields to Waldur offering schema.
B. Implement sync worker that listens to offering create/update events.
C. Create/update/disable offerings in Waldur based on on-chain state.
D. Store sync state (checksum, last synced version, error) in WaldurSyncRecord.
E. Implement retry/backoff and dead-letter handling.
F. Add reconciliation job to detect drift and re-sync.
G. Remove WaldurOfferingMap dependency in provider daemon config.
H. Add audit logs and metrics for sync success/failure.
I. Document configuration and recovery steps.

Acceptance criteria:
- On-chain offering changes propagate to Waldur automatically.
- Sync state and errors recorded on-chain.
- Manual mapping no longer required.
- Drift reconciliation validated.

How it can be done:
- Use CometBFT event subscriptions for offering updates.
- Implement sync worker using pkg/waldur marketplace client.
- Store sync records via x/market keeper methods.
- Add integration tests with mock Waldur API.

MCP guidance:
- Use Context7 for Waldur API schema.
- Use Exa for Waldur marketplace integration patterns.

Deliverables:
- Sync worker, mapping schema, reconciliation job, and tests.