### PR TITLE
feat(market): ingest Waldur listings into on-chain marketplace

### DIFF
--- a/pkg/provider_daemon/waldur_ingest_state.go
+++ b/pkg/provider_daemon/waldur_ingest_state.go
@@ -1,0 +1,597 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-3D: Waldur ingestion state persistence for Waldur-to-chain synchronization.
+// This file manages the ingestion state including checksum tracking, version history,
+// error recording, and dead-letter queue handling.
+package provider_daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// WaldurIngestState tracks ingestion state for all Waldur offerings.
+type WaldurIngestState struct {
+	// WaldurCustomerUUID is the Waldur customer this state belongs to.
+	WaldurCustomerUUID string `json:"waldur_customer_uuid"`
+
+	// ProviderAddress is the corresponding on-chain provider address.
+	ProviderAddress string `json:"provider_address"`
+
+	// Records maps Waldur offering UUIDs to their ingestion records.
+	Records map[string]*WaldurIngestRecord `json:"records"`
+
+	// DeadLetterQueue contains offerings that failed max retries.
+	DeadLetterQueue []*IngestDeadLetterItem `json:"dead_letter_queue,omitempty"`
+
+	// LastReconcileAt is when the last reconciliation ran.
+	LastReconcileAt *time.Time `json:"last_reconcile_at,omitempty"`
+
+	// LastIngestAt is when the last ingestion job ran.
+	LastIngestAt *time.Time `json:"last_ingest_at,omitempty"`
+
+	// Cursor is the pagination cursor for resuming ingestion.
+	Cursor *IngestCursor `json:"cursor,omitempty"`
+
+	// Metrics tracks ingestion operation metrics.
+	Metrics *IngestStateMetrics `json:"metrics"`
+
+	// UpdatedAt is when this state was last modified.
+	UpdatedAt time.Time `json:"updated_at"`
+
+	mu sync.RWMutex
+}
+
+// WaldurIngestRecord tracks ingestion state for a single Waldur offering.
+type WaldurIngestRecord struct {
+	// WaldurUUID is the Waldur offering UUID.
+	WaldurUUID string `json:"waldur_uuid"`
+
+	// ChainOfferingID is the on-chain offering ID (after first ingest).
+	ChainOfferingID string `json:"chain_offering_id,omitempty"`
+
+	// State is the current ingestion state.
+	State IngestRecordState `json:"state"`
+
+	// WaldurChecksum is the checksum of Waldur data at last ingest.
+	WaldurChecksum string `json:"waldur_checksum"`
+
+	// ChainVersion is the on-chain offering version.
+	ChainVersion uint64 `json:"chain_version"`
+
+	// LastIngestedAt is when the offering was last successfully ingested.
+	LastIngestedAt *time.Time `json:"last_ingested_at,omitempty"`
+
+	// LastAttemptAt is when ingestion was last attempted.
+	LastAttemptAt *time.Time `json:"last_attempt_at,omitempty"`
+
+	// LastWaldurModified is when the Waldur offering was last modified.
+	LastWaldurModified *time.Time `json:"last_waldur_modified,omitempty"`
+
+	// LastError is the most recent error message.
+	LastError string `json:"last_error,omitempty"`
+
+	// RetryCount is the number of consecutive retry attempts.
+	RetryCount int `json:"retry_count"`
+
+	// NextRetryAt is when the next retry should be attempted.
+	NextRetryAt *time.Time `json:"next_retry_at,omitempty"`
+
+	// ProviderAddress is the resolved provider address.
+	ProviderAddress string `json:"provider_address"`
+
+	// Category is the resolved category.
+	Category string `json:"category"`
+
+	// OfferingName is cached for logging.
+	OfferingName string `json:"offering_name"`
+
+	// CreatedAt is when this record was first created.
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// IngestRecordState represents the ingestion state of a Waldur offering.
+type IngestRecordState string
+
+const (
+	// IngestRecordStatePending indicates ingestion is pending.
+	IngestRecordStatePending IngestRecordState = "pending"
+
+	// IngestRecordStateIngested indicates offering is ingested on-chain.
+	IngestRecordStateIngested IngestRecordState = "ingested"
+
+	// IngestRecordStateFailed indicates last ingestion attempt failed.
+	IngestRecordStateFailed IngestRecordState = "failed"
+
+	// IngestRecordStateRetrying indicates ingestion is being retried.
+	IngestRecordStateRetrying IngestRecordState = "retrying"
+
+	// IngestRecordStateDeadLettered indicates ingestion failed permanently.
+	IngestRecordStateDeadLettered IngestRecordState = "dead_lettered"
+
+	// IngestRecordStateOutOfSync indicates Waldur data changed since last ingest.
+	IngestRecordStateOutOfSync IngestRecordState = "out_of_sync"
+
+	// IngestRecordStateSkipped indicates offering was intentionally skipped.
+	IngestRecordStateSkipped IngestRecordState = "skipped"
+
+	// IngestRecordStateDeprecated indicates the Waldur offering was archived.
+	IngestRecordStateDeprecated IngestRecordState = "deprecated"
+)
+
+// IngestDeadLetterItem represents an offering that failed to ingest after max retries.
+type IngestDeadLetterItem struct {
+	// WaldurUUID is the Waldur offering UUID.
+	WaldurUUID string `json:"waldur_uuid"`
+
+	// OfferingName is the offering name for reference.
+	OfferingName string `json:"offering_name"`
+
+	// Action is the action that failed (create, update, deprecate).
+	Action string `json:"action"`
+
+	// LastError is the final error.
+	LastError string `json:"last_error"`
+
+	// RetryCount is the number of attempts made.
+	RetryCount int `json:"retry_count"`
+
+	// FirstAttemptAt is when the first attempt was made.
+	FirstAttemptAt time.Time `json:"first_attempt_at"`
+
+	// DeadLetteredAt is when the item was dead-lettered.
+	DeadLetteredAt time.Time `json:"dead_lettered_at"`
+
+	// WaldurChecksum is the checksum at time of failure.
+	WaldurChecksum string `json:"waldur_checksum"`
+}
+
+// IngestCursor tracks pagination state for resuming ingestion.
+type IngestCursor struct {
+	// Page is the current page number.
+	Page int `json:"page"`
+
+	// PageSize is the number of items per page.
+	PageSize int `json:"page_size"`
+
+	// TotalPages is the estimated total pages.
+	TotalPages int `json:"total_pages,omitempty"`
+
+	// ProcessedCount is the number of offerings processed.
+	ProcessedCount int `json:"processed_count"`
+
+	// LastProcessedUUID is the UUID of the last processed offering.
+	LastProcessedUUID string `json:"last_processed_uuid,omitempty"`
+
+	// StartedAt is when this ingestion run started.
+	StartedAt time.Time `json:"started_at"`
+}
+
+// IngestStateMetrics tracks aggregate ingestion metrics.
+type IngestStateMetrics struct {
+	// TotalIngests is the total number of ingestion operations.
+	TotalIngests int64 `json:"total_ingests"`
+
+	// SuccessfulIngests is the count of successful ingestions.
+	SuccessfulIngests int64 `json:"successful_ingests"`
+
+	// FailedIngests is the count of failed ingestion attempts.
+	FailedIngests int64 `json:"failed_ingests"`
+
+	// DeadLettered is the count of dead-lettered offerings.
+	DeadLettered int64 `json:"dead_lettered"`
+
+	// Skipped is the count of skipped offerings.
+	Skipped int64 `json:"skipped"`
+
+	// DriftDetections is the count of drift detections.
+	DriftDetections int64 `json:"drift_detections"`
+
+	// ReconciliationsRun is the count of reconciliation cycles.
+	ReconciliationsRun int64 `json:"reconciliations_run"`
+
+	// OfferingsCreated is the count of offerings created on-chain.
+	OfferingsCreated int64 `json:"offerings_created"`
+
+	// OfferingsUpdated is the count of offerings updated on-chain.
+	OfferingsUpdated int64 `json:"offerings_updated"`
+
+	// OfferingsDeprecated is the count of offerings deprecated.
+	OfferingsDeprecated int64 `json:"offerings_deprecated"`
+
+	// LastIngestDurationMs is the duration of the last ingest in milliseconds.
+	LastIngestDurationMs int64 `json:"last_ingest_duration_ms"`
+
+	// AverageIngestDurationMs is the rolling average ingest duration.
+	AverageIngestDurationMs float64 `json:"average_ingest_duration_ms"`
+}
+
+// NewWaldurIngestState creates a new ingestion state.
+func NewWaldurIngestState(waldurCustomerUUID, providerAddress string) *WaldurIngestState {
+	return &WaldurIngestState{
+		WaldurCustomerUUID: waldurCustomerUUID,
+		ProviderAddress:    providerAddress,
+		Records:            make(map[string]*WaldurIngestRecord),
+		DeadLetterQueue:    make([]*IngestDeadLetterItem, 0),
+		Metrics:            &IngestStateMetrics{},
+		UpdatedAt:          time.Now().UTC(),
+	}
+}
+
+// GetRecord retrieves an ingestion record by Waldur UUID.
+func (s *WaldurIngestState) GetRecord(waldurUUID string) *WaldurIngestRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.Records[waldurUUID]
+}
+
+// GetOrCreateRecord retrieves or creates an ingestion record.
+func (s *WaldurIngestState) GetOrCreateRecord(waldurUUID, offeringName string) *WaldurIngestRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if record, exists := s.Records[waldurUUID]; exists {
+		return record
+	}
+
+	record := &WaldurIngestRecord{
+		WaldurUUID:      waldurUUID,
+		State:           IngestRecordStatePending,
+		OfferingName:    offeringName,
+		ProviderAddress: s.ProviderAddress,
+		CreatedAt:       time.Now().UTC(),
+	}
+	s.Records[waldurUUID] = record
+	return record
+}
+
+// MarkIngested marks an offering as successfully ingested.
+func (s *WaldurIngestState) MarkIngested(waldurUUID, chainOfferingID, checksum string, version uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.Records[waldurUUID]
+	if record == nil {
+		record = &WaldurIngestRecord{
+			WaldurUUID: waldurUUID,
+			CreatedAt:  time.Now().UTC(),
+		}
+		s.Records[waldurUUID] = record
+	}
+
+	now := time.Now().UTC()
+	record.ChainOfferingID = chainOfferingID
+	record.State = IngestRecordStateIngested
+	record.WaldurChecksum = checksum
+	record.ChainVersion = version
+	record.LastIngestedAt = &now
+	record.LastError = ""
+	record.RetryCount = 0
+	record.NextRetryAt = nil
+	s.UpdatedAt = now
+	s.Metrics.SuccessfulIngests++
+	s.Metrics.TotalIngests++
+}
+
+// MarkFailed marks an ingestion as failed. Returns true if the item was dead-lettered.
+func (s *WaldurIngestState) MarkFailed(waldurUUID, errorMsg string, maxRetries int, baseBackoff, maxBackoff time.Duration) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.Records[waldurUUID]
+	if record == nil {
+		return false
+	}
+
+	now := time.Now().UTC()
+	record.State = IngestRecordStateFailed
+	record.LastAttemptAt = &now
+	record.LastError = errorMsg
+	record.RetryCount++
+
+	deadLettered := false
+
+	// Calculate next retry with exponential backoff
+	if record.RetryCount <= maxRetries {
+		record.State = IngestRecordStateRetrying
+		backoff := baseBackoff * time.Duration(1<<uint(record.RetryCount-1))
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+		nextRetry := now.Add(backoff)
+		record.NextRetryAt = &nextRetry
+	} else {
+		// Move to dead letter queue
+		s.addToDeadLetter(record)
+		deadLettered = true
+	}
+
+	s.UpdatedAt = now
+	s.Metrics.FailedIngests++
+	s.Metrics.TotalIngests++
+	return deadLettered
+}
+
+// MarkOutOfSync marks an offering as out of sync with Waldur.
+func (s *WaldurIngestState) MarkOutOfSync(waldurUUID, newChecksum string, waldurModified time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.Records[waldurUUID]
+	if record == nil {
+		return
+	}
+
+	record.State = IngestRecordStateOutOfSync
+	record.WaldurChecksum = newChecksum
+	record.LastWaldurModified = &waldurModified
+	s.UpdatedAt = time.Now().UTC()
+	s.Metrics.DriftDetections++
+}
+
+// MarkSkipped marks an offering as intentionally skipped.
+func (s *WaldurIngestState) MarkSkipped(waldurUUID, reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.Records[waldurUUID]
+	if record == nil {
+		return
+	}
+
+	record.State = IngestRecordStateSkipped
+	record.LastError = reason
+	s.UpdatedAt = time.Now().UTC()
+	s.Metrics.Skipped++
+}
+
+// MarkDeprecated marks an offering as deprecated (archived in Waldur).
+func (s *WaldurIngestState) MarkDeprecated(waldurUUID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record := s.Records[waldurUUID]
+	if record == nil {
+		return
+	}
+
+	record.State = IngestRecordStateDeprecated
+	s.UpdatedAt = time.Now().UTC()
+	s.Metrics.OfferingsDeprecated++
+}
+
+// addToDeadLetter adds a record to the dead letter queue (must hold lock).
+func (s *WaldurIngestState) addToDeadLetter(record *WaldurIngestRecord) {
+	now := time.Now().UTC()
+	item := &IngestDeadLetterItem{
+		WaldurUUID:     record.WaldurUUID,
+		OfferingName:   record.OfferingName,
+		Action:         "ingest",
+		LastError:      record.LastError,
+		RetryCount:     record.RetryCount,
+		FirstAttemptAt: record.CreatedAt,
+		DeadLetteredAt: now,
+		WaldurChecksum: record.WaldurChecksum,
+	}
+
+	s.DeadLetterQueue = append(s.DeadLetterQueue, item)
+	record.State = IngestRecordStateDeadLettered
+	s.Metrics.DeadLettered++
+}
+
+// NeedsIngestOfferings returns Waldur UUIDs that need ingestion.
+func (s *WaldurIngestState) NeedsIngestOfferings() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var uuids []string
+	now := time.Now().UTC()
+
+	for uuid, record := range s.Records {
+		switch record.State {
+		case IngestRecordStatePending, IngestRecordStateOutOfSync:
+			uuids = append(uuids, uuid)
+		case IngestRecordStateRetrying, IngestRecordStateFailed:
+			if record.NextRetryAt != nil && now.After(*record.NextRetryAt) {
+				uuids = append(uuids, uuid)
+			}
+		}
+	}
+
+	return uuids
+}
+
+// ReprocessDeadLetter attempts to reprocess a dead-lettered offering.
+func (s *WaldurIngestState) ReprocessDeadLetter(waldurUUID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Find and remove from dead letter queue
+	for i, item := range s.DeadLetterQueue {
+		if item.WaldurUUID == waldurUUID {
+			s.DeadLetterQueue = append(s.DeadLetterQueue[:i], s.DeadLetterQueue[i+1:]...)
+			break
+		}
+	}
+
+	// Reset the record for retry
+	record := s.Records[waldurUUID]
+	if record != nil {
+		record.State = IngestRecordStatePending
+		record.RetryCount = 0
+		record.LastError = ""
+		record.NextRetryAt = nil
+		s.UpdatedAt = time.Now().UTC()
+		return true
+	}
+
+	return false
+}
+
+// RecordReconciliation records that a reconciliation cycle ran.
+func (s *WaldurIngestState) RecordReconciliation() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	s.LastReconcileAt = &now
+	s.Metrics.ReconciliationsRun++
+	s.UpdatedAt = now
+}
+
+// UpdateCursor updates the pagination cursor.
+func (s *WaldurIngestState) UpdateCursor(cursor *IngestCursor) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Cursor = cursor
+	s.UpdatedAt = time.Now().UTC()
+}
+
+// ResetCursor resets the pagination cursor.
+func (s *WaldurIngestState) ResetCursor() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Cursor = nil
+	now := time.Now().UTC()
+	s.LastIngestAt = &now
+	s.UpdatedAt = now
+}
+
+// GetStats returns summary statistics.
+func (s *WaldurIngestState) GetStats() IngestStats {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	stats := IngestStats{
+		TotalRecords: len(s.Records),
+		DeadLettered: len(s.DeadLetterQueue),
+	}
+
+	for _, record := range s.Records {
+		switch record.State {
+		case IngestRecordStatePending:
+			stats.Pending++
+		case IngestRecordStateIngested:
+			stats.Ingested++
+		case IngestRecordStateFailed, IngestRecordStateRetrying:
+			stats.Failed++
+		case IngestRecordStateOutOfSync:
+			stats.OutOfSync++
+		case IngestRecordStateSkipped:
+			stats.Skipped++
+		case IngestRecordStateDeprecated:
+			stats.Deprecated++
+		}
+	}
+
+	return stats
+}
+
+// IngestStats provides summary statistics.
+type IngestStats struct {
+	TotalRecords int `json:"total_records"`
+	Pending      int `json:"pending"`
+	Ingested     int `json:"ingested"`
+	Failed       int `json:"failed"`
+	OutOfSync    int `json:"out_of_sync"`
+	Skipped      int `json:"skipped"`
+	Deprecated   int `json:"deprecated"`
+	DeadLettered int `json:"dead_lettered"`
+}
+
+// WaldurIngestStateStore persists ingestion state to disk.
+type WaldurIngestStateStore struct {
+	path string
+	mu   sync.RWMutex
+}
+
+// NewWaldurIngestStateStore creates a new state store.
+func NewWaldurIngestStateStore(path string) *WaldurIngestStateStore {
+	return &WaldurIngestStateStore{path: path}
+}
+
+// Load reads state from disk or returns a new state.
+func (s *WaldurIngestStateStore) Load(waldurCustomerUUID, providerAddress string) (*WaldurIngestState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return NewWaldurIngestState(waldurCustomerUUID, providerAddress), nil
+		}
+		return nil, fmt.Errorf("read waldur ingest state: %w", err)
+	}
+
+	var state WaldurIngestState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("decode waldur ingest state: %w", err)
+	}
+
+	// Initialize maps if nil
+	if state.Records == nil {
+		state.Records = make(map[string]*WaldurIngestRecord)
+	}
+	if state.DeadLetterQueue == nil {
+		state.DeadLetterQueue = make([]*IngestDeadLetterItem, 0)
+	}
+	if state.Metrics == nil {
+		state.Metrics = &IngestStateMetrics{}
+	}
+
+	return &state, nil
+}
+
+// Save writes state to disk atomically.
+func (s *WaldurIngestStateStore) Save(state *WaldurIngestState) error {
+	if state == nil {
+		return fmt.Errorf("state is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state.mu.RLock()
+	state.UpdatedAt = time.Now().UTC()
+	data, err := json.MarshalIndent(state, "", "  ")
+	state.mu.RUnlock()
+
+	if err != nil {
+		return fmt.Errorf("encode waldur ingest state: %w", err)
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create state dir: %w", err)
+	}
+
+	// Atomic write via temp file
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write state tmp: %w", err)
+	}
+
+	if err := os.Rename(tmp, s.path); err != nil {
+		return fmt.Errorf("replace state: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes the state file.
+func (s *WaldurIngestStateStore) Delete() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete state: %w", err)
+	}
+	return nil
+}

--- a/pkg/provider_daemon/waldur_ingest_worker.go
+++ b/pkg/provider_daemon/waldur_ingest_worker.go
@@ -1,0 +1,1005 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-3D: Waldur ingestion worker for automatic Waldur-to-chain synchronization.
+// This file implements the ingestion worker that fetches Waldur offerings and
+// ingests them on-chain, with retry/backoff, rate limiting, and reconciliation.
+package provider_daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/virtengine/virtengine/pkg/waldur"
+	"github.com/virtengine/virtengine/x/market/types/marketplace"
+	"golang.org/x/time/rate"
+)
+
+// WaldurIngestAuditLogger defines the interface for audit logging.
+type WaldurIngestAuditLogger interface {
+	// LogIngestAttempt logs an ingestion operation attempt.
+	LogIngestAttempt(entry IngestAuditEntry)
+	// LogReconciliation logs a reconciliation run.
+	LogReconciliation(entry IngestReconciliationAuditEntry)
+	// LogDeadLetter logs a dead-letter event.
+	LogDeadLetter(entry IngestDeadLetterAuditEntry)
+}
+
+// IngestAuditEntry represents an audit log entry for an ingestion operation.
+type IngestAuditEntry struct {
+	Timestamp       time.Time              `json:"timestamp"`
+	WaldurUUID      string                 `json:"waldur_uuid"`
+	OfferingName    string                 `json:"offering_name"`
+	ChainOfferingID string                 `json:"chain_offering_id,omitempty"`
+	Action          string                 `json:"action"`
+	Success         bool                   `json:"success"`
+	Duration        time.Duration          `json:"duration_ns"`
+	Error           string                 `json:"error,omitempty"`
+	RetryCount      int                    `json:"retry_count"`
+	ProviderAddress string                 `json:"provider_address"`
+	Checksum        string                 `json:"checksum,omitempty"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// IngestReconciliationAuditEntry represents an audit log entry for reconciliation.
+type IngestReconciliationAuditEntry struct {
+	Timestamp         time.Time `json:"timestamp"`
+	WaldurCustomer    string    `json:"waldur_customer"`
+	ProviderAddress   string    `json:"provider_address"`
+	OfferingsChecked  int       `json:"offerings_checked"`
+	DriftDetected     int       `json:"drift_detected"`
+	OfferingsQueued   int       `json:"offerings_queued"`
+	NewOfferingsFound int       `json:"new_offerings_found"`
+	Duration          time.Duration `json:"duration_ns"`
+	Error             string    `json:"error,omitempty"`
+}
+
+// IngestDeadLetterAuditEntry represents an audit log entry for dead-letter events.
+type IngestDeadLetterAuditEntry struct {
+	Timestamp       time.Time `json:"timestamp"`
+	WaldurUUID      string    `json:"waldur_uuid"`
+	OfferingName    string    `json:"offering_name"`
+	ProviderAddress string    `json:"provider_address"`
+	TotalAttempts   int       `json:"total_attempts"`
+	LastError       string    `json:"last_error"`
+	Action          string    `json:"action"` // "dead_lettered" or "reprocessed"
+}
+
+// DefaultIngestAuditLogger logs to standard log in JSON format.
+type DefaultIngestAuditLogger struct {
+	prefix string
+}
+
+// NewDefaultIngestAuditLogger creates a new default audit logger.
+func NewDefaultIngestAuditLogger(prefix string) *DefaultIngestAuditLogger {
+	if prefix == "" {
+		prefix = "[waldur-ingest-audit]"
+	}
+	return &DefaultIngestAuditLogger{prefix: prefix}
+}
+
+// LogIngestAttempt logs an ingestion operation.
+func (l *DefaultIngestAuditLogger) LogIngestAttempt(entry IngestAuditEntry) {
+	data, _ := json.Marshal(entry)
+	log.Printf("%s ingest: %s", l.prefix, string(data))
+}
+
+// LogReconciliation logs a reconciliation run.
+func (l *DefaultIngestAuditLogger) LogReconciliation(entry IngestReconciliationAuditEntry) {
+	data, _ := json.Marshal(entry)
+	log.Printf("%s reconcile: %s", l.prefix, string(data))
+}
+
+// LogDeadLetter logs a dead-letter event.
+func (l *DefaultIngestAuditLogger) LogDeadLetter(entry IngestDeadLetterAuditEntry) {
+	data, _ := json.Marshal(entry)
+	log.Printf("%s dead_letter: %s", l.prefix, string(data))
+}
+
+// WaldurIngestPrometheusMetrics provides Prometheus-compatible metric counters.
+type WaldurIngestPrometheusMetrics struct {
+	// Ingestion operation counters
+	IngestsTotal        atomic.Int64
+	IngestsSuccessful   atomic.Int64
+	IngestsFailed       atomic.Int64
+	IngestsDeadLettered atomic.Int64
+	IngestsSkipped      atomic.Int64
+
+	// Offering counters
+	OfferingsCreated    atomic.Int64
+	OfferingsUpdated    atomic.Int64
+	OfferingsDeprecated atomic.Int64
+
+	// Fetch counters
+	FetchesTotal    atomic.Int64
+	FetchesSuccessful atomic.Int64
+	FetchesFailed   atomic.Int64
+
+	// Reconciliation counters
+	ReconciliationsRun atomic.Int64
+	DriftDetected      atomic.Int64
+
+	// Rate limiting
+	RateLimitHits atomic.Int64
+
+	// Timing histograms (simplified - in production use prometheus.Histogram)
+	IngestDurationSum   atomic.Int64
+	IngestDurationCount atomic.Int64
+
+	// Current state
+	QueueDepth     atomic.Int64
+	ActiveIngests  atomic.Int64
+	DeadLetterSize atomic.Int64
+}
+
+// WaldurIngestWorkerConfig configures the ingestion worker.
+type WaldurIngestWorkerConfig struct {
+	// Enabled toggles the ingestion worker.
+	Enabled bool
+
+	// ProviderAddress is the provider's on-chain address.
+	ProviderAddress string
+
+	// WaldurCustomerUUID is the Waldur customer UUID to ingest from.
+	WaldurCustomerUUID string
+
+	// WaldurCategoryUUIDs filters offerings to specific categories (empty = all).
+	WaldurCategoryUUIDs []string
+
+	// WaldurOfferingTypes filters offerings to specific types (empty = all).
+	WaldurOfferingTypes []string
+
+	// IngestIntervalSeconds is how often to run full ingestion.
+	IngestIntervalSeconds int64
+
+	// ReconcileIntervalSeconds is how often to run reconciliation.
+	ReconcileIntervalSeconds int64
+
+	// ReconcileOnStartup triggers full reconciliation on start.
+	ReconcileOnStartup bool
+
+	// PageSize is the number of offerings to fetch per page.
+	PageSize int
+
+	// MaxRetries is the max retry attempts before dead-lettering.
+	MaxRetries int
+
+	// RetryBackoffSeconds is the base backoff duration.
+	RetryBackoffSeconds int64
+
+	// MaxBackoffSeconds is the maximum backoff duration.
+	MaxBackoffSeconds int64
+
+	// StateFilePath is the path to persist ingestion state.
+	StateFilePath string
+
+	// RateLimitPerSecond limits Waldur API calls per second.
+	RateLimitPerSecond float64
+
+	// RateLimitBurst is the burst limit for rate limiting.
+	RateLimitBurst int
+
+	// OperationTimeout for individual ingestion operations.
+	OperationTimeout time.Duration
+
+	// IngestConfig contains field mapping configuration.
+	IngestConfig marketplace.IngestConfig
+
+	// SkipSharedOfferings skips offerings not marked as shared.
+	SkipSharedOfferings bool
+
+	// SkipNonBillableOfferings skips non-billable offerings.
+	SkipNonBillableOfferings bool
+
+	// OnlyActiveOfferings only ingests Active state offerings.
+	OnlyActiveOfferings bool
+}
+
+// DefaultWaldurIngestWorkerConfig returns sensible defaults.
+func DefaultWaldurIngestWorkerConfig() WaldurIngestWorkerConfig {
+	return WaldurIngestWorkerConfig{
+		IngestIntervalSeconds:    3600,  // 1 hour
+		ReconcileIntervalSeconds: 300,   // 5 minutes
+		ReconcileOnStartup:       true,
+		PageSize:                 50,
+		MaxRetries:               5,
+		RetryBackoffSeconds:      30,
+		MaxBackoffSeconds:        3600,
+		RateLimitPerSecond:       2.0,
+		RateLimitBurst:           5,
+		OperationTimeout:         60 * time.Second,
+		StateFilePath:            "data/waldur_ingest_state.json",
+		IngestConfig:             marketplace.DefaultIngestConfig(),
+		SkipSharedOfferings:      false,
+		SkipNonBillableOfferings: false,
+		OnlyActiveOfferings:      true,
+	}
+}
+
+// OfferingSubmitter defines the interface for submitting offerings on-chain.
+type OfferingSubmitter interface {
+	// CreateOffering creates a new offering on-chain.
+	CreateOffering(ctx context.Context, offering *marketplace.Offering) (string, error)
+	// UpdateOffering updates an existing offering on-chain.
+	UpdateOffering(ctx context.Context, offeringID string, offering *marketplace.Offering) error
+	// DeprecateOffering deprecates an offering on-chain.
+	DeprecateOffering(ctx context.Context, offeringID string) error
+	// GetNextOfferingSequence returns the next sequence number for offerings.
+	GetNextOfferingSequence(ctx context.Context, providerAddress string) (uint64, error)
+	// ValidateProviderVEID validates the provider's VEID score.
+	ValidateProviderVEID(ctx context.Context, providerAddress string, minScore uint32) error
+}
+
+// WaldurIngestWorker ingests Waldur offerings onto the chain.
+type WaldurIngestWorker struct {
+	cfg         WaldurIngestWorkerConfig
+	marketplace *waldur.MarketplaceClient
+	submitter   OfferingSubmitter
+	stateStore  *WaldurIngestStateStore
+	state       *WaldurIngestState
+	rateLimiter *rate.Limiter
+
+	mu          sync.RWMutex
+	running     bool
+	stopCh      chan struct{}
+	doneCh      chan struct{}
+	ingestQueue chan *WaldurIngestTask
+
+	metrics     *WaldurIngestWorkerMetrics
+	auditLogger WaldurIngestAuditLogger
+	promMetrics *WaldurIngestPrometheusMetrics
+}
+
+// WaldurIngestTask represents an ingestion task to execute.
+type WaldurIngestTask struct {
+	WaldurUUID string
+	Offering   *marketplace.WaldurOfferingImport
+	Action     marketplace.IngestAction
+	Timestamp  time.Time
+}
+
+// WaldurIngestWorkerMetrics tracks worker metrics.
+type WaldurIngestWorkerMetrics struct {
+	mu                   sync.RWMutex
+	IngestsTotal         int64
+	IngestsSuccessful    int64
+	IngestsFailed        int64
+	IngestsDeadLettered  int64
+	IngestsSkipped       int64
+	DriftDetections      int64
+	ReconciliationsRun   int64
+	LastIngestTime       time.Time
+	LastSuccessTime      time.Time
+	LastReconcileTime    time.Time
+	WorkerUptime         time.Time
+	OfferingsCreated     int64
+	OfferingsUpdated     int64
+	OfferingsDeprecated  int64
+	QueueDepth           int
+	AverageIngestDuration time.Duration
+}
+
+// NewWaldurIngestWorker creates a new ingestion worker.
+func NewWaldurIngestWorker(
+	cfg WaldurIngestWorkerConfig,
+	marketplaceClient *waldur.MarketplaceClient,
+	submitter OfferingSubmitter,
+) (*WaldurIngestWorker, error) {
+	return NewWaldurIngestWorkerWithLogger(cfg, marketplaceClient, submitter, nil)
+}
+
+// NewWaldurIngestWorkerWithLogger creates a new ingestion worker with a custom audit logger.
+func NewWaldurIngestWorkerWithLogger(
+	cfg WaldurIngestWorkerConfig,
+	marketplaceClient *waldur.MarketplaceClient,
+	submitter OfferingSubmitter,
+	auditLogger WaldurIngestAuditLogger,
+) (*WaldurIngestWorker, error) {
+	if marketplaceClient == nil {
+		return nil, fmt.Errorf("marketplace client is required")
+	}
+	if submitter == nil {
+		return nil, fmt.Errorf("offering submitter is required")
+	}
+
+	if auditLogger == nil {
+		auditLogger = NewDefaultIngestAuditLogger("[waldur-ingest-audit]")
+	}
+
+	stateStore := NewWaldurIngestStateStore(cfg.StateFilePath)
+
+	// Create rate limiter
+	rateLimiter := rate.NewLimiter(rate.Limit(cfg.RateLimitPerSecond), cfg.RateLimitBurst)
+
+	return &WaldurIngestWorker{
+		cfg:         cfg,
+		marketplace: marketplaceClient,
+		submitter:   submitter,
+		stateStore:  stateStore,
+		rateLimiter: rateLimiter,
+		stopCh:      make(chan struct{}),
+		doneCh:      make(chan struct{}),
+		ingestQueue: make(chan *WaldurIngestTask, 100),
+		metrics: &WaldurIngestWorkerMetrics{
+			WorkerUptime: time.Now().UTC(),
+		},
+		auditLogger: auditLogger,
+		promMetrics: &WaldurIngestPrometheusMetrics{},
+	}, nil
+}
+
+// Start starts the ingestion worker.
+func (w *WaldurIngestWorker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return fmt.Errorf("worker already running")
+	}
+	w.running = true
+	w.mu.Unlock()
+
+	// Load persisted state
+	state, err := w.stateStore.Load(w.cfg.WaldurCustomerUUID, w.cfg.ProviderAddress)
+	if err != nil {
+		return fmt.Errorf("load ingest state: %w", err)
+	}
+	w.state = state
+
+	log.Printf("[waldur-ingest] started for provider %s (customer %s)",
+		w.cfg.ProviderAddress, w.cfg.WaldurCustomerUUID)
+
+	// Start background goroutines
+	go w.ingestLoop(ctx)
+	go w.processLoop(ctx)
+	go w.reconcileLoop(ctx)
+
+	// Initial reconciliation if enabled
+	if w.cfg.ReconcileOnStartup {
+		go func() {
+			time.Sleep(5 * time.Second) // Wait for system to stabilize
+			if err := w.Reconcile(ctx); err != nil {
+				log.Printf("[waldur-ingest] initial reconcile failed: %v", err)
+			}
+		}()
+	}
+
+	return nil
+}
+
+// Stop stops the ingestion worker.
+func (w *WaldurIngestWorker) Stop() error {
+	w.mu.Lock()
+	if !w.running {
+		w.mu.Unlock()
+		return nil
+	}
+	w.running = false
+	w.mu.Unlock()
+
+	close(w.stopCh)
+
+	// Wait for goroutines to finish with timeout
+	select {
+	case <-w.doneCh:
+	case <-time.After(10 * time.Second):
+		log.Printf("[waldur-ingest] shutdown timeout")
+	}
+
+	// Save final state
+	if err := w.stateStore.Save(w.state); err != nil {
+		log.Printf("[waldur-ingest] failed to save final state: %v", err)
+	}
+
+	log.Printf("[waldur-ingest] stopped")
+	return nil
+}
+
+// ingestLoop periodically fetches and queues Waldur offerings.
+func (w *WaldurIngestWorker) ingestLoop(ctx context.Context) {
+	if w.cfg.IngestIntervalSeconds <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(time.Duration(w.cfg.IngestIntervalSeconds) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			if err := w.FetchAndQueueOfferings(ctx); err != nil {
+				log.Printf("[waldur-ingest] fetch error: %v", err)
+			}
+		}
+	}
+}
+
+// FetchAndQueueOfferings fetches offerings from Waldur and queues them for ingestion.
+func (w *WaldurIngestWorker) FetchAndQueueOfferings(ctx context.Context) error {
+	log.Printf("[waldur-ingest] starting offering fetch")
+	startTime := time.Now()
+
+	page := 1
+	totalQueued := 0
+
+	for {
+		// Rate limit
+		if err := w.rateLimiter.Wait(ctx); err != nil {
+			return fmt.Errorf("rate limit wait: %w", err)
+		}
+
+		w.promMetrics.FetchesTotal.Add(1)
+
+		// Build list params with filters
+		params := waldur.ListOfferingsParams{
+			CustomerUUID: w.cfg.WaldurCustomerUUID,
+			Page:         page,
+			PageSize:     w.cfg.PageSize,
+		}
+
+		if w.cfg.OnlyActiveOfferings {
+			params.State = "Active"
+		}
+
+		offerings, err := w.marketplace.ListOfferings(ctx, params)
+		if err != nil {
+			w.promMetrics.FetchesFailed.Add(1)
+			return fmt.Errorf("list offerings page %d: %w", page, err)
+		}
+
+		w.promMetrics.FetchesSuccessful.Add(1)
+
+		if len(offerings) == 0 {
+			break
+		}
+
+		for _, o := range offerings {
+			// Apply filters
+			if w.shouldSkipOffering(&o) {
+				continue
+			}
+
+			// Convert to import format
+			importOffering := w.convertToImport(&o)
+
+			// Validate
+			validation := importOffering.Validate(w.cfg.IngestConfig)
+			if !validation.Valid {
+				log.Printf("[waldur-ingest] skipping %s: %v", o.UUID, validation.Errors)
+				w.state.MarkSkipped(o.UUID, fmt.Sprintf("validation failed: %v", validation.Errors))
+				continue
+			}
+
+			// Determine action
+			action := w.determineAction(importOffering)
+
+			task := &WaldurIngestTask{
+				WaldurUUID: o.UUID,
+				Offering:   importOffering,
+				Action:     action,
+				Timestamp:  time.Now().UTC(),
+			}
+
+			select {
+			case w.ingestQueue <- task:
+				totalQueued++
+			default:
+				log.Printf("[waldur-ingest] queue full, skipping %s", o.UUID)
+			}
+		}
+
+		// Update cursor
+		w.state.UpdateCursor(&IngestCursor{
+			Page:          page,
+			PageSize:      w.cfg.PageSize,
+			ProcessedCount: totalQueued,
+			StartedAt:     startTime,
+		})
+
+		if len(offerings) < w.cfg.PageSize {
+			break // Last page
+		}
+		page++
+	}
+
+	w.state.ResetCursor()
+	log.Printf("[waldur-ingest] fetch complete: queued %d offerings (took %v)",
+		totalQueued, time.Since(startTime))
+
+	return nil
+}
+
+// shouldSkipOffering returns true if the offering should be skipped based on filters.
+func (w *WaldurIngestWorker) shouldSkipOffering(o *waldur.Offering) bool {
+	if w.cfg.SkipSharedOfferings && !o.Shared {
+		return true
+	}
+	if w.cfg.SkipNonBillableOfferings && !o.Billable {
+		return true
+	}
+
+	// Filter by category UUIDs
+	if len(w.cfg.WaldurCategoryUUIDs) > 0 {
+		found := false
+		for _, catUUID := range w.cfg.WaldurCategoryUUIDs {
+			if o.Category == catUUID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return true
+		}
+	}
+
+	// Filter by offering types
+	if len(w.cfg.WaldurOfferingTypes) > 0 {
+		found := false
+		for _, t := range w.cfg.WaldurOfferingTypes {
+			if o.Type == t {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return true
+		}
+	}
+
+	return false
+}
+
+// convertToImport converts a Waldur offering to the import format.
+func (w *WaldurIngestWorker) convertToImport(o *waldur.Offering) *marketplace.WaldurOfferingImport {
+	return &marketplace.WaldurOfferingImport{
+		UUID:         o.UUID,
+		Name:         o.Name,
+		Description:  o.Description,
+		Type:         o.Type,
+		State:        o.State,
+		CategoryUUID: o.Category,
+		Shared:       o.Shared,
+		Billable:     o.Billable,
+		Created:      o.CreatedAt,
+		Modified:     o.CreatedAt, // Use created as modified if not available
+	}
+}
+
+// determineAction determines the ingestion action based on current state.
+func (w *WaldurIngestWorker) determineAction(o *marketplace.WaldurOfferingImport) marketplace.IngestAction {
+	record := w.state.GetRecord(o.UUID)
+	if record == nil {
+		return marketplace.IngestActionCreate
+	}
+
+	// Check for archived/deprecated
+	if o.State == "Archived" {
+		return marketplace.IngestActionDeprecate
+	}
+
+	// Check for drift
+	newChecksum := o.IngestChecksum()
+	if record.WaldurChecksum != newChecksum {
+		return marketplace.IngestActionUpdate
+	}
+
+	return marketplace.IngestActionSkip
+}
+
+// processLoop processes ingestion tasks from the queue.
+func (w *WaldurIngestWorker) processLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			close(w.doneCh)
+			return
+		case <-w.stopCh:
+			close(w.doneCh)
+			return
+		case task := <-w.ingestQueue:
+			w.processTask(ctx, task)
+		}
+	}
+}
+
+// processTask executes an ingestion task.
+func (w *WaldurIngestWorker) processTask(ctx context.Context, task *WaldurIngestTask) {
+	startTime := time.Now()
+
+	w.metrics.mu.Lock()
+	w.metrics.IngestsTotal++
+	w.metrics.LastIngestTime = startTime
+	w.metrics.mu.Unlock()
+
+	w.promMetrics.IngestsTotal.Add(1)
+	w.promMetrics.ActiveIngests.Add(1)
+	defer w.promMetrics.ActiveIngests.Add(-1)
+
+	var err error
+	var chainOfferingID string
+	var retryCount int
+
+	// Get current retry count from state
+	record := w.state.GetRecord(task.WaldurUUID)
+	if record != nil {
+		retryCount = record.RetryCount
+	}
+
+	opCtx, cancel := context.WithTimeout(ctx, w.cfg.OperationTimeout)
+	defer cancel()
+
+	switch task.Action {
+	case marketplace.IngestActionCreate:
+		chainOfferingID, err = w.ingestCreate(opCtx, task)
+	case marketplace.IngestActionUpdate:
+		chainOfferingID, err = w.ingestUpdate(opCtx, task)
+	case marketplace.IngestActionDeprecate:
+		err = w.ingestDeprecate(opCtx, task)
+	case marketplace.IngestActionSkip:
+		// No action needed
+	}
+
+	duration := time.Since(startTime)
+
+	// Update prometheus timing metrics
+	w.promMetrics.IngestDurationSum.Add(int64(duration))
+	w.promMetrics.IngestDurationCount.Add(1)
+
+	// Prepare checksum
+	checksum := ""
+	if task.Offering != nil {
+		checksum = task.Offering.IngestChecksum()
+	}
+
+	// Create audit entry
+	auditEntry := IngestAuditEntry{
+		Timestamp:       startTime,
+		WaldurUUID:      task.WaldurUUID,
+		OfferingName:    task.Offering.Name,
+		ChainOfferingID: chainOfferingID,
+		Action:          string(task.Action),
+		Success:         err == nil,
+		Duration:        duration,
+		RetryCount:      retryCount,
+		ProviderAddress: w.cfg.ProviderAddress,
+		Checksum:        checksum,
+	}
+
+	if err != nil {
+		auditEntry.Error = err.Error()
+		log.Printf("[waldur-ingest] %s failed for %s: %v", task.Action, task.WaldurUUID, err)
+
+		deadLettered := w.state.MarkFailed(
+			task.WaldurUUID,
+			err.Error(),
+			w.cfg.MaxRetries,
+			time.Duration(w.cfg.RetryBackoffSeconds)*time.Second,
+			time.Duration(w.cfg.MaxBackoffSeconds)*time.Second,
+		)
+
+		w.metrics.mu.Lock()
+		w.metrics.IngestsFailed++
+		w.metrics.mu.Unlock()
+
+		w.promMetrics.IngestsFailed.Add(1)
+
+		if deadLettered {
+			w.metrics.mu.Lock()
+			w.metrics.IngestsDeadLettered++
+			w.metrics.mu.Unlock()
+
+			w.promMetrics.IngestsDeadLettered.Add(1)
+			w.promMetrics.DeadLetterSize.Add(1)
+
+			w.auditLogger.LogDeadLetter(IngestDeadLetterAuditEntry{
+				Timestamp:       time.Now().UTC(),
+				WaldurUUID:      task.WaldurUUID,
+				OfferingName:    task.Offering.Name,
+				ProviderAddress: w.cfg.ProviderAddress,
+				TotalAttempts:   retryCount + 1,
+				LastError:       err.Error(),
+				Action:          "dead_lettered",
+			})
+		}
+	} else {
+		version := uint64(1)
+		if record != nil {
+			version = record.ChainVersion + 1
+		}
+
+		w.state.MarkIngested(task.WaldurUUID, chainOfferingID, checksum, version)
+		log.Printf("[waldur-ingest] %s succeeded for %s → %s (took %v)",
+			task.Action, task.WaldurUUID, chainOfferingID, duration)
+
+		w.metrics.mu.Lock()
+		w.metrics.IngestsSuccessful++
+		w.metrics.LastSuccessTime = time.Now().UTC()
+		switch task.Action {
+		case marketplace.IngestActionCreate:
+			w.metrics.OfferingsCreated++
+		case marketplace.IngestActionUpdate:
+			w.metrics.OfferingsUpdated++
+		case marketplace.IngestActionDeprecate:
+			w.metrics.OfferingsDeprecated++
+		}
+		w.metrics.mu.Unlock()
+
+		w.promMetrics.IngestsSuccessful.Add(1)
+		switch task.Action {
+		case marketplace.IngestActionCreate:
+			w.promMetrics.OfferingsCreated.Add(1)
+		case marketplace.IngestActionUpdate:
+			w.promMetrics.OfferingsUpdated.Add(1)
+		case marketplace.IngestActionDeprecate:
+			w.promMetrics.OfferingsDeprecated.Add(1)
+		}
+	}
+
+	// Log audit entry
+	w.auditLogger.LogIngestAttempt(auditEntry)
+
+	// Persist state
+	if saveErr := w.stateStore.Save(w.state); saveErr != nil {
+		log.Printf("[waldur-ingest] failed to save state: %v", saveErr)
+	}
+}
+
+// ingestCreate creates a new on-chain offering from Waldur.
+func (w *WaldurIngestWorker) ingestCreate(ctx context.Context, task *WaldurIngestTask) (string, error) {
+	if task.Offering == nil {
+		return "", fmt.Errorf("offering data required for create")
+	}
+
+	// Validate provider VEID if required
+	if w.cfg.IngestConfig.MinIdentityScore > 0 {
+		if err := w.submitter.ValidateProviderVEID(ctx, w.cfg.ProviderAddress, w.cfg.IngestConfig.MinIdentityScore); err != nil {
+			return "", fmt.Errorf("provider VEID validation failed: %w", err)
+		}
+	}
+
+	// Get next sequence number
+	sequence, err := w.submitter.GetNextOfferingSequence(ctx, w.cfg.ProviderAddress)
+	if err != nil {
+		return "", fmt.Errorf("get next sequence: %w", err)
+	}
+
+	// Convert to on-chain offering
+	offering := task.Offering.ToOffering(w.cfg.ProviderAddress, sequence, w.cfg.IngestConfig)
+
+	// Validate offering
+	if err := offering.Validate(); err != nil {
+		return "", fmt.Errorf("invalid offering: %w", err)
+	}
+
+	// Submit to chain
+	offeringID, err := w.submitter.CreateOffering(ctx, offering)
+	if err != nil {
+		return "", fmt.Errorf("create offering: %w", err)
+	}
+
+	return offeringID, nil
+}
+
+// ingestUpdate updates an existing on-chain offering.
+func (w *WaldurIngestWorker) ingestUpdate(ctx context.Context, task *WaldurIngestTask) (string, error) {
+	record := w.state.GetRecord(task.WaldurUUID)
+	if record == nil || record.ChainOfferingID == "" {
+		// No existing record, try create instead
+		return w.ingestCreate(ctx, task)
+	}
+
+	if task.Offering == nil {
+		return "", fmt.Errorf("offering data required for update")
+	}
+
+	// Convert to on-chain offering
+	offering := task.Offering.ToOffering(w.cfg.ProviderAddress, record.ChainVersion, w.cfg.IngestConfig)
+
+	// Update on chain
+	if err := w.submitter.UpdateOffering(ctx, record.ChainOfferingID, offering); err != nil {
+		return "", fmt.Errorf("update offering: %w", err)
+	}
+
+	return record.ChainOfferingID, nil
+}
+
+// ingestDeprecate deprecates an on-chain offering.
+func (w *WaldurIngestWorker) ingestDeprecate(ctx context.Context, task *WaldurIngestTask) error {
+	record := w.state.GetRecord(task.WaldurUUID)
+	if record == nil || record.ChainOfferingID == "" {
+		return nil // Nothing to deprecate
+	}
+
+	if err := w.submitter.DeprecateOffering(ctx, record.ChainOfferingID); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		// Log but don't fail - offering might already be deprecated
+		log.Printf("[waldur-ingest] deprecate warning for %s: %v", record.ChainOfferingID, err)
+	}
+
+	w.state.MarkDeprecated(task.WaldurUUID)
+	return nil
+}
+
+// reconcileLoop runs periodic reconciliation.
+func (w *WaldurIngestWorker) reconcileLoop(ctx context.Context) {
+	if w.cfg.ReconcileIntervalSeconds <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(time.Duration(w.cfg.ReconcileIntervalSeconds) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			if err := w.Reconcile(ctx); err != nil {
+				log.Printf("[waldur-ingest] reconcile error: %v", err)
+			}
+		}
+	}
+}
+
+// Reconcile performs full reconciliation between Waldur and chain state.
+func (w *WaldurIngestWorker) Reconcile(ctx context.Context) error {
+	log.Printf("[waldur-ingest] starting reconciliation")
+	startTime := time.Now()
+
+	// Get offerings that need re-ingestion
+	needsIngest := w.state.NeedsIngestOfferings()
+	offeringsQueued := 0
+	driftDetected := 0
+
+	for _, waldurUUID := range needsIngest {
+		record := w.state.GetRecord(waldurUUID)
+		if record == nil {
+			continue
+		}
+
+		// Re-fetch from Waldur to check for drift
+		if err := w.rateLimiter.Wait(ctx); err != nil {
+			break
+		}
+
+		// Queue for re-ingestion
+		task := &WaldurIngestTask{
+			WaldurUUID: waldurUUID,
+			Action:     marketplace.IngestActionUpdate,
+			Timestamp:  time.Now().UTC(),
+		}
+
+		select {
+		case w.ingestQueue <- task:
+			offeringsQueued++
+			if record.State == IngestRecordStateOutOfSync {
+				driftDetected++
+			}
+		case <-ctx.Done():
+			break
+		default:
+			log.Printf("[waldur-ingest] reconcile queue full, skipping %s", waldurUUID)
+		}
+	}
+
+	duration := time.Since(startTime)
+
+	w.state.RecordReconciliation()
+	w.metrics.mu.Lock()
+	w.metrics.ReconciliationsRun++
+	w.metrics.LastReconcileTime = time.Now().UTC()
+	w.metrics.DriftDetections += int64(driftDetected)
+	w.metrics.mu.Unlock()
+
+	w.promMetrics.ReconciliationsRun.Add(1)
+	w.promMetrics.DriftDetected.Add(int64(driftDetected))
+	w.promMetrics.QueueDepth.Store(int64(len(w.ingestQueue)))
+
+	// Log reconciliation audit entry
+	w.auditLogger.LogReconciliation(IngestReconciliationAuditEntry{
+		Timestamp:        startTime,
+		WaldurCustomer:   w.cfg.WaldurCustomerUUID,
+		ProviderAddress:  w.cfg.ProviderAddress,
+		OfferingsChecked: len(needsIngest),
+		DriftDetected:    driftDetected,
+		OfferingsQueued:  offeringsQueued,
+		Duration:         duration,
+	})
+
+	log.Printf("[waldur-ingest] reconciliation queued %d offerings (drift: %d) (took %v)",
+		offeringsQueued, driftDetected, duration)
+
+	return nil
+}
+
+// QueueIngest manually queues an ingestion task.
+func (w *WaldurIngestWorker) QueueIngest(waldurUUID string, offering *marketplace.WaldurOfferingImport, action marketplace.IngestAction) error {
+	task := &WaldurIngestTask{
+		WaldurUUID: waldurUUID,
+		Offering:   offering,
+		Action:     action,
+		Timestamp:  time.Now().UTC(),
+	}
+
+	select {
+	case w.ingestQueue <- task:
+		return nil
+	default:
+		return fmt.Errorf("ingest queue full")
+	}
+}
+
+// Metrics returns current worker metrics.
+func (w *WaldurIngestWorker) Metrics() WaldurIngestWorkerMetrics {
+	w.metrics.mu.RLock()
+	defer w.metrics.mu.RUnlock()
+
+	// Copy all fields except the mutex
+	return WaldurIngestWorkerMetrics{
+		IngestsTotal:         w.metrics.IngestsTotal,
+		IngestsSuccessful:    w.metrics.IngestsSuccessful,
+		IngestsFailed:        w.metrics.IngestsFailed,
+		IngestsDeadLettered:  w.metrics.IngestsDeadLettered,
+		IngestsSkipped:       w.metrics.IngestsSkipped,
+		DriftDetections:      w.metrics.DriftDetections,
+		ReconciliationsRun:   w.metrics.ReconciliationsRun,
+		LastIngestTime:       w.metrics.LastIngestTime,
+		LastSuccessTime:      w.metrics.LastSuccessTime,
+		LastReconcileTime:    w.metrics.LastReconcileTime,
+		WorkerUptime:         w.metrics.WorkerUptime,
+		OfferingsCreated:     w.metrics.OfferingsCreated,
+		OfferingsUpdated:     w.metrics.OfferingsUpdated,
+		OfferingsDeprecated:  w.metrics.OfferingsDeprecated,
+		QueueDepth:           len(w.ingestQueue),
+	}
+}
+
+// State returns the current ingestion state.
+func (w *WaldurIngestWorker) State() *WaldurIngestState {
+	return w.state
+}
+
+// Stats returns summary statistics.
+func (w *WaldurIngestWorker) Stats() IngestStats {
+	return w.state.GetStats()
+}
+
+// ReprocessDeadLetter attempts to reprocess a dead-lettered offering.
+func (w *WaldurIngestWorker) ReprocessDeadLetter(waldurUUID string) error {
+	if w.state.ReprocessDeadLetter(waldurUUID) {
+		w.promMetrics.DeadLetterSize.Add(-1)
+
+		w.auditLogger.LogDeadLetter(IngestDeadLetterAuditEntry{
+			Timestamp:       time.Now().UTC(),
+			WaldurUUID:      waldurUUID,
+			ProviderAddress: w.cfg.ProviderAddress,
+			Action:          "reprocessed",
+		})
+
+		// Queue for re-ingestion
+		return w.QueueIngest(waldurUUID, nil, marketplace.IngestActionUpdate)
+	}
+	return fmt.Errorf("offering %s not found in dead letter queue", waldurUUID)
+}
+
+// PrometheusMetrics returns the prometheus-compatible metrics.
+func (w *WaldurIngestWorker) PrometheusMetrics() *WaldurIngestPrometheusMetrics {
+	return w.promMetrics
+}
+
+// SetAuditLogger allows replacing the audit logger.
+func (w *WaldurIngestWorker) SetAuditLogger(logger WaldurIngestAuditLogger) {
+	w.auditLogger = logger
+}

--- a/pkg/provider_daemon/waldur_ingest_worker_test.go
+++ b/pkg/provider_daemon/waldur_ingest_worker_test.go
@@ -1,0 +1,596 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-3D: Tests for Waldur ingestion worker and state management.
+package provider_daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/virtengine/virtengine/x/market/types/marketplace"
+)
+
+// MockOfferingSubmitter implements OfferingSubmitter for testing.
+type MockOfferingSubmitter struct {
+	CreateOfferingFn          func(ctx context.Context, offering *marketplace.Offering) (string, error)
+	UpdateOfferingFn          func(ctx context.Context, offeringID string, offering *marketplace.Offering) error
+	DeprecateOfferingFn       func(ctx context.Context, offeringID string) error
+	GetNextOfferingSequenceFn func(ctx context.Context, providerAddress string) (uint64, error)
+	ValidateProviderVEIDFn    func(ctx context.Context, providerAddress string, minScore uint32) error
+
+	CreateCalls    int
+	UpdateCalls    int
+	DeprecateCalls int
+	SequenceNumber uint64
+}
+
+func (m *MockOfferingSubmitter) CreateOffering(ctx context.Context, offering *marketplace.Offering) (string, error) {
+	m.CreateCalls++
+	if m.CreateOfferingFn != nil {
+		return m.CreateOfferingFn(ctx, offering)
+	}
+	return offering.ID.String(), nil
+}
+
+func (m *MockOfferingSubmitter) UpdateOffering(ctx context.Context, offeringID string, offering *marketplace.Offering) error {
+	m.UpdateCalls++
+	if m.UpdateOfferingFn != nil {
+		return m.UpdateOfferingFn(ctx, offeringID, offering)
+	}
+	return nil
+}
+
+func (m *MockOfferingSubmitter) DeprecateOffering(ctx context.Context, offeringID string) error {
+	m.DeprecateCalls++
+	if m.DeprecateOfferingFn != nil {
+		return m.DeprecateOfferingFn(ctx, offeringID)
+	}
+	return nil
+}
+
+func (m *MockOfferingSubmitter) GetNextOfferingSequence(ctx context.Context, providerAddress string) (uint64, error) {
+	m.SequenceNumber++
+	if m.GetNextOfferingSequenceFn != nil {
+		return m.GetNextOfferingSequenceFn(ctx, providerAddress)
+	}
+	return m.SequenceNumber, nil
+}
+
+func (m *MockOfferingSubmitter) ValidateProviderVEID(ctx context.Context, providerAddress string, minScore uint32) error {
+	if m.ValidateProviderVEIDFn != nil {
+		return m.ValidateProviderVEIDFn(ctx, providerAddress, minScore)
+	}
+	return nil
+}
+
+// Sample Waldur offering payloads for testing
+var sampleWaldurCompute = &marketplace.WaldurOfferingImport{
+	UUID:         "uuid-compute-001",
+	Name:         "Basic Compute Instance",
+	Description:  "A basic compute instance with 2 vCPUs and 4GB RAM",
+	Type:         "VirtEngine.Compute",
+	State:        "Active",
+	CategoryUUID: "cat-compute-uuid",
+	CustomerUUID: "cust-provider-001",
+	Shared:       true,
+	Billable:     true,
+	Attributes: map[string]interface{}{
+		"tags":                  []interface{}{"compute", "basic"},
+		"regions":               []interface{}{"us-east-1", "eu-west-1"},
+		"spec_vcpu":             "2",
+		"spec_memory_gb":        "4",
+		"spec_disk_gb":          "50",
+		"ve_min_identity_score": float64(10),
+		"ve_require_mfa":        true,
+	},
+	Components: []marketplace.WaldurPricingComponent{
+		{
+			Type:         "usage",
+			Name:         "base",
+			MeasuredUnit: "hour",
+			BillingType:  "usage",
+			Price:        "0.050000",
+		},
+	},
+	Created:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	Modified: time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+}
+
+var sampleWaldurHPC = &marketplace.WaldurOfferingImport{
+	UUID:         "uuid-hpc-001",
+	Name:         "HPC Cluster Access",
+	Description:  "High-performance computing cluster with SLURM scheduling",
+	Type:         "VirtEngine.HPC",
+	State:        "Active",
+	CategoryUUID: "cat-hpc-uuid",
+	CustomerUUID: "cust-provider-001",
+	Shared:       true,
+	Billable:     true,
+	Attributes: map[string]interface{}{
+		"tags":           []interface{}{"hpc", "slurm", "research"},
+		"regions":        []interface{}{"us-west-2"},
+		"spec_cpu_limit": "1000",
+		"spec_gpu_limit": "8",
+		"spec_ram_gb":    "512",
+	},
+	Components: []marketplace.WaldurPricingComponent{
+		{
+			Type:         "usage",
+			Name:         "cpu_hours",
+			MeasuredUnit: "cpu_hour",
+			BillingType:  "usage",
+			Price:        "0.010000",
+		},
+		{
+			Type:         "usage",
+			Name:         "gpu_hours",
+			MeasuredUnit: "gpu_hour",
+			BillingType:  "usage",
+			Price:        "1.500000",
+		},
+	},
+	Created:  time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+	Modified: time.Date(2026, 1, 20, 0, 0, 0, 0, time.UTC),
+}
+
+var sampleWaldurStorage = &marketplace.WaldurOfferingImport{
+	UUID:         "uuid-storage-001",
+	Name:         "Block Storage",
+	Description:  "High-performance block storage for VMs",
+	Type:         "VirtEngine.Storage",
+	State:        "Paused",
+	CategoryUUID: "cat-storage-uuid",
+	CustomerUUID: "cust-provider-001",
+	Shared:       true,
+	Billable:     true,
+	Attributes: map[string]interface{}{
+		"tags":             []interface{}{"storage", "ssd"},
+		"regions":          []interface{}{"us-east-1"},
+		"spec_type":        "ssd",
+		"spec_iops":        "3000",
+		"spec_throughput":  "250",
+	},
+	Components: []marketplace.WaldurPricingComponent{
+		{
+			Type:         "usage",
+			Name:         "base",
+			MeasuredUnit: "gb_month",
+			BillingType:  "monthly",
+			Price:        "0.100000",
+		},
+	},
+	Created:  time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+	Modified: time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+}
+
+func TestWaldurOfferingImport_Validate(t *testing.T) {
+	cfg := marketplace.DefaultIngestConfig()
+	cfg.CustomerProviderMap = map[string]string{
+		"cust-provider-001": "virtengine1provider123",
+	}
+
+	tests := []struct {
+		name     string
+		offering *marketplace.WaldurOfferingImport
+		wantValid bool
+		wantErrors int
+	}{
+		{
+			name:     "valid compute offering",
+			offering: sampleWaldurCompute,
+			wantValid: true,
+			wantErrors: 0,
+		},
+		{
+			name:     "valid hpc offering",
+			offering: sampleWaldurHPC,
+			wantValid: true,
+			wantErrors: 0,
+		},
+		{
+			name:     "valid storage offering",
+			offering: sampleWaldurStorage,
+			wantValid: true,
+			wantErrors: 0,
+		},
+		{
+			name: "missing UUID",
+			offering: &marketplace.WaldurOfferingImport{
+				Name:         "Test",
+				CustomerUUID: "cust-provider-001",
+			},
+			wantValid: false,
+			wantErrors: 1,
+		},
+		{
+			name: "missing name",
+			offering: &marketplace.WaldurOfferingImport{
+				UUID:         "test-uuid",
+				CustomerUUID: "cust-provider-001",
+			},
+			wantValid: false,
+			wantErrors: 1,
+		},
+		{
+			name: "unmapped customer",
+			offering: &marketplace.WaldurOfferingImport{
+				UUID:         "test-uuid",
+				Name:         "Test",
+				CustomerUUID: "unknown-customer",
+			},
+			wantValid: false,
+			wantErrors: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.offering.Validate(cfg)
+			if result.Valid != tt.wantValid {
+				t.Errorf("Valid = %v, want %v", result.Valid, tt.wantValid)
+			}
+			if len(result.Errors) < tt.wantErrors {
+				t.Errorf("Errors count = %d, want >= %d", len(result.Errors), tt.wantErrors)
+			}
+		})
+	}
+}
+
+func TestWaldurOfferingImport_ResolveCategory(t *testing.T) {
+	cfg := marketplace.DefaultIngestConfig()
+
+	tests := []struct {
+		name     string
+		offering *marketplace.WaldurOfferingImport
+		want     marketplace.OfferingCategory
+	}{
+		{
+			name:     "compute type",
+			offering: &marketplace.WaldurOfferingImport{Type: "VirtEngine.Compute"},
+			want:     marketplace.OfferingCategoryCompute,
+		},
+		{
+			name:     "hpc type",
+			offering: &marketplace.WaldurOfferingImport{Type: "VirtEngine.HPC"},
+			want:     marketplace.OfferingCategoryHPC,
+		},
+		{
+			name:     "storage type",
+			offering: &marketplace.WaldurOfferingImport{Type: "VirtEngine.Storage"},
+			want:     marketplace.OfferingCategoryStorage,
+		},
+		{
+			name:     "gpu type",
+			offering: &marketplace.WaldurOfferingImport{Type: "VirtEngine.GPU"},
+			want:     marketplace.OfferingCategoryGPU,
+		},
+		{
+			name:     "infer from vm keyword",
+			offering: &marketplace.WaldurOfferingImport{Type: "Custom.VirtualMachine"},
+			want:     marketplace.OfferingCategoryCompute,
+		},
+		{
+			name:     "infer from slurm keyword",
+			offering: &marketplace.WaldurOfferingImport{Type: "Custom.SlurmCluster"},
+			want:     marketplace.OfferingCategoryHPC,
+		},
+		{
+			name:     "unknown type",
+			offering: &marketplace.WaldurOfferingImport{Type: "Custom.Unknown"},
+			want:     marketplace.OfferingCategoryOther,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.offering.ResolveCategory(cfg)
+			if got != tt.want {
+				t.Errorf("ResolveCategory() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaldurOfferingImport_ResolveState(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    string
+		want     marketplace.OfferingState
+	}{
+		{"active", "Active", marketplace.OfferingStateActive},
+		{"paused", "Paused", marketplace.OfferingStatePaused},
+		{"archived", "Archived", marketplace.OfferingStateTerminated},
+		{"unknown", "Unknown", marketplace.OfferingStatePaused},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &marketplace.WaldurOfferingImport{State: tt.state}
+			got := o.ResolveState()
+			if got != tt.want {
+				t.Errorf("ResolveState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaldurOfferingImport_ResolvePricing(t *testing.T) {
+	cfg := marketplace.DefaultIngestConfig()
+
+	t.Run("base price only", func(t *testing.T) {
+		o := &marketplace.WaldurOfferingImport{
+			Components: []marketplace.WaldurPricingComponent{
+				{Name: "base", Price: "0.050000", BillingType: "usage"},
+			},
+		}
+		pricing := o.ResolvePricing(cfg)
+		if pricing.BasePrice != 50000 {
+			t.Errorf("BasePrice = %d, want 50000", pricing.BasePrice)
+		}
+		if pricing.Model != marketplace.PricingModelHourly {
+			t.Errorf("Model = %v, want hourly", pricing.Model)
+		}
+	})
+
+	t.Run("with usage rates", func(t *testing.T) {
+		o := sampleWaldurHPC
+		pricing := o.ResolvePricing(cfg)
+		if len(pricing.UsageRates) != 2 {
+			t.Errorf("UsageRates count = %d, want 2", len(pricing.UsageRates))
+		}
+		if pricing.UsageRates["cpu_hours"] != 10000 {
+			t.Errorf("cpu_hours rate = %d, want 10000", pricing.UsageRates["cpu_hours"])
+		}
+		if pricing.UsageRates["gpu_hours"] != 1500000 {
+			t.Errorf("gpu_hours rate = %d, want 1500000", pricing.UsageRates["gpu_hours"])
+		}
+	})
+
+	t.Run("monthly billing", func(t *testing.T) {
+		o := sampleWaldurStorage
+		pricing := o.ResolvePricing(cfg)
+		if pricing.Model != marketplace.PricingModelMonthly {
+			t.Errorf("Model = %v, want monthly", pricing.Model)
+		}
+	})
+}
+
+func TestWaldurOfferingImport_ExtractTags(t *testing.T) {
+	tags := sampleWaldurCompute.ExtractTags()
+	if len(tags) != 2 {
+		t.Errorf("tags count = %d, want 2", len(tags))
+	}
+	if tags[0] != "compute" {
+		t.Errorf("first tag = %s, want 'compute'", tags[0])
+	}
+}
+
+func TestWaldurOfferingImport_ExtractRegions(t *testing.T) {
+	cfg := marketplace.DefaultIngestConfig()
+	regions := sampleWaldurCompute.ExtractRegions(cfg)
+	if len(regions) != 2 {
+		t.Errorf("regions count = %d, want 2", len(regions))
+	}
+}
+
+func TestWaldurOfferingImport_ExtractSpecifications(t *testing.T) {
+	specs := sampleWaldurCompute.ExtractSpecifications()
+	if specs["vcpu"] != "2" {
+		t.Errorf("vcpu = %s, want '2'", specs["vcpu"])
+	}
+	if specs["memory_gb"] != "4" {
+		t.Errorf("memory_gb = %s, want '4'", specs["memory_gb"])
+	}
+}
+
+func TestWaldurOfferingImport_ToOffering(t *testing.T) {
+	cfg := marketplace.DefaultIngestConfig()
+	cfg.CustomerProviderMap = map[string]string{
+		"cust-provider-001": "virtengine1provider123",
+	}
+
+	offering := sampleWaldurCompute.ToOffering("virtengine1provider123", 1, cfg)
+
+	if offering.ID.ProviderAddress != "virtengine1provider123" {
+		t.Errorf("ProviderAddress = %s, want virtengine1provider123", offering.ID.ProviderAddress)
+	}
+	if offering.ID.Sequence != 1 {
+		t.Errorf("Sequence = %d, want 1", offering.ID.Sequence)
+	}
+	if offering.Name != sampleWaldurCompute.Name {
+		t.Errorf("Name = %s, want %s", offering.Name, sampleWaldurCompute.Name)
+	}
+	if offering.Category != marketplace.OfferingCategoryCompute {
+		t.Errorf("Category = %v, want compute", offering.Category)
+	}
+	if offering.State != marketplace.OfferingStateActive {
+		t.Errorf("State = %v, want active", offering.State)
+	}
+	if offering.Pricing.BasePrice != 50000 {
+		t.Errorf("BasePrice = %d, want 50000", offering.Pricing.BasePrice)
+	}
+	if offering.IdentityRequirement.MinScore != 10 {
+		t.Errorf("MinScore = %d, want 10", offering.IdentityRequirement.MinScore)
+	}
+}
+
+func TestWaldurOfferingImport_IngestChecksum(t *testing.T) {
+	checksum1 := sampleWaldurCompute.IngestChecksum()
+	checksum2 := sampleWaldurCompute.IngestChecksum()
+
+	if checksum1 != checksum2 {
+		t.Errorf("checksums should be deterministic")
+	}
+
+	modified := *sampleWaldurCompute
+	modified.Name = "Modified Name"
+	checksum3 := modified.IngestChecksum()
+
+	if checksum1 == checksum3 {
+		t.Errorf("checksums should differ for modified offerings")
+	}
+}
+
+func TestWaldurIngestState(t *testing.T) {
+	state := NewWaldurIngestState("cust-001", "provider-001")
+
+	t.Run("mark ingested", func(t *testing.T) {
+		state.MarkIngested("waldur-001", "chain/1", "checksum123", 1)
+		record := state.GetRecord("waldur-001")
+		if record == nil {
+			t.Fatal("record should exist")
+		}
+		if record.State != IngestRecordStateIngested {
+			t.Errorf("state = %v, want ingested", record.State)
+		}
+		if record.ChainOfferingID != "chain/1" {
+			t.Errorf("ChainOfferingID = %s, want chain/1", record.ChainOfferingID)
+		}
+	})
+
+	t.Run("mark failed with retry", func(t *testing.T) {
+		state.GetOrCreateRecord("waldur-002", "Test Offering")
+		deadLettered := state.MarkFailed("waldur-002", "test error", 3, time.Second, time.Minute)
+		if deadLettered {
+			t.Error("should not be dead-lettered on first failure")
+		}
+		record := state.GetRecord("waldur-002")
+		if record.State != IngestRecordStateRetrying {
+			t.Errorf("state = %v, want retrying", record.State)
+		}
+		if record.RetryCount != 1 {
+			t.Errorf("RetryCount = %d, want 1", record.RetryCount)
+		}
+	})
+
+	t.Run("dead letter after max retries", func(t *testing.T) {
+		state.GetOrCreateRecord("waldur-003", "Test Offering")
+		for i := 0; i <= 3; i++ {
+			state.MarkFailed("waldur-003", "persistent error", 3, time.Second, time.Minute)
+		}
+		record := state.GetRecord("waldur-003")
+		if record.State != IngestRecordStateDeadLettered {
+			t.Errorf("state = %v, want dead_lettered", record.State)
+		}
+		if len(state.DeadLetterQueue) != 1 {
+			t.Errorf("dead letter queue size = %d, want 1", len(state.DeadLetterQueue))
+		}
+	})
+
+	t.Run("needs ingest", func(t *testing.T) {
+		state.GetOrCreateRecord("waldur-004", "Pending Offering")
+		needs := state.NeedsIngestOfferings()
+		found := false
+		for _, uuid := range needs {
+			if uuid == "waldur-004" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("waldur-004 should need ingestion")
+		}
+	})
+
+	t.Run("reprocess dead letter", func(t *testing.T) {
+		ok := state.ReprocessDeadLetter("waldur-003")
+		if !ok {
+			t.Error("reprocess should succeed")
+		}
+		record := state.GetRecord("waldur-003")
+		if record.State != IngestRecordStatePending {
+			t.Errorf("state = %v, want pending after reprocess", record.State)
+		}
+		if len(state.DeadLetterQueue) != 0 {
+			t.Errorf("dead letter queue size = %d, want 0", len(state.DeadLetterQueue))
+		}
+	})
+}
+
+func TestWaldurIngestStateStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "ingest_state.json")
+	store := NewWaldurIngestStateStore(statePath)
+
+	// Load non-existent creates new
+	state, err := store.Load("cust-001", "provider-001")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if state.WaldurCustomerUUID != "cust-001" {
+		t.Errorf("WaldurCustomerUUID = %s, want cust-001", state.WaldurCustomerUUID)
+	}
+
+	// Add data and save
+	state.MarkIngested("waldur-001", "chain/1", "checksum", 1)
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(statePath); os.IsNotExist(err) {
+		t.Fatal("state file should exist")
+	}
+
+	// Load and verify
+	loaded, err := store.Load("cust-001", "provider-001")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.GetRecord("waldur-001") == nil {
+		t.Error("loaded state should contain waldur-001")
+	}
+
+	// Delete
+	if err := store.Delete(); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Error("state file should be deleted")
+	}
+}
+
+func TestWaldurIngestStats(t *testing.T) {
+	state := NewWaldurIngestState("cust-001", "provider-001")
+
+	state.MarkIngested("w1", "c1", "cs1", 1)
+	state.MarkIngested("w2", "c2", "cs2", 1)
+	state.GetOrCreateRecord("w3", "Pending")
+	state.MarkSkipped("w3", "skipped")
+
+	stats := state.GetStats()
+	if stats.TotalRecords != 3 {
+		t.Errorf("TotalRecords = %d, want 3", stats.TotalRecords)
+	}
+	if stats.Ingested != 2 {
+		t.Errorf("Ingested = %d, want 2", stats.Ingested)
+	}
+	if stats.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", stats.Skipped)
+	}
+}
+
+// TestMockAuditLogger tests the audit logger interface.
+func TestMockAuditLogger(t *testing.T) {
+	logger := NewDefaultIngestAuditLogger("[test]")
+
+	// Should not panic
+	logger.LogIngestAttempt(IngestAuditEntry{
+		WaldurUUID: "test-uuid",
+		Action:     "create",
+		Success:    true,
+	})
+
+	logger.LogReconciliation(IngestReconciliationAuditEntry{
+		WaldurCustomer:   "test-customer",
+		OfferingsChecked: 10,
+	})
+
+	logger.LogDeadLetter(IngestDeadLetterAuditEntry{
+		WaldurUUID: "test-uuid",
+		Action:     "dead_lettered",
+	})
+}

--- a/x/market/types/marketplace/waldur_ingest.go
+++ b/x/market/types/marketplace/waldur_ingest.go
@@ -1,0 +1,685 @@
+// Package marketplace provides types for the marketplace on-chain module.
+//
+// VE-3D: Waldur ingestion types for Waldur-to-chain synchronization.
+// This file defines the canonical mapping from Waldur offerings to on-chain offerings.
+package marketplace
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// WaldurOfferingImport represents a Waldur offering to be ingested on-chain.
+type WaldurOfferingImport struct {
+	// UUID is the Waldur offering UUID.
+	UUID string `json:"uuid"`
+
+	// Name is the offering name.
+	Name string `json:"name"`
+
+	// Description is the offering description.
+	Description string `json:"description"`
+
+	// Type is the Waldur offering type (e.g., "VirtEngine.Compute").
+	Type string `json:"type"`
+
+	// State is the Waldur state (Active, Paused, Archived).
+	State string `json:"state"`
+
+	// CategoryUUID is the Waldur category UUID.
+	CategoryUUID string `json:"category_uuid"`
+
+	// CustomerUUID is the Waldur customer UUID (provider organization).
+	CustomerUUID string `json:"customer_uuid"`
+
+	// Shared indicates if the offering is publicly visible.
+	Shared bool `json:"shared"`
+
+	// Billable indicates if the offering is billable.
+	Billable bool `json:"billable"`
+
+	// BackendID is the on-chain offering ID if already synced (optional).
+	BackendID string `json:"backend_id,omitempty"`
+
+	// Attributes contains offering attributes from Waldur.
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+
+	// Components contains pricing components.
+	Components []WaldurPricingComponent `json:"components,omitempty"`
+
+	// Created is the Waldur creation timestamp.
+	Created time.Time `json:"created"`
+
+	// Modified is the Waldur modification timestamp.
+	Modified time.Time `json:"modified"`
+}
+
+// IngestConfig configures the ingestion mapping behavior.
+type IngestConfig struct {
+	// CategoryMap maps Waldur category UUIDs to VirtEngine categories.
+	CategoryMap map[string]OfferingCategory `json:"category_map"`
+
+	// TypeMap maps Waldur offering types to VirtEngine categories.
+	TypeMap map[string]OfferingCategory `json:"type_map"`
+
+	// RegionMap maps Waldur location UUIDs to VirtEngine region codes.
+	RegionMap map[string]string `json:"region_map"`
+
+	// CustomerProviderMap maps Waldur customer UUIDs to provider addresses.
+	CustomerProviderMap map[string]string `json:"customer_provider_map"`
+
+	// CurrencyDenominator is the denominator for price conversion (e.g., 1000000 for utoken).
+	CurrencyDenominator uint64 `json:"currency_denominator"`
+
+	// DefaultCurrency is the default currency if not specified.
+	DefaultCurrency string `json:"default_currency"`
+
+	// MinIdentityScore is the minimum identity score required for imported offerings.
+	MinIdentityScore uint32 `json:"min_identity_score"`
+
+	// RequireProviderRegistration requires the provider to be registered on-chain.
+	RequireProviderRegistration bool `json:"require_provider_registration"`
+}
+
+// DefaultIngestConfig returns sensible defaults for ingestion config.
+func DefaultIngestConfig() IngestConfig {
+	return IngestConfig{
+		CategoryMap: map[string]OfferingCategory{},
+		TypeMap: map[string]OfferingCategory{
+			"VirtEngine.Compute": OfferingCategoryCompute,
+			"VirtEngine.Storage": OfferingCategoryStorage,
+			"VirtEngine.Network": OfferingCategoryNetwork,
+			"VirtEngine.HPC":     OfferingCategoryHPC,
+			"VirtEngine.GPU":     OfferingCategoryGPU,
+			"VirtEngine.ML":      OfferingCategoryML,
+			"VirtEngine.Generic": OfferingCategoryOther,
+		},
+		RegionMap:                   map[string]string{},
+		CustomerProviderMap:         map[string]string{},
+		CurrencyDenominator:         1000000,
+		DefaultCurrency:             "uvirt",
+		MinIdentityScore:            0,
+		RequireProviderRegistration: true,
+	}
+}
+
+// IngestValidationResult contains the result of validating a Waldur offering for ingestion.
+type IngestValidationResult struct {
+	// Valid indicates if the offering can be ingested.
+	Valid bool `json:"valid"`
+
+	// Errors contains validation errors.
+	Errors []string `json:"errors,omitempty"`
+
+	// Warnings contains non-fatal warnings.
+	Warnings []string `json:"warnings,omitempty"`
+
+	// ProviderAddress is the resolved provider address.
+	ProviderAddress string `json:"provider_address,omitempty"`
+
+	// Category is the resolved category.
+	Category OfferingCategory `json:"category,omitempty"`
+
+	// NeedsProviderRegistration indicates if provider needs to register first.
+	NeedsProviderRegistration bool `json:"needs_provider_registration,omitempty"`
+
+	// NeedsVEIDVerification indicates if provider needs VEID verification.
+	NeedsVEIDVerification bool `json:"needs_veid_verification,omitempty"`
+}
+
+// Validate validates a Waldur offering for ingestion.
+func (w *WaldurOfferingImport) Validate(cfg IngestConfig) IngestValidationResult {
+	result := IngestValidationResult{Valid: true}
+
+	// Validate required fields
+	if w.UUID == "" {
+		result.Errors = append(result.Errors, "UUID is required")
+		result.Valid = false
+	}
+	if w.Name == "" {
+		result.Errors = append(result.Errors, "name is required")
+		result.Valid = false
+	}
+	if w.CustomerUUID == "" {
+		result.Errors = append(result.Errors, "customer UUID is required")
+		result.Valid = false
+	}
+
+	// Validate state
+	if w.State != "Active" && w.State != "Paused" && w.State != "Archived" {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("unknown state: %s", w.State))
+	}
+
+	// Resolve provider address
+	if providerAddr, ok := cfg.CustomerProviderMap[w.CustomerUUID]; ok {
+		result.ProviderAddress = providerAddr
+	} else if cfg.RequireProviderRegistration {
+		result.Errors = append(result.Errors, fmt.Sprintf("customer UUID %s not mapped to provider address", w.CustomerUUID))
+		result.Valid = false
+		result.NeedsProviderRegistration = true
+	}
+
+	// Resolve category
+	result.Category = w.ResolveCategory(cfg)
+	if result.Category == "" {
+		result.Category = OfferingCategoryOther
+		result.Warnings = append(result.Warnings, "category defaulted to 'other'")
+	}
+
+	// Check for VEID requirements
+	if cfg.MinIdentityScore > 0 {
+		result.NeedsVEIDVerification = true
+	}
+
+	return result
+}
+
+// ResolveCategory resolves the VirtEngine category from Waldur type/category.
+func (w *WaldurOfferingImport) ResolveCategory(cfg IngestConfig) OfferingCategory {
+	// First try type mapping
+	if cat, ok := cfg.TypeMap[w.Type]; ok {
+		return cat
+	}
+
+	// Then try category UUID mapping
+	if cat, ok := cfg.CategoryMap[w.CategoryUUID]; ok {
+		return cat
+	}
+
+	// Try to infer from type string
+	typeLower := strings.ToLower(w.Type)
+	switch {
+	case strings.Contains(typeLower, "compute") || strings.Contains(typeLower, "vm"):
+		return OfferingCategoryCompute
+	case strings.Contains(typeLower, "storage") || strings.Contains(typeLower, "volume"):
+		return OfferingCategoryStorage
+	case strings.Contains(typeLower, "network"):
+		return OfferingCategoryNetwork
+	case strings.Contains(typeLower, "hpc") || strings.Contains(typeLower, "slurm"):
+		return OfferingCategoryHPC
+	case strings.Contains(typeLower, "gpu"):
+		return OfferingCategoryGPU
+	case strings.Contains(typeLower, "ml") || strings.Contains(typeLower, "machine"):
+		return OfferingCategoryML
+	}
+
+	return OfferingCategoryOther
+}
+
+// ResolveState resolves the VirtEngine offering state from Waldur state.
+func (w *WaldurOfferingImport) ResolveState() OfferingState {
+	switch w.State {
+	case "Active":
+		return OfferingStateActive
+	case "Paused":
+		return OfferingStatePaused
+	case "Archived":
+		return OfferingStateTerminated
+	default:
+		return OfferingStatePaused
+	}
+}
+
+// ResolvePricing extracts pricing information from Waldur components.
+func (w *WaldurOfferingImport) ResolvePricing(cfg IngestConfig) PricingInfo {
+	pricing := PricingInfo{
+		Model:      PricingModelHourly,
+		Currency:   cfg.DefaultCurrency,
+		UsageRates: make(map[string]uint64),
+	}
+
+	for _, comp := range w.Components {
+		price := denormalizePrice(comp.Price, cfg.CurrencyDenominator)
+
+		if comp.Name == "base" || comp.Type == "fixed" {
+			pricing.BasePrice = price
+			pricing.Model = resolvePricingModel(comp.BillingType)
+		} else {
+			pricing.UsageRates[comp.Name] = price
+			if pricing.Model == PricingModelHourly && comp.BillingType == "usage" {
+				pricing.Model = PricingModelUsageBased
+			}
+		}
+	}
+
+	return pricing
+}
+
+// ExtractRegions extracts region codes from Waldur attributes.
+func (w *WaldurOfferingImport) ExtractRegions(cfg IngestConfig) []string {
+	var regions []string
+
+	if regionsAttr, ok := w.Attributes["regions"]; ok {
+		if regArr, ok := regionsAttr.([]interface{}); ok {
+			for _, r := range regArr {
+				if rStr, ok := r.(string); ok {
+					regions = append(regions, rStr)
+				}
+			}
+		}
+	}
+
+	// Map Waldur location UUIDs to chain region codes
+	if locations, ok := w.Attributes["locations"]; ok {
+		if locArr, ok := locations.([]interface{}); ok {
+			for _, loc := range locArr {
+				if locStr, ok := loc.(string); ok {
+					if region, ok := cfg.RegionMap[locStr]; ok {
+						regions = append(regions, region)
+					}
+				}
+			}
+		}
+	}
+
+	return regions
+}
+
+// ExtractTags extracts tags from Waldur attributes.
+func (w *WaldurOfferingImport) ExtractTags() []string {
+	var tags []string
+
+	if tagsAttr, ok := w.Attributes["tags"]; ok {
+		if tagArr, ok := tagsAttr.([]interface{}); ok {
+			for _, t := range tagArr {
+				if tStr, ok := t.(string); ok {
+					tags = append(tags, tStr)
+				}
+			}
+		}
+	}
+
+	return tags
+}
+
+// ExtractSpecifications extracts specifications from Waldur attributes.
+func (w *WaldurOfferingImport) ExtractSpecifications() map[string]string {
+	specs := make(map[string]string)
+
+	for key, value := range w.Attributes {
+		if strings.HasPrefix(key, "spec_") {
+			specKey := strings.TrimPrefix(key, "spec_")
+			if strVal, ok := value.(string); ok {
+				specs[specKey] = strVal
+			} else {
+				specs[specKey] = fmt.Sprintf("%v", value)
+			}
+		}
+	}
+
+	return specs
+}
+
+// ExtractPublicMetadata extracts public metadata from Waldur attributes.
+func (w *WaldurOfferingImport) ExtractPublicMetadata() map[string]string {
+	meta := make(map[string]string)
+
+	for key, value := range w.Attributes {
+		if strings.HasPrefix(key, "ve_") && !isReservedAttribute(key) {
+			metaKey := strings.TrimPrefix(key, "ve_")
+			if strVal, ok := value.(string); ok {
+				meta[metaKey] = strVal
+			} else {
+				meta[metaKey] = fmt.Sprintf("%v", value)
+			}
+		}
+	}
+
+	return meta
+}
+
+// ExtractIdentityRequirements extracts identity requirements from Waldur attributes.
+func (w *WaldurOfferingImport) ExtractIdentityRequirements() IdentityRequirement {
+	req := DefaultIdentityRequirement()
+
+	if minScore, ok := w.Attributes["ve_min_identity_score"]; ok {
+		switch v := minScore.(type) {
+		case float64:
+			req.MinScore = uint32(v)
+		case int:
+			req.MinScore = uint32(v)
+		}
+	}
+
+	if requireMFA, ok := w.Attributes["ve_require_mfa"]; ok {
+		if mfa, ok := requireMFA.(bool); ok {
+			req.RequireMFA = mfa
+		}
+	}
+
+	return req
+}
+
+// ToOffering converts a Waldur offering import to an on-chain Offering.
+func (w *WaldurOfferingImport) ToOffering(providerAddr string, sequence uint64, cfg IngestConfig) *Offering {
+	return w.ToOfferingAt(providerAddr, sequence, cfg, time.Now())
+}
+
+// ToOfferingAt converts a Waldur offering import to an on-chain Offering with a specific timestamp.
+func (w *WaldurOfferingImport) ToOfferingAt(providerAddr string, sequence uint64, cfg IngestConfig, now time.Time) *Offering {
+	id := OfferingID{
+		ProviderAddress: providerAddr,
+		Sequence:        sequence,
+	}
+
+	category := w.ResolveCategory(cfg)
+	pricing := w.ResolvePricing(cfg)
+	createdAt := now.UTC()
+
+	offering := &Offering{
+		ID:                  id,
+		State:               w.ResolveState(),
+		Category:            category,
+		Name:                w.Name,
+		Description:         w.Description,
+		Version:             "1.0.0",
+		Pricing:             pricing,
+		IdentityRequirement: w.ExtractIdentityRequirements(),
+		PublicMetadata:      w.ExtractPublicMetadata(),
+		Specifications:      w.ExtractSpecifications(),
+		Tags:                w.ExtractTags(),
+		Regions:             w.ExtractRegions(cfg),
+		CreatedAt:           createdAt,
+		UpdatedAt:           createdAt,
+	}
+
+	// Extract max concurrent orders
+	if maxOrders, ok := w.Attributes["ve_max_concurrent_orders"]; ok {
+		switch v := maxOrders.(type) {
+		case float64:
+			offering.MaxConcurrentOrders = uint32(v)
+		case int:
+			offering.MaxConcurrentOrders = uint32(v)
+		}
+	}
+
+	// Extract MFA requirement
+	if requireMFA, ok := w.Attributes["ve_require_mfa"]; ok {
+		if mfa, ok := requireMFA.(bool); ok {
+			offering.RequireMFAForOrders = mfa
+		}
+	}
+
+	// Set activated timestamp if active
+	if offering.State == OfferingStateActive {
+		offering.ActivatedAt = &createdAt
+	}
+
+	return offering
+}
+
+// IngestChecksum computes a deterministic checksum for drift detection.
+func (w *WaldurOfferingImport) IngestChecksum() string {
+	h := sha256.New()
+
+	h.Write([]byte(w.UUID))
+	h.Write([]byte(w.Name))
+	h.Write([]byte(w.Description))
+	h.Write([]byte(w.Type))
+	h.Write([]byte(w.State))
+	h.Write([]byte(w.CategoryUUID))
+	h.Write([]byte(w.CustomerUUID))
+	h.Write([]byte(fmt.Sprintf("%t", w.Shared)))
+	h.Write([]byte(fmt.Sprintf("%t", w.Billable)))
+	h.Write([]byte(fmt.Sprintf("%d", w.Modified.Unix())))
+
+	for _, comp := range w.Components {
+		h.Write([]byte(comp.Name))
+		h.Write([]byte(comp.Price))
+		h.Write([]byte(comp.Type))
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// IngestSyncRecord tracks the ingestion state of a Waldur offering.
+type IngestSyncRecord struct {
+	// WaldurUUID is the Waldur offering UUID.
+	WaldurUUID string `json:"waldur_uuid"`
+
+	// ChainOfferingID is the on-chain offering ID (if created).
+	ChainOfferingID string `json:"chain_offering_id,omitempty"`
+
+	// State is the current ingestion state.
+	State IngestState `json:"state"`
+
+	// WaldurVersion is a hash of the Waldur data at last ingest.
+	WaldurVersion string `json:"waldur_version"`
+
+	// ChainVersion is the on-chain offering version.
+	ChainVersion uint64 `json:"chain_version"`
+
+	// LastIngestedAt is when the offering was last ingested.
+	LastIngestedAt *time.Time `json:"last_ingested_at,omitempty"`
+
+	// LastAttemptAt is when ingestion was last attempted.
+	LastAttemptAt *time.Time `json:"last_attempt_at,omitempty"`
+
+	// LastError is the most recent error message.
+	LastError string `json:"last_error,omitempty"`
+
+	// RetryCount is the number of consecutive retry attempts.
+	RetryCount int `json:"retry_count"`
+
+	// NextRetryAt is when the next retry should be attempted.
+	NextRetryAt *time.Time `json:"next_retry_at,omitempty"`
+
+	// ProviderAddress is the resolved provider address.
+	ProviderAddress string `json:"provider_address"`
+
+	// CreatedAt is when this record was first created.
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// IngestState represents the ingestion state of a Waldur offering.
+type IngestState string
+
+const (
+	// IngestStatePending indicates ingestion is pending.
+	IngestStatePending IngestState = "pending"
+
+	// IngestStateIngested indicates offering is ingested on-chain.
+	IngestStateIngested IngestState = "ingested"
+
+	// IngestStateFailed indicates last ingestion attempt failed.
+	IngestStateFailed IngestState = "failed"
+
+	// IngestStateRetrying indicates ingestion is being retried.
+	IngestStateRetrying IngestState = "retrying"
+
+	// IngestStateDeadLettered indicates ingestion failed permanently.
+	IngestStateDeadLettered IngestState = "dead_lettered"
+
+	// IngestStateOutOfSync indicates Waldur data changed since last ingest.
+	IngestStateOutOfSync IngestState = "out_of_sync"
+
+	// IngestStateSkipped indicates offering was intentionally skipped.
+	IngestStateSkipped IngestState = "skipped"
+
+	// IngestStateDeprecated indicates the Waldur offering was archived.
+	IngestStateDeprecated IngestState = "deprecated"
+)
+
+// IngestResult represents the result of an ingestion operation.
+type IngestResult struct {
+	// WaldurUUID is the Waldur offering UUID.
+	WaldurUUID string `json:"waldur_uuid"`
+
+	// ChainOfferingID is the on-chain offering ID (on success).
+	ChainOfferingID string `json:"chain_offering_id,omitempty"`
+
+	// Action is the ingestion action performed (create, update, deprecate).
+	Action IngestAction `json:"action"`
+
+	// Success indicates if the ingestion succeeded.
+	Success bool `json:"success"`
+
+	// Error is the error message on failure.
+	Error string `json:"error,omitempty"`
+
+	// Checksum is the data checksum after ingestion.
+	Checksum string `json:"checksum,omitempty"`
+
+	// Timestamp is when the ingestion completed.
+	Timestamp time.Time `json:"timestamp"`
+
+	// RetryCount is the number of retries attempted.
+	RetryCount int `json:"retry_count"`
+
+	// Duration is how long the ingestion took.
+	Duration time.Duration `json:"duration_ns"`
+}
+
+// IngestAction represents the ingestion action to perform.
+type IngestAction string
+
+const (
+	// IngestActionCreate creates a new on-chain offering.
+	IngestActionCreate IngestAction = "create"
+
+	// IngestActionUpdate updates an existing on-chain offering.
+	IngestActionUpdate IngestAction = "update"
+
+	// IngestActionDeprecate deprecates an on-chain offering.
+	IngestActionDeprecate IngestAction = "deprecate"
+
+	// IngestActionSkip skips ingestion (validation failed).
+	IngestActionSkip IngestAction = "skip"
+)
+
+// IngestMetrics tracks ingestion operation metrics.
+type IngestMetrics struct {
+	// TotalIngests is the total ingestion attempts.
+	TotalIngests int64 `json:"total_ingests"`
+
+	// SuccessfulIngests is the count of successful ingestions.
+	SuccessfulIngests int64 `json:"successful_ingests"`
+
+	// FailedIngests is the count of failed ingestion attempts.
+	FailedIngests int64 `json:"failed_ingests"`
+
+	// DeadLetteredIngests is the count of dead-lettered ingestions.
+	DeadLetteredIngests int64 `json:"dead_lettered_ingests"`
+
+	// SkippedIngests is the count of skipped ingestions.
+	SkippedIngests int64 `json:"skipped_ingests"`
+
+	// DriftDetections is the count of drift detections.
+	DriftDetections int64 `json:"drift_detections"`
+
+	// ReconciliationsRun is the count of reconciliation runs.
+	ReconciliationsRun int64 `json:"reconciliations_run"`
+
+	// LastIngestTime is the timestamp of the last ingestion attempt.
+	LastIngestTime time.Time `json:"last_ingest_time"`
+
+	// LastSuccessTime is the timestamp of the last successful ingestion.
+	LastSuccessTime time.Time `json:"last_success_time"`
+
+	// LastReconcileTime is the timestamp of the last reconciliation.
+	LastReconcileTime time.Time `json:"last_reconcile_time"`
+
+	// AverageIngestDurationMs is the average ingestion duration in milliseconds.
+	AverageIngestDurationMs float64 `json:"average_ingest_duration_ms"`
+
+	// OfferingsIngested is the count of offerings successfully ingested.
+	OfferingsIngested int64 `json:"offerings_ingested"`
+
+	// OfferingsUpdated is the count of offerings updated.
+	OfferingsUpdated int64 `json:"offerings_updated"`
+
+	// OfferingsDeprecated is the count of offerings deprecated.
+	OfferingsDeprecated int64 `json:"offerings_deprecated"`
+}
+
+// Helper functions
+
+// denormalizePrice converts a decimal string price to smallest token denomination.
+func denormalizePrice(priceStr string, denominator uint64) uint64 {
+	if denominator == 0 {
+		denominator = 1000000
+	}
+
+	// Parse the price string
+	priceStr = strings.TrimSpace(priceStr)
+	if priceStr == "" {
+		return 0
+	}
+
+	// Handle integer prices
+	if !strings.Contains(priceStr, ".") {
+		intVal, err := strconv.ParseUint(priceStr, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return intVal * denominator
+	}
+
+	// Split on decimal point
+	parts := strings.Split(priceStr, ".")
+	if len(parts) != 2 {
+		return 0
+	}
+
+	intPart, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	// Pad or truncate fractional part to 6 digits
+	fracStr := parts[1]
+	for len(fracStr) < 6 {
+		fracStr += "0"
+	}
+	if len(fracStr) > 6 {
+		fracStr = fracStr[:6]
+	}
+
+	fracPart, err := strconv.ParseUint(fracStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return intPart*denominator + fracPart
+}
+
+// resolvePricingModel maps Waldur billing type to VirtEngine pricing model.
+func resolvePricingModel(billingType string) PricingModel {
+	switch strings.ToLower(billingType) {
+	case "usage":
+		return PricingModelHourly
+	case "monthly":
+		return PricingModelMonthly
+	case "fixed", "one":
+		return PricingModelFixed
+	default:
+		return PricingModelHourly
+	}
+}
+
+// isReservedAttribute returns true if the attribute key is reserved.
+func isReservedAttribute(key string) bool {
+	reserved := map[string]bool{
+		"ve_offering_id":          true,
+		"ve_provider":             true,
+		"ve_category":             true,
+		"ve_version":              true,
+		"ve_min_identity_score":   true,
+		"ve_require_mfa":          true,
+		"ve_max_concurrent_orders": true,
+	}
+	return reserved[key]
+}
+
+// Ingestion event types (extend the events in events.go)
+const (
+	// EventOfferingIngested is emitted when an offering is ingested from Waldur.
+	EventOfferingIngested MarketplaceEventType = "offering_ingested"
+
+	// EventOfferingIngestFailed is emitted when an offering ingestion fails.
+	EventOfferingIngestFailed MarketplaceEventType = "offering_ingest_failed"
+)


### PR DESCRIPTION
Objective:
Import Waldur offerings/services into on-chain marketplace for decentralized listing visibility.

Prerequisites:
- 1D feat(market): define chain<->Waldur mapping + policy spec

Needs to be done (A–H):
A. Define ingestion mapping from Waldur listing fields to x/market offering schema.
B. Implement ingestion job with pagination, filtering, and rate limiting.
C. Validate provider ownership and VEID requirements before on-chain insertion.
D. Normalize pricing, regions, and resource specs.
E. Handle updates and deprecations with sync state tracking.
F. Provide reconciliation job for drift detection.
G. Add audit logs and metrics.
H. Document ingestion schedule and operational controls.

Acceptance criteria:
- Waldur listings appear on-chain with normalized fields.
- Ownership and VEID validation enforced.
- Updates/deprecations synchronized.
- Repeatable ingestion job with audit logs.

How it can be done:
- Use pkg/waldur marketplace client for list queries.
- Create ingestion worker (cron or daemon) with checkpointing.
- Store sync state via WaldurSyncRecord.
- Add tests with sample Waldur payloads.

MCP guidance:
- Use Context7 for Waldur client usage.
- Use Exa for normalization strategies.

Deliverables:
- Ingestion worker, mapping schema, sync state handling, and tests.