### PR TITLE
feat(escrow): generate invoices and persist ledger records

### DIFF
--- a/x/escrow/keeper/invoice.go
+++ b/x/escrow/keeper/invoice.go
@@ -1,0 +1,594 @@
+// Package keeper provides the escrow module keeper with invoice management capabilities.
+package keeper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+
+	"github.com/virtengine/virtengine/x/escrow/types/billing"
+)
+
+// InvoiceKeeper defines the interface for invoice management
+type InvoiceKeeper interface {
+	// CreateInvoice creates a new invoice and its ledger record
+	CreateInvoice(ctx sdk.Context, invoice *billing.Invoice, artifactCID string) (*billing.InvoiceLedgerRecord, error)
+
+	// GetInvoice retrieves an invoice ledger record by ID
+	GetInvoice(ctx sdk.Context, invoiceID string) (*billing.InvoiceLedgerRecord, error)
+
+	// GetInvoicesByProvider retrieves invoices by provider
+	GetInvoicesByProvider(ctx sdk.Context, provider string, pagination *query.PageRequest) ([]*billing.InvoiceLedgerRecord, *query.PageResponse, error)
+
+	// GetInvoicesByCustomer retrieves invoices by customer
+	GetInvoicesByCustomer(ctx sdk.Context, customer string, pagination *query.PageRequest) ([]*billing.InvoiceLedgerRecord, *query.PageResponse, error)
+
+	// GetInvoicesByStatus retrieves invoices by status
+	GetInvoicesByStatus(ctx sdk.Context, status billing.InvoiceStatus, pagination *query.PageRequest) ([]*billing.InvoiceLedgerRecord, *query.PageResponse, error)
+
+	// GetInvoicesByEscrow retrieves invoices by escrow ID
+	GetInvoicesByEscrow(ctx sdk.Context, escrowID string, pagination *query.PageRequest) ([]*billing.InvoiceLedgerRecord, *query.PageResponse, error)
+
+	// UpdateInvoiceStatus updates an invoice status with state machine enforcement
+	UpdateInvoiceStatus(ctx sdk.Context, invoiceID string, newStatus billing.InvoiceStatus, initiator string) (*billing.InvoiceLedgerEntry, error)
+
+	// RecordPayment records a payment against an invoice
+	RecordPayment(ctx sdk.Context, invoiceID string, amount sdk.Coins, initiator string) (*billing.InvoiceLedgerEntry, error)
+
+	// GetInvoiceLedgerEntries retrieves ledger entries for an invoice
+	GetInvoiceLedgerEntries(ctx sdk.Context, invoiceID string) ([]*billing.InvoiceLedgerEntry, error)
+
+	// WithInvoices iterates over all invoices
+	WithInvoices(ctx sdk.Context, fn func(*billing.InvoiceLedgerRecord) bool)
+
+	// GetInvoiceSequence gets the current invoice sequence number
+	GetInvoiceSequence(ctx sdk.Context) uint64
+
+	// SetInvoiceSequence sets the invoice sequence number
+	SetInvoiceSequence(ctx sdk.Context, sequence uint64)
+
+	// SaveReconciliationReport saves a reconciliation report
+	SaveReconciliationReport(ctx sdk.Context, report *billing.ReconciliationReport) error
+
+	// GetReconciliationReport retrieves a reconciliation report
+	GetReconciliationReport(ctx sdk.Context, reportID string) (*billing.ReconciliationReport, error)
+}
+
+// invoiceKeeper implements InvoiceKeeper
+type invoiceKeeper struct {
+	k *keeper
+}
+
+// NewInvoiceKeeper creates a new invoice keeper from the base keeper
+func (k *keeper) NewInvoiceKeeper() InvoiceKeeper {
+	return &invoiceKeeper{k: k}
+}
+
+// CreateInvoice creates a new invoice and its ledger record
+func (ik *invoiceKeeper) CreateInvoice(
+	ctx sdk.Context,
+	invoice *billing.Invoice,
+	artifactCID string,
+) (*billing.InvoiceLedgerRecord, error) {
+	store := ctx.KVStore(ik.k.skey)
+
+	// Check if invoice already exists
+	key := billing.BuildInvoiceLedgerRecordKey(invoice.InvoiceID)
+	if store.Has(key) {
+		return nil, fmt.Errorf("invoice already exists: %s", invoice.InvoiceID)
+	}
+
+	// Create ledger record
+	record, err := billing.NewInvoiceLedgerRecord(
+		invoice,
+		artifactCID,
+		ctx.BlockHeight(),
+		ctx.BlockTime(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ledger record: %w", err)
+	}
+
+	// Validate record
+	if err := record.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid ledger record: %w", err)
+	}
+
+	// Marshal and store
+	bz, err := json.Marshal(record)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ledger record: %w", err)
+	}
+	store.Set(key, bz)
+
+	// Create indexes
+	ik.setInvoiceIndexes(store, record)
+
+	// Create initial ledger entry
+	entry := billing.NewInvoiceLedgerEntry(
+		fmt.Sprintf("%s-created", invoice.InvoiceID),
+		invoice.InvoiceID,
+		billing.LedgerEntryTypeCreated,
+		billing.InvoiceStatusDraft,
+		invoice.Status,
+		sdk.NewCoins(),
+		"invoice created",
+		"system",
+		"",
+		ctx.BlockHeight(),
+		ctx.BlockTime(),
+	)
+	ik.saveLedgerEntry(store, entry)
+
+	// Increment sequence
+	seq := ik.GetInvoiceSequence(ctx)
+	ik.SetInvoiceSequence(ctx, seq+1)
+
+	return record, nil
+}
+
+// GetInvoice retrieves an invoice ledger record by ID
+func (ik *invoiceKeeper) GetInvoice(ctx sdk.Context, invoiceID string) (*billing.InvoiceLedgerRecord, error) {
+	store := ctx.KVStore(ik.k.skey)
+	key := billing.BuildInvoiceLedgerRecordKey(invoiceID)
+
+	bz := store.Get(key)
+	if bz == nil {
+		return nil, fmt.Errorf("invoice not found: %s", invoiceID)
+	}
+
+	var record billing.InvoiceLedgerRecord
+	if err := json.Unmarshal(bz, &record); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ledger record: %w", err)
+	}
+
+	return &record, nil
+}
+
+// GetInvoicesByProvider retrieves invoices by provider
+func (ik *invoiceKeeper) GetInvoicesByProvider(
+	ctx sdk.Context,
+	provider string,
+	pagination *query.PageRequest,
+) ([]*billing.InvoiceLedgerRecord, *query.PageResponse, error) {
+	store := ctx.KVStore(ik.k.skey)
+	prefix := billing.BuildInvoiceByProviderPrefix(provider)
+
+	return ik.paginateInvoiceIndex(store, prefix, pagination)
+}
+
+// GetInvoicesByCustomer retrieves invoices by customer
+func (ik *invoiceKeeper) GetInvoicesByCustomer(
+	ctx sdk.Context,
+	customer string,
+	pagination *query.PageRequest,
+) ([]*billing.InvoiceLedgerRecord, *query.PageResponse, error) {
+	store := ctx.KVStore(ik.k.skey)
+	prefix := billing.BuildInvoiceByCustomerPrefix(customer)
+
+	return ik.paginateInvoiceIndex(store, prefix, pagination)
+}
+
+// GetInvoicesByStatus retrieves invoices by status
+func (ik *invoiceKeeper) GetInvoicesByStatus(
+	ctx sdk.Context,
+	status billing.InvoiceStatus,
+	pagination *query.PageRequest,
+) ([]*billing.InvoiceLedgerRecord, *query.PageResponse, error) {
+	store := ctx.KVStore(ik.k.skey)
+	prefix := billing.BuildInvoiceByStatusPrefix(status)
+
+	return ik.paginateInvoiceIndex(store, prefix, pagination)
+}
+
+// GetInvoicesByEscrow retrieves invoices by escrow ID
+func (ik *invoiceKeeper) GetInvoicesByEscrow(
+	ctx sdk.Context,
+	escrowID string,
+	pagination *query.PageRequest,
+) ([]*billing.InvoiceLedgerRecord, *query.PageResponse, error) {
+	store := ctx.KVStore(ik.k.skey)
+	prefix := billing.BuildInvoiceByEscrowPrefix(escrowID)
+
+	return ik.paginateInvoiceIndex(store, prefix, pagination)
+}
+
+// UpdateInvoiceStatus updates an invoice status with state machine enforcement
+func (ik *invoiceKeeper) UpdateInvoiceStatus(
+	ctx sdk.Context,
+	invoiceID string,
+	newStatus billing.InvoiceStatus,
+	initiator string,
+) (*billing.InvoiceLedgerEntry, error) {
+	store := ctx.KVStore(ik.k.skey)
+
+	// Get current record
+	record, err := ik.GetInvoice(ctx, invoiceID)
+	if err != nil {
+		return nil, err
+	}
+
+	oldStatus := record.Status
+
+	// Validate transition
+	if !billing.IsValidTransition(oldStatus, newStatus) {
+		return nil, fmt.Errorf("invalid transition from %s to %s", oldStatus, newStatus)
+	}
+
+	// Remove old status index
+	oldStatusKey := billing.BuildInvoiceByStatusKey(oldStatus, invoiceID)
+	store.Delete(oldStatusKey)
+
+	// Update record
+	record.Status = newStatus
+	record.UpdatedAt = ctx.BlockTime()
+
+	if newStatus == billing.InvoiceStatusPaid {
+		now := ctx.BlockTime()
+		record.PaidAt = &now
+		record.AmountDue = sdk.NewCoins()
+	}
+
+	// Save updated record
+	key := billing.BuildInvoiceLedgerRecordKey(invoiceID)
+	bz, err := json.Marshal(record)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal updated record: %w", err)
+	}
+	store.Set(key, bz)
+
+	// Add new status index
+	newStatusKey := billing.BuildInvoiceByStatusKey(newStatus, invoiceID)
+	store.Set(newStatusKey, []byte(invoiceID))
+
+	// Create ledger entry
+	transition, _ := billing.GetTransition(oldStatus, newStatus)
+	entry := billing.NewInvoiceLedgerEntry(
+		fmt.Sprintf("%s-status-%d", invoiceID, ctx.BlockHeight()),
+		invoiceID,
+		ik.getEntryTypeForStatus(newStatus),
+		oldStatus,
+		newStatus,
+		sdk.NewCoins(),
+		transition.Description,
+		initiator,
+		"",
+		ctx.BlockHeight(),
+		ctx.BlockTime(),
+	)
+	ik.saveLedgerEntry(store, entry)
+
+	return entry, nil
+}
+
+// RecordPayment records a payment against an invoice
+func (ik *invoiceKeeper) RecordPayment(
+	ctx sdk.Context,
+	invoiceID string,
+	amount sdk.Coins,
+	initiator string,
+) (*billing.InvoiceLedgerEntry, error) {
+	store := ctx.KVStore(ik.k.skey)
+
+	// Get current record
+	record, err := ik.GetInvoice(ctx, invoiceID)
+	if err != nil {
+		return nil, err
+	}
+
+	oldStatus := record.Status
+
+	// Check if payment is allowed
+	if record.Status.IsTerminal() {
+		return nil, fmt.Errorf("cannot record payment on %s invoice", record.Status)
+	}
+
+	// Update payment amounts
+	record.AmountPaid = record.AmountPaid.Add(amount...)
+	record.AmountDue = record.Total.Sub(record.AmountPaid...)
+
+	// Determine new status
+	newStatus := record.Status
+	if record.AmountDue.IsZero() || record.AmountPaid.IsAllGTE(record.Total) {
+		newStatus = billing.InvoiceStatusPaid
+		now := ctx.BlockTime()
+		record.PaidAt = &now
+	} else if record.AmountPaid.IsAllPositive() && oldStatus != billing.InvoiceStatusPartiallyPaid {
+		newStatus = billing.InvoiceStatusPartiallyPaid
+	}
+
+	// Remove old status index if changed
+	if oldStatus != newStatus {
+		oldStatusKey := billing.BuildInvoiceByStatusKey(oldStatus, invoiceID)
+		store.Delete(oldStatusKey)
+
+		// Add new status index
+		newStatusKey := billing.BuildInvoiceByStatusKey(newStatus, invoiceID)
+		store.Set(newStatusKey, []byte(invoiceID))
+	}
+
+	record.Status = newStatus
+	record.UpdatedAt = ctx.BlockTime()
+
+	// Save updated record
+	key := billing.BuildInvoiceLedgerRecordKey(invoiceID)
+	bz, err := json.Marshal(record)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal updated record: %w", err)
+	}
+	store.Set(key, bz)
+
+	// Create ledger entry
+	entry := billing.NewInvoiceLedgerEntry(
+		fmt.Sprintf("%s-payment-%d", invoiceID, ctx.BlockHeight()),
+		invoiceID,
+		billing.LedgerEntryTypePayment,
+		oldStatus,
+		newStatus,
+		amount,
+		fmt.Sprintf("payment recorded: %s", amount.String()),
+		initiator,
+		"",
+		ctx.BlockHeight(),
+		ctx.BlockTime(),
+	)
+	ik.saveLedgerEntry(store, entry)
+
+	return entry, nil
+}
+
+// GetInvoiceLedgerEntries retrieves ledger entries for an invoice
+func (ik *invoiceKeeper) GetInvoiceLedgerEntries(ctx sdk.Context, invoiceID string) ([]*billing.InvoiceLedgerEntry, error) {
+	store := ctx.KVStore(ik.k.skey)
+	prefix := billing.BuildInvoiceLedgerEntryByInvoicePrefix(invoiceID)
+
+	iter := storetypes.KVStorePrefixIterator(store, prefix)
+	defer iter.Close()
+
+	var entries []*billing.InvoiceLedgerEntry
+	for ; iter.Valid(); iter.Next() {
+		entryID := string(iter.Value())
+		entryKey := billing.BuildInvoiceLedgerEntryKey(entryID)
+		bz := store.Get(entryKey)
+		if bz == nil {
+			continue
+		}
+
+		var entry billing.InvoiceLedgerEntry
+		if err := json.Unmarshal(bz, &entry); err != nil {
+			continue
+		}
+		entries = append(entries, &entry)
+	}
+
+	return entries, nil
+}
+
+// WithInvoices iterates over all invoices
+func (ik *invoiceKeeper) WithInvoices(ctx sdk.Context, fn func(*billing.InvoiceLedgerRecord) bool) {
+	store := ctx.KVStore(ik.k.skey)
+	iter := storetypes.KVStorePrefixIterator(store, billing.InvoiceLedgerRecordPrefix)
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		var record billing.InvoiceLedgerRecord
+		if err := json.Unmarshal(iter.Value(), &record); err != nil {
+			continue
+		}
+
+		if stop := fn(&record); stop {
+			break
+		}
+	}
+}
+
+// GetInvoiceSequence gets the current invoice sequence number
+func (ik *invoiceKeeper) GetInvoiceSequence(ctx sdk.Context) uint64 {
+	store := ctx.KVStore(ik.k.skey)
+	bz := store.Get(billing.InvoiceSequenceKey)
+	if bz == nil {
+		return 0
+	}
+
+	var seq uint64
+	if err := json.Unmarshal(bz, &seq); err != nil {
+		return 0
+	}
+	return seq
+}
+
+// SetInvoiceSequence sets the invoice sequence number
+func (ik *invoiceKeeper) SetInvoiceSequence(ctx sdk.Context, sequence uint64) {
+	store := ctx.KVStore(ik.k.skey)
+	bz, _ := json.Marshal(sequence)
+	store.Set(billing.InvoiceSequenceKey, bz)
+}
+
+// SaveReconciliationReport saves a reconciliation report
+func (ik *invoiceKeeper) SaveReconciliationReport(ctx sdk.Context, report *billing.ReconciliationReport) error {
+	store := ctx.KVStore(ik.k.skey)
+
+	if err := report.Validate(); err != nil {
+		return fmt.Errorf("invalid report: %w", err)
+	}
+
+	key := billing.BuildReconciliationReportKey(report.ReportID)
+	bz, err := json.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("failed to marshal report: %w", err)
+	}
+	store.Set(key, bz)
+
+	// Create indexes
+	if report.Provider != "" {
+		providerKey := billing.BuildReconciliationReportByProviderKey(report.Provider, report.ReportID)
+		store.Set(providerKey, []byte(report.ReportID))
+	}
+
+	if report.Customer != "" {
+		customerKey := billing.BuildReconciliationReportByCustomerKey(report.Customer, report.ReportID)
+		store.Set(customerKey, []byte(report.ReportID))
+	}
+
+	return nil
+}
+
+// GetReconciliationReport retrieves a reconciliation report
+func (ik *invoiceKeeper) GetReconciliationReport(ctx sdk.Context, reportID string) (*billing.ReconciliationReport, error) {
+	store := ctx.KVStore(ik.k.skey)
+	key := billing.BuildReconciliationReportKey(reportID)
+
+	bz := store.Get(key)
+	if bz == nil {
+		return nil, fmt.Errorf("reconciliation report not found: %s", reportID)
+	}
+
+	var report billing.ReconciliationReport
+	if err := json.Unmarshal(bz, &report); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal report: %w", err)
+	}
+
+	return &report, nil
+}
+
+// Helper methods
+
+func (ik *invoiceKeeper) setInvoiceIndexes(store storetypes.KVStore, record *billing.InvoiceLedgerRecord) {
+	// Provider index
+	providerKey := billing.BuildInvoiceByProviderKey(record.Provider, record.InvoiceID)
+	store.Set(providerKey, []byte(record.InvoiceID))
+
+	// Customer index
+	customerKey := billing.BuildInvoiceByCustomerKey(record.Customer, record.InvoiceID)
+	store.Set(customerKey, []byte(record.InvoiceID))
+
+	// Status index
+	statusKey := billing.BuildInvoiceByStatusKey(record.Status, record.InvoiceID)
+	store.Set(statusKey, []byte(record.InvoiceID))
+
+	// Escrow index
+	escrowKey := billing.BuildInvoiceByEscrowKey(record.EscrowID, record.InvoiceID)
+	store.Set(escrowKey, []byte(record.InvoiceID))
+}
+
+func (ik *invoiceKeeper) saveLedgerEntry(store storetypes.KVStore, entry *billing.InvoiceLedgerEntry) {
+	// Save entry
+	entryKey := billing.BuildInvoiceLedgerEntryKey(entry.EntryID)
+	bz, _ := json.Marshal(entry)
+	store.Set(entryKey, bz)
+
+	// Create invoice index
+	indexKey := billing.BuildInvoiceLedgerEntryByInvoiceKey(entry.InvoiceID, entry.EntryID)
+	store.Set(indexKey, []byte(entry.EntryID))
+}
+
+func (ik *invoiceKeeper) paginateInvoiceIndex(
+	store storetypes.KVStore,
+	prefix []byte,
+	pagination *query.PageRequest,
+) ([]*billing.InvoiceLedgerRecord, *query.PageResponse, error) {
+	var records []*billing.InvoiceLedgerRecord
+
+	pageRes, err := query.Paginate(store, pagination, func(key []byte, value []byte) error {
+		invoiceID := string(value)
+		recordKey := billing.BuildInvoiceLedgerRecordKey(invoiceID)
+		bz := store.Get(recordKey)
+		if bz == nil {
+			return nil
+		}
+
+		var record billing.InvoiceLedgerRecord
+		if err := json.Unmarshal(bz, &record); err != nil {
+			return nil
+		}
+
+		records = append(records, &record)
+		return nil
+	})
+
+	return records, pageRes, err
+}
+
+func (ik *invoiceKeeper) getEntryTypeForStatus(status billing.InvoiceStatus) billing.InvoiceLedgerEntryType {
+	switch status {
+	case billing.InvoiceStatusPending:
+		return billing.LedgerEntryTypeIssued
+	case billing.InvoiceStatusPaid, billing.InvoiceStatusPartiallyPaid:
+		return billing.LedgerEntryTypePayment
+	case billing.InvoiceStatusDisputed:
+		return billing.LedgerEntryTypeDisputed
+	case billing.InvoiceStatusCancelled:
+		return billing.LedgerEntryTypeCancelled
+	case billing.InvoiceStatusRefunded:
+		return billing.LedgerEntryTypeRefunded
+	case billing.InvoiceStatusOverdue:
+		return billing.LedgerEntryTypeOverdue
+	default:
+		return billing.LedgerEntryTypeCreated
+	}
+}
+
+// InvoiceQueryServer defines the gRPC query server interface for invoices
+type InvoiceQueryServer interface {
+	// Invoice returns an invoice by ID
+	Invoice(ctx context.Context, req *QueryInvoiceRequest) (*QueryInvoiceResponse, error)
+
+	// InvoicesByProvider returns invoices for a provider
+	InvoicesByProvider(ctx context.Context, req *QueryInvoicesByProviderRequest) (*QueryInvoicesByProviderResponse, error)
+
+	// InvoicesByCustomer returns invoices for a customer
+	InvoicesByCustomer(ctx context.Context, req *QueryInvoicesByCustomerRequest) (*QueryInvoicesByCustomerResponse, error)
+
+	// InvoiceLedger returns the ledger entries for an invoice
+	InvoiceLedger(ctx context.Context, req *QueryInvoiceLedgerRequest) (*QueryInvoiceLedgerResponse, error)
+}
+
+// Query request/response types
+
+// QueryInvoiceRequest is the request for Invoice query
+type QueryInvoiceRequest struct {
+	InvoiceID string `json:"invoice_id"`
+}
+
+// QueryInvoiceResponse is the response for Invoice query
+type QueryInvoiceResponse struct {
+	Invoice *billing.InvoiceLedgerRecord `json:"invoice"`
+}
+
+// QueryInvoicesByProviderRequest is the request for InvoicesByProvider query
+type QueryInvoicesByProviderRequest struct {
+	Provider   string              `json:"provider"`
+	Pagination *query.PageRequest  `json:"pagination,omitempty"`
+}
+
+// QueryInvoicesByProviderResponse is the response for InvoicesByProvider query
+type QueryInvoicesByProviderResponse struct {
+	Invoices   []*billing.InvoiceLedgerRecord `json:"invoices"`
+	Pagination *query.PageResponse            `json:"pagination,omitempty"`
+}
+
+// QueryInvoicesByCustomerRequest is the request for InvoicesByCustomer query
+type QueryInvoicesByCustomerRequest struct {
+	Customer   string              `json:"customer"`
+	Pagination *query.PageRequest  `json:"pagination,omitempty"`
+}
+
+// QueryInvoicesByCustomerResponse is the response for InvoicesByCustomer query
+type QueryInvoicesByCustomerResponse struct {
+	Invoices   []*billing.InvoiceLedgerRecord `json:"invoices"`
+	Pagination *query.PageResponse            `json:"pagination,omitempty"`
+}
+
+// QueryInvoiceLedgerRequest is the request for InvoiceLedger query
+type QueryInvoiceLedgerRequest struct {
+	InvoiceID string `json:"invoice_id"`
+}
+
+// QueryInvoiceLedgerResponse is the response for InvoiceLedger query
+type QueryInvoiceLedgerResponse struct {
+	Entries []*billing.InvoiceLedgerEntry `json:"entries"`
+}

--- a/x/escrow/types/billing/INVOICE_LIFECYCLE.md
+++ b/x/escrow/types/billing/INVOICE_LIFECYCLE.md
@@ -1,0 +1,295 @@
+# Invoice Lifecycle and API Documentation
+
+## Overview
+
+The VirtEngine invoice system provides deterministic invoice generation, immutable on-chain ledger records, and artifact storage for full invoice documents. This enables transparent billing for marketplace and HPC usage.
+
+## Invoice Lifecycle
+
+### Status States
+
+| Status | Description | Terminal |
+|--------|-------------|----------|
+| `draft` | Invoice being prepared, not yet issued | No |
+| `pending` | Awaiting payment | No |
+| `paid` | Fully paid | Yes |
+| `partially_paid` | Partial payment received | No |
+| `overdue` | Past due date | No |
+| `disputed` | Under dispute | No |
+| `cancelled` | Cancelled/voided | Yes |
+| `refunded` | Refunded | Yes |
+
+### Valid Transitions
+
+```
+draft → pending (issue invoice)
+draft → cancelled (cancel draft)
+
+pending → paid (full payment)
+pending → partially_paid (partial payment)
+pending → overdue (mark overdue)
+pending → disputed (dispute invoice)
+pending → cancelled (cancel pending)
+
+partially_paid → paid (complete payment)
+partially_paid → overdue (mark overdue)
+partially_paid → disputed (dispute invoice)
+
+overdue → paid (pay overdue)
+overdue → partially_paid (partial pay overdue)
+overdue → disputed (dispute overdue)
+overdue → cancelled (write off)
+
+disputed → pending (resolve - pending)
+disputed → paid (resolve - paid)
+disputed → cancelled (resolve - cancel)
+disputed → refunded (resolve - refund)
+
+paid → refunded (refund paid)
+```
+
+## Invoice Generation
+
+### From Usage Records
+
+```go
+gen := billing.NewInvoiceGenerator(billing.DefaultInvoiceGeneratorConfig())
+
+req := billing.InvoiceGenerationRequest{
+    EscrowID:    "escrow-001",
+    OrderID:     "order-001",
+    LeaseID:     "lease-001",
+    Provider:    "virtengine1provider...",
+    Customer:    "virtengine1customer...",
+    UsageInputs: []billing.UsageInput{
+        {
+            UsageRecordID: "usage-001",
+            UsageType:     billing.UsageTypeCPU,
+            Quantity:      sdkmath.LegacyNewDec(10),
+            Unit:          "core-hour",
+            UnitPrice:     sdk.NewDecCoinFromDec("uvirt", sdkmath.LegacyNewDec(100)),
+            Description:   "CPU usage for 10 core-hours",
+            PeriodStart:   periodStart,
+            PeriodEnd:     periodEnd,
+        },
+    },
+    BillingPeriod: billing.BillingPeriod{
+        StartTime:       periodStart,
+        EndTime:         periodEnd,
+        DurationSeconds: 86400,
+        PeriodType:      billing.BillingPeriodTypeDaily,
+    },
+    Currency: "uvirt",
+}
+
+invoice, err := gen.GenerateInvoice(req, blockHeight, now)
+```
+
+### From HPC Usage
+
+```go
+hpcUsage := billing.HPCUsageInput{
+    JobID:           "job-001",
+    CPUHours:        sdkmath.LegacyNewDec(100),
+    GPUHours:        sdkmath.LegacyNewDec(10),
+    MemoryGBHours:   sdkmath.LegacyNewDec(512),
+    StorageGBMonths: sdkmath.LegacyNewDec(100),
+    NetworkGB:       sdkmath.LegacyNewDec(50),
+    PeriodStart:     periodStart,
+    PeriodEnd:       periodEnd,
+}
+
+invoice, err := gen.GenerateHPCInvoice(
+    escrowID, orderID, leaseID,
+    provider, customer,
+    hpcUsage, pricingPolicy,
+    blockHeight, now,
+)
+```
+
+## On-Chain Storage
+
+### Invoice Ledger Record
+
+The `InvoiceLedgerRecord` is the immutable on-chain record containing:
+
+- Invoice metadata (ID, number, provider, customer, amounts)
+- Content hash (SHA-256) for artifact verification
+- Artifact CID for document retrieval
+- Status and timestamps
+
+```go
+record, err := billing.NewInvoiceLedgerRecord(invoice, artifactCID, blockHeight, now)
+```
+
+### Ledger Entries
+
+Each state change creates an `InvoiceLedgerEntry` for audit trail:
+
+```go
+entry := billing.NewInvoiceLedgerEntry(
+    entryID,
+    invoiceID,
+    billing.LedgerEntryTypePayment,
+    previousStatus,
+    newStatus,
+    amount,
+    description,
+    initiator,
+    txHash,
+    blockHeight,
+    timestamp,
+)
+```
+
+## Artifact Storage
+
+Invoice documents are stored off-chain with on-chain verification:
+
+```go
+store := billing.NewMemoryArtifactStore() // or production implementation
+docGen := billing.NewInvoiceDocumentGenerator(store)
+
+artifact, err := docGen.GenerateJSONDocument(ctx, invoice, createdBy)
+// Returns CID and content hash for on-chain reference
+```
+
+### Verification
+
+```go
+valid, err := record.VerifyContentHash(fullInvoice)
+// or
+valid, err := store.Verify(ctx, cid, content)
+```
+
+## Query APIs
+
+### Get Invoice by ID
+
+```go
+record, err := invoiceKeeper.GetInvoice(ctx, invoiceID)
+```
+
+### Get Invoices by Provider
+
+```go
+records, pageRes, err := invoiceKeeper.GetInvoicesByProvider(ctx, provider, pagination)
+```
+
+### Get Invoices by Customer
+
+```go
+records, pageRes, err := invoiceKeeper.GetInvoicesByCustomer(ctx, customer, pagination)
+```
+
+### Get Invoices by Status
+
+```go
+records, pageRes, err := invoiceKeeper.GetInvoicesByStatus(ctx, billing.InvoiceStatusPending, pagination)
+```
+
+### Get Invoice Ledger History
+
+```go
+entries, err := invoiceKeeper.GetInvoiceLedgerEntries(ctx, invoiceID)
+```
+
+## Status Transitions
+
+Use the `InvoiceStatusMachine` for safe state transitions:
+
+```go
+sm := billing.NewInvoiceStatusMachine(invoice, blockHeight, now)
+
+// Issue invoice
+err := sm.MarkIssued(initiator)
+
+// Record payment
+err := sm.TransitionWithPayment(amount, initiator)
+
+// Mark disputed
+err := sm.MarkDisputed(disputeWindow, initiator, reason)
+
+// Get ledger entry
+entry := sm.GetLedgerEntry()
+```
+
+## Reconciliation
+
+Generate reconciliation reports for billing verification:
+
+```go
+report := &billing.ReconciliationReport{
+    ReportID:    "report-001",
+    ReportType:  billing.ReconciliationReportTypeDaily,
+    PeriodStart: periodStart,
+    PeriodEnd:   periodEnd,
+    Status:      billing.ReconciliationStatusComplete,
+    Summary:     summary,
+    InvoiceIDs:  invoiceIDs,
+    GeneratedAt: now,
+    GeneratedBy: "system",
+    BlockHeight: blockHeight,
+}
+
+err := invoiceKeeper.SaveReconciliationReport(ctx, report)
+```
+
+## Deterministic Properties
+
+1. **Invoice IDs**: Generated deterministically from escrow ID, order ID, addresses, period, and block height
+2. **Content Hashes**: SHA-256 of canonical invoice JSON
+3. **Rounding**: Configurable banker's rounding (half-even) for amounts
+
+## Store Keys
+
+| Prefix | Description |
+|--------|-------------|
+| `0x01` | Invoices |
+| `0x02` | Invoice by provider index |
+| `0x03` | Invoice by customer index |
+| `0x04` | Invoice by status index |
+| `0x05` | Invoice by escrow index |
+| `0x60` | Invoice ledger records |
+| `0x61` | Invoice ledger entries |
+| `0x62` | Ledger entries by invoice index |
+| `0x63` | Invoice artifacts |
+| `0x70` | Reconciliation reports |
+
+## Usage Types
+
+| Type | Unit | Description |
+|------|------|-------------|
+| `cpu` | core-hour | CPU usage |
+| `memory` | gb-hour | Memory usage |
+| `storage` | gb-month | Storage usage |
+| `network` | gb | Network bandwidth |
+| `gpu` | gpu-hour | GPU usage |
+| `fixed` | unit | Fixed charges |
+| `setup` | unit | One-time setup fees |
+| `other` | unit | Other charges |
+
+## Configuration
+
+```go
+config := billing.InvoiceGeneratorConfig{
+    InvoiceNumberPrefix:    "VE-INV",
+    DefaultPaymentTermDays: 7,
+    RoundingMode:           billing.RoundingModeHalfEven,
+    DefaultCurrency:        "uvirt",
+    ApplyTax:               false,
+    DefaultTaxJurisdiction: "US",
+}
+```
+
+## Events
+
+Invoice operations emit the following events:
+
+- `invoice.created` - New invoice created
+- `invoice.issued` - Invoice issued (draft → pending)
+- `invoice.payment` - Payment recorded
+- `invoice.paid` - Invoice fully paid
+- `invoice.disputed` - Invoice disputed
+- `invoice.cancelled` - Invoice cancelled
+- `invoice.refunded` - Invoice refunded

--- a/x/escrow/types/billing/artifact_store.go
+++ b/x/escrow/types/billing/artifact_store.go
@@ -1,0 +1,328 @@
+// Package billing provides billing and invoice types for the escrow module.
+package billing
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ArtifactType defines the type of invoice artifact
+type ArtifactType uint8
+
+const (
+	// ArtifactTypeJSON is a JSON invoice document
+	ArtifactTypeJSON ArtifactType = 0
+
+	// ArtifactTypePDF is a PDF invoice document
+	ArtifactTypePDF ArtifactType = 1
+
+	// ArtifactTypeReceipt is a payment receipt
+	ArtifactTypeReceipt ArtifactType = 2
+)
+
+// ArtifactTypeNames maps types to names
+var ArtifactTypeNames = map[ArtifactType]string{
+	ArtifactTypeJSON:    "json",
+	ArtifactTypePDF:     "pdf",
+	ArtifactTypeReceipt: "receipt",
+}
+
+// String returns string representation
+func (t ArtifactType) String() string {
+	if name, ok := ArtifactTypeNames[t]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown(%d)", t)
+}
+
+// ContentType returns the MIME type for the artifact
+func (t ArtifactType) ContentType() string {
+	switch t {
+	case ArtifactTypeJSON:
+		return "application/json"
+	case ArtifactTypePDF:
+		return "application/pdf"
+	case ArtifactTypeReceipt:
+		return "application/json"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// InvoiceArtifact represents an invoice document artifact
+type InvoiceArtifact struct {
+	// CID is the content-addressable identifier
+	CID string `json:"cid"`
+
+	// InvoiceID is the invoice this artifact belongs to
+	InvoiceID string `json:"invoice_id"`
+
+	// Type is the artifact type
+	Type ArtifactType `json:"type"`
+
+	// ContentHash is the SHA-256 hash of the content
+	ContentHash string `json:"content_hash"`
+
+	// Size is the content size in bytes
+	Size int64 `json:"size"`
+
+	// StorageBackend is where the artifact is stored
+	StorageBackend string `json:"storage_backend"`
+
+	// StorageRef is the reference in the storage backend
+	StorageRef string `json:"storage_ref"`
+
+	// CreatedAt is when the artifact was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// CreatedBy is who created the artifact
+	CreatedBy string `json:"created_by"`
+}
+
+// Validate validates the artifact
+func (a *InvoiceArtifact) Validate() error {
+	if a.CID == "" {
+		return fmt.Errorf("cid is required")
+	}
+
+	if a.InvoiceID == "" {
+		return fmt.Errorf("invoice_id is required")
+	}
+
+	if a.ContentHash == "" {
+		return fmt.Errorf("content_hash is required")
+	}
+
+	if len(a.ContentHash) != 64 {
+		return fmt.Errorf("content_hash must be 64 hex characters (SHA-256)")
+	}
+
+	if a.Size <= 0 {
+		return fmt.Errorf("size must be positive")
+	}
+
+	return nil
+}
+
+// ArtifactStore defines the interface for storing invoice artifacts
+type ArtifactStore interface {
+	// Store stores an artifact and returns its CID
+	Store(ctx context.Context, invoiceID string, artifactType ArtifactType, content []byte, createdBy string) (*InvoiceArtifact, error)
+
+	// Get retrieves an artifact by CID
+	Get(ctx context.Context, cid string) ([]byte, *InvoiceArtifact, error)
+
+	// GetByInvoice retrieves all artifacts for an invoice
+	GetByInvoice(ctx context.Context, invoiceID string) ([]*InvoiceArtifact, error)
+
+	// Delete deletes an artifact (if allowed)
+	Delete(ctx context.Context, cid string) error
+
+	// Verify verifies an artifact's content hash
+	Verify(ctx context.Context, cid string, content []byte) (bool, error)
+}
+
+// MemoryArtifactStore is an in-memory implementation of ArtifactStore (for testing)
+type MemoryArtifactStore struct {
+	artifacts map[string]*InvoiceArtifact
+	content   map[string][]byte
+	byInvoice map[string][]string
+}
+
+// NewMemoryArtifactStore creates a new in-memory artifact store
+func NewMemoryArtifactStore() *MemoryArtifactStore {
+	return &MemoryArtifactStore{
+		artifacts: make(map[string]*InvoiceArtifact),
+		content:   make(map[string][]byte),
+		byInvoice: make(map[string][]string),
+	}
+}
+
+// Store stores an artifact
+func (s *MemoryArtifactStore) Store(
+	ctx context.Context,
+	invoiceID string,
+	artifactType ArtifactType,
+	content []byte,
+	createdBy string,
+) (*InvoiceArtifact, error) {
+	// Compute content hash
+	hash := sha256.Sum256(content)
+	contentHash := hex.EncodeToString(hash[:])
+
+	// Generate CID (simplified - in production would use IPFS or similar)
+	cid := fmt.Sprintf("baf%s", contentHash[:32])
+
+	artifact := &InvoiceArtifact{
+		CID:            cid,
+		InvoiceID:      invoiceID,
+		Type:           artifactType,
+		ContentHash:    contentHash,
+		Size:           int64(len(content)),
+		StorageBackend: "memory",
+		StorageRef:     cid,
+		CreatedAt:      time.Now().UTC(),
+		CreatedBy:      createdBy,
+	}
+
+	s.artifacts[cid] = artifact
+	s.content[cid] = content
+	s.byInvoice[invoiceID] = append(s.byInvoice[invoiceID], cid)
+
+	return artifact, nil
+}
+
+// Get retrieves an artifact
+func (s *MemoryArtifactStore) Get(ctx context.Context, cid string) ([]byte, *InvoiceArtifact, error) {
+	artifact, ok := s.artifacts[cid]
+	if !ok {
+		return nil, nil, fmt.Errorf("artifact not found: %s", cid)
+	}
+
+	content, ok := s.content[cid]
+	if !ok {
+		return nil, nil, fmt.Errorf("artifact content not found: %s", cid)
+	}
+
+	return content, artifact, nil
+}
+
+// GetByInvoice retrieves all artifacts for an invoice
+func (s *MemoryArtifactStore) GetByInvoice(ctx context.Context, invoiceID string) ([]*InvoiceArtifact, error) {
+	cids := s.byInvoice[invoiceID]
+	artifacts := make([]*InvoiceArtifact, 0, len(cids))
+
+	for _, cid := range cids {
+		if artifact, ok := s.artifacts[cid]; ok {
+			artifacts = append(artifacts, artifact)
+		}
+	}
+
+	return artifacts, nil
+}
+
+// Delete deletes an artifact
+func (s *MemoryArtifactStore) Delete(ctx context.Context, cid string) error {
+	artifact, ok := s.artifacts[cid]
+	if !ok {
+		return fmt.Errorf("artifact not found: %s", cid)
+	}
+
+	// Remove from byInvoice index
+	invoiceID := artifact.InvoiceID
+	cids := s.byInvoice[invoiceID]
+	newCIDs := make([]string, 0, len(cids)-1)
+	for _, c := range cids {
+		if c != cid {
+			newCIDs = append(newCIDs, c)
+		}
+	}
+	s.byInvoice[invoiceID] = newCIDs
+
+	delete(s.artifacts, cid)
+	delete(s.content, cid)
+
+	return nil
+}
+
+// Verify verifies an artifact's content hash
+func (s *MemoryArtifactStore) Verify(ctx context.Context, cid string, content []byte) (bool, error) {
+	artifact, ok := s.artifacts[cid]
+	if !ok {
+		return false, fmt.Errorf("artifact not found: %s", cid)
+	}
+
+	hash := sha256.Sum256(content)
+	contentHash := hex.EncodeToString(hash[:])
+
+	return artifact.ContentHash == contentHash, nil
+}
+
+// InvoiceDocumentGenerator generates invoice documents in various formats
+type InvoiceDocumentGenerator struct {
+	store ArtifactStore
+}
+
+// NewInvoiceDocumentGenerator creates a new document generator
+func NewInvoiceDocumentGenerator(store ArtifactStore) *InvoiceDocumentGenerator {
+	return &InvoiceDocumentGenerator{store: store}
+}
+
+// GenerateJSONDocument generates a JSON invoice document
+func (g *InvoiceDocumentGenerator) GenerateJSONDocument(
+	ctx context.Context,
+	invoice *Invoice,
+	createdBy string,
+) (*InvoiceArtifact, error) {
+	// Create the JSON document
+	doc := InvoiceJSONDocument{
+		Version:       "1.0",
+		SchemaVersion: "virtengine/invoice/v1",
+		Invoice:       invoice,
+		GeneratedAt:   time.Now().UTC(),
+	}
+
+	content, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal invoice document: %w", err)
+	}
+
+	return g.store.Store(ctx, invoice.InvoiceID, ArtifactTypeJSON, content, createdBy)
+}
+
+// InvoiceJSONDocument is the JSON document structure
+type InvoiceJSONDocument struct {
+	// Version is the document version
+	Version string `json:"version"`
+
+	// SchemaVersion is the schema version
+	SchemaVersion string `json:"schema_version"`
+
+	// Invoice is the full invoice
+	Invoice *Invoice `json:"invoice"`
+
+	// GeneratedAt is when the document was generated
+	GeneratedAt time.Time `json:"generated_at"`
+}
+
+// ComputeInvoiceHash computes a deterministic hash for an invoice
+func ComputeInvoiceHash(inv *Invoice) (string, error) {
+	// Create a canonical representation for hashing
+	canonical := struct {
+		InvoiceID     string `json:"invoice_id"`
+		InvoiceNumber string `json:"invoice_number"`
+		EscrowID      string `json:"escrow_id"`
+		OrderID       string `json:"order_id"`
+		LeaseID       string `json:"lease_id"`
+		Provider      string `json:"provider"`
+		Customer      string `json:"customer"`
+		Status        string `json:"status"`
+		Currency      string `json:"currency"`
+		Total         string `json:"total"`
+		CreatedAt     int64  `json:"created_at"`
+	}{
+		InvoiceID:     inv.InvoiceID,
+		InvoiceNumber: inv.InvoiceNumber,
+		EscrowID:      inv.EscrowID,
+		OrderID:       inv.OrderID,
+		LeaseID:       inv.LeaseID,
+		Provider:      inv.Provider,
+		Customer:      inv.Customer,
+		Status:        inv.Status.String(),
+		Currency:      inv.Currency,
+		Total:         inv.Total.String(),
+		CreatedAt:     inv.CreatedAt.Unix(),
+	}
+
+	data, err := json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal canonical invoice: %w", err)
+	}
+
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
+}

--- a/x/escrow/types/billing/codec.go
+++ b/x/escrow/types/billing/codec.go
@@ -8,20 +8,47 @@ import (
 
 // RegisterLegacyAminoCodec registers billing types for Amino encoding
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	// Invoice types
 	cdc.RegisterConcrete(&Invoice{}, "virtengine/billing/Invoice", nil)
 	cdc.RegisterConcrete(&LineItem{}, "virtengine/billing/LineItem", nil)
+	cdc.RegisterConcrete(&InvoiceSummary{}, "virtengine/billing/InvoiceSummary", nil)
+
+	// Ledger types
+	cdc.RegisterConcrete(&InvoiceLedgerRecord{}, "virtengine/billing/InvoiceLedgerRecord", nil)
+	cdc.RegisterConcrete(&InvoiceLedgerEntry{}, "virtengine/billing/InvoiceLedgerEntry", nil)
+
+	// Artifact types
+	cdc.RegisterConcrete(&InvoiceArtifact{}, "virtengine/billing/InvoiceArtifact", nil)
+
+	// Discount types
 	cdc.RegisterConcrete(&DiscountPolicy{}, "virtengine/billing/DiscountPolicy", nil)
 	cdc.RegisterConcrete(&CouponCode{}, "virtengine/billing/CouponCode", nil)
 	cdc.RegisterConcrete(&AppliedDiscount{}, "virtengine/billing/AppliedDiscount", nil)
+	cdc.RegisterConcrete(&LoyaltyProgram{}, "virtengine/billing/LoyaltyProgram", nil)
+	cdc.RegisterConcrete(&CustomerLoyalty{}, "virtengine/billing/CustomerLoyalty", nil)
+
+	// Tax types
 	cdc.RegisterConcrete(&TaxJurisdiction{}, "virtengine/billing/TaxJurisdiction", nil)
 	cdc.RegisterConcrete(&TaxDetails{}, "virtengine/billing/TaxDetails", nil)
 	cdc.RegisterConcrete(&CustomerTaxProfile{}, "virtengine/billing/CustomerTaxProfile", nil)
 	cdc.RegisterConcrete(&ProviderTaxProfile{}, "virtengine/billing/ProviderTaxProfile", nil)
+
+	// Dispute types
 	cdc.RegisterConcrete(&DisputeWindow{}, "virtengine/billing/DisputeWindow", nil)
+
+	// Pricing types
 	cdc.RegisterConcrete(&PricingPolicy{}, "virtengine/billing/PricingPolicy", nil)
+	cdc.RegisterConcrete(&ResourcePricing{}, "virtengine/billing/ResourcePricing", nil)
+
+	// Settlement types
 	cdc.RegisterConcrete(&SettlementConfig{}, "virtengine/billing/SettlementConfig", nil)
-	cdc.RegisterConcrete(&LoyaltyProgram{}, "virtengine/billing/LoyaltyProgram", nil)
-	cdc.RegisterConcrete(&CustomerLoyalty{}, "virtengine/billing/CustomerLoyalty", nil)
+	cdc.RegisterConcrete(&SettlementHookConfig{}, "virtengine/billing/SettlementHookConfig", nil)
+	cdc.RegisterConcrete(&SettlementHookResult{}, "virtengine/billing/SettlementHookResult", nil)
+
+	// Reconciliation types
+	cdc.RegisterConcrete(&ReconciliationReport{}, "virtengine/billing/ReconciliationReport", nil)
+	cdc.RegisterConcrete(&ReconciliationDiscrepancy{}, "virtengine/billing/ReconciliationDiscrepancy", nil)
+	cdc.RegisterConcrete(&ReconciliationHookConfig{}, "virtengine/billing/ReconciliationHookConfig", nil)
 }
 
 // RegisterInterfaces registers billing types with the interface registry

--- a/x/escrow/types/billing/generator.go
+++ b/x/escrow/types/billing/generator.go
@@ -1,0 +1,626 @@
+// Package billing provides billing and invoice types for the escrow module.
+package billing
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// InvoiceGeneratorConfig configures the invoice generator
+type InvoiceGeneratorConfig struct {
+	// InvoiceNumberPrefix is the prefix for invoice numbers
+	InvoiceNumberPrefix string `json:"invoice_number_prefix"`
+
+	// DefaultPaymentTermDays is the default days until payment is due
+	DefaultPaymentTermDays int32 `json:"default_payment_term_days"`
+
+	// RoundingMode is the rounding mode for calculations
+	RoundingMode RoundingMode `json:"rounding_mode"`
+
+	// DefaultCurrency is the default currency
+	DefaultCurrency string `json:"default_currency"`
+
+	// ApplyTax indicates if tax should be calculated
+	ApplyTax bool `json:"apply_tax"`
+
+	// DefaultTaxJurisdiction is the default tax jurisdiction
+	DefaultTaxJurisdiction string `json:"default_tax_jurisdiction"`
+}
+
+// DefaultInvoiceGeneratorConfig returns default configuration
+func DefaultInvoiceGeneratorConfig() InvoiceGeneratorConfig {
+	return InvoiceGeneratorConfig{
+		InvoiceNumberPrefix:    "VE-INV",
+		DefaultPaymentTermDays: 7,
+		RoundingMode:           RoundingModeHalfEven,
+		DefaultCurrency:        DefaultCurrency,
+		ApplyTax:               false,
+		DefaultTaxJurisdiction: "US",
+	}
+}
+
+// UsageInput represents usage data for invoice generation
+type UsageInput struct {
+	// UsageRecordID is the unique usage record ID
+	UsageRecordID string `json:"usage_record_id"`
+
+	// UsageType is the type of usage
+	UsageType UsageType `json:"usage_type"`
+
+	// Quantity is the quantity consumed
+	Quantity sdkmath.LegacyDec `json:"quantity"`
+
+	// Unit is the measurement unit
+	Unit string `json:"unit"`
+
+	// UnitPrice is the price per unit
+	UnitPrice sdk.DecCoin `json:"unit_price"`
+
+	// Description is a description of the usage
+	Description string `json:"description"`
+
+	// PeriodStart is the usage period start
+	PeriodStart time.Time `json:"period_start"`
+
+	// PeriodEnd is the usage period end
+	PeriodEnd time.Time `json:"period_end"`
+
+	// Metadata contains additional usage details
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// Validate validates the usage input
+func (u *UsageInput) Validate() error {
+	if u.UsageRecordID == "" {
+		return fmt.Errorf("usage_record_id is required")
+	}
+
+	if u.Quantity.IsNegative() {
+		return fmt.Errorf("quantity cannot be negative")
+	}
+
+	if u.UnitPrice.IsNegative() {
+		return fmt.Errorf("unit_price cannot be negative")
+	}
+
+	if u.Description == "" {
+		return fmt.Errorf("description is required")
+	}
+
+	return nil
+}
+
+// InvoiceGenerationRequest contains all data needed to generate an invoice
+type InvoiceGenerationRequest struct {
+	// EscrowID is the escrow account ID
+	EscrowID string `json:"escrow_id"`
+
+	// OrderID is the marketplace order ID
+	OrderID string `json:"order_id"`
+
+	// LeaseID is the marketplace lease ID
+	LeaseID string `json:"lease_id"`
+
+	// Provider is the provider address
+	Provider string `json:"provider"`
+
+	// Customer is the customer address
+	Customer string `json:"customer"`
+
+	// UsageInputs are the usage records to include
+	UsageInputs []UsageInput `json:"usage_inputs"`
+
+	// BillingPeriod is the billing period
+	BillingPeriod BillingPeriod `json:"billing_period"`
+
+	// Currency is the invoice currency
+	Currency string `json:"currency"`
+
+	// DiscountPolicies are discount policies to apply
+	DiscountPolicies []DiscountPolicy `json:"discount_policies,omitempty"`
+
+	// CustomerTaxProfile is the customer's tax profile (optional)
+	CustomerTaxProfile *CustomerTaxProfile `json:"customer_tax_profile,omitempty"`
+
+	// ProviderTaxProfile is the provider's tax profile (optional)
+	ProviderTaxProfile *ProviderTaxProfile `json:"provider_tax_profile,omitempty"`
+
+	// Metadata contains additional invoice details
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// Validate validates the request
+func (r *InvoiceGenerationRequest) Validate() error {
+	if r.EscrowID == "" {
+		return fmt.Errorf("escrow_id is required")
+	}
+
+	if _, err := sdk.AccAddressFromBech32(r.Provider); err != nil {
+		return fmt.Errorf("invalid provider address: %w", err)
+	}
+
+	if _, err := sdk.AccAddressFromBech32(r.Customer); err != nil {
+		return fmt.Errorf("invalid customer address: %w", err)
+	}
+
+	if len(r.UsageInputs) == 0 {
+		return fmt.Errorf("at least one usage_input is required")
+	}
+
+	for i, input := range r.UsageInputs {
+		if err := input.Validate(); err != nil {
+			return fmt.Errorf("usage_inputs[%d]: %w", i, err)
+		}
+	}
+
+	if r.Currency == "" {
+		return fmt.Errorf("currency is required")
+	}
+
+	return nil
+}
+
+// InvoiceGenerator generates invoices from usage records
+type InvoiceGenerator struct {
+	config        InvoiceGeneratorConfig
+	taxCalculator *TaxCalculator
+	sequence      uint64
+}
+
+// NewInvoiceGenerator creates a new invoice generator
+func NewInvoiceGenerator(config InvoiceGeneratorConfig) *InvoiceGenerator {
+	gen := &InvoiceGenerator{
+		config:   config,
+		sequence: 0,
+	}
+
+	// Initialize tax calculator if tax is enabled
+	if config.ApplyTax {
+		gen.taxCalculator = NewTaxCalculator(config.DefaultTaxJurisdiction)
+		for code, jurisdiction := range DefaultTaxJurisdictions() {
+			_ = gen.taxCalculator.AddJurisdiction(jurisdiction)
+			_ = code // silence unused variable warning
+		}
+	}
+
+	return gen
+}
+
+// SetSequence sets the invoice sequence number
+func (g *InvoiceGenerator) SetSequence(seq uint64) {
+	g.sequence = seq
+}
+
+// GenerateInvoice generates an invoice from the request
+func (g *InvoiceGenerator) GenerateInvoice(
+	req InvoiceGenerationRequest,
+	blockHeight int64,
+	now time.Time,
+) (*Invoice, error) {
+	if err := req.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid request: %w", err)
+	}
+
+	// Generate invoice ID deterministically
+	invoiceID := g.generateInvoiceID(req, blockHeight)
+
+	// Generate invoice number
+	g.sequence++
+	invoiceNumber := NextInvoiceNumber(g.sequence-1, g.config.InvoiceNumberPrefix)
+
+	// Calculate due date
+	dueDate := now.Add(time.Duration(g.config.DefaultPaymentTermDays) * 24 * time.Hour)
+
+	// Create invoice
+	invoice := NewInvoice(
+		invoiceID,
+		invoiceNumber,
+		req.EscrowID,
+		req.OrderID,
+		req.LeaseID,
+		req.Provider,
+		req.Customer,
+		req.Currency,
+		req.BillingPeriod,
+		dueDate,
+		blockHeight,
+		now,
+	)
+
+	// Add line items from usage inputs
+	for i, usage := range req.UsageInputs {
+		lineItem := g.createLineItem(usage, i, req.Currency)
+		invoice.AddLineItem(lineItem)
+	}
+
+	// Apply discounts
+	if len(req.DiscountPolicies) > 0 {
+		g.applyDiscounts(invoice, req.DiscountPolicies, now)
+	}
+
+	// Apply tax if configured
+	if g.config.ApplyTax && g.taxCalculator != nil {
+		g.applyTax(invoice, req.CustomerTaxProfile, req.ProviderTaxProfile, now)
+	}
+
+	// Add metadata
+	if req.Metadata != nil {
+		for k, v := range req.Metadata {
+			invoice.Metadata[k] = v
+		}
+	}
+
+	// Validate final invoice
+	if err := invoice.Validate(); err != nil {
+		return nil, fmt.Errorf("generated invoice is invalid: %w", err)
+	}
+
+	return invoice, nil
+}
+
+// generateInvoiceID generates a deterministic invoice ID
+func (g *InvoiceGenerator) generateInvoiceID(req InvoiceGenerationRequest, blockHeight int64) string {
+	// Create deterministic input
+	input := fmt.Sprintf(
+		"%s:%s:%s:%s:%d:%d",
+		req.EscrowID,
+		req.OrderID,
+		req.Provider,
+		req.Customer,
+		req.BillingPeriod.StartTime.Unix(),
+		blockHeight,
+	)
+
+	hash := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(hash[:16]) // Use first 16 bytes for ID
+}
+
+// createLineItem creates a line item from usage input
+func (g *InvoiceGenerator) createLineItem(usage UsageInput, index int, currency string) LineItem {
+	// Calculate line item amount with deterministic rounding
+	rawAmount := usage.Quantity.Mul(usage.UnitPrice.Amount)
+	roundedAmount := applyRounding(rawAmount, g.config.RoundingMode)
+
+	return LineItem{
+		LineItemID:     fmt.Sprintf("li-%d", index+1),
+		Description:    usage.Description,
+		UsageType:      usage.UsageType,
+		Quantity:       usage.Quantity,
+		Unit:           usage.Unit,
+		UnitPrice:      usage.UnitPrice,
+		Amount:         sdk.NewCoins(sdk.NewCoin(currency, roundedAmount)),
+		UsageRecordIDs: []string{usage.UsageRecordID},
+		Metadata:       usage.Metadata,
+	}
+}
+
+// applyDiscounts applies discount policies to the invoice
+func (g *InvoiceGenerator) applyDiscounts(
+	invoice *Invoice,
+	policies []DiscountPolicy,
+	now time.Time,
+) {
+	// Calculate total volume for volume-based discounts
+	totalVolume := sdkmath.LegacyZeroDec()
+	for _, item := range invoice.LineItems {
+		totalVolume = totalVolume.Add(item.Quantity)
+	}
+
+	for _, policy := range policies {
+		if !policy.IsValidAt(now) {
+			continue
+		}
+
+		discountAmount := policy.CalculateDiscount(invoice.Subtotal, totalVolume)
+		if discountAmount.IsZero() {
+			continue
+		}
+
+		applied := AppliedDiscount{
+			DiscountID:  fmt.Sprintf("disc-%s", policy.PolicyID),
+			PolicyID:    policy.PolicyID,
+			Type:        policy.Type,
+			Description: policy.Description,
+			Amount:      discountAmount,
+			AppliedAt:   now,
+			AppliedBy:   "system",
+		}
+
+		invoice.Discounts = append(invoice.Discounts, applied)
+	}
+
+	// Recalculate totals
+	invoice.recalculateTotals()
+}
+
+// applyTax applies tax to the invoice
+func (g *InvoiceGenerator) applyTax(
+	invoice *Invoice,
+	customerProfile *CustomerTaxProfile,
+	providerProfile *ProviderTaxProfile,
+	now time.Time,
+) {
+	customerCountry := g.config.DefaultTaxJurisdiction
+	providerCountry := g.config.DefaultTaxJurisdiction
+	exemptionCategory := TaxExemptionNone
+
+	if customerProfile != nil {
+		customerCountry = customerProfile.CountryCode
+		exemptionCategory = customerProfile.ExemptionCategory
+	}
+
+	if providerProfile != nil {
+		providerCountry = providerProfile.CountryCode
+	}
+
+	// Calculate tax on the subtotal after discounts
+	taxableAmount := invoice.Subtotal.Sub(invoice.DiscountTotal...)
+
+	taxDetails, err := g.taxCalculator.CalculateTax(
+		taxableAmount,
+		customerCountry,
+		exemptionCategory,
+		providerCountry,
+		now,
+	)
+	if err != nil {
+		return // Skip tax on error
+	}
+
+	if customerProfile != nil {
+		taxDetails.CustomerTaxID = customerProfile.TaxID
+	}
+
+	if providerProfile != nil {
+		taxDetails.ProviderTaxID = providerProfile.TaxID
+	}
+
+	invoice.TaxDetails = taxDetails
+	invoice.recalculateTotals()
+}
+
+// GenerateInvoiceFromSettlement generates an invoice from a settlement record
+func (g *InvoiceGenerator) GenerateInvoiceFromSettlement(
+	settlementID string,
+	escrowID string,
+	orderID string,
+	leaseID string,
+	provider string,
+	customer string,
+	totalAmount sdk.Coins,
+	usageRecordIDs []string,
+	periodStart time.Time,
+	periodEnd time.Time,
+	blockHeight int64,
+	now time.Time,
+) (*Invoice, error) {
+	// Create usage inputs from the total amount
+	currency := DefaultCurrency
+	if len(totalAmount) > 0 {
+		currency = totalAmount[0].Denom
+	}
+
+	// Create a single usage input for the settlement
+	usageInputs := []UsageInput{
+		{
+			UsageRecordID: fmt.Sprintf("settlement-%s", settlementID),
+			UsageType:     UsageTypeOther,
+			Quantity:      sdkmath.LegacyOneDec(),
+			Unit:          "unit",
+			UnitPrice:     sdk.NewDecCoinFromCoin(totalAmount[0]),
+			Description:   fmt.Sprintf("Settlement for order %s", orderID),
+			PeriodStart:   periodStart,
+			PeriodEnd:     periodEnd,
+		},
+	}
+
+	req := InvoiceGenerationRequest{
+		EscrowID:    escrowID,
+		OrderID:     orderID,
+		LeaseID:     leaseID,
+		Provider:    provider,
+		Customer:    customer,
+		UsageInputs: usageInputs,
+		BillingPeriod: BillingPeriod{
+			StartTime:       periodStart,
+			EndTime:         periodEnd,
+			DurationSeconds: int64(periodEnd.Sub(periodStart).Seconds()),
+			PeriodType:      BillingPeriodTypeUsageBased,
+		},
+		Currency: currency,
+		Metadata: map[string]string{
+			"settlement_id":    settlementID,
+			"usage_record_ids": fmt.Sprintf("%v", usageRecordIDs),
+		},
+	}
+
+	invoice, err := g.GenerateInvoice(req, blockHeight, now)
+	if err != nil {
+		return nil, err
+	}
+
+	invoice.SettlementID = settlementID
+	return invoice, nil
+}
+
+// HPCUsageInput represents HPC-specific usage data
+type HPCUsageInput struct {
+	// JobID is the HPC job ID
+	JobID string `json:"job_id"`
+
+	// CPUHours is the CPU hours consumed
+	CPUHours sdkmath.LegacyDec `json:"cpu_hours"`
+
+	// GPUHours is the GPU hours consumed
+	GPUHours sdkmath.LegacyDec `json:"gpu_hours"`
+
+	// MemoryGBHours is the memory GB-hours consumed
+	MemoryGBHours sdkmath.LegacyDec `json:"memory_gb_hours"`
+
+	// StorageGBMonths is the storage GB-months consumed
+	StorageGBMonths sdkmath.LegacyDec `json:"storage_gb_months"`
+
+	// NetworkGB is the network transfer in GB
+	NetworkGB sdkmath.LegacyDec `json:"network_gb"`
+
+	// PeriodStart is the usage period start
+	PeriodStart time.Time `json:"period_start"`
+
+	// PeriodEnd is the usage period end
+	PeriodEnd time.Time `json:"period_end"`
+}
+
+// GenerateHPCInvoice generates an invoice from HPC usage data
+func (g *InvoiceGenerator) GenerateHPCInvoice(
+	escrowID string,
+	orderID string,
+	leaseID string,
+	provider string,
+	customer string,
+	hpcUsage HPCUsageInput,
+	pricingPolicy *PricingPolicy,
+	blockHeight int64,
+	now time.Time,
+) (*Invoice, error) {
+	currency := g.config.DefaultCurrency
+	if pricingPolicy != nil {
+		currency = pricingPolicy.DefaultCurrency
+	}
+
+	var usageInputs []UsageInput
+
+	// Add CPU usage
+	if hpcUsage.CPUHours.IsPositive() {
+		cpuPricing := DefaultResourcePricing(currency)[UsageTypeCPU]
+		if pricingPolicy != nil {
+			if rp, ok := pricingPolicy.GetResourcePricing(UsageTypeCPU); ok {
+				cpuPricing = rp
+			}
+		}
+
+		usageInputs = append(usageInputs, UsageInput{
+			UsageRecordID: fmt.Sprintf("%s-cpu", hpcUsage.JobID),
+			UsageType:     UsageTypeCPU,
+			Quantity:      hpcUsage.CPUHours,
+			Unit:          cpuPricing.Unit,
+			UnitPrice:     cpuPricing.BaseRate,
+			Description:   fmt.Sprintf("CPU usage for job %s", hpcUsage.JobID),
+			PeriodStart:   hpcUsage.PeriodStart,
+			PeriodEnd:     hpcUsage.PeriodEnd,
+		})
+	}
+
+	// Add GPU usage
+	if hpcUsage.GPUHours.IsPositive() {
+		gpuPricing := DefaultResourcePricing(currency)[UsageTypeGPU]
+		if pricingPolicy != nil {
+			if rp, ok := pricingPolicy.GetResourcePricing(UsageTypeGPU); ok {
+				gpuPricing = rp
+			}
+		}
+
+		usageInputs = append(usageInputs, UsageInput{
+			UsageRecordID: fmt.Sprintf("%s-gpu", hpcUsage.JobID),
+			UsageType:     UsageTypeGPU,
+			Quantity:      hpcUsage.GPUHours,
+			Unit:          gpuPricing.Unit,
+			UnitPrice:     gpuPricing.BaseRate,
+			Description:   fmt.Sprintf("GPU usage for job %s", hpcUsage.JobID),
+			PeriodStart:   hpcUsage.PeriodStart,
+			PeriodEnd:     hpcUsage.PeriodEnd,
+		})
+	}
+
+	// Add Memory usage
+	if hpcUsage.MemoryGBHours.IsPositive() {
+		memPricing := DefaultResourcePricing(currency)[UsageTypeMemory]
+		if pricingPolicy != nil {
+			if rp, ok := pricingPolicy.GetResourcePricing(UsageTypeMemory); ok {
+				memPricing = rp
+			}
+		}
+
+		usageInputs = append(usageInputs, UsageInput{
+			UsageRecordID: fmt.Sprintf("%s-mem", hpcUsage.JobID),
+			UsageType:     UsageTypeMemory,
+			Quantity:      hpcUsage.MemoryGBHours,
+			Unit:          memPricing.Unit,
+			UnitPrice:     memPricing.BaseRate,
+			Description:   fmt.Sprintf("Memory usage for job %s", hpcUsage.JobID),
+			PeriodStart:   hpcUsage.PeriodStart,
+			PeriodEnd:     hpcUsage.PeriodEnd,
+		})
+	}
+
+	// Add Storage usage
+	if hpcUsage.StorageGBMonths.IsPositive() {
+		storagePricing := DefaultResourcePricing(currency)[UsageTypeStorage]
+		if pricingPolicy != nil {
+			if rp, ok := pricingPolicy.GetResourcePricing(UsageTypeStorage); ok {
+				storagePricing = rp
+			}
+		}
+
+		usageInputs = append(usageInputs, UsageInput{
+			UsageRecordID: fmt.Sprintf("%s-storage", hpcUsage.JobID),
+			UsageType:     UsageTypeStorage,
+			Quantity:      hpcUsage.StorageGBMonths,
+			Unit:          storagePricing.Unit,
+			UnitPrice:     storagePricing.BaseRate,
+			Description:   fmt.Sprintf("Storage usage for job %s", hpcUsage.JobID),
+			PeriodStart:   hpcUsage.PeriodStart,
+			PeriodEnd:     hpcUsage.PeriodEnd,
+		})
+	}
+
+	// Add Network usage
+	if hpcUsage.NetworkGB.IsPositive() {
+		netPricing := DefaultResourcePricing(currency)[UsageTypeNetwork]
+		if pricingPolicy != nil {
+			if rp, ok := pricingPolicy.GetResourcePricing(UsageTypeNetwork); ok {
+				netPricing = rp
+			}
+		}
+
+		usageInputs = append(usageInputs, UsageInput{
+			UsageRecordID: fmt.Sprintf("%s-net", hpcUsage.JobID),
+			UsageType:     UsageTypeNetwork,
+			Quantity:      hpcUsage.NetworkGB,
+			Unit:          netPricing.Unit,
+			UnitPrice:     netPricing.BaseRate,
+			Description:   fmt.Sprintf("Network usage for job %s", hpcUsage.JobID),
+			PeriodStart:   hpcUsage.PeriodStart,
+			PeriodEnd:     hpcUsage.PeriodEnd,
+		})
+	}
+
+	if len(usageInputs) == 0 {
+		return nil, fmt.Errorf("no usage data provided")
+	}
+
+	req := InvoiceGenerationRequest{
+		EscrowID:    escrowID,
+		OrderID:     orderID,
+		LeaseID:     leaseID,
+		Provider:    provider,
+		Customer:    customer,
+		UsageInputs: usageInputs,
+		BillingPeriod: BillingPeriod{
+			StartTime:       hpcUsage.PeriodStart,
+			EndTime:         hpcUsage.PeriodEnd,
+			DurationSeconds: int64(hpcUsage.PeriodEnd.Sub(hpcUsage.PeriodStart).Seconds()),
+			PeriodType:      BillingPeriodTypeUsageBased,
+		},
+		Currency: currency,
+		Metadata: map[string]string{
+			"hpc_job_id": hpcUsage.JobID,
+		},
+	}
+
+	return g.GenerateInvoice(req, blockHeight, now)
+}

--- a/x/escrow/types/billing/invoice_test.go
+++ b/x/escrow/types/billing/invoice_test.go
@@ -1,0 +1,627 @@
+// Package billing provides tests for invoice generation and ledger management.
+package billing
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// testAddress generates a valid test bech32 address from a seed number
+func testAddress(seed int) string {
+	var buffer bytes.Buffer
+	buffer.WriteString("A58856F0FD53BF058B4909A21AEC019107BA6")
+	buffer.WriteString(string(rune('0' + (seed/100)%10)))
+	buffer.WriteString(string(rune('0' + (seed/10)%10)))
+	buffer.WriteString(string(rune('0' + seed%10)))
+	res, _ := sdk.AccAddressFromHexUnsafe(buffer.String())
+	return res.String()
+}
+
+func TestInvoiceLedgerRecord_NewAndValidate(t *testing.T) {
+	now := time.Now().UTC()
+	blockHeight := int64(12345)
+
+	invoice := createTestInvoice(now)
+	artifactCID := "baf1234567890abcdef"
+
+	record, err := NewInvoiceLedgerRecord(invoice, artifactCID, blockHeight, now)
+	if err != nil {
+		t.Fatalf("NewInvoiceLedgerRecord failed: %v", err)
+	}
+
+	if record.InvoiceID != invoice.InvoiceID {
+		t.Errorf("expected InvoiceID %s, got %s", invoice.InvoiceID, record.InvoiceID)
+	}
+
+	if record.ContentHash == "" {
+		t.Error("ContentHash should not be empty")
+	}
+
+	if len(record.ContentHash) != 64 {
+		t.Errorf("ContentHash should be 64 hex characters, got %d", len(record.ContentHash))
+	}
+
+	if record.ArtifactCID != artifactCID {
+		t.Errorf("expected ArtifactCID %s, got %s", artifactCID, record.ArtifactCID)
+	}
+
+	if record.LineItemCount != uint32(len(invoice.LineItems)) {
+		t.Errorf("expected LineItemCount %d, got %d", len(invoice.LineItems), record.LineItemCount)
+	}
+
+	if err := record.Validate(); err != nil {
+		t.Errorf("Validate failed: %v", err)
+	}
+}
+
+func TestInvoiceLedgerRecord_VerifyContentHash(t *testing.T) {
+	now := time.Now().UTC()
+	blockHeight := int64(12345)
+
+	invoice := createTestInvoice(now)
+	artifactCID := "baf1234567890abcdef"
+
+	record, err := NewInvoiceLedgerRecord(invoice, artifactCID, blockHeight, now)
+	if err != nil {
+		t.Fatalf("NewInvoiceLedgerRecord failed: %v", err)
+	}
+
+	// Verify with original invoice
+	valid, err := record.VerifyContentHash(invoice)
+	if err != nil {
+		t.Fatalf("VerifyContentHash failed: %v", err)
+	}
+	if !valid {
+		t.Error("ContentHash should be valid for original invoice")
+	}
+
+	// Modify invoice and verify again
+	modifiedInvoice := createTestInvoice(now)
+	modifiedInvoice.InvoiceNumber = "MODIFIED-001"
+
+	valid, err = record.VerifyContentHash(modifiedInvoice)
+	if err != nil {
+		t.Fatalf("VerifyContentHash failed: %v", err)
+	}
+	if valid {
+		t.Error("ContentHash should be invalid for modified invoice")
+	}
+}
+
+func TestInvoiceLedgerEntry_NewAndValidate(t *testing.T) {
+	now := time.Now().UTC()
+	blockHeight := int64(12345)
+
+	entry := NewInvoiceLedgerEntry(
+		"entry-001",
+		"invoice-001",
+		LedgerEntryTypeCreated,
+		InvoiceStatusDraft,
+		InvoiceStatusDraft,
+		sdk.NewCoins(),
+		"invoice created",
+		"virtengine1abc...",
+		"txhash123",
+		blockHeight,
+		now,
+	)
+
+	if entry.EntryID != "entry-001" {
+		t.Errorf("expected EntryID entry-001, got %s", entry.EntryID)
+	}
+
+	if entry.EntryType != LedgerEntryTypeCreated {
+		t.Errorf("expected EntryType %s, got %s", LedgerEntryTypeCreated, entry.EntryType)
+	}
+
+	if err := entry.Validate(); err != nil {
+		t.Errorf("Validate failed: %v", err)
+	}
+}
+
+func TestInvoiceStatusTransitions(t *testing.T) {
+	tests := []struct {
+		name     string
+		from     InvoiceStatus
+		to       InvoiceStatus
+		expected bool
+	}{
+		{"draft to pending", InvoiceStatusDraft, InvoiceStatusPending, true},
+		{"draft to cancelled", InvoiceStatusDraft, InvoiceStatusCancelled, true},
+		{"draft to paid", InvoiceStatusDraft, InvoiceStatusPaid, false},
+		{"pending to paid", InvoiceStatusPending, InvoiceStatusPaid, true},
+		{"pending to partially paid", InvoiceStatusPending, InvoiceStatusPartiallyPaid, true},
+		{"pending to overdue", InvoiceStatusPending, InvoiceStatusOverdue, true},
+		{"pending to disputed", InvoiceStatusPending, InvoiceStatusDisputed, true},
+		{"partially paid to paid", InvoiceStatusPartiallyPaid, InvoiceStatusPaid, true},
+		{"partially paid to disputed", InvoiceStatusPartiallyPaid, InvoiceStatusDisputed, true},
+		{"overdue to paid", InvoiceStatusOverdue, InvoiceStatusPaid, true},
+		{"disputed to pending", InvoiceStatusDisputed, InvoiceStatusPending, true},
+		{"disputed to refunded", InvoiceStatusDisputed, InvoiceStatusRefunded, true},
+		{"paid to refunded", InvoiceStatusPaid, InvoiceStatusRefunded, true},
+		{"paid to cancelled", InvoiceStatusPaid, InvoiceStatusCancelled, false},
+		{"cancelled to paid", InvoiceStatusCancelled, InvoiceStatusPaid, false},
+		{"refunded to paid", InvoiceStatusRefunded, InvoiceStatusPaid, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsValidTransition(tt.from, tt.to)
+			if result != tt.expected {
+				t.Errorf("IsValidTransition(%s, %s) = %v, want %v",
+					tt.from, tt.to, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetValidNextStates(t *testing.T) {
+	tests := []struct {
+		status   InvoiceStatus
+		minCount int
+	}{
+		{InvoiceStatusDraft, 2},
+		{InvoiceStatusPending, 4},
+		{InvoiceStatusPartiallyPaid, 3},
+		{InvoiceStatusOverdue, 4},
+		{InvoiceStatusDisputed, 4},
+		{InvoiceStatusPaid, 1},
+		{InvoiceStatusCancelled, 0},
+		{InvoiceStatusRefunded, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status.String(), func(t *testing.T) {
+			states := GetValidNextStates(tt.status)
+			if len(states) < tt.minCount {
+				t.Errorf("GetValidNextStates(%s) returned %d states, want at least %d",
+					tt.status, len(states), tt.minCount)
+			}
+		})
+	}
+}
+
+func TestInvoiceStatusMachine_MarkIssued(t *testing.T) {
+	now := time.Now().UTC()
+	blockHeight := int64(12345)
+
+	invoice := createTestInvoice(now)
+
+	sm := NewInvoiceStatusMachine(invoice, blockHeight, now)
+	err := sm.MarkIssued("provider-addr")
+	if err != nil {
+		t.Fatalf("MarkIssued failed: %v", err)
+	}
+
+	if invoice.Status != InvoiceStatusPending {
+		t.Errorf("expected status %s, got %s", InvoiceStatusPending, invoice.Status)
+	}
+
+	entry := sm.GetLedgerEntry()
+	if entry == nil {
+		t.Fatal("ledger entry should not be nil")
+	}
+
+	if entry.EntryType != LedgerEntryTypeIssued {
+		t.Errorf("expected entry type %s, got %s", LedgerEntryTypeIssued, entry.EntryType)
+	}
+}
+
+func TestInvoiceStatusMachine_TransitionWithPayment(t *testing.T) {
+	now := time.Now().UTC()
+	blockHeight := int64(12345)
+
+	invoice := createTestInvoice(now)
+	_ = invoice.Finalize(now)
+
+	sm := NewInvoiceStatusMachine(invoice, blockHeight, now)
+
+	// Record full payment
+	err := sm.TransitionWithPayment(invoice.Total, "customer-addr")
+	if err != nil {
+		t.Fatalf("TransitionWithPayment failed: %v", err)
+	}
+
+	if invoice.Status != InvoiceStatusPaid {
+		t.Errorf("expected status %s, got %s", InvoiceStatusPaid, invoice.Status)
+	}
+
+	entry := sm.GetLedgerEntry()
+	if entry == nil {
+		t.Fatal("ledger entry should not be nil")
+	}
+
+	if entry.EntryType != LedgerEntryTypePayment {
+		t.Errorf("expected entry type %s, got %s", LedgerEntryTypePayment, entry.EntryType)
+	}
+}
+
+func TestMemoryArtifactStore(t *testing.T) {
+	store := NewMemoryArtifactStore()
+	ctx := context.Background()
+
+	invoiceID := "invoice-001"
+	content := []byte(`{"test": "data"}`)
+	createdBy := "system"
+
+	// Store artifact
+	artifact, err := store.Store(ctx, invoiceID, ArtifactTypeJSON, content, createdBy)
+	if err != nil {
+		t.Fatalf("Store failed: %v", err)
+	}
+
+	if artifact.CID == "" {
+		t.Error("CID should not be empty")
+	}
+
+	if artifact.InvoiceID != invoiceID {
+		t.Errorf("expected InvoiceID %s, got %s", invoiceID, artifact.InvoiceID)
+	}
+
+	if artifact.Size != int64(len(content)) {
+		t.Errorf("expected Size %d, got %d", len(content), artifact.Size)
+	}
+
+	// Get artifact
+	retrievedContent, retrievedArtifact, err := store.Get(ctx, artifact.CID)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+
+	if string(retrievedContent) != string(content) {
+		t.Error("retrieved content does not match original")
+	}
+
+	if retrievedArtifact.CID != artifact.CID {
+		t.Error("retrieved artifact CID does not match")
+	}
+
+	// Get by invoice
+	artifacts, err := store.GetByInvoice(ctx, invoiceID)
+	if err != nil {
+		t.Fatalf("GetByInvoice failed: %v", err)
+	}
+
+	if len(artifacts) != 1 {
+		t.Errorf("expected 1 artifact, got %d", len(artifacts))
+	}
+
+	// Verify
+	valid, err := store.Verify(ctx, artifact.CID, content)
+	if err != nil {
+		t.Fatalf("Verify failed: %v", err)
+	}
+
+	if !valid {
+		t.Error("content verification should succeed")
+	}
+
+	// Verify with wrong content
+	valid, err = store.Verify(ctx, artifact.CID, []byte("wrong content"))
+	if err != nil {
+		t.Fatalf("Verify failed: %v", err)
+	}
+
+	if valid {
+		t.Error("content verification should fail for wrong content")
+	}
+
+	// Delete
+	err = store.Delete(ctx, artifact.CID)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	// Verify deleted
+	_, _, err = store.Get(ctx, artifact.CID)
+	if err == nil {
+		t.Error("Get should fail after delete")
+	}
+}
+
+func TestInvoiceGenerator_GenerateInvoice(t *testing.T) {
+	config := DefaultInvoiceGeneratorConfig()
+	gen := NewInvoiceGenerator(config)
+
+	now := time.Now().UTC()
+	blockHeight := int64(12345)
+
+	req := InvoiceGenerationRequest{
+		EscrowID: "escrow-001",
+		OrderID:  "order-001",
+		LeaseID:  "lease-001",
+		Provider: testAddress(100),
+		Customer: testAddress(101),
+		UsageInputs: []UsageInput{
+			{
+				UsageRecordID: "usage-001",
+				UsageType:     UsageTypeCPU,
+				Quantity:      sdkmath.LegacyNewDec(10),
+				Unit:          "core-hour",
+				UnitPrice:     sdk.NewDecCoinFromDec("uvirt", sdkmath.LegacyNewDecWithPrec(100, 0)),
+				Description:   "CPU usage for 10 core-hours",
+				PeriodStart:   now.Add(-24 * time.Hour),
+				PeriodEnd:     now,
+			},
+			{
+				UsageRecordID: "usage-002",
+				UsageType:     UsageTypeMemory,
+				Quantity:      sdkmath.LegacyNewDec(32),
+				Unit:          "gb-hour",
+				UnitPrice:     sdk.NewDecCoinFromDec("uvirt", sdkmath.LegacyNewDecWithPrec(50, 0)),
+				Description:   "Memory usage for 32 GB-hours",
+				PeriodStart:   now.Add(-24 * time.Hour),
+				PeriodEnd:     now,
+			},
+		},
+		BillingPeriod: BillingPeriod{
+			StartTime:       now.Add(-24 * time.Hour),
+			EndTime:         now,
+			DurationSeconds: 86400,
+			PeriodType:      BillingPeriodTypeDaily,
+		},
+		Currency: "uvirt",
+	}
+
+	invoice, err := gen.GenerateInvoice(req, blockHeight, now)
+	if err != nil {
+		t.Fatalf("GenerateInvoice failed: %v", err)
+	}
+
+	if invoice.InvoiceID == "" {
+		t.Error("InvoiceID should not be empty")
+	}
+
+	if invoice.InvoiceNumber == "" {
+		t.Error("InvoiceNumber should not be empty")
+	}
+
+	if len(invoice.LineItems) != 2 {
+		t.Errorf("expected 2 line items, got %d", len(invoice.LineItems))
+	}
+
+	if invoice.Status != InvoiceStatusDraft {
+		t.Errorf("expected status %s, got %s", InvoiceStatusDraft, invoice.Status)
+	}
+
+	// Verify totals
+	expectedSubtotal := int64(10*100 + 32*50) // 1000 + 1600 = 2600
+	if !invoice.Subtotal.IsAllGTE(sdk.NewCoins(sdk.NewCoin("uvirt", sdkmath.NewInt(expectedSubtotal)))) {
+		t.Errorf("subtotal mismatch, expected at least %d uvirt", expectedSubtotal)
+	}
+
+	if err := invoice.Validate(); err != nil {
+		t.Errorf("generated invoice validation failed: %v", err)
+	}
+}
+
+func TestInvoiceGenerator_GenerateHPCInvoice(t *testing.T) {
+	config := DefaultInvoiceGeneratorConfig()
+	gen := NewInvoiceGenerator(config)
+
+	now := time.Now().UTC()
+	blockHeight := int64(12345)
+
+	hpcUsage := HPCUsageInput{
+		JobID:           "job-001",
+		CPUHours:        sdkmath.LegacyNewDec(100),
+		GPUHours:        sdkmath.LegacyNewDec(10),
+		MemoryGBHours:   sdkmath.LegacyNewDec(512),
+		StorageGBMonths: sdkmath.LegacyNewDec(100),
+		NetworkGB:       sdkmath.LegacyNewDec(50),
+		PeriodStart:     now.Add(-24 * time.Hour),
+		PeriodEnd:       now,
+	}
+
+	invoice, err := gen.GenerateHPCInvoice(
+		"escrow-001",
+		"order-001",
+		"lease-001",
+		testAddress(100),
+		testAddress(101),
+		hpcUsage,
+		nil, // use default pricing
+		blockHeight,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("GenerateHPCInvoice failed: %v", err)
+	}
+
+	// Should have 5 line items (CPU, GPU, Memory, Storage, Network)
+	if len(invoice.LineItems) != 5 {
+		t.Errorf("expected 5 line items, got %d", len(invoice.LineItems))
+	}
+
+	// Verify job ID in metadata
+	if invoice.Metadata["hpc_job_id"] != "job-001" {
+		t.Error("hpc_job_id metadata should be set")
+	}
+}
+
+func TestInvoiceGenerator_DeterministicInvoiceID(t *testing.T) {
+	config := DefaultInvoiceGeneratorConfig()
+	gen := NewInvoiceGenerator(config)
+
+	now := time.Now().UTC()
+	blockHeight := int64(12345)
+
+	req := createTestRequest(now)
+
+	// Generate invoice twice with same inputs
+	invoice1, err := gen.GenerateInvoice(req, blockHeight, now)
+	if err != nil {
+		t.Fatalf("GenerateInvoice failed: %v", err)
+	}
+
+	gen2 := NewInvoiceGenerator(config)
+	invoice2, err := gen2.GenerateInvoice(req, blockHeight, now)
+	if err != nil {
+		t.Fatalf("GenerateInvoice failed: %v", err)
+	}
+
+	// Invoice IDs should be the same (deterministic)
+	if invoice1.InvoiceID != invoice2.InvoiceID {
+		t.Errorf("invoice IDs should be deterministic: %s != %s",
+			invoice1.InvoiceID, invoice2.InvoiceID)
+	}
+}
+
+func TestReconciliationReport_Validate(t *testing.T) {
+	now := time.Now().UTC()
+
+	report := &ReconciliationReport{
+		ReportID:    "report-001",
+		ReportType:  ReconciliationReportTypeDaily,
+		PeriodStart: now.Add(-24 * time.Hour),
+		PeriodEnd:   now,
+		Status:      ReconciliationStatusComplete,
+		Summary: ReconciliationSummary{
+			TotalInvoices:      10,
+			TotalInvoiceAmount: sdk.NewCoins(sdk.NewCoin("uvirt", sdkmath.NewInt(1000000))),
+		},
+		GeneratedAt: now,
+		GeneratedBy: "system",
+		BlockHeight: 12345,
+	}
+
+	if err := report.Validate(); err != nil {
+		t.Errorf("Validate failed: %v", err)
+	}
+
+	// Test invalid: period end before start
+	invalidReport := *report
+	invalidReport.PeriodStart = now
+	invalidReport.PeriodEnd = now.Add(-24 * time.Hour)
+
+	if err := invalidReport.Validate(); err == nil {
+		t.Error("should fail validation when period_end before period_start")
+	}
+}
+
+func TestComputeInvoiceHash(t *testing.T) {
+	now := time.Now().UTC()
+	invoice := createTestInvoice(now)
+
+	hash1, err := ComputeInvoiceHash(invoice)
+	if err != nil {
+		t.Fatalf("ComputeInvoiceHash failed: %v", err)
+	}
+
+	if hash1 == "" {
+		t.Error("hash should not be empty")
+	}
+
+	if len(hash1) != 64 {
+		t.Errorf("hash should be 64 hex characters, got %d", len(hash1))
+	}
+
+	// Same invoice should produce same hash
+	hash2, err := ComputeInvoiceHash(invoice)
+	if err != nil {
+		t.Fatalf("ComputeInvoiceHash failed: %v", err)
+	}
+
+	if hash1 != hash2 {
+		t.Error("same invoice should produce same hash")
+	}
+
+	// Modified invoice should produce different hash
+	modifiedInvoice := createTestInvoice(now)
+	modifiedInvoice.InvoiceNumber = "MODIFIED-001"
+
+	hash3, err := ComputeInvoiceHash(modifiedInvoice)
+	if err != nil {
+		t.Fatalf("ComputeInvoiceHash failed: %v", err)
+	}
+
+	if hash1 == hash3 {
+		t.Error("modified invoice should produce different hash")
+	}
+}
+
+// Helper functions
+
+func createTestInvoice(now time.Time) *Invoice {
+	provider := testAddress(100)
+	customer := testAddress(101)
+	dueDate := now.Add(7 * 24 * time.Hour)
+	invoice := NewInvoice(
+		"invoice-001",
+		"VE-INV-00000001",
+		"escrow-001",
+		"order-001",
+		"lease-001",
+		provider,
+		customer,
+		"uvirt",
+		BillingPeriod{
+			StartTime:       now.Add(-24 * time.Hour),
+			EndTime:         now,
+			DurationSeconds: 86400,
+			PeriodType:      BillingPeriodTypeDaily,
+		},
+		dueDate,
+		12345,
+		now,
+	)
+
+	// Add line items
+	invoice.AddLineItem(LineItem{
+		LineItemID:     "li-1",
+		Description:    "CPU Usage",
+		UsageType:      UsageTypeCPU,
+		Quantity:       sdkmath.LegacyNewDec(10),
+		Unit:           "core-hour",
+		UnitPrice:      sdk.NewDecCoinFromDec("uvirt", sdkmath.LegacyNewDec(100)),
+		Amount:         sdk.NewCoins(sdk.NewCoin("uvirt", sdkmath.NewInt(1000))),
+		UsageRecordIDs: []string{"usage-001"},
+	})
+
+	invoice.AddLineItem(LineItem{
+		LineItemID:     "li-2",
+		Description:    "Memory Usage",
+		UsageType:      UsageTypeMemory,
+		Quantity:       sdkmath.LegacyNewDec(32),
+		Unit:           "gb-hour",
+		UnitPrice:      sdk.NewDecCoinFromDec("uvirt", sdkmath.LegacyNewDec(50)),
+		Amount:         sdk.NewCoins(sdk.NewCoin("uvirt", sdkmath.NewInt(1600))),
+		UsageRecordIDs: []string{"usage-002"},
+	})
+
+	return invoice
+}
+
+func createTestRequest(now time.Time) InvoiceGenerationRequest {
+	return InvoiceGenerationRequest{
+		EscrowID: "escrow-001",
+		OrderID:  "order-001",
+		LeaseID:  "lease-001",
+		Provider: testAddress(100),
+		Customer: testAddress(101),
+		UsageInputs: []UsageInput{
+			{
+				UsageRecordID: "usage-001",
+				UsageType:     UsageTypeCPU,
+				Quantity:      sdkmath.LegacyNewDec(10),
+				Unit:          "core-hour",
+				UnitPrice:     sdk.NewDecCoinFromDec("uvirt", sdkmath.LegacyNewDecWithPrec(100, 0)),
+				Description:   "CPU usage",
+				PeriodStart:   now.Add(-24 * time.Hour),
+				PeriodEnd:     now,
+			},
+		},
+		BillingPeriod: BillingPeriod{
+			StartTime:       now.Add(-24 * time.Hour),
+			EndTime:         now,
+			DurationSeconds: 86400,
+			PeriodType:      BillingPeriodTypeDaily,
+		},
+		Currency: "uvirt",
+	}
+}

--- a/x/escrow/types/billing/ledger.go
+++ b/x/escrow/types/billing/ledger.go
@@ -1,0 +1,392 @@
+// Package billing provides billing and invoice types for the escrow module.
+package billing
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// InvoiceLedgerRecord is the immutable on-chain invoice record.
+// This contains a hash of the full invoice for verification,
+// while the full invoice document is stored in the artifact store.
+type InvoiceLedgerRecord struct {
+	// InvoiceID is the unique identifier
+	InvoiceID string `json:"invoice_id"`
+
+	// InvoiceNumber is the human-readable invoice number
+	InvoiceNumber string `json:"invoice_number"`
+
+	// EscrowID links to the escrow account
+	EscrowID string `json:"escrow_id"`
+
+	// OrderID links to the marketplace order
+	OrderID string `json:"order_id"`
+
+	// LeaseID links to the marketplace lease
+	LeaseID string `json:"lease_id"`
+
+	// Provider is the service provider address
+	Provider string `json:"provider"`
+
+	// Customer is the customer address
+	Customer string `json:"customer"`
+
+	// Status is the current invoice status
+	Status InvoiceStatus `json:"status"`
+
+	// Currency is the primary currency/denomination
+	Currency string `json:"currency"`
+
+	// Subtotal is the sum of line items before adjustments
+	Subtotal sdk.Coins `json:"subtotal"`
+
+	// DiscountTotal is the total discount amount
+	DiscountTotal sdk.Coins `json:"discount_total"`
+
+	// TaxTotal is the total tax amount
+	TaxTotal sdk.Coins `json:"tax_total"`
+
+	// Total is the final amount due
+	Total sdk.Coins `json:"total"`
+
+	// AmountPaid is the amount already paid
+	AmountPaid sdk.Coins `json:"amount_paid"`
+
+	// AmountDue is the remaining amount due
+	AmountDue sdk.Coins `json:"amount_due"`
+
+	// LineItemCount is the number of line items
+	LineItemCount uint32 `json:"line_item_count"`
+
+	// BillingPeriodStart is the billing period start
+	BillingPeriodStart time.Time `json:"billing_period_start"`
+
+	// BillingPeriodEnd is the billing period end
+	BillingPeriodEnd time.Time `json:"billing_period_end"`
+
+	// DueDate is when payment is due
+	DueDate time.Time `json:"due_date"`
+
+	// IssuedAt is when the invoice was issued
+	IssuedAt time.Time `json:"issued_at"`
+
+	// PaidAt is when fully paid (if paid)
+	PaidAt *time.Time `json:"paid_at,omitempty"`
+
+	// ContentHash is the SHA-256 hash of the full invoice document
+	ContentHash string `json:"content_hash"`
+
+	// ArtifactCID is the content-addressable identifier for the full invoice
+	ArtifactCID string `json:"artifact_cid"`
+
+	// SettlementID links to the settlement record (if settled)
+	SettlementID string `json:"settlement_id,omitempty"`
+
+	// BlockHeight is when the invoice was created on-chain
+	BlockHeight int64 `json:"block_height"`
+
+	// CreatedAt is when the record was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is when the record was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// NewInvoiceLedgerRecord creates a ledger record from a full invoice
+func NewInvoiceLedgerRecord(inv *Invoice, artifactCID string, blockHeight int64, now time.Time) (*InvoiceLedgerRecord, error) {
+	// Compute content hash from invoice JSON
+	invJSON, err := json.Marshal(inv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal invoice for hashing: %w", err)
+	}
+
+	hash := sha256.Sum256(invJSON)
+	contentHash := hex.EncodeToString(hash[:])
+
+	return &InvoiceLedgerRecord{
+		InvoiceID:          inv.InvoiceID,
+		InvoiceNumber:      inv.InvoiceNumber,
+		EscrowID:           inv.EscrowID,
+		OrderID:            inv.OrderID,
+		LeaseID:            inv.LeaseID,
+		Provider:           inv.Provider,
+		Customer:           inv.Customer,
+		Status:             inv.Status,
+		Currency:           inv.Currency,
+		Subtotal:           inv.Subtotal,
+		DiscountTotal:      inv.DiscountTotal,
+		TaxTotal:           inv.TaxTotal,
+		Total:              inv.Total,
+		AmountPaid:         inv.AmountPaid,
+		AmountDue:          inv.AmountDue,
+		LineItemCount:      uint32(len(inv.LineItems)),
+		BillingPeriodStart: inv.BillingPeriod.StartTime,
+		BillingPeriodEnd:   inv.BillingPeriod.EndTime,
+		DueDate:            inv.DueDate,
+		IssuedAt:           inv.IssuedAt,
+		PaidAt:             inv.PaidAt,
+		ContentHash:        contentHash,
+		ArtifactCID:        artifactCID,
+		SettlementID:       inv.SettlementID,
+		BlockHeight:        blockHeight,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}, nil
+}
+
+// Validate validates the ledger record
+func (r *InvoiceLedgerRecord) Validate() error {
+	if r.InvoiceID == "" {
+		return fmt.Errorf("invoice_id is required")
+	}
+
+	if len(r.InvoiceID) > 64 {
+		return fmt.Errorf("invoice_id exceeds maximum length of 64")
+	}
+
+	if r.EscrowID == "" {
+		return fmt.Errorf("escrow_id is required")
+	}
+
+	if _, err := sdk.AccAddressFromBech32(r.Provider); err != nil {
+		return fmt.Errorf("invalid provider address: %w", err)
+	}
+
+	if _, err := sdk.AccAddressFromBech32(r.Customer); err != nil {
+		return fmt.Errorf("invalid customer address: %w", err)
+	}
+
+	if r.Currency == "" {
+		return fmt.Errorf("currency is required")
+	}
+
+	if r.ContentHash == "" {
+		return fmt.Errorf("content_hash is required")
+	}
+
+	if len(r.ContentHash) != 64 {
+		return fmt.Errorf("content_hash must be 64 hex characters (SHA-256)")
+	}
+
+	if r.BillingPeriodEnd.Before(r.BillingPeriodStart) {
+		return fmt.Errorf("billing_period_end must be after billing_period_start")
+	}
+
+	if !r.Total.IsValid() {
+		return fmt.Errorf("total must be valid coins")
+	}
+
+	return nil
+}
+
+// VerifyContentHash verifies the content hash against a full invoice
+func (r *InvoiceLedgerRecord) VerifyContentHash(inv *Invoice) (bool, error) {
+	invJSON, err := json.Marshal(inv)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal invoice for verification: %w", err)
+	}
+
+	hash := sha256.Sum256(invJSON)
+	expectedHash := hex.EncodeToString(hash[:])
+
+	return r.ContentHash == expectedHash, nil
+}
+
+// ToSummary creates a summary view from the ledger record
+func (r *InvoiceLedgerRecord) ToSummary() InvoiceSummary {
+	return InvoiceSummary{
+		InvoiceID:     r.InvoiceID,
+		InvoiceNumber: r.InvoiceNumber,
+		Provider:      r.Provider,
+		Customer:      r.Customer,
+		Status:        r.Status,
+		Total:         r.Total,
+		AmountPaid:    r.AmountPaid,
+		AmountDue:     r.AmountDue,
+		DueDate:       r.DueDate,
+		IssuedAt:      r.IssuedAt,
+	}
+}
+
+// InvoiceLedgerEntry represents a state change in the invoice ledger
+type InvoiceLedgerEntry struct {
+	// EntryID is the unique identifier for this entry
+	EntryID string `json:"entry_id"`
+
+	// InvoiceID is the invoice this entry relates to
+	InvoiceID string `json:"invoice_id"`
+
+	// EntryType is the type of ledger entry
+	EntryType InvoiceLedgerEntryType `json:"entry_type"`
+
+	// PreviousStatus is the status before this change
+	PreviousStatus InvoiceStatus `json:"previous_status"`
+
+	// NewStatus is the status after this change
+	NewStatus InvoiceStatus `json:"new_status"`
+
+	// Amount is the amount involved in this entry (for payments/refunds)
+	Amount sdk.Coins `json:"amount,omitempty"`
+
+	// Description describes the entry
+	Description string `json:"description"`
+
+	// Initiator is who initiated this change
+	Initiator string `json:"initiator"`
+
+	// TransactionHash is the on-chain transaction hash (if applicable)
+	TransactionHash string `json:"transaction_hash,omitempty"`
+
+	// BlockHeight is when this entry was created
+	BlockHeight int64 `json:"block_height"`
+
+	// Timestamp is when this entry was created
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// InvoiceLedgerEntryType defines types of ledger entries
+type InvoiceLedgerEntryType uint8
+
+const (
+	// LedgerEntryTypeCreated is when invoice is created
+	LedgerEntryTypeCreated InvoiceLedgerEntryType = 0
+
+	// LedgerEntryTypeIssued is when invoice is issued
+	LedgerEntryTypeIssued InvoiceLedgerEntryType = 1
+
+	// LedgerEntryTypePayment is when payment is recorded
+	LedgerEntryTypePayment InvoiceLedgerEntryType = 2
+
+	// LedgerEntryTypeDisputed is when invoice is disputed
+	LedgerEntryTypeDisputed InvoiceLedgerEntryType = 3
+
+	// LedgerEntryTypeResolved is when dispute is resolved
+	LedgerEntryTypeResolved InvoiceLedgerEntryType = 4
+
+	// LedgerEntryTypeCancelled is when invoice is cancelled
+	LedgerEntryTypeCancelled InvoiceLedgerEntryType = 5
+
+	// LedgerEntryTypeRefunded is when invoice is refunded
+	LedgerEntryTypeRefunded InvoiceLedgerEntryType = 6
+
+	// LedgerEntryTypeOverdue is when invoice becomes overdue
+	LedgerEntryTypeOverdue InvoiceLedgerEntryType = 7
+
+	// LedgerEntryTypeArtifactStored is when artifact is stored
+	LedgerEntryTypeArtifactStored InvoiceLedgerEntryType = 8
+)
+
+// LedgerEntryTypeNames maps types to names
+var LedgerEntryTypeNames = map[InvoiceLedgerEntryType]string{
+	LedgerEntryTypeCreated:        "created",
+	LedgerEntryTypeIssued:         "issued",
+	LedgerEntryTypePayment:        "payment",
+	LedgerEntryTypeDisputed:       "disputed",
+	LedgerEntryTypeResolved:       "resolved",
+	LedgerEntryTypeCancelled:      "cancelled",
+	LedgerEntryTypeRefunded:       "refunded",
+	LedgerEntryTypeOverdue:        "overdue",
+	LedgerEntryTypeArtifactStored: "artifact_stored",
+}
+
+// String returns string representation
+func (t InvoiceLedgerEntryType) String() string {
+	if name, ok := LedgerEntryTypeNames[t]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown(%d)", t)
+}
+
+// NewInvoiceLedgerEntry creates a new ledger entry
+func NewInvoiceLedgerEntry(
+	entryID string,
+	invoiceID string,
+	entryType InvoiceLedgerEntryType,
+	previousStatus InvoiceStatus,
+	newStatus InvoiceStatus,
+	amount sdk.Coins,
+	description string,
+	initiator string,
+	txHash string,
+	blockHeight int64,
+	timestamp time.Time,
+) *InvoiceLedgerEntry {
+	return &InvoiceLedgerEntry{
+		EntryID:         entryID,
+		InvoiceID:       invoiceID,
+		EntryType:       entryType,
+		PreviousStatus:  previousStatus,
+		NewStatus:       newStatus,
+		Amount:          amount,
+		Description:     description,
+		Initiator:       initiator,
+		TransactionHash: txHash,
+		BlockHeight:     blockHeight,
+		Timestamp:       timestamp,
+	}
+}
+
+// Validate validates the ledger entry
+func (e *InvoiceLedgerEntry) Validate() error {
+	if e.EntryID == "" {
+		return fmt.Errorf("entry_id is required")
+	}
+
+	if e.InvoiceID == "" {
+		return fmt.Errorf("invoice_id is required")
+	}
+
+	if e.Initiator == "" {
+		return fmt.Errorf("initiator is required")
+	}
+
+	return nil
+}
+
+// Store key prefixes for ledger types
+var (
+	// InvoiceLedgerRecordPrefix is the prefix for ledger records
+	InvoiceLedgerRecordPrefix = []byte{0x60}
+
+	// InvoiceLedgerEntryPrefix is the prefix for ledger entries
+	InvoiceLedgerEntryPrefix = []byte{0x61}
+
+	// InvoiceLedgerEntryByInvoicePrefix indexes entries by invoice
+	InvoiceLedgerEntryByInvoicePrefix = []byte{0x62}
+
+	// InvoiceArtifactPrefix is the prefix for artifact references
+	InvoiceArtifactPrefix = []byte{0x63}
+)
+
+// BuildInvoiceLedgerRecordKey builds the key for a ledger record
+func BuildInvoiceLedgerRecordKey(invoiceID string) []byte {
+	return append(InvoiceLedgerRecordPrefix, []byte(invoiceID)...)
+}
+
+// BuildInvoiceLedgerEntryKey builds the key for a ledger entry
+func BuildInvoiceLedgerEntryKey(entryID string) []byte {
+	return append(InvoiceLedgerEntryPrefix, []byte(entryID)...)
+}
+
+// BuildInvoiceLedgerEntryByInvoiceKey builds the index key for entries by invoice
+func BuildInvoiceLedgerEntryByInvoiceKey(invoiceID string, entryID string) []byte {
+	key := append(InvoiceLedgerEntryByInvoicePrefix, []byte(invoiceID)...)
+	key = append(key, byte('/'))
+	return append(key, []byte(entryID)...)
+}
+
+// BuildInvoiceLedgerEntryByInvoicePrefix builds the prefix for invoice's entries
+func BuildInvoiceLedgerEntryByInvoicePrefix(invoiceID string) []byte {
+	key := append(InvoiceLedgerEntryByInvoicePrefix, []byte(invoiceID)...)
+	return append(key, byte('/'))
+}
+
+// BuildInvoiceArtifactKey builds the key for an artifact reference
+func BuildInvoiceArtifactKey(cid string) []byte {
+	return append(InvoiceArtifactPrefix, []byte(cid)...)
+}

--- a/x/escrow/types/billing/reconciliation.go
+++ b/x/escrow/types/billing/reconciliation.go
@@ -1,0 +1,497 @@
+// Package billing provides billing and invoice types for the escrow module.
+package billing
+
+import (
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// ReconciliationStatus defines the status of a reconciliation report
+type ReconciliationStatus uint8
+
+const (
+	// ReconciliationStatusPending is a pending reconciliation
+	ReconciliationStatusPending ReconciliationStatus = 0
+
+	// ReconciliationStatusComplete is a completed reconciliation
+	ReconciliationStatusComplete ReconciliationStatus = 1
+
+	// ReconciliationStatusFailed is a failed reconciliation
+	ReconciliationStatusFailed ReconciliationStatus = 2
+
+	// ReconciliationStatusPartial is a partially complete reconciliation
+	ReconciliationStatusPartial ReconciliationStatus = 3
+)
+
+// ReconciliationStatusNames maps status to names
+var ReconciliationStatusNames = map[ReconciliationStatus]string{
+	ReconciliationStatusPending:  "pending",
+	ReconciliationStatusComplete: "complete",
+	ReconciliationStatusFailed:   "failed",
+	ReconciliationStatusPartial:  "partial",
+}
+
+// String returns string representation
+func (s ReconciliationStatus) String() string {
+	if name, ok := ReconciliationStatusNames[s]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown(%d)", s)
+}
+
+// ReconciliationReport represents a reconciliation report for invoices
+type ReconciliationReport struct {
+	// ReportID is the unique identifier
+	ReportID string `json:"report_id"`
+
+	// ReportType is the type of reconciliation
+	ReportType ReconciliationReportType `json:"report_type"`
+
+	// PeriodStart is the start of the reconciliation period
+	PeriodStart time.Time `json:"period_start"`
+
+	// PeriodEnd is the end of the reconciliation period
+	PeriodEnd time.Time `json:"period_end"`
+
+	// Provider is the provider address (optional, for provider-specific reports)
+	Provider string `json:"provider,omitempty"`
+
+	// Customer is the customer address (optional, for customer-specific reports)
+	Customer string `json:"customer,omitempty"`
+
+	// Status is the reconciliation status
+	Status ReconciliationStatus `json:"status"`
+
+	// Summary contains the reconciliation summary
+	Summary ReconciliationSummary `json:"summary"`
+
+	// Discrepancies lists any discrepancies found
+	Discrepancies []ReconciliationDiscrepancy `json:"discrepancies,omitempty"`
+
+	// InvoiceIDs are the invoices included in this report
+	InvoiceIDs []string `json:"invoice_ids"`
+
+	// SettlementIDs are the settlements included in this report
+	SettlementIDs []string `json:"settlement_ids"`
+
+	// UsageRecordIDs are the usage records included in this report
+	UsageRecordIDs []string `json:"usage_record_ids"`
+
+	// GeneratedAt is when the report was generated
+	GeneratedAt time.Time `json:"generated_at"`
+
+	// GeneratedBy is who generated the report
+	GeneratedBy string `json:"generated_by"`
+
+	// BlockHeight is when the report was generated
+	BlockHeight int64 `json:"block_height"`
+
+	// Notes contains any additional notes
+	Notes string `json:"notes,omitempty"`
+}
+
+// ReconciliationReportType defines types of reconciliation reports
+type ReconciliationReportType uint8
+
+const (
+	// ReconciliationReportTypeDaily is a daily reconciliation
+	ReconciliationReportTypeDaily ReconciliationReportType = 0
+
+	// ReconciliationReportTypeWeekly is a weekly reconciliation
+	ReconciliationReportTypeWeekly ReconciliationReportType = 1
+
+	// ReconciliationReportTypeMonthly is a monthly reconciliation
+	ReconciliationReportTypeMonthly ReconciliationReportType = 2
+
+	// ReconciliationReportTypeOnDemand is an on-demand reconciliation
+	ReconciliationReportTypeOnDemand ReconciliationReportType = 3
+
+	// ReconciliationReportTypeSettlement is a settlement-based reconciliation
+	ReconciliationReportTypeSettlement ReconciliationReportType = 4
+)
+
+// ReconciliationReportTypeNames maps types to names
+var ReconciliationReportTypeNames = map[ReconciliationReportType]string{
+	ReconciliationReportTypeDaily:      "daily",
+	ReconciliationReportTypeWeekly:     "weekly",
+	ReconciliationReportTypeMonthly:    "monthly",
+	ReconciliationReportTypeOnDemand:   "on_demand",
+	ReconciliationReportTypeSettlement: "settlement",
+}
+
+// String returns string representation
+func (t ReconciliationReportType) String() string {
+	if name, ok := ReconciliationReportTypeNames[t]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown(%d)", t)
+}
+
+// ReconciliationSummary contains summary statistics
+type ReconciliationSummary struct {
+	// TotalInvoices is the total number of invoices
+	TotalInvoices uint32 `json:"total_invoices"`
+
+	// TotalInvoiceAmount is the total invoiced amount
+	TotalInvoiceAmount sdk.Coins `json:"total_invoice_amount"`
+
+	// TotalSettlements is the total number of settlements
+	TotalSettlements uint32 `json:"total_settlements"`
+
+	// TotalSettlementAmount is the total settled amount
+	TotalSettlementAmount sdk.Coins `json:"total_settlement_amount"`
+
+	// TotalUsageRecords is the total number of usage records
+	TotalUsageRecords uint32 `json:"total_usage_records"`
+
+	// TotalUsageAmount is the total usage amount
+	TotalUsageAmount sdk.Coins `json:"total_usage_amount"`
+
+	// PaidInvoices is the number of paid invoices
+	PaidInvoices uint32 `json:"paid_invoices"`
+
+	// PaidAmount is the total paid amount
+	PaidAmount sdk.Coins `json:"paid_amount"`
+
+	// OutstandingInvoices is the number of outstanding invoices
+	OutstandingInvoices uint32 `json:"outstanding_invoices"`
+
+	// OutstandingAmount is the total outstanding amount
+	OutstandingAmount sdk.Coins `json:"outstanding_amount"`
+
+	// DisputedInvoices is the number of disputed invoices
+	DisputedInvoices uint32 `json:"disputed_invoices"`
+
+	// DisputedAmount is the total disputed amount
+	DisputedAmount sdk.Coins `json:"disputed_amount"`
+
+	// OverdueInvoices is the number of overdue invoices
+	OverdueInvoices uint32 `json:"overdue_invoices"`
+
+	// OverdueAmount is the total overdue amount
+	OverdueAmount sdk.Coins `json:"overdue_amount"`
+
+	// DiscrepancyCount is the number of discrepancies found
+	DiscrepancyCount uint32 `json:"discrepancy_count"`
+
+	// DiscrepancyAmount is the total discrepancy amount
+	DiscrepancyAmount sdk.Coins `json:"discrepancy_amount"`
+}
+
+// ReconciliationDiscrepancy represents a discrepancy found during reconciliation
+type ReconciliationDiscrepancy struct {
+	// DiscrepancyID is the unique identifier
+	DiscrepancyID string `json:"discrepancy_id"`
+
+	// Type is the type of discrepancy
+	Type DiscrepancyType `json:"type"`
+
+	// InvoiceID is the related invoice (if applicable)
+	InvoiceID string `json:"invoice_id,omitempty"`
+
+	// SettlementID is the related settlement (if applicable)
+	SettlementID string `json:"settlement_id,omitempty"`
+
+	// UsageRecordID is the related usage record (if applicable)
+	UsageRecordID string `json:"usage_record_id,omitempty"`
+
+	// ExpectedAmount is the expected amount
+	ExpectedAmount sdk.Coins `json:"expected_amount"`
+
+	// ActualAmount is the actual amount
+	ActualAmount sdk.Coins `json:"actual_amount"`
+
+	// Difference is the difference amount
+	Difference sdk.Coins `json:"difference"`
+
+	// Description describes the discrepancy
+	Description string `json:"description"`
+
+	// Severity is the severity level
+	Severity DiscrepancySeverity `json:"severity"`
+
+	// Resolution is the recommended resolution
+	Resolution string `json:"resolution,omitempty"`
+
+	// ResolvedAt is when the discrepancy was resolved (if resolved)
+	ResolvedAt *time.Time `json:"resolved_at,omitempty"`
+
+	// ResolvedBy is who resolved the discrepancy
+	ResolvedBy string `json:"resolved_by,omitempty"`
+}
+
+// DiscrepancyType defines types of discrepancies
+type DiscrepancyType uint8
+
+const (
+	// DiscrepancyTypeAmountMismatch is an amount mismatch
+	DiscrepancyTypeAmountMismatch DiscrepancyType = 0
+
+	// DiscrepancyTypeMissingInvoice is a missing invoice
+	DiscrepancyTypeMissingInvoice DiscrepancyType = 1
+
+	// DiscrepancyTypeMissingSettlement is a missing settlement
+	DiscrepancyTypeMissingSettlement DiscrepancyType = 2
+
+	// DiscrepancyTypeMissingUsage is a missing usage record
+	DiscrepancyTypeMissingUsage DiscrepancyType = 3
+
+	// DiscrepancyTypeDuplicateInvoice is a duplicate invoice
+	DiscrepancyTypeDuplicateInvoice DiscrepancyType = 4
+
+	// DiscrepancyTypeStatusMismatch is a status mismatch
+	DiscrepancyTypeStatusMismatch DiscrepancyType = 5
+
+	// DiscrepancyTypeDateMismatch is a date mismatch
+	DiscrepancyTypeDateMismatch DiscrepancyType = 6
+)
+
+// DiscrepancyTypeNames maps types to names
+var DiscrepancyTypeNames = map[DiscrepancyType]string{
+	DiscrepancyTypeAmountMismatch:    "amount_mismatch",
+	DiscrepancyTypeMissingInvoice:    "missing_invoice",
+	DiscrepancyTypeMissingSettlement: "missing_settlement",
+	DiscrepancyTypeMissingUsage:      "missing_usage",
+	DiscrepancyTypeDuplicateInvoice:  "duplicate_invoice",
+	DiscrepancyTypeStatusMismatch:    "status_mismatch",
+	DiscrepancyTypeDateMismatch:      "date_mismatch",
+}
+
+// String returns string representation
+func (t DiscrepancyType) String() string {
+	if name, ok := DiscrepancyTypeNames[t]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown(%d)", t)
+}
+
+// DiscrepancySeverity defines severity levels
+type DiscrepancySeverity uint8
+
+const (
+	// DiscrepancySeverityLow is low severity
+	DiscrepancySeverityLow DiscrepancySeverity = 0
+
+	// DiscrepancySeverityMedium is medium severity
+	DiscrepancySeverityMedium DiscrepancySeverity = 1
+
+	// DiscrepancySeverityHigh is high severity
+	DiscrepancySeverityHigh DiscrepancySeverity = 2
+
+	// DiscrepancySeverityCritical is critical severity
+	DiscrepancySeverityCritical DiscrepancySeverity = 3
+)
+
+// DiscrepancySeverityNames maps severity to names
+var DiscrepancySeverityNames = map[DiscrepancySeverity]string{
+	DiscrepancySeverityLow:      "low",
+	DiscrepancySeverityMedium:   "medium",
+	DiscrepancySeverityHigh:     "high",
+	DiscrepancySeverityCritical: "critical",
+}
+
+// String returns string representation
+func (s DiscrepancySeverity) String() string {
+	if name, ok := DiscrepancySeverityNames[s]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown(%d)", s)
+}
+
+// Validate validates the reconciliation report
+func (r *ReconciliationReport) Validate() error {
+	if r.ReportID == "" {
+		return fmt.Errorf("report_id is required")
+	}
+
+	if r.PeriodEnd.Before(r.PeriodStart) {
+		return fmt.Errorf("period_end must be after period_start")
+	}
+
+	return nil
+}
+
+// ReconciliationHookType defines types of reconciliation hooks
+type ReconciliationHookType uint8
+
+const (
+	// ReconciliationHookPreGenerate runs before report generation
+	ReconciliationHookPreGenerate ReconciliationHookType = 0
+
+	// ReconciliationHookPostGenerate runs after report generation
+	ReconciliationHookPostGenerate ReconciliationHookType = 1
+
+	// ReconciliationHookOnDiscrepancy runs when discrepancy is found
+	ReconciliationHookOnDiscrepancy ReconciliationHookType = 2
+
+	// ReconciliationHookOnComplete runs when reconciliation completes
+	ReconciliationHookOnComplete ReconciliationHookType = 3
+)
+
+// ReconciliationHookTypeNames maps types to names
+var ReconciliationHookTypeNames = map[ReconciliationHookType]string{
+	ReconciliationHookPreGenerate:   "pre_generate",
+	ReconciliationHookPostGenerate:  "post_generate",
+	ReconciliationHookOnDiscrepancy: "on_discrepancy",
+	ReconciliationHookOnComplete:    "on_complete",
+}
+
+// String returns string representation
+func (t ReconciliationHookType) String() string {
+	if name, ok := ReconciliationHookTypeNames[t]; ok {
+		return name
+	}
+	return fmt.Sprintf("unknown(%d)", t)
+}
+
+// ReconciliationHookConfig defines a reconciliation hook
+type ReconciliationHookConfig struct {
+	// HookID is the unique identifier
+	HookID string `json:"hook_id"`
+
+	// HookType is the type of hook
+	HookType ReconciliationHookType `json:"hook_type"`
+
+	// Name is the hook name
+	Name string `json:"name"`
+
+	// Description describes the hook
+	Description string `json:"description"`
+
+	// Priority determines execution order
+	Priority uint32 `json:"priority"`
+
+	// IsEnabled indicates if hook is enabled
+	IsEnabled bool `json:"is_enabled"`
+
+	// Action is the action to perform
+	Action string `json:"action"`
+
+	// Parameters are hook-specific parameters
+	Parameters map[string]string `json:"parameters,omitempty"`
+}
+
+// Validate validates the hook config
+func (h *ReconciliationHookConfig) Validate() error {
+	if h.HookID == "" {
+		return fmt.Errorf("hook_id is required")
+	}
+
+	if h.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	if h.Action == "" {
+		return fmt.Errorf("action is required")
+	}
+
+	return nil
+}
+
+// ReconciliationHookResult records a hook execution result
+type ReconciliationHookResult struct {
+	// HookID is the hook that was executed
+	HookID string `json:"hook_id"`
+
+	// HookType is the type of hook
+	HookType ReconciliationHookType `json:"hook_type"`
+
+	// ReportID is the report this hook was executed for
+	ReportID string `json:"report_id"`
+
+	// Success indicates if the hook succeeded
+	Success bool `json:"success"`
+
+	// Error is the error message if failed
+	Error string `json:"error,omitempty"`
+
+	// ExecutionTimeMs is execution time in milliseconds
+	ExecutionTimeMs int64 `json:"execution_time_ms"`
+
+	// ExecutedAt is when the hook was executed
+	ExecutedAt time.Time `json:"executed_at"`
+
+	// Output is any output from the hook
+	Output map[string]string `json:"output,omitempty"`
+}
+
+// DefaultReconciliationHooks returns default reconciliation hooks
+func DefaultReconciliationHooks() []ReconciliationHookConfig {
+	return []ReconciliationHookConfig{
+		{
+			HookID:      "validate-invoice-totals",
+			HookType:    ReconciliationHookPreGenerate,
+			Name:        "Validate Invoice Totals",
+			Description: "Validates that invoice totals match line items",
+			Priority:    1,
+			IsEnabled:   true,
+			Action:      "validate_totals",
+		},
+		{
+			HookID:      "check-settlement-coverage",
+			HookType:    ReconciliationHookPreGenerate,
+			Name:        "Check Settlement Coverage",
+			Description: "Checks that all usage records have settlements",
+			Priority:    2,
+			IsEnabled:   true,
+			Action:      "check_coverage",
+		},
+		{
+			HookID:      "emit-reconciliation-event",
+			HookType:    ReconciliationHookPostGenerate,
+			Name:        "Emit Reconciliation Event",
+			Description: "Emits blockchain event for reconciliation",
+			Priority:    1,
+			IsEnabled:   true,
+			Action:      "emit_event",
+		},
+		{
+			HookID:      "alert-on-discrepancy",
+			HookType:    ReconciliationHookOnDiscrepancy,
+			Name:        "Alert on Discrepancy",
+			Description: "Alerts when discrepancy is found",
+			Priority:    1,
+			IsEnabled:   true,
+			Action:      "alert",
+		},
+	}
+}
+
+// Store key prefixes for reconciliation types
+var (
+	// ReconciliationReportPrefix is the prefix for reconciliation reports
+	ReconciliationReportPrefix = []byte{0x70}
+
+	// ReconciliationReportByProviderPrefix indexes reports by provider
+	ReconciliationReportByProviderPrefix = []byte{0x71}
+
+	// ReconciliationReportByCustomerPrefix indexes reports by customer
+	ReconciliationReportByCustomerPrefix = []byte{0x72}
+
+	// ReconciliationDiscrepancyPrefix is the prefix for discrepancies
+	ReconciliationDiscrepancyPrefix = []byte{0x73}
+
+	// ReconciliationHookResultPrefix is the prefix for hook results
+	ReconciliationHookResultPrefix = []byte{0x74}
+)
+
+// BuildReconciliationReportKey builds the key for a reconciliation report
+func BuildReconciliationReportKey(reportID string) []byte {
+	return append(ReconciliationReportPrefix, []byte(reportID)...)
+}
+
+// BuildReconciliationReportByProviderKey builds the index key
+func BuildReconciliationReportByProviderKey(provider string, reportID string) []byte {
+	key := append(ReconciliationReportByProviderPrefix, []byte(provider)...)
+	key = append(key, byte('/'))
+	return append(key, []byte(reportID)...)
+}
+
+// BuildReconciliationReportByCustomerKey builds the index key
+func BuildReconciliationReportByCustomerKey(customer string, reportID string) []byte {
+	key := append(ReconciliationReportByCustomerPrefix, []byte(customer)...)
+	key = append(key, byte('/'))
+	return append(key, []byte(reportID)...)
+}

--- a/x/escrow/types/billing/transitions.go
+++ b/x/escrow/types/billing/transitions.go
@@ -1,0 +1,320 @@
+// Package billing provides billing and invoice types for the escrow module.
+package billing
+
+import (
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// InvoiceStatusTransition defines a valid status transition
+type InvoiceStatusTransition struct {
+	From        InvoiceStatus
+	To          InvoiceStatus
+	RequiresPay bool   // true if this transition requires payment
+	Description string // description of the transition
+}
+
+// ValidInvoiceTransitions defines all valid invoice status transitions
+var ValidInvoiceTransitions = []InvoiceStatusTransition{
+	{From: InvoiceStatusDraft, To: InvoiceStatusPending, Description: "issue invoice"},
+	{From: InvoiceStatusDraft, To: InvoiceStatusCancelled, Description: "cancel draft"},
+	{From: InvoiceStatusPending, To: InvoiceStatusPaid, RequiresPay: true, Description: "full payment"},
+	{From: InvoiceStatusPending, To: InvoiceStatusPartiallyPaid, RequiresPay: true, Description: "partial payment"},
+	{From: InvoiceStatusPending, To: InvoiceStatusOverdue, Description: "mark overdue"},
+	{From: InvoiceStatusPending, To: InvoiceStatusDisputed, Description: "dispute invoice"},
+	{From: InvoiceStatusPending, To: InvoiceStatusCancelled, Description: "cancel pending"},
+	{From: InvoiceStatusPartiallyPaid, To: InvoiceStatusPaid, RequiresPay: true, Description: "complete payment"},
+	{From: InvoiceStatusPartiallyPaid, To: InvoiceStatusOverdue, Description: "mark overdue"},
+	{From: InvoiceStatusPartiallyPaid, To: InvoiceStatusDisputed, Description: "dispute invoice"},
+	{From: InvoiceStatusOverdue, To: InvoiceStatusPaid, RequiresPay: true, Description: "pay overdue"},
+	{From: InvoiceStatusOverdue, To: InvoiceStatusPartiallyPaid, RequiresPay: true, Description: "partial pay overdue"},
+	{From: InvoiceStatusOverdue, To: InvoiceStatusDisputed, Description: "dispute overdue"},
+	{From: InvoiceStatusOverdue, To: InvoiceStatusCancelled, Description: "write off"},
+	{From: InvoiceStatusDisputed, To: InvoiceStatusPending, Description: "resolve dispute - pending"},
+	{From: InvoiceStatusDisputed, To: InvoiceStatusPaid, Description: "resolve dispute - paid"},
+	{From: InvoiceStatusDisputed, To: InvoiceStatusCancelled, Description: "resolve dispute - cancel"},
+	{From: InvoiceStatusDisputed, To: InvoiceStatusRefunded, Description: "resolve dispute - refund"},
+	{From: InvoiceStatusPaid, To: InvoiceStatusRefunded, Description: "refund paid"},
+}
+
+// validTransitionsMap is a pre-computed map for fast lookup
+var validTransitionsMap map[InvoiceStatus]map[InvoiceStatus]InvoiceStatusTransition
+
+func init() {
+	validTransitionsMap = make(map[InvoiceStatus]map[InvoiceStatus]InvoiceStatusTransition)
+	for _, t := range ValidInvoiceTransitions {
+		if validTransitionsMap[t.From] == nil {
+			validTransitionsMap[t.From] = make(map[InvoiceStatus]InvoiceStatusTransition)
+		}
+		validTransitionsMap[t.From][t.To] = t
+	}
+}
+
+// IsValidTransition checks if a status transition is valid
+func IsValidTransition(from, to InvoiceStatus) bool {
+	if fromMap, ok := validTransitionsMap[from]; ok {
+		_, valid := fromMap[to]
+		return valid
+	}
+	return false
+}
+
+// GetTransition returns the transition details if valid
+func GetTransition(from, to InvoiceStatus) (InvoiceStatusTransition, bool) {
+	if fromMap, ok := validTransitionsMap[from]; ok {
+		t, valid := fromMap[to]
+		return t, valid
+	}
+	return InvoiceStatusTransition{}, false
+}
+
+// GetValidNextStates returns all valid next states from current state
+func GetValidNextStates(current InvoiceStatus) []InvoiceStatus {
+	var states []InvoiceStatus
+	if fromMap, ok := validTransitionsMap[current]; ok {
+		for to := range fromMap {
+			states = append(states, to)
+		}
+	}
+	return states
+}
+
+// InvoiceStatusMachine manages invoice status transitions
+type InvoiceStatusMachine struct {
+	invoice     *Invoice
+	ledgerEntry *InvoiceLedgerEntry
+	now         time.Time
+	blockHeight int64
+}
+
+// NewInvoiceStatusMachine creates a new status machine for an invoice
+func NewInvoiceStatusMachine(inv *Invoice, blockHeight int64, now time.Time) *InvoiceStatusMachine {
+	return &InvoiceStatusMachine{
+		invoice:     inv,
+		now:         now,
+		blockHeight: blockHeight,
+	}
+}
+
+// Transition attempts to transition to a new status
+func (sm *InvoiceStatusMachine) Transition(
+	to InvoiceStatus,
+	initiator string,
+	description string,
+) error {
+	from := sm.invoice.Status
+
+	transition, valid := GetTransition(from, to)
+	if !valid {
+		return fmt.Errorf("invalid transition from %s to %s", from, to)
+	}
+
+	// Create ledger entry
+	entryType := sm.getEntryTypeForTransition(to)
+	sm.ledgerEntry = NewInvoiceLedgerEntry(
+		fmt.Sprintf("%s-%d", sm.invoice.InvoiceID, sm.blockHeight),
+		sm.invoice.InvoiceID,
+		entryType,
+		from,
+		to,
+		sdk.NewCoins(),
+		fmt.Sprintf("%s: %s", transition.Description, description),
+		initiator,
+		"",
+		sm.blockHeight,
+		sm.now,
+	)
+
+	// Update invoice status
+	sm.invoice.Status = to
+	sm.invoice.UpdatedAt = sm.now
+
+	return nil
+}
+
+// TransitionWithPayment attempts a payment-related transition
+func (sm *InvoiceStatusMachine) TransitionWithPayment(
+	amount sdk.Coins,
+	initiator string,
+) error {
+	from := sm.invoice.Status
+
+	// Record payment on invoice
+	if err := sm.invoice.RecordPayment(amount, sm.now); err != nil {
+		return err
+	}
+
+	to := sm.invoice.Status
+
+	transition, valid := GetTransition(from, to)
+	if !valid {
+		return fmt.Errorf("invalid transition from %s to %s after payment", from, to)
+	}
+
+	if !transition.RequiresPay {
+		return fmt.Errorf("transition from %s to %s does not require payment", from, to)
+	}
+
+	// Create ledger entry
+	sm.ledgerEntry = NewInvoiceLedgerEntry(
+		fmt.Sprintf("%s-pay-%d", sm.invoice.InvoiceID, sm.blockHeight),
+		sm.invoice.InvoiceID,
+		LedgerEntryTypePayment,
+		from,
+		to,
+		amount,
+		fmt.Sprintf("payment recorded: %s", amount.String()),
+		initiator,
+		"",
+		sm.blockHeight,
+		sm.now,
+	)
+
+	return nil
+}
+
+// MarkIssued transitions from draft to issued/pending
+func (sm *InvoiceStatusMachine) MarkIssued(initiator string) error {
+	if sm.invoice.Status != InvoiceStatusDraft {
+		return fmt.Errorf("can only issue draft invoices, current status: %s", sm.invoice.Status)
+	}
+
+	if err := sm.invoice.Finalize(sm.now); err != nil {
+		return err
+	}
+
+	sm.ledgerEntry = NewInvoiceLedgerEntry(
+		fmt.Sprintf("%s-issued-%d", sm.invoice.InvoiceID, sm.blockHeight),
+		sm.invoice.InvoiceID,
+		LedgerEntryTypeIssued,
+		InvoiceStatusDraft,
+		InvoiceStatusPending,
+		sdk.NewCoins(),
+		"invoice issued",
+		initiator,
+		"",
+		sm.blockHeight,
+		sm.now,
+	)
+
+	return nil
+}
+
+// MarkDisputed transitions to disputed status
+func (sm *InvoiceStatusMachine) MarkDisputed(
+	disputeWindow *DisputeWindow,
+	initiator string,
+	reason string,
+) error {
+	from := sm.invoice.Status
+
+	if err := sm.invoice.MarkDisputed(disputeWindow, sm.now); err != nil {
+		return err
+	}
+
+	sm.ledgerEntry = NewInvoiceLedgerEntry(
+		fmt.Sprintf("%s-disputed-%d", sm.invoice.InvoiceID, sm.blockHeight),
+		sm.invoice.InvoiceID,
+		LedgerEntryTypeDisputed,
+		from,
+		InvoiceStatusDisputed,
+		sdk.NewCoins(),
+		fmt.Sprintf("disputed: %s", reason),
+		initiator,
+		"",
+		sm.blockHeight,
+		sm.now,
+	)
+
+	return nil
+}
+
+// MarkOverdue transitions to overdue status
+func (sm *InvoiceStatusMachine) MarkOverdue(initiator string) error {
+	from := sm.invoice.Status
+
+	if !IsValidTransition(from, InvoiceStatusOverdue) {
+		return fmt.Errorf("cannot mark as overdue from status: %s", from)
+	}
+
+	// Check if actually past due date
+	if sm.now.Before(sm.invoice.DueDate) {
+		return fmt.Errorf("invoice is not past due date")
+	}
+
+	sm.invoice.Status = InvoiceStatusOverdue
+	sm.invoice.UpdatedAt = sm.now
+
+	sm.ledgerEntry = NewInvoiceLedgerEntry(
+		fmt.Sprintf("%s-overdue-%d", sm.invoice.InvoiceID, sm.blockHeight),
+		sm.invoice.InvoiceID,
+		LedgerEntryTypeOverdue,
+		from,
+		InvoiceStatusOverdue,
+		sdk.NewCoins(),
+		"marked as overdue",
+		initiator,
+		"",
+		sm.blockHeight,
+		sm.now,
+	)
+
+	return nil
+}
+
+// Cancel cancels the invoice
+func (sm *InvoiceStatusMachine) Cancel(initiator string, reason string) error {
+	from := sm.invoice.Status
+
+	if err := sm.invoice.Cancel(sm.now); err != nil {
+		return err
+	}
+
+	sm.ledgerEntry = NewInvoiceLedgerEntry(
+		fmt.Sprintf("%s-cancelled-%d", sm.invoice.InvoiceID, sm.blockHeight),
+		sm.invoice.InvoiceID,
+		LedgerEntryTypeCancelled,
+		from,
+		InvoiceStatusCancelled,
+		sdk.NewCoins(),
+		fmt.Sprintf("cancelled: %s", reason),
+		initiator,
+		"",
+		sm.blockHeight,
+		sm.now,
+	)
+
+	return nil
+}
+
+// GetLedgerEntry returns the ledger entry created by the last operation
+func (sm *InvoiceStatusMachine) GetLedgerEntry() *InvoiceLedgerEntry {
+	return sm.ledgerEntry
+}
+
+// GetInvoice returns the modified invoice
+func (sm *InvoiceStatusMachine) GetInvoice() *Invoice {
+	return sm.invoice
+}
+
+// getEntryTypeForTransition maps status changes to entry types
+func (sm *InvoiceStatusMachine) getEntryTypeForTransition(to InvoiceStatus) InvoiceLedgerEntryType {
+	switch to {
+	case InvoiceStatusPending:
+		return LedgerEntryTypeIssued
+	case InvoiceStatusPaid, InvoiceStatusPartiallyPaid:
+		return LedgerEntryTypePayment
+	case InvoiceStatusDisputed:
+		return LedgerEntryTypeDisputed
+	case InvoiceStatusCancelled:
+		return LedgerEntryTypeCancelled
+	case InvoiceStatusRefunded:
+		return LedgerEntryTypeRefunded
+	case InvoiceStatusOverdue:
+		return LedgerEntryTypeOverdue
+	default:
+		return LedgerEntryTypeCreated
+	}
+}


### PR DESCRIPTION
Objective:
Generate invoices from usage and persist immutable invoice ledger records.

Prerequisites:
- 1E feat(escrow): define billing/invoice schema + pricing rules

Needs to be done (A–J):
A. Implement invoice schema in on-chain types and storage.
B. Build invoice generation from marketplace + HPC usage inputs.
C. Persist invoice metadata on-chain (hash, totals, status).
D. Store invoice documents in artifact store (JSON/PDF).
E. Add invoice status transitions (draft -> issued -> paid -> disputed).
F. Implement query APIs for customer/provider invoice history.
G. Add deterministic rounding rules and currency handling.
H. Add reconciliation report hooks for later use.
I. Add tests for invoice generation and state transitions.
J. Document invoice lifecycle and APIs.

Acceptance criteria:
- Invoices generated deterministically and stored on-chain.
- Invoice artifacts stored with verifiable hashes.
- Query APIs return correct invoice history.
- Invoice lifecycle transitions are enforced.

How it can be done:
- Extend x/settlement or create billing module.
- Add invoice generation job in provider daemon or dedicated service.
- Store artifacts in artifact store and link via CID.

MCP guidance:
- Use Context7 for billing/invoice data models.
- Use Exa for billing compliance patterns.

Deliverables:
- Invoice module/service, artifacts, queries, tests.