### PR TITLE
feat(app): integrate Jira/Waldur service desk sync

### DIFF
--- a/_docs/operations/servicedesk-sync.md
+++ b/_docs/operations/servicedesk-sync.md
@@ -1,0 +1,343 @@
+# Service Desk Sync Operations Guide
+
+This document describes the operational aspects of the Jira/Waldur service desk sync feature (VE-3E).
+
+## Overview
+
+The service desk bridge enables bi-directional synchronization between VirtEngine on-chain support tickets and external service desk systems (Jira Service Desk and Waldur).
+
+### Architecture
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌────────────────┐
+│  VirtEngine     │◄───►│  Service Desk    │◄───►│  Jira / Waldur │
+│  On-Chain       │     │  Bridge Service  │     │  External APIs │
+│  Support Module │     │                  │     │                │
+└─────────────────┘     └──────────────────┘     └────────────────┘
+         │                       │                       │
+         │                       ▼                       │
+         │              ┌──────────────────┐             │
+         │              │  Audit Logger    │             │
+         │              └──────────────────┘             │
+         │                       │                       │
+         ▼                       ▼                       ▼
+┌─────────────────┐     ┌──────────────────┐     ┌────────────────┐
+│  Artifact Store │     │  Retry Queue     │     │  Webhook Server│
+│  (Attachments)  │     │                  │     │  (Callbacks)   │
+└─────────────────┘     └──────────────────┘     └────────────────┘
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Jira Configuration
+VIRTENGINE_SERVICEDESK_JIRA_URL=https://company.atlassian.net
+VIRTENGINE_SERVICEDESK_JIRA_USERNAME=service-account
+VIRTENGINE_SERVICEDESK_JIRA_API_TOKEN=<api-token>  # SENSITIVE
+VIRTENGINE_SERVICEDESK_JIRA_PROJECT_KEY=VESUPPORT
+VIRTENGINE_SERVICEDESK_JIRA_WEBHOOK_SECRET=<secret>  # SENSITIVE
+
+# Waldur Configuration
+VIRTENGINE_SERVICEDESK_WALDUR_URL=https://waldur.example.com/api
+VIRTENGINE_SERVICEDESK_WALDUR_TOKEN=<api-token>  # SENSITIVE
+VIRTENGINE_SERVICEDESK_WALDUR_ORG_UUID=<uuid>
+VIRTENGINE_SERVICEDESK_WALDUR_WEBHOOK_SECRET=<secret>  # SENSITIVE
+
+# Sync Configuration
+VIRTENGINE_SERVICEDESK_SYNC_INTERVAL=30s
+VIRTENGINE_SERVICEDESK_SYNC_BATCH_SIZE=50
+VIRTENGINE_SERVICEDESK_CONFLICT_RESOLUTION=on_chain_wins
+
+# Webhook Server
+VIRTENGINE_SERVICEDESK_WEBHOOK_LISTEN=:8480
+VIRTENGINE_SERVICEDESK_WEBHOOK_PATH_PREFIX=/webhooks
+VIRTENGINE_SERVICEDESK_WEBHOOK_REQUIRE_SIGNATURE=true
+```
+
+### YAML Configuration
+
+```yaml
+servicedesk:
+  enabled: true
+  
+  jira:
+    base_url: "https://company.atlassian.net"
+    project_key: "VESUPPORT"
+    issue_type: "Service Request"
+    timeout: 30s
+    # username and api_token from secrets
+  
+  waldur:
+    base_url: "https://waldur.example.com/api"
+    organization_uuid: "org-uuid"
+    timeout: 30s
+    # token from secrets
+  
+  sync:
+    sync_interval: 30s
+    batch_size: 50
+    conflict_resolution: on_chain_wins
+    enable_inbound: true
+    enable_outbound: true
+    sync_attachments: true
+  
+  retry:
+    max_retries: 5
+    initial_backoff: 1s
+    max_backoff: 5m
+    backoff_multiplier: 2.0
+  
+  webhook:
+    enabled: true
+    listen_addr: ":8480"
+    path_prefix: "/webhooks"
+    require_signature: true
+    rate_limit_per_second: 100
+  
+  audit:
+    enabled: true
+    log_level: info
+    retention_days: 90
+```
+
+## Credentials Management
+
+### Secrets Storage
+
+**CRITICAL: Never store credentials in configuration files or environment variables in plain text on disk.**
+
+Recommended approaches:
+
+1. **HashiCorp Vault** (preferred)
+   ```bash
+   vault kv put secret/virtengine/servicedesk \
+     jira_api_token=<token> \
+     jira_webhook_secret=<secret> \
+     waldur_token=<token> \
+     waldur_webhook_secret=<secret>
+   ```
+
+2. **Kubernetes Secrets**
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: virtengine-servicedesk-secrets
+   type: Opaque
+   data:
+     jira-api-token: <base64>
+     jira-webhook-secret: <base64>
+     waldur-token: <base64>
+     waldur-webhook-secret: <base64>
+   ```
+
+3. **AWS Secrets Manager / Azure Key Vault / GCP Secret Manager**
+
+### Rotating Credentials
+
+1. Generate new API tokens in Jira/Waldur
+2. Update secrets in your secrets manager
+3. Restart the service desk bridge service
+4. Verify connectivity with health check endpoint
+5. Revoke old tokens
+
+## Operational Flow
+
+### Outbound Sync (On-Chain → External)
+
+1. User creates support ticket on-chain
+2. `ticket_created` event is emitted
+3. Bridge receives event and queues for sync
+4. Bridge creates ticket in Jira/Waldur with mapped fields
+5. External ticket reference is stored in sync record
+6. Audit entry is logged
+
+### Inbound Sync (External → On-Chain)
+
+1. Agent updates ticket in Jira/Waldur
+2. Webhook is sent to callback server
+3. Signature is verified
+4. Nonce is checked for replay prevention
+5. Conflict detection runs
+6. If no conflict, callback payload is processed
+7. On-chain transaction is created (if enabled)
+8. Audit entry is logged
+
+### Conflict Resolution
+
+| Strategy | Behavior |
+|----------|----------|
+| `on_chain_wins` | On-chain state is authoritative |
+| `external_wins` | External state is authoritative |
+| `newest_wins` | Most recent update wins |
+| `manual` | Requires manual resolution |
+
+## Monitoring
+
+### Health Check Endpoint
+
+```bash
+curl http://localhost:8480/webhooks/health
+```
+
+Response:
+```json
+{
+  "healthy": true,
+  "jira_status": "healthy",
+  "waldur_status": "healthy",
+  "last_sync": "2024-01-15T10:30:00Z",
+  "pending_events": 0,
+  "failed_events": 0
+}
+```
+
+### Metrics
+
+The service exports Prometheus metrics:
+
+- `servicedesk_sync_events_total{direction,status}` - Total sync events
+- `servicedesk_sync_latency_seconds{direction,service}` - Sync latency
+- `servicedesk_api_requests_total{service,method,status}` - API requests
+- `servicedesk_queue_pending` - Pending events in queue
+- `servicedesk_queue_failed` - Failed events
+
+### Alerting
+
+Recommended alerts:
+
+```yaml
+groups:
+  - name: servicedesk
+    rules:
+      - alert: ServiceDeskSyncFailed
+        expr: increase(servicedesk_sync_events_total{status="failed"}[5m]) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Service desk sync failures detected"
+          
+      - alert: ServiceDeskQueueBacklog
+        expr: servicedesk_queue_pending > 100
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Service desk sync queue backlog"
+          
+      - alert: ServiceDeskUnhealthy
+        expr: servicedesk_health_check != 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Service desk bridge unhealthy"
+```
+
+## Webhook Setup
+
+### Jira Webhook Configuration
+
+1. Navigate to Jira Settings → System → Webhooks
+2. Create new webhook with URL: `https://your-domain.com/webhooks/jira`
+3. Set secret for signature verification
+4. Select events:
+   - Issue: created, updated, deleted
+   - Comment: created, updated, deleted
+5. Save and test
+
+### Waldur Webhook Configuration
+
+1. Navigate to Waldur admin panel
+2. Configure webhook endpoint: `https://your-domain.com/webhooks/waldur`
+3. Set secret for signature verification
+4. Enable relevant event types
+5. Save and verify
+
+## Troubleshooting
+
+### Common Issues
+
+#### Sync Delays
+
+- Check network connectivity to external APIs
+- Verify rate limits are not being hit
+- Check retry queue for backed-up events
+- Review audit logs for errors
+
+#### Authentication Failures
+
+- Verify API tokens are valid and not expired
+- Check username/email matches token owner
+- Ensure service account has required permissions
+
+#### Webhook Not Receiving
+
+- Verify webhook URL is publicly accessible
+- Check firewall rules allow incoming connections
+- Verify signature configuration matches
+- Check IP allowlist if configured
+
+#### Conflict Errors
+
+- Review audit log for conflict details
+- Check sync timing and conflict resolution strategy
+- Consider adjusting sync interval
+
+### Log Analysis
+
+```bash
+# View sync errors
+grep "sync failed" /var/log/virtengine/servicedesk.log
+
+# View webhook events
+grep "external callback" /var/log/virtengine/servicedesk.log
+
+# View audit events
+grep "audit" /var/log/virtengine/servicedesk.log | jq
+```
+
+### Manual Sync
+
+To manually trigger sync for a specific ticket:
+
+```bash
+virtengine tx support sync-external <ticket-id> --direction=outbound
+```
+
+## Security Considerations
+
+1. **Never log sensitive data** - API tokens, webhook secrets, and ticket content are never logged
+2. **Signature verification** - All webhooks should require signature verification
+3. **Nonce replay prevention** - Callback nonces prevent replay attacks
+4. **TLS only** - All external API calls use HTTPS
+5. **IP allowlisting** - Consider restricting webhook sources by IP
+6. **Audit logging** - All external actions are logged for compliance
+
+## Disaster Recovery
+
+### Backup Considerations
+
+- Sync records are stored on-chain (immutable)
+- Audit logs should be backed up separately
+- External ticket references are stored on-chain
+
+### Recovery Procedure
+
+1. If bridge service fails, events are queued for retry
+2. On restart, pending events are processed
+3. Manual sync can reconcile any missed updates
+4. Audit log provides recovery information
+
+## Capacity Planning
+
+| Metric | Recommended Limit |
+|--------|-------------------|
+| Tickets per day | 10,000 |
+| Sync interval | 30s minimum |
+| Batch size | 50-100 |
+| Retry queue | 10,000 events |
+| Webhook rate | 100 req/s |

--- a/pkg/jira/bridge.go
+++ b/pkg/jira/bridge.go
@@ -8,7 +8,6 @@
 package jira
 
 import (
-	verrors "github.com/virtengine/virtengine/pkg/errors"
 	"context"
 	"fmt"
 	"strings"

--- a/pkg/jira/client.go
+++ b/pkg/jira/client.go
@@ -7,7 +7,6 @@
 package jira
 
 import (
-	verrors "github.com/virtengine/virtengine/pkg/errors"
 	"bytes"
 	"context"
 	"encoding/json"

--- a/pkg/jira/service.go
+++ b/pkg/jira/service.go
@@ -7,7 +7,6 @@
 package jira
 
 import (
-	verrors "github.com/virtengine/virtengine/pkg/errors"
 	"context"
 	"fmt"
 	"sync"

--- a/pkg/jira/sla.go
+++ b/pkg/jira/sla.go
@@ -7,7 +7,6 @@
 package jira
 
 import (
-	verrors "github.com/virtengine/virtengine/pkg/errors"
 	"context"
 	"fmt"
 	"sync"

--- a/pkg/jira/webhook.go
+++ b/pkg/jira/webhook.go
@@ -7,7 +7,6 @@
 package jira
 
 import (
-	verrors "github.com/virtengine/virtengine/pkg/errors"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"

--- a/pkg/servicedesk/attachments.go
+++ b/pkg/servicedesk/attachments.go
@@ -1,0 +1,439 @@
+package servicedesk
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"time"
+
+	"cosmossdk.io/log"
+
+	"github.com/virtengine/virtengine/pkg/artifact_store"
+)
+
+// AttachmentHandler handles attachment synchronization via the artifact store
+type AttachmentHandler struct {
+	store  artifact_store.ArtifactStore
+	config AttachmentConfig
+	logger log.Logger
+}
+
+// AttachmentConfig holds attachment handling configuration
+type AttachmentConfig struct {
+	// MaxSize is the maximum attachment size in bytes
+	MaxSize int64 `json:"max_size"`
+
+	// AllowedTypes are allowed MIME types
+	AllowedTypes []string `json:"allowed_types"`
+
+	// AccessTokenTTL is the TTL for temporary access tokens
+	AccessTokenTTL time.Duration `json:"access_token_ttl"`
+
+	// EncryptionRequired requires attachments to be encrypted
+	EncryptionRequired bool `json:"encryption_required"`
+}
+
+// DefaultAttachmentConfig returns default attachment configuration
+func DefaultAttachmentConfig() AttachmentConfig {
+	return AttachmentConfig{
+		MaxSize: 10 * 1024 * 1024, // 10 MB
+		AllowedTypes: []string{
+			"image/jpeg",
+			"image/png",
+			"image/gif",
+			"application/pdf",
+			"text/plain",
+			"application/json",
+			"application/zip",
+		},
+		AccessTokenTTL:     1 * time.Hour,
+		EncryptionRequired: true,
+	}
+}
+
+// NewAttachmentHandler creates a new attachment handler
+func NewAttachmentHandler(store artifact_store.ArtifactStore, config AttachmentConfig, logger log.Logger) *AttachmentHandler {
+	return &AttachmentHandler{
+		store:  store,
+		config: config,
+		logger: logger.With("component", "attachments"),
+	}
+}
+
+// UploadAttachment uploads an attachment to the artifact store
+func (h *AttachmentHandler) UploadAttachment(ctx context.Context, req *UploadAttachmentRequest) (*UploadAttachmentResponse, error) {
+	if err := h.validateUpload(req); err != nil {
+		return nil, err
+	}
+
+	// Read the attachment data
+	data, err := io.ReadAll(req.Reader)
+	if err != nil {
+		return nil, ErrAttachmentFailed.Wrapf("failed to read attachment: %v", err)
+	}
+
+	// Check size
+	if int64(len(data)) > h.config.MaxSize {
+		return nil, ErrAttachmentFailed.Wrapf("attachment exceeds max size of %d bytes", h.config.MaxSize)
+	}
+
+	// Compute content hash
+	contentHash := sha256.Sum256(data)
+
+	// Store in artifact store
+	putReq := &artifact_store.PutRequest{
+		Data:         data,
+		ContentHash:  contentHash[:],
+		Owner:        req.Owner,
+		ArtifactType: "support_attachment",
+		Metadata: map[string]string{
+			"ticket_id":    req.TicketID,
+			"file_name":    req.FileName,
+			"content_type": req.ContentType,
+		},
+		EncryptionMetadata: &artifact_store.EncryptionMetadata{
+			AlgorithmID:     "X25519-XSalsa20-Poly1305",
+			RecipientKeyIDs: []string{req.EncryptionKeyID},
+		},
+	}
+
+	resp, err := h.store.Put(ctx, putReq)
+	if err != nil {
+		return nil, ErrAttachmentFailed.Wrapf("failed to store attachment: %v", err)
+	}
+
+	// Generate access token
+	accessToken, expiresAt := h.generateAccessToken()
+
+	h.logger.Debug("attachment uploaded",
+		"ticket_id", req.TicketID,
+		"file_name", req.FileName,
+		"size", len(data),
+		"content_address", resp.ContentAddress.HashHex(),
+	)
+
+	return &UploadAttachmentResponse{
+		ArtifactAddress: resp.ContentAddress.HashHex(),
+		AccessToken:     accessToken,
+		ExpiresAt:       expiresAt,
+	}, nil
+}
+
+// GetAttachment retrieves an attachment from the artifact store
+func (h *AttachmentHandler) GetAttachment(ctx context.Context, req *GetAttachmentRequest) (*GetAttachmentResponse, error) {
+	// Parse content address from hex string
+	hashBytes, err := hex.DecodeString(req.ArtifactAddress)
+	if err != nil {
+		return nil, ErrAttachmentFailed.Wrapf("invalid artifact address: %v", err)
+	}
+
+	// Create content address from hash
+	contentAddr := artifact_store.NewContentAddressFromHash(
+		hashBytes,
+		0, // Size unknown from hash alone
+		artifact_store.BackendWaldur,
+		req.ArtifactAddress,
+	)
+
+	// Verify access token (in production, would validate cryptographically)
+	if req.AccessToken == "" {
+		return nil, ErrAttachmentFailed.Wrap("access token required")
+	}
+
+	// Retrieve from artifact store
+	getReq := &artifact_store.GetRequest{
+		ContentAddress:    contentAddr,
+		RequestingAccount: req.RequestingAccount,
+		AuthToken:         req.AccessToken,
+	}
+
+	resp, err := h.store.Get(ctx, getReq)
+	if err != nil {
+		return nil, ErrAttachmentFailed.Wrapf("failed to retrieve attachment: %v", err)
+	}
+
+	h.logger.Debug("attachment retrieved",
+		"artifact_address", req.ArtifactAddress,
+	)
+
+	return &GetAttachmentResponse{
+		Data:        resp.Data,
+		ContentType: "", // Would be stored in metadata
+	}, nil
+}
+
+// SyncAttachmentToExternal syncs an attachment to an external service desk
+func (h *AttachmentHandler) SyncAttachmentToExternal(ctx context.Context, req *AttachmentSyncRequest) (*AttachmentSyncResponse, error) {
+	h.logger.Debug("syncing attachment to external",
+		"ticket_id", req.TicketID,
+		"artifact_address", req.ArtifactAddress,
+		"service_desk", req.ServiceDeskType,
+	)
+
+	// Generate temporary access token for external system
+	accessToken, expiresAt := h.generateAccessToken()
+
+	// In a full implementation, this would:
+	// 1. Generate a time-limited signed URL for the attachment
+	// 2. Call the external API to upload/link the attachment
+	// 3. Track the external attachment ID
+
+	return &AttachmentSyncResponse{
+		AttachmentSync: AttachmentSync{
+			TicketID:        req.TicketID,
+			ArtifactAddress: req.ArtifactAddress,
+			FileName:        req.FileName,
+			ContentType:     req.ContentType,
+			Size:            req.Size,
+			AccessToken:     accessToken,
+			ExpiresAt:       &expiresAt,
+		},
+		SyncStatus: SyncStatusPending,
+	}, nil
+}
+
+// DeleteAttachment deletes an attachment from the artifact store
+func (h *AttachmentHandler) DeleteAttachment(ctx context.Context, req *DeleteAttachmentRequest) error {
+	// Parse content address from hex string
+	hashBytes, err := hex.DecodeString(req.ArtifactAddress)
+	if err != nil {
+		return ErrAttachmentFailed.Wrapf("invalid artifact address: %v", err)
+	}
+
+	// Create content address from hash
+	contentAddr := artifact_store.NewContentAddressFromHash(
+		hashBytes,
+		0, // Size unknown from hash alone
+		artifact_store.BackendWaldur,
+		req.ArtifactAddress,
+	)
+
+	// Delete from artifact store
+	delReq := &artifact_store.DeleteRequest{
+		ContentAddress:    contentAddr,
+		RequestingAccount: req.RequestingAccount,
+		Force:             req.Force,
+	}
+
+	if err := h.store.Delete(ctx, delReq); err != nil {
+		return ErrAttachmentFailed.Wrapf("failed to delete attachment: %v", err)
+	}
+
+	h.logger.Debug("attachment deleted",
+		"artifact_address", req.ArtifactAddress,
+	)
+
+	return nil
+}
+
+// ListAttachments lists attachments for a ticket
+func (h *AttachmentHandler) ListAttachments(ctx context.Context, ticketID string, owner string) ([]*AttachmentInfo, error) {
+	// List from artifact store by owner
+	listResp, err := h.store.ListByOwner(ctx, owner, &artifact_store.Pagination{
+		Limit: 100,
+	})
+	if err != nil {
+		return nil, ErrAttachmentFailed.Wrapf("failed to list attachments: %v", err)
+	}
+
+	// Filter by ticket ID
+	var attachments []*AttachmentInfo
+	for _, ref := range listResp.References {
+		if ref.Metadata["ticket_id"] == ticketID {
+			attachments = append(attachments, &AttachmentInfo{
+				ArtifactAddress: ref.ContentAddress.HashHex(),
+				FileName:        ref.Metadata["file_name"],
+				ContentType:     ref.Metadata["content_type"],
+				Size:            int64(ref.ContentAddress.Size),
+				CreatedAt:       ref.CreatedAt,
+			})
+		}
+	}
+
+	return attachments, nil
+}
+
+// validateUpload validates an upload request
+func (h *AttachmentHandler) validateUpload(req *UploadAttachmentRequest) error {
+	if req.TicketID == "" {
+		return ErrAttachmentFailed.Wrap("ticket_id is required")
+	}
+	if req.FileName == "" {
+		return ErrAttachmentFailed.Wrap("file_name is required")
+	}
+	if req.Owner == "" {
+		return ErrAttachmentFailed.Wrap("owner is required")
+	}
+	if req.Reader == nil {
+		return ErrAttachmentFailed.Wrap("reader is required")
+	}
+
+	// Check content type
+	if req.ContentType != "" && len(h.config.AllowedTypes) > 0 {
+		allowed := false
+		for _, t := range h.config.AllowedTypes {
+			if t == req.ContentType {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return ErrAttachmentFailed.Wrapf("content type %s not allowed", req.ContentType)
+		}
+	}
+
+	// Check encryption requirement
+	if h.config.EncryptionRequired && req.EncryptionKeyID == "" {
+		return ErrAttachmentFailed.Wrap("encryption key required")
+	}
+
+	return nil
+}
+
+// generateAccessToken generates a temporary access token
+func (h *AttachmentHandler) generateAccessToken() (string, time.Time) {
+	token := make([]byte, 32)
+	_, _ = rand.Read(token)
+	expiresAt := time.Now().Add(h.config.AccessTokenTTL)
+	return hex.EncodeToString(token), expiresAt
+}
+
+// UploadAttachmentRequest contains parameters for uploading an attachment
+type UploadAttachmentRequest struct {
+	// TicketID is the ticket to attach to
+	TicketID string
+
+	// FileName is the original file name
+	FileName string
+
+	// ContentType is the MIME content type
+	ContentType string
+
+	// Owner is the account that owns the attachment
+	Owner string
+
+	// Reader provides the attachment data
+	Reader io.Reader
+
+	// EncryptionKeyID is the key ID for encryption
+	EncryptionKeyID string
+}
+
+// UploadAttachmentResponse contains the upload result
+type UploadAttachmentResponse struct {
+	// ArtifactAddress is the content-addressed reference
+	ArtifactAddress string
+
+	// AccessToken is a temporary access token
+	AccessToken string
+
+	// ExpiresAt is when the access token expires
+	ExpiresAt time.Time
+}
+
+// GetAttachmentRequest contains parameters for retrieving an attachment
+type GetAttachmentRequest struct {
+	// ArtifactAddress is the content address (hex-encoded hash)
+	ArtifactAddress string
+
+	// AccessToken is the access token
+	AccessToken string
+
+	// RequestingAccount is the account requesting access
+	RequestingAccount string
+}
+
+// GetAttachmentResponse contains the retrieved attachment
+type GetAttachmentResponse struct {
+	// Data is the attachment data (encrypted)
+	Data []byte
+
+	// ContentType is the MIME content type
+	ContentType string
+}
+
+// DeleteAttachmentRequest contains parameters for deleting an attachment
+type DeleteAttachmentRequest struct {
+	// ArtifactAddress is the content address (hex-encoded hash)
+	ArtifactAddress string
+
+	// RequestingAccount is the account requesting deletion
+	RequestingAccount string
+
+	// Force forces deletion even if not expired
+	Force bool
+}
+
+// AttachmentSyncRequest contains parameters for syncing an attachment
+type AttachmentSyncRequest struct {
+	// TicketID is the on-chain ticket ID
+	TicketID string
+
+	// ArtifactAddress is the artifact store address
+	ArtifactAddress string
+
+	// FileName is the file name
+	FileName string
+
+	// ContentType is the MIME type
+	ContentType string
+
+	// Size is the file size
+	Size int64
+
+	// ServiceDeskType is the target service desk
+	ServiceDeskType ServiceDeskType
+
+	// ExternalTicketID is the external ticket ID
+	ExternalTicketID string
+}
+
+// AttachmentSyncResponse contains the sync result
+type AttachmentSyncResponse struct {
+	// AttachmentSync is the sync record
+	AttachmentSync AttachmentSync
+
+	// SyncStatus is the status
+	SyncStatus SyncStatus
+
+	// Error is any error
+	Error string
+}
+
+// AttachmentInfo contains attachment metadata
+type AttachmentInfo struct {
+	// ArtifactAddress is the content address (hex-encoded hash)
+	ArtifactAddress string `json:"artifact_address"`
+
+	// FileName is the original file name
+	FileName string `json:"file_name"`
+
+	// ContentType is the MIME type
+	ContentType string `json:"content_type"`
+
+	// Size is the file size
+	Size int64 `json:"size"`
+
+	// CreatedAt is when the attachment was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// ExternalRefs are external attachment references
+	ExternalRefs []ExternalAttachmentRef `json:"external_refs,omitempty"`
+}
+
+// ExternalAttachmentRef references an external attachment
+type ExternalAttachmentRef struct {
+	// ServiceDeskType is the service desk type
+	ServiceDeskType ServiceDeskType `json:"service_desk_type"`
+
+	// ExternalID is the external attachment ID
+	ExternalID string `json:"external_id"`
+
+	// ExternalURL is the URL to the external attachment
+	ExternalURL string `json:"external_url,omitempty"`
+
+	// SyncedAt is when the attachment was synced
+	SyncedAt time.Time `json:"synced_at"`
+}

--- a/pkg/servicedesk/audit.go
+++ b/pkg/servicedesk/audit.go
@@ -1,0 +1,332 @@
+package servicedesk
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"cosmossdk.io/log"
+)
+
+// AuditEventType represents types of audit events
+type AuditEventType string
+
+const (
+	// Ticket lifecycle events
+	AuditEventTicketCreate AuditEventType = "ticket_create"
+	AuditEventTicketUpdate AuditEventType = "ticket_update"
+	AuditEventTicketClose  AuditEventType = "ticket_close"
+
+	// Sync events
+	AuditEventSyncSuccess       AuditEventType = "sync_success"
+	AuditEventSyncFailed        AuditEventType = "sync_failed"
+	AuditEventConflictDetected  AuditEventType = "conflict_detected"
+	AuditEventConflictResolved  AuditEventType = "conflict_resolved"
+
+	// External events
+	AuditEventExternalCallback  AuditEventType = "external_callback"
+	AuditEventAttachmentSync    AuditEventType = "attachment_sync"
+
+	// Admin events
+	AuditEventManualSync        AuditEventType = "manual_sync"
+	AuditEventConfigChange      AuditEventType = "config_change"
+)
+
+// AuditEntry represents an audit log entry
+type AuditEntry struct {
+	// ID is the unique entry ID
+	ID string `json:"id"`
+
+	// Timestamp is when the event occurred
+	Timestamp time.Time `json:"timestamp"`
+
+	// EventType is the type of event
+	EventType AuditEventType `json:"event_type"`
+
+	// TicketID is the related ticket ID (if applicable)
+	TicketID string `json:"ticket_id,omitempty"`
+
+	// Actor is who performed the action
+	Actor string `json:"actor,omitempty"`
+
+	// ServiceDesk is the external service desk (if applicable)
+	ServiceDesk ServiceDeskType `json:"service_desk,omitempty"`
+
+	// ExternalID is the external ticket ID (if applicable)
+	ExternalID string `json:"external_id,omitempty"`
+
+	// Direction is the sync direction
+	Direction SyncDirection `json:"direction,omitempty"`
+
+	// Status indicates success or failure
+	Status string `json:"status"`
+
+	// Details contains additional event details
+	Details map[string]interface{} `json:"details,omitempty"`
+
+	// Error contains error information (if failed)
+	Error string `json:"error,omitempty"`
+
+	// BlockHeight is the on-chain block height (if applicable)
+	BlockHeight int64 `json:"block_height,omitempty"`
+
+	// TxHash is the transaction hash (if applicable)
+	TxHash string `json:"tx_hash,omitempty"`
+}
+
+// AuditLogger handles audit logging for the service desk bridge
+type AuditLogger struct {
+	config AuditConfig
+	logger log.Logger
+
+	// In-memory storage (would use persistent storage in production)
+	mu      sync.RWMutex
+	entries []AuditEntry
+	seq     int64
+}
+
+// NewAuditLogger creates a new audit logger
+func NewAuditLogger(config AuditConfig, logger log.Logger) *AuditLogger {
+	return &AuditLogger{
+		config:  config,
+		logger:  logger.With("component", "audit"),
+		entries: make([]AuditEntry, 0),
+	}
+}
+
+// LogEvent logs an audit event
+func (a *AuditLogger) LogEvent(ctx context.Context, eventType AuditEventType, details map[string]interface{}) {
+	if !a.config.Enabled {
+		return
+	}
+
+	entry := AuditEntry{
+		ID:        a.generateID(),
+		Timestamp: time.Now().UTC(),
+		EventType: eventType,
+		Status:    "success",
+		Details:   details,
+	}
+
+	// Extract common fields from details
+	if ticketID, ok := details["ticket_id"].(string); ok {
+		entry.TicketID = ticketID
+	}
+	if actor, ok := details["actor"].(string); ok {
+		entry.Actor = actor
+	}
+	if service, ok := details["service_desk"].(ServiceDeskType); ok {
+		entry.ServiceDesk = service
+	}
+	if externalID, ok := details["external_id"].(string); ok {
+		entry.ExternalID = externalID
+	}
+	if direction, ok := details["direction"].(SyncDirection); ok {
+		entry.Direction = direction
+	}
+	if blockHeight, ok := details["block_height"].(int64); ok {
+		entry.BlockHeight = blockHeight
+	}
+	if txHash, ok := details["tx_hash"].(string); ok {
+		entry.TxHash = txHash
+	}
+	if errStr, ok := details["error"].(string); ok {
+		entry.Error = errStr
+		entry.Status = "failed"
+	}
+
+	a.store(entry)
+	a.logEntry(entry)
+}
+
+// LogError logs an error audit event
+func (a *AuditLogger) LogError(ctx context.Context, eventType AuditEventType, err error, details map[string]interface{}) {
+	if !a.config.Enabled {
+		return
+	}
+
+	if details == nil {
+		details = make(map[string]interface{})
+	}
+	details["error"] = err.Error()
+
+	a.LogEvent(ctx, eventType, details)
+}
+
+// GetEntries returns audit entries matching the filter
+func (a *AuditLogger) GetEntries(filter AuditFilter) []AuditEntry {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	var result []AuditEntry
+	for _, entry := range a.entries {
+		if filter.Matches(entry) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+// GetEntriesByTicket returns audit entries for a specific ticket
+func (a *AuditLogger) GetEntriesByTicket(ticketID string) []AuditEntry {
+	return a.GetEntries(AuditFilter{TicketID: ticketID})
+}
+
+// GetEntriesByTimeRange returns audit entries within a time range
+func (a *AuditLogger) GetEntriesByTimeRange(start, end time.Time) []AuditEntry {
+	return a.GetEntries(AuditFilter{StartTime: start, EndTime: end})
+}
+
+// PurgeOldEntries removes entries older than retention period
+func (a *AuditLogger) PurgeOldEntries() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	cutoff := time.Now().AddDate(0, 0, -a.config.RetentionDays)
+	var remaining []AuditEntry
+	purged := 0
+
+	for _, entry := range a.entries {
+		if entry.Timestamp.After(cutoff) {
+			remaining = append(remaining, entry)
+		} else {
+			purged++
+		}
+	}
+
+	a.entries = remaining
+	return purged
+}
+
+// store stores an audit entry
+func (a *AuditLogger) store(entry AuditEntry) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.entries = append(a.entries, entry)
+
+	// Trim if too many entries (keep last 10000)
+	if len(a.entries) > 10000 {
+		a.entries = a.entries[len(a.entries)-10000:]
+	}
+}
+
+// generateID generates a unique audit entry ID
+func (a *AuditLogger) generateID() string {
+	a.mu.Lock()
+	a.seq++
+	seq := a.seq
+	a.mu.Unlock()
+
+	return time.Now().Format("20060102150405") + "-" + string(rune(seq))
+}
+
+// logEntry logs the entry to the configured logger
+func (a *AuditLogger) logEntry(entry AuditEntry) {
+	// Determine log level
+	logFn := a.logger.Info
+	switch a.config.LogLevel {
+	case "debug":
+		logFn = a.logger.Debug
+	case "warn":
+		if entry.Status == "failed" {
+			logFn = a.logger.Warn
+		}
+	case "error":
+		if entry.Status == "failed" {
+			logFn = a.logger.Error
+		} else {
+			return // Don't log non-errors at error level
+		}
+	}
+
+	// Build log message
+	args := []interface{}{
+		"event_type", entry.EventType,
+		"status", entry.Status,
+	}
+	if entry.TicketID != "" {
+		args = append(args, "ticket_id", entry.TicketID)
+	}
+	if entry.ServiceDesk != "" {
+		args = append(args, "service_desk", entry.ServiceDesk)
+	}
+	if entry.ExternalID != "" {
+		args = append(args, "external_id", entry.ExternalID)
+	}
+	if entry.Error != "" {
+		args = append(args, "error", entry.Error)
+	}
+
+	// Add details if sensitive logging is enabled
+	if a.config.LogSensitive && entry.Details != nil {
+		detailsJSON, _ := json.Marshal(entry.Details)
+		args = append(args, "details", string(detailsJSON))
+	}
+
+	logFn("audit", args...)
+}
+
+// AuditFilter defines criteria for filtering audit entries
+type AuditFilter struct {
+	// TicketID filters by ticket ID
+	TicketID string
+
+	// EventType filters by event type
+	EventType AuditEventType
+
+	// ServiceDesk filters by service desk
+	ServiceDesk ServiceDeskType
+
+	// Status filters by status
+	Status string
+
+	// StartTime filters entries after this time
+	StartTime time.Time
+
+	// EndTime filters entries before this time
+	EndTime time.Time
+
+	// Actor filters by actor
+	Actor string
+}
+
+// Matches checks if an entry matches the filter
+func (f AuditFilter) Matches(entry AuditEntry) bool {
+	if f.TicketID != "" && entry.TicketID != f.TicketID {
+		return false
+	}
+	if f.EventType != "" && entry.EventType != f.EventType {
+		return false
+	}
+	if f.ServiceDesk != "" && entry.ServiceDesk != f.ServiceDesk {
+		return false
+	}
+	if f.Status != "" && entry.Status != f.Status {
+		return false
+	}
+	if !f.StartTime.IsZero() && entry.Timestamp.Before(f.StartTime) {
+		return false
+	}
+	if !f.EndTime.IsZero() && entry.Timestamp.After(f.EndTime) {
+		return false
+	}
+	if f.Actor != "" && entry.Actor != f.Actor {
+		return false
+	}
+	return true
+}
+
+// ExportAuditLog exports the audit log as JSON
+func (a *AuditLogger) ExportAuditLog(filter AuditFilter) ([]byte, error) {
+	entries := a.GetEntries(filter)
+	return json.MarshalIndent(entries, "", "  ")
+}
+
+// EntryCount returns the total number of entries
+func (a *AuditLogger) EntryCount() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return len(a.entries)
+}

--- a/pkg/servicedesk/audit_test.go
+++ b/pkg/servicedesk/audit_test.go
@@ -1,0 +1,212 @@
+package servicedesk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+)
+
+func TestAuditLogger(t *testing.T) {
+	config := AuditConfig{
+		Enabled:       true,
+		LogLevel:      "info",
+		RetentionDays: 30,
+		LogSensitive:  false,
+	}
+
+	logger := NewAuditLogger(config, log.NewNopLogger())
+
+	ctx := context.Background()
+
+	// Log an event
+	logger.LogEvent(ctx, AuditEventTicketCreate, map[string]interface{}{
+		"ticket_id": "TKT-00000001",
+		"customer":  "cosmos1abc...",
+		"category":  "technical",
+	})
+
+	// Check entry was recorded
+	entries := logger.GetEntriesByTicket("TKT-00000001")
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	entry := entries[0]
+	if entry.EventType != AuditEventTicketCreate {
+		t.Errorf("expected event type %s, got %s", AuditEventTicketCreate, entry.EventType)
+	}
+	if entry.TicketID != "TKT-00000001" {
+		t.Errorf("expected ticket ID TKT-00000001, got %s", entry.TicketID)
+	}
+	if entry.Status != "success" {
+		t.Errorf("expected status success, got %s", entry.Status)
+	}
+}
+
+func TestAuditLoggerError(t *testing.T) {
+	config := DefaultAuditConfig()
+	logger := NewAuditLogger(config, log.NewNopLogger())
+
+	ctx := context.Background()
+
+	// Log an error event
+	logger.LogEvent(ctx, AuditEventSyncFailed, map[string]interface{}{
+		"ticket_id": "TKT-00000002",
+		"error":     "connection timeout",
+	})
+
+	entries := logger.GetEntriesByTicket("TKT-00000002")
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	entry := entries[0]
+	if entry.Status != "failed" {
+		t.Errorf("expected status failed, got %s", entry.Status)
+	}
+	if entry.Error != "connection timeout" {
+		t.Errorf("expected error 'connection timeout', got %s", entry.Error)
+	}
+}
+
+func TestAuditLoggerDisabled(t *testing.T) {
+	config := AuditConfig{
+		Enabled: false,
+	}
+	logger := NewAuditLogger(config, log.NewNopLogger())
+
+	ctx := context.Background()
+
+	logger.LogEvent(ctx, AuditEventTicketCreate, map[string]interface{}{
+		"ticket_id": "TKT-00000001",
+	})
+
+	// Should not record when disabled
+	entries := logger.GetEntriesByTicket("TKT-00000001")
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries when disabled, got %d", len(entries))
+	}
+}
+
+func TestAuditFilter(t *testing.T) {
+	config := DefaultAuditConfig()
+	logger := NewAuditLogger(config, log.NewNopLogger())
+
+	ctx := context.Background()
+
+	// Log multiple events
+	logger.LogEvent(ctx, AuditEventTicketCreate, map[string]interface{}{
+		"ticket_id":    "TKT-00000001",
+		"service_desk": ServiceDeskJira,
+	})
+	logger.LogEvent(ctx, AuditEventSyncSuccess, map[string]interface{}{
+		"ticket_id":    "TKT-00000001",
+		"service_desk": ServiceDeskJira,
+	})
+	logger.LogEvent(ctx, AuditEventTicketCreate, map[string]interface{}{
+		"ticket_id":    "TKT-00000002",
+		"service_desk": ServiceDeskWaldur,
+	})
+
+	// Filter by ticket ID
+	entries := logger.GetEntries(AuditFilter{TicketID: "TKT-00000001"})
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries for TKT-00000001, got %d", len(entries))
+	}
+
+	// Filter by event type
+	entries = logger.GetEntries(AuditFilter{EventType: AuditEventTicketCreate})
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries for ticket_create, got %d", len(entries))
+	}
+
+	// Filter by service desk
+	entries = logger.GetEntries(AuditFilter{ServiceDesk: ServiceDeskJira})
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries for jira, got %d", len(entries))
+	}
+
+	// Filter by service desk waldur
+	entries = logger.GetEntries(AuditFilter{ServiceDesk: ServiceDeskWaldur})
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry for waldur, got %d", len(entries))
+	}
+}
+
+func TestAuditPurge(t *testing.T) {
+	config := AuditConfig{
+		Enabled:       true,
+		RetentionDays: 1, // 1 day retention
+	}
+	logger := NewAuditLogger(config, log.NewNopLogger())
+
+	// Manually add an old entry
+	logger.mu.Lock()
+	logger.entries = append(logger.entries, AuditEntry{
+		ID:        "old-1",
+		Timestamp: time.Now().AddDate(0, 0, -5), // 5 days old
+		EventType: AuditEventTicketCreate,
+		TicketID:  "TKT-OLD",
+		Status:    "success",
+	})
+	logger.mu.Unlock()
+
+	ctx := context.Background()
+	logger.LogEvent(ctx, AuditEventTicketCreate, map[string]interface{}{
+		"ticket_id": "TKT-NEW",
+	})
+
+	// Should have 2 entries before purge
+	if logger.EntryCount() != 2 {
+		t.Errorf("expected 2 entries before purge, got %d", logger.EntryCount())
+	}
+
+	// Purge old entries
+	purged := logger.PurgeOldEntries()
+	if purged != 1 {
+		t.Errorf("expected to purge 1 entry, purged %d", purged)
+	}
+
+	// Should have 1 entry after purge
+	if logger.EntryCount() != 1 {
+		t.Errorf("expected 1 entry after purge, got %d", logger.EntryCount())
+	}
+
+	// Old entry should be gone
+	entries := logger.GetEntriesByTicket("TKT-OLD")
+	if len(entries) != 0 {
+		t.Error("expected old entry to be purged")
+	}
+
+	// New entry should remain
+	entries = logger.GetEntriesByTicket("TKT-NEW")
+	if len(entries) != 1 {
+		t.Error("expected new entry to remain")
+	}
+}
+
+func TestAuditExport(t *testing.T) {
+	config := DefaultAuditConfig()
+	logger := NewAuditLogger(config, log.NewNopLogger())
+
+	ctx := context.Background()
+	logger.LogEvent(ctx, AuditEventTicketCreate, map[string]interface{}{
+		"ticket_id": "TKT-00000001",
+	})
+
+	data, err := logger.ExportAuditLog(AuditFilter{})
+	if err != nil {
+		t.Fatalf("export failed: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("expected non-empty export")
+	}
+
+	// Should be valid JSON
+	if data[0] != '[' {
+		t.Error("expected JSON array")
+	}
+}

--- a/pkg/servicedesk/bridge.go
+++ b/pkg/servicedesk/bridge.go
@@ -1,0 +1,753 @@
+package servicedesk
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"cosmossdk.io/log"
+
+	"github.com/virtengine/virtengine/pkg/jira"
+	"github.com/virtengine/virtengine/pkg/waldur"
+)
+
+// Bridge is the main service that orchestrates ticket sync between
+// VirtEngine on-chain tickets and external service desk systems.
+type Bridge struct {
+	config *Config
+	logger log.Logger
+
+	// Adapters
+	jiraClient   jira.IClient
+	jiraBridge   jira.ITicketBridge
+	waldurClient *waldur.Client
+
+	// Internal components
+	syncManager    *SyncManager
+	auditLogger    *AuditLogger
+	callbackServer *CallbackServer
+	retryQueue     *RetryQueue
+
+	// State
+	mu      sync.RWMutex
+	running bool
+	stopCh  chan struct{}
+	wg      sync.WaitGroup
+
+	// Event channel for on-chain events
+	eventCh chan *SyncEvent
+}
+
+// IBridge defines the bridge service interface
+type IBridge interface {
+	// Start starts the bridge service
+	Start(ctx context.Context) error
+
+	// Stop stops the bridge service
+	Stop(ctx context.Context) error
+
+	// HandleTicketCreated handles a ticket created event
+	HandleTicketCreated(ctx context.Context, event *TicketCreatedEvent) error
+
+	// HandleTicketUpdated handles a ticket updated event
+	HandleTicketUpdated(ctx context.Context, event *TicketUpdatedEvent) error
+
+	// HandleTicketClosed handles a ticket closed event
+	HandleTicketClosed(ctx context.Context, event *TicketClosedEvent) error
+
+	// HandleExternalCallback handles a callback from external service desk
+	HandleExternalCallback(ctx context.Context, payload *CallbackPayload) error
+
+	// GetSyncStatus returns the sync status for a ticket
+	GetSyncStatus(ctx context.Context, ticketID string) (*TicketSyncRecord, error)
+
+	// SyncTicket manually triggers sync for a ticket
+	SyncTicket(ctx context.Context, ticketID string, direction SyncDirection) error
+
+	// Health returns the health status
+	Health(ctx context.Context) (*HealthStatus, error)
+}
+
+// Ensure Bridge implements IBridge
+var _ IBridge = (*Bridge)(nil)
+
+// TicketCreatedEvent represents an on-chain ticket creation event
+type TicketCreatedEvent struct {
+	TicketID        string            `json:"ticket_id"`
+	CustomerAddress string            `json:"customer_address"`
+	ProviderAddress string            `json:"provider_address,omitempty"`
+	Category        string            `json:"category"`
+	Priority        string            `json:"priority"`
+	Subject         string            `json:"subject"`
+	Description     string            `json:"description"`
+	RelatedEntity   *RelatedEntity    `json:"related_entity,omitempty"`
+	BlockHeight     int64             `json:"block_height"`
+	Timestamp       time.Time         `json:"timestamp"`
+	TxHash          string            `json:"tx_hash"`
+}
+
+// RelatedEntity represents a related on-chain entity
+type RelatedEntity struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+// TicketUpdatedEvent represents an on-chain ticket update event
+type TicketUpdatedEvent struct {
+	TicketID    string                 `json:"ticket_id"`
+	Changes     map[string]interface{} `json:"changes"`
+	UpdatedBy   string                 `json:"updated_by"`
+	BlockHeight int64                  `json:"block_height"`
+	Timestamp   time.Time              `json:"timestamp"`
+	TxHash      string                 `json:"tx_hash"`
+}
+
+// TicketClosedEvent represents an on-chain ticket closed event
+type TicketClosedEvent struct {
+	TicketID    string    `json:"ticket_id"`
+	ClosedBy    string    `json:"closed_by"`
+	Resolution  string    `json:"resolution,omitempty"`
+	BlockHeight int64     `json:"block_height"`
+	Timestamp   time.Time `json:"timestamp"`
+	TxHash      string    `json:"tx_hash"`
+}
+
+// HealthStatus represents the bridge health status
+type HealthStatus struct {
+	Healthy     bool      `json:"healthy"`
+	JiraStatus  string    `json:"jira_status,omitempty"`
+	WaldurStatus string   `json:"waldur_status,omitempty"`
+	LastSync    time.Time `json:"last_sync"`
+	PendingEvents int     `json:"pending_events"`
+	FailedEvents  int     `json:"failed_events"`
+}
+
+// NewBridge creates a new bridge service
+func NewBridge(config *Config, logger log.Logger) (*Bridge, error) {
+	if err := config.Validate(); err != nil {
+		return nil, ErrConfigInvalid.Wrap(err.Error())
+	}
+
+	bridge := &Bridge{
+		config:  config,
+		logger:  logger.With("module", "servicedesk"),
+		stopCh:  make(chan struct{}),
+		eventCh: make(chan *SyncEvent, 1000),
+	}
+
+	// Initialize Jira client if configured
+	if config.JiraConfig != nil {
+		jiraClient, err := jira.NewClient(jira.ClientConfig{
+			BaseURL: config.JiraConfig.BaseURL,
+			Auth: jira.AuthConfig{
+				Type:     jira.AuthTypeBasic,
+				Username: config.JiraConfig.Username,
+				APIToken: config.JiraConfig.APIToken,
+			},
+			Timeout: config.JiraConfig.Timeout,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create jira client: %w", err)
+		}
+		bridge.jiraClient = jiraClient
+		bridge.jiraBridge = jira.NewTicketBridge(jiraClient, jira.TicketBridgeConfig{
+			ProjectKey:       config.JiraConfig.ProjectKey,
+			DefaultIssueType: jira.IssueType(config.JiraConfig.IssueType),
+			PriorityMapping:  mapPriorityToJira(config.MappingSchema),
+		})
+	}
+
+	// Initialize Waldur client if configured
+	if config.WaldurConfig != nil {
+		waldurClient, err := waldur.NewClient(waldur.Config{
+			BaseURL: config.WaldurConfig.BaseURL,
+			Token:   config.WaldurConfig.Token,
+			Timeout: config.WaldurConfig.Timeout,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create waldur client: %w", err)
+		}
+		bridge.waldurClient = waldurClient
+	}
+
+	// Initialize internal components
+	bridge.syncManager = NewSyncManager(bridge, config.SyncConfig)
+	bridge.auditLogger = NewAuditLogger(config.AuditConfig, logger)
+	bridge.retryQueue = NewRetryQueue(config.RetryConfig, logger)
+
+	return bridge, nil
+}
+
+// mapPriorityToJira creates the priority mapping for Jira
+func mapPriorityToJira(schema *MappingSchema) map[string]jira.Priority {
+	mapping := make(map[string]jira.Priority)
+	if schema == nil {
+		return mapping
+	}
+	for _, m := range schema.PriorityMappings {
+		mapping[m.OnChainPriority] = jira.Priority(m.JiraPriority)
+	}
+	return mapping
+}
+
+// Start starts the bridge service
+func (b *Bridge) Start(ctx context.Context) error {
+	b.mu.Lock()
+	if b.running {
+		b.mu.Unlock()
+		return nil
+	}
+	b.running = true
+	b.mu.Unlock()
+
+	b.logger.Info("starting service desk bridge")
+
+	// Start internal components
+	b.wg.Add(1)
+	go b.eventProcessor(ctx)
+
+	b.wg.Add(1)
+	go b.syncLoop(ctx)
+
+	// Start callback server if enabled
+	if b.config.WebhookConfig.Enabled {
+		b.callbackServer = NewCallbackServer(b, b.config, b.logger)
+		if err := b.callbackServer.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start callback server: %w", err)
+		}
+	}
+
+	// Start retry queue processor
+	b.wg.Add(1)
+	go b.retryQueue.Start(ctx, b.processRetryEvent)
+
+	b.logger.Info("service desk bridge started")
+	return nil
+}
+
+// Stop stops the bridge service
+func (b *Bridge) Stop(ctx context.Context) error {
+	b.mu.Lock()
+	if !b.running {
+		b.mu.Unlock()
+		return nil
+	}
+	b.running = false
+	b.mu.Unlock()
+
+	b.logger.Info("stopping service desk bridge")
+
+	// Signal stop
+	close(b.stopCh)
+
+	// Stop callback server
+	if b.callbackServer != nil {
+		if err := b.callbackServer.Stop(ctx); err != nil {
+			b.logger.Error("failed to stop callback server", "error", err)
+		}
+	}
+
+	// Wait for goroutines
+	done := make(chan struct{})
+	go func() {
+		b.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	b.logger.Info("service desk bridge stopped")
+	return nil
+}
+
+// HandleTicketCreated handles a ticket created event
+func (b *Bridge) HandleTicketCreated(ctx context.Context, event *TicketCreatedEvent) error {
+	b.logger.Debug("handling ticket created event", "ticket_id", event.TicketID)
+
+	// Create audit entry
+	b.auditLogger.LogEvent(ctx, AuditEventTicketCreate, map[string]interface{}{
+		"ticket_id":    event.TicketID,
+		"customer":     event.CustomerAddress,
+		"category":     event.Category,
+		"priority":     event.Priority,
+		"block_height": event.BlockHeight,
+	})
+
+	// Create sync event
+	syncEvent := &SyncEvent{
+		ID:          fmt.Sprintf("create-%s-%d", event.TicketID, event.BlockHeight),
+		Type:        "ticket_created",
+		TicketID:    event.TicketID,
+		Direction:   SyncDirectionOutbound,
+		Payload: map[string]interface{}{
+			"customer_address":  event.CustomerAddress,
+			"provider_address":  event.ProviderAddress,
+			"category":          event.Category,
+			"priority":          event.Priority,
+			"subject":           event.Subject,
+			"description":       event.Description,
+			"related_entity":    event.RelatedEntity,
+			"tx_hash":           event.TxHash,
+		},
+		Timestamp:   event.Timestamp,
+		BlockHeight: event.BlockHeight,
+		MaxRetries:  b.config.RetryConfig.MaxRetries,
+		Status:      SyncStatusPending,
+	}
+
+	// Queue for processing
+	select {
+	case b.eventCh <- syncEvent:
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		// Queue full, add to retry queue
+		b.retryQueue.Add(syncEvent)
+	}
+
+	return nil
+}
+
+// HandleTicketUpdated handles a ticket updated event
+func (b *Bridge) HandleTicketUpdated(ctx context.Context, event *TicketUpdatedEvent) error {
+	b.logger.Debug("handling ticket updated event", "ticket_id", event.TicketID)
+
+	// Create audit entry
+	b.auditLogger.LogEvent(ctx, AuditEventTicketUpdate, map[string]interface{}{
+		"ticket_id":    event.TicketID,
+		"updated_by":   event.UpdatedBy,
+		"changes":      event.Changes,
+		"block_height": event.BlockHeight,
+	})
+
+	// Create sync event
+	syncEvent := &SyncEvent{
+		ID:          fmt.Sprintf("update-%s-%d", event.TicketID, event.BlockHeight),
+		Type:        "ticket_updated",
+		TicketID:    event.TicketID,
+		Direction:   SyncDirectionOutbound,
+		Payload:     event.Changes,
+		Timestamp:   event.Timestamp,
+		BlockHeight: event.BlockHeight,
+		MaxRetries:  b.config.RetryConfig.MaxRetries,
+		Status:      SyncStatusPending,
+	}
+
+	// Queue for processing
+	select {
+	case b.eventCh <- syncEvent:
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		b.retryQueue.Add(syncEvent)
+	}
+
+	return nil
+}
+
+// HandleTicketClosed handles a ticket closed event
+func (b *Bridge) HandleTicketClosed(ctx context.Context, event *TicketClosedEvent) error {
+	b.logger.Debug("handling ticket closed event", "ticket_id", event.TicketID)
+
+	// Create audit entry
+	b.auditLogger.LogEvent(ctx, AuditEventTicketClose, map[string]interface{}{
+		"ticket_id":    event.TicketID,
+		"closed_by":    event.ClosedBy,
+		"resolution":   event.Resolution,
+		"block_height": event.BlockHeight,
+	})
+
+	// Create sync event
+	syncEvent := &SyncEvent{
+		ID:          fmt.Sprintf("close-%s-%d", event.TicketID, event.BlockHeight),
+		Type:        "ticket_closed",
+		TicketID:    event.TicketID,
+		Direction:   SyncDirectionOutbound,
+		Payload: map[string]interface{}{
+			"closed_by":  event.ClosedBy,
+			"resolution": event.Resolution,
+			"tx_hash":    event.TxHash,
+		},
+		Timestamp:   event.Timestamp,
+		BlockHeight: event.BlockHeight,
+		MaxRetries:  b.config.RetryConfig.MaxRetries,
+		Status:      SyncStatusPending,
+	}
+
+	// Queue for processing
+	select {
+	case b.eventCh <- syncEvent:
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		b.retryQueue.Add(syncEvent)
+	}
+
+	return nil
+}
+
+// HandleExternalCallback handles a callback from external service desk
+func (b *Bridge) HandleExternalCallback(ctx context.Context, payload *CallbackPayload) error {
+	if err := payload.Validate(); err != nil {
+		return ErrSignatureInvalid.Wrap(err.Error())
+	}
+
+	b.logger.Debug("handling external callback",
+		"event_type", payload.EventType,
+		"external_id", payload.ExternalID,
+		"ticket_id", payload.OnChainTicketID,
+	)
+
+	// Create audit entry
+	b.auditLogger.LogEvent(ctx, AuditEventExternalCallback, map[string]interface{}{
+		"event_type":   payload.EventType,
+		"service_desk": payload.ServiceDeskType,
+		"external_id":  payload.ExternalID,
+		"ticket_id":    payload.OnChainTicketID,
+		"changes":      payload.Changes,
+	})
+
+	// Create sync event for inbound sync
+	syncEvent := &SyncEvent{
+		ID:        fmt.Sprintf("callback-%s-%s", payload.ExternalID, payload.Nonce),
+		Type:      payload.EventType,
+		TicketID:  payload.OnChainTicketID,
+		Direction: SyncDirectionInbound,
+		Payload:   payload.Changes,
+		Timestamp: payload.Timestamp,
+		MaxRetries: b.config.RetryConfig.MaxRetries,
+		Status:    SyncStatusPending,
+	}
+
+	// Queue for processing
+	select {
+	case b.eventCh <- syncEvent:
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		b.retryQueue.Add(syncEvent)
+	}
+
+	return nil
+}
+
+// GetSyncStatus returns the sync status for a ticket
+func (b *Bridge) GetSyncStatus(ctx context.Context, ticketID string) (*TicketSyncRecord, error) {
+	return b.syncManager.GetSyncRecord(ctx, ticketID)
+}
+
+// SyncTicket manually triggers sync for a ticket
+func (b *Bridge) SyncTicket(ctx context.Context, ticketID string, direction SyncDirection) error {
+	b.logger.Info("manual sync triggered", "ticket_id", ticketID, "direction", direction)
+
+	b.auditLogger.LogEvent(ctx, AuditEventManualSync, map[string]interface{}{
+		"ticket_id": ticketID,
+		"direction": direction,
+	})
+
+	return b.syncManager.SyncTicket(ctx, ticketID, direction)
+}
+
+// Health returns the health status
+func (b *Bridge) Health(ctx context.Context) (*HealthStatus, error) {
+	status := &HealthStatus{
+		Healthy:       true,
+		LastSync:      b.syncManager.LastSyncTime(),
+		PendingEvents: len(b.eventCh),
+		FailedEvents:  b.retryQueue.FailedCount(),
+	}
+
+	// Check Jira health
+	if b.jiraClient != nil {
+		_, err := b.jiraClient.GetServiceDeskInfo(ctx)
+		if err != nil {
+			status.JiraStatus = "unhealthy: " + err.Error()
+			status.Healthy = false
+		} else {
+			status.JiraStatus = "healthy"
+		}
+	}
+
+	// Check Waldur health
+	if b.waldurClient != nil {
+		err := b.waldurClient.HealthCheck(ctx)
+		if err != nil {
+			status.WaldurStatus = "unhealthy: " + err.Error()
+			status.Healthy = false
+		} else {
+			status.WaldurStatus = "healthy"
+		}
+	}
+
+	return status, nil
+}
+
+// eventProcessor processes sync events from the queue
+func (b *Bridge) eventProcessor(ctx context.Context) {
+	defer b.wg.Done()
+
+	for {
+		select {
+		case <-b.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case event := <-b.eventCh:
+			if err := b.processEvent(ctx, event); err != nil {
+				b.logger.Error("failed to process event",
+					"event_id", event.ID,
+					"error", err,
+				)
+				event.Error = err.Error()
+				event.RetryCount++
+				if event.CanRetry() {
+					b.retryQueue.Add(event)
+				} else {
+					event.Status = SyncStatusFailed
+					b.auditLogger.LogEvent(ctx, AuditEventSyncFailed, map[string]interface{}{
+						"event_id":    event.ID,
+						"ticket_id":   event.TicketID,
+						"error":       err.Error(),
+						"retry_count": event.RetryCount,
+					})
+				}
+			}
+		}
+	}
+}
+
+// processEvent processes a single sync event
+func (b *Bridge) processEvent(ctx context.Context, event *SyncEvent) error {
+	switch event.Direction {
+	case SyncDirectionOutbound:
+		return b.processOutboundEvent(ctx, event)
+	case SyncDirectionInbound:
+		return b.processInboundEvent(ctx, event)
+	default:
+		return fmt.Errorf("unknown sync direction: %s", event.Direction)
+	}
+}
+
+// processOutboundEvent processes an outbound sync event (on-chain to external)
+func (b *Bridge) processOutboundEvent(ctx context.Context, event *SyncEvent) error {
+	if !b.config.SyncConfig.EnableOutbound {
+		return nil
+	}
+
+	switch event.Type {
+	case "ticket_created":
+		return b.syncTicketCreated(ctx, event)
+	case "ticket_updated":
+		return b.syncTicketUpdated(ctx, event)
+	case "ticket_closed":
+		return b.syncTicketClosed(ctx, event)
+	default:
+		b.logger.Warn("unknown outbound event type", "type", event.Type)
+		return nil
+	}
+}
+
+// processInboundEvent processes an inbound sync event (external to on-chain)
+func (b *Bridge) processInboundEvent(ctx context.Context, event *SyncEvent) error {
+	if !b.config.SyncConfig.EnableInbound {
+		return nil
+	}
+
+	// Check for conflicts
+	conflict, err := b.syncManager.CheckConflict(ctx, event)
+	if err != nil {
+		return err
+	}
+	if conflict != nil {
+		return b.handleConflict(ctx, event, conflict)
+	}
+
+	// Process inbound update
+	return b.syncManager.ProcessInboundUpdate(ctx, event)
+}
+
+// syncTicketCreated syncs a new ticket to external systems
+func (b *Bridge) syncTicketCreated(ctx context.Context, event *SyncEvent) error {
+	// Create in Jira
+	if b.jiraBridge != nil {
+		req := &jira.VirtEngineSupportRequest{
+			TicketID:         event.TicketID,
+			TicketNumber:     event.TicketID,
+			SubmitterAddress: event.Payload["customer_address"].(string),
+			Category:         event.Payload["category"].(string),
+			Priority:         event.Payload["priority"].(string),
+			Subject:          event.Payload["subject"].(string),
+			Description:      event.Payload["description"].(string),
+			CreatedAt:        event.Timestamp,
+		}
+
+		if entity, ok := event.Payload["related_entity"].(*RelatedEntity); ok && entity != nil {
+			req.RelatedEntity = &jira.RelatedEntity{
+				Type: entity.Type,
+				ID:   entity.ID,
+			}
+		}
+
+		issue, err := b.jiraBridge.CreateFromSupportRequest(ctx, req)
+		if err != nil {
+			return ErrExternalAPIError.Wrapf("jira create failed: %v", err)
+		}
+
+		// Update sync record
+		b.syncManager.UpdateExternalRef(ctx, event.TicketID, ExternalTicketRef{
+			Type:        ServiceDeskJira,
+			ExternalID:  issue.Key,
+			ExternalURL: issue.Self,
+			SyncStatus:  SyncStatusSynced,
+			CreatedAt:   time.Now(),
+		})
+
+		b.auditLogger.LogEvent(ctx, AuditEventSyncSuccess, map[string]interface{}{
+			"ticket_id":   event.TicketID,
+			"external_id": issue.Key,
+			"service":     "jira",
+		})
+	}
+
+	// Create in Waldur (placeholder - would need Waldur support ticket API)
+	if b.waldurClient != nil {
+		// Waldur doesn't have a direct support ticket API in the generated client
+		// This would need custom implementation or use of Waldur's issue tracking
+		b.logger.Debug("waldur ticket creation not yet implemented")
+	}
+
+	return nil
+}
+
+// syncTicketUpdated syncs ticket updates to external systems
+func (b *Bridge) syncTicketUpdated(ctx context.Context, event *SyncEvent) error {
+	record, err := b.syncManager.GetSyncRecord(ctx, event.TicketID)
+	if err != nil {
+		return err
+	}
+	if record == nil {
+		// No sync record, ticket not yet synced
+		return nil
+	}
+
+	// Update in Jira
+	if jiraRef := record.GetExternalRef(ServiceDeskJira); jiraRef != nil && b.jiraBridge != nil {
+		// Sync status changes
+		if status, ok := event.Payload["status"].(string); ok {
+			if err := b.jiraBridge.SyncStatus(ctx, jiraRef.ExternalID, status); err != nil {
+				return ErrExternalAPIError.Wrapf("jira status sync failed: %v", err)
+			}
+		}
+
+		b.auditLogger.LogEvent(ctx, AuditEventSyncSuccess, map[string]interface{}{
+			"ticket_id":   event.TicketID,
+			"external_id": jiraRef.ExternalID,
+			"service":     "jira",
+			"changes":     event.Payload,
+		})
+	}
+
+	return nil
+}
+
+// syncTicketClosed syncs ticket closure to external systems
+func (b *Bridge) syncTicketClosed(ctx context.Context, event *SyncEvent) error {
+	record, err := b.syncManager.GetSyncRecord(ctx, event.TicketID)
+	if err != nil {
+		return err
+	}
+	if record == nil {
+		return nil
+	}
+
+	// Close in Jira
+	if jiraRef := record.GetExternalRef(ServiceDeskJira); jiraRef != nil && b.jiraBridge != nil {
+		resolution := ""
+		if r, ok := event.Payload["resolution"].(string); ok {
+			resolution = r
+		}
+		if err := b.jiraBridge.CloseTicket(ctx, jiraRef.ExternalID, resolution); err != nil {
+			return ErrExternalAPIError.Wrapf("jira close failed: %v", err)
+		}
+
+		// Update sync record
+		now := time.Now()
+		jiraRef.SyncStatus = SyncStatusSynced
+		jiraRef.LastSyncAt = &now
+		b.syncManager.UpdateExternalRef(ctx, event.TicketID, *jiraRef)
+
+		b.auditLogger.LogEvent(ctx, AuditEventSyncSuccess, map[string]interface{}{
+			"ticket_id":   event.TicketID,
+			"external_id": jiraRef.ExternalID,
+			"service":     "jira",
+			"action":      "close",
+		})
+	}
+
+	return nil
+}
+
+// handleConflict handles a sync conflict
+func (b *Bridge) handleConflict(ctx context.Context, event *SyncEvent, conflict *Conflict) error {
+	b.auditLogger.LogEvent(ctx, AuditEventConflictDetected, map[string]interface{}{
+		"ticket_id":   event.TicketID,
+		"event_id":    event.ID,
+		"conflict":    conflict,
+		"resolution":  b.config.SyncConfig.ConflictResolution,
+	})
+
+	switch b.config.SyncConfig.ConflictResolution {
+	case ConflictResolutionOnChainWins:
+		// Ignore inbound update, on-chain data wins
+		b.logger.Info("conflict resolved: on-chain wins", "ticket_id", event.TicketID)
+		return nil
+
+	case ConflictResolutionExternalWins:
+		// Process the inbound update
+		return b.syncManager.ProcessInboundUpdate(ctx, event)
+
+	case ConflictResolutionNewestWins:
+		if event.Timestamp.After(conflict.OnChainTimestamp) {
+			return b.syncManager.ProcessInboundUpdate(ctx, event)
+		}
+		return nil
+
+	case ConflictResolutionManual:
+		event.Status = SyncStatusConflict
+		return ErrConflict.Wrapf("manual resolution required for ticket %s", event.TicketID)
+
+	default:
+		return fmt.Errorf("unknown conflict resolution strategy: %s", b.config.SyncConfig.ConflictResolution)
+	}
+}
+
+// syncLoop runs the periodic sync loop
+func (b *Bridge) syncLoop(ctx context.Context) {
+	defer b.wg.Done()
+
+	ticker := time.NewTicker(b.config.SyncConfig.SyncInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-b.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := b.syncManager.RunSync(ctx); err != nil {
+				b.logger.Error("sync cycle failed", "error", err)
+			}
+		}
+	}
+}
+
+// processRetryEvent processes a retry event
+func (b *Bridge) processRetryEvent(ctx context.Context, event *SyncEvent) error {
+	return b.processEvent(ctx, event)
+}

--- a/pkg/servicedesk/callbacks.go
+++ b/pkg/servicedesk/callbacks.go
@@ -1,0 +1,530 @@
+package servicedesk
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"cosmossdk.io/log"
+
+	"github.com/virtengine/virtengine/pkg/jira"
+)
+
+// CallbackServer handles webhooks from external service desks
+type CallbackServer struct {
+	bridge *Bridge
+	config *Config
+	logger log.Logger
+
+	server *http.Server
+	mux    *http.ServeMux
+
+	// Nonce tracking to prevent replay attacks
+	mu     sync.RWMutex
+	nonces map[string]time.Time
+
+	// Jira webhook handler
+	jiraHandler jira.IWebhookHandler
+}
+
+// NewCallbackServer creates a new callback server
+func NewCallbackServer(bridge *Bridge, config *Config, logger log.Logger) *CallbackServer {
+	s := &CallbackServer{
+		bridge: bridge,
+		config: config,
+		logger: logger.With("component", "callback_server"),
+		nonces: make(map[string]time.Time),
+	}
+
+	// Create HTTP mux
+	s.mux = http.NewServeMux()
+	s.setupRoutes()
+
+	// Create HTTP server
+	s.server = &http.Server{
+		Addr:         config.WebhookConfig.ListenAddr,
+		Handler:      s.mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+	}
+
+	// Initialize Jira webhook handler if Jira is configured
+	if config.JiraConfig != nil {
+		s.jiraHandler = jira.NewWebhookHandler(jira.WebhookConfig{
+			Secret:           config.JiraConfig.WebhookSecret,
+			RequireSignature: config.WebhookConfig.RequireSignature,
+		})
+		s.registerJiraHandlers()
+	}
+
+	return s
+}
+
+// setupRoutes sets up HTTP routes
+func (s *CallbackServer) setupRoutes() {
+	prefix := s.config.WebhookConfig.PathPrefix
+
+	// Health check
+	s.mux.HandleFunc(prefix+"/health", s.handleHealth)
+
+	// Jira webhooks
+	s.mux.HandleFunc(prefix+"/jira", s.handleJiraWebhook)
+
+	// Waldur webhooks
+	s.mux.HandleFunc(prefix+"/waldur", s.handleWaldurWebhook)
+
+	// Generic signed callback endpoint
+	s.mux.HandleFunc(prefix+"/callback", s.handleSignedCallback)
+}
+
+// Start starts the callback server
+func (s *CallbackServer) Start(ctx context.Context) error {
+	s.logger.Info("starting callback server", "addr", s.config.WebhookConfig.ListenAddr)
+
+	go func() {
+		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			s.logger.Error("callback server error", "error", err)
+		}
+	}()
+
+	// Start nonce cleanup goroutine
+	go s.cleanupNonces(ctx)
+
+	return nil
+}
+
+// Stop stops the callback server
+func (s *CallbackServer) Stop(ctx context.Context) error {
+	s.logger.Info("stopping callback server")
+	return s.server.Shutdown(ctx)
+}
+
+// handleHealth handles health check requests
+func (s *CallbackServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+// handleJiraWebhook handles Jira webhook requests
+func (s *CallbackServer) handleJiraWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check IP allowlist if configured
+	if !s.isAllowedIP(r) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Delegate to Jira webhook handler
+	if s.jiraHandler != nil {
+		s.jiraHandler.HandleHTTP(w, r)
+		return
+	}
+
+	http.Error(w, "Jira not configured", http.StatusServiceUnavailable)
+}
+
+// handleWaldurWebhook handles Waldur webhook requests
+func (s *CallbackServer) handleWaldurWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check IP allowlist if configured
+	if !s.isAllowedIP(r) {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Read body
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	// Verify signature if required
+	if s.config.WebhookConfig.RequireSignature && s.config.WaldurConfig != nil {
+		signature := r.Header.Get("X-Waldur-Signature")
+		if !s.verifySignature(body, signature, s.config.WaldurConfig.WebhookSecret) {
+			http.Error(w, "Invalid signature", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	// Parse Waldur event
+	var event WaldurWebhookEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Convert to callback payload
+	payload := s.waldurEventToCallback(&event)
+	if payload == nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Process callback
+	ctx := r.Context()
+	if err := s.bridge.HandleExternalCallback(ctx, payload); err != nil {
+		s.logger.Error("failed to process waldur callback", "error", err)
+		http.Error(w, "Processing failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+// handleSignedCallback handles generic signed callback requests
+func (s *CallbackServer) handleSignedCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Read body
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Failed to read body", http.StatusBadRequest)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	// Parse payload
+	var payload CallbackPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Validate payload
+	if err := payload.Validate(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Check nonce (prevent replay)
+	if !s.checkAndRecordNonce(payload.Nonce) {
+		http.Error(w, "Duplicate nonce", http.StatusConflict)
+		return
+	}
+
+	// Verify signature
+	secret := s.getSecretForServiceDesk(payload.ServiceDeskType)
+	if s.config.WebhookConfig.RequireSignature && secret != "" {
+		if !s.verifyCallbackSignature(&payload, secret) {
+			http.Error(w, "Invalid signature", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	// Process callback
+	ctx := r.Context()
+	if err := s.bridge.HandleExternalCallback(ctx, &payload); err != nil {
+		s.logger.Error("failed to process callback", "error", err)
+		http.Error(w, "Processing failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+// registerJiraHandlers registers handlers for Jira webhook events
+func (s *CallbackServer) registerJiraHandlers() {
+	// Handle status changes
+	s.jiraHandler.RegisterHandler(jira.WebhookEventIssueUpdated,
+		jira.StatusChangeHandler(func(ctx context.Context, issueKey, fromStatus, toStatus string) error {
+			s.logger.Debug("jira status change",
+				"issue_key", issueKey,
+				"from", fromStatus,
+				"to", toStatus,
+			)
+
+			// Find the on-chain ticket ID from the Jira issue
+			ticketID := s.findTicketIDFromJiraKey(ctx, issueKey)
+			if ticketID == "" {
+				s.logger.Warn("could not find ticket for jira issue", "issue_key", issueKey)
+				return nil
+			}
+
+			// Create callback payload
+			payload := &CallbackPayload{
+				EventType:       "status_changed",
+				ServiceDeskType: ServiceDeskJira,
+				ExternalID:      issueKey,
+				OnChainTicketID: ticketID,
+				Changes: map[string]interface{}{
+					"status":      s.config.MappingSchema.MapJiraStatusToOnChain(toStatus),
+					"from_status": fromStatus,
+					"to_status":   toStatus,
+				},
+				Timestamp: time.Now(),
+				Nonce:     fmt.Sprintf("jira-%s-%d", issueKey, time.Now().UnixNano()),
+			}
+
+			return s.bridge.HandleExternalCallback(ctx, payload)
+		}),
+	)
+
+	// Handle comments
+	s.jiraHandler.RegisterHandler(jira.WebhookEventCommentCreated,
+		jira.CommentHandler(func(ctx context.Context, issueKey string, comment *jira.Comment) error {
+			s.logger.Debug("jira comment created",
+				"issue_key", issueKey,
+				"comment_id", comment.ID,
+			)
+
+			ticketID := s.findTicketIDFromJiraKey(ctx, issueKey)
+			if ticketID == "" {
+				return nil
+			}
+
+			payload := &CallbackPayload{
+				EventType:       "comment_added",
+				ServiceDeskType: ServiceDeskJira,
+				ExternalID:      issueKey,
+				OnChainTicketID: ticketID,
+				Changes: map[string]interface{}{
+					"comment_id":   comment.ID,
+					"comment_body": comment.Body, // Note: should be encrypted before storing
+				},
+				Timestamp: time.Now(),
+				Nonce:     fmt.Sprintf("jira-comment-%s-%d", comment.ID, time.Now().UnixNano()),
+			}
+
+			return s.bridge.HandleExternalCallback(ctx, payload)
+		}),
+	)
+
+	// Handle assignee changes
+	s.jiraHandler.RegisterHandler(jira.WebhookEventIssueUpdated,
+		jira.AssigneeChangeHandler(func(ctx context.Context, issueKey, fromAssignee, toAssignee string) error {
+			s.logger.Debug("jira assignee change",
+				"issue_key", issueKey,
+				"from", fromAssignee,
+				"to", toAssignee,
+			)
+
+			ticketID := s.findTicketIDFromJiraKey(ctx, issueKey)
+			if ticketID == "" {
+				return nil
+			}
+
+			payload := &CallbackPayload{
+				EventType:       "assignee_changed",
+				ServiceDeskType: ServiceDeskJira,
+				ExternalID:      issueKey,
+				OnChainTicketID: ticketID,
+				Changes: map[string]interface{}{
+					"from_assignee": fromAssignee,
+					"to_assignee":   toAssignee,
+				},
+				Timestamp: time.Now(),
+				Nonce:     fmt.Sprintf("jira-assign-%s-%d", issueKey, time.Now().UnixNano()),
+			}
+
+			return s.bridge.HandleExternalCallback(ctx, payload)
+		}),
+	)
+}
+
+// findTicketIDFromJiraKey finds the on-chain ticket ID from a Jira issue key
+func (s *CallbackServer) findTicketIDFromJiraKey(ctx context.Context, jiraKey string) string {
+	// In a full implementation, this would look up the mapping in persistent storage
+	// For now, we'll try to extract it from the Jira issue custom fields
+
+	if s.bridge.jiraClient == nil {
+		return ""
+	}
+
+	issue, err := s.bridge.jiraClient.GetIssue(ctx, jiraKey)
+	if err != nil {
+		s.logger.Error("failed to get jira issue", "key", jiraKey, "error", err)
+		return ""
+	}
+
+	// Look for the ticket ID in custom fields
+	if cfID, ok := s.config.MappingSchema.CustomFieldMappings["ticket_id"]; ok {
+		if ticketID, ok := issue.Fields.CustomFields[cfID].(string); ok {
+			return ticketID
+		}
+	}
+
+	// Try to extract from summary if it contains the ticket ID pattern
+	if strings.HasPrefix(issue.Fields.Summary, "[TKT-") {
+		end := strings.Index(issue.Fields.Summary, "]")
+		if end > 1 {
+			return issue.Fields.Summary[1:end]
+		}
+	}
+
+	return ""
+}
+
+// WaldurWebhookEvent represents a Waldur webhook event
+type WaldurWebhookEvent struct {
+	EventType string                 `json:"event_type"`
+	UUID      string                 `json:"uuid"`
+	ObjectID  string                 `json:"object_id"`
+	Hook      string                 `json:"hook"`
+	Timestamp string                 `json:"timestamp"`
+	Payload   map[string]interface{} `json:"payload"`
+}
+
+// waldurEventToCallback converts a Waldur event to a callback payload
+func (s *CallbackServer) waldurEventToCallback(event *WaldurWebhookEvent) *CallbackPayload {
+	// In a full implementation, this would map Waldur event types to our callback format
+	// and look up the on-chain ticket ID
+
+	// Placeholder implementation
+	ticketID := ""
+	if id, ok := event.Payload["virtengine_ticket_id"].(string); ok {
+		ticketID = id
+	}
+	if ticketID == "" {
+		return nil
+	}
+
+	return &CallbackPayload{
+		EventType:       event.EventType,
+		ServiceDeskType: ServiceDeskWaldur,
+		ExternalID:      event.ObjectID,
+		OnChainTicketID: ticketID,
+		Changes:         event.Payload,
+		Timestamp:       time.Now(),
+		Nonce:           fmt.Sprintf("waldur-%s-%d", event.UUID, time.Now().UnixNano()),
+	}
+}
+
+// verifySignature verifies an HMAC signature
+func (s *CallbackServer) verifySignature(payload []byte, signature, secret string) bool {
+	if secret == "" {
+		return true
+	}
+	if signature == "" {
+		return false
+	}
+
+	// Remove prefix if present
+	signature = strings.TrimPrefix(signature, "sha256=")
+
+	// Compute expected signature
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	expectedSig := hex.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(signature), []byte(expectedSig))
+}
+
+// verifyCallbackSignature verifies the signature in a callback payload
+func (s *CallbackServer) verifyCallbackSignature(payload *CallbackPayload, secret string) bool {
+	// Compute signature over relevant fields
+	toSign := fmt.Sprintf("%s:%s:%s:%s:%d",
+		payload.EventType,
+		payload.ServiceDeskType,
+		payload.ExternalID,
+		payload.OnChainTicketID,
+		payload.Timestamp.Unix(),
+	)
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(toSign))
+	expectedSig := hex.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(payload.Signature), []byte(expectedSig))
+}
+
+// getSecretForServiceDesk returns the webhook secret for a service desk type
+func (s *CallbackServer) getSecretForServiceDesk(t ServiceDeskType) string {
+	switch t {
+	case ServiceDeskJira:
+		if s.config.JiraConfig != nil {
+			return s.config.JiraConfig.WebhookSecret
+		}
+	case ServiceDeskWaldur:
+		if s.config.WaldurConfig != nil {
+			return s.config.WaldurConfig.WebhookSecret
+		}
+	}
+	return ""
+}
+
+// checkAndRecordNonce checks if a nonce has been used and records it
+func (s *CallbackServer) checkAndRecordNonce(nonce string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.nonces[nonce]; exists {
+		return false // Already used
+	}
+
+	s.nonces[nonce] = time.Now()
+	return true
+}
+
+// cleanupNonces removes old nonces
+func (s *CallbackServer) cleanupNonces(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.mu.Lock()
+			cutoff := time.Now().Add(-1 * time.Hour)
+			for nonce, timestamp := range s.nonces {
+				if timestamp.Before(cutoff) {
+					delete(s.nonces, nonce)
+				}
+			}
+			s.mu.Unlock()
+		}
+	}
+}
+
+// isAllowedIP checks if the request IP is allowed
+func (s *CallbackServer) isAllowedIP(r *http.Request) bool {
+	if len(s.config.WebhookConfig.AllowedIPs) == 0 {
+		return true // No allowlist configured
+	}
+
+	// Get client IP
+	clientIP := r.RemoteAddr
+	if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+		clientIP = strings.Split(forwarded, ",")[0]
+	}
+	clientIP = strings.TrimSpace(clientIP)
+
+	// Remove port if present
+	if idx := strings.LastIndex(clientIP, ":"); idx != -1 {
+		clientIP = clientIP[:idx]
+	}
+
+	for _, allowed := range s.config.WebhookConfig.AllowedIPs {
+		if clientIP == allowed {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/servicedesk/config.go
+++ b/pkg/servicedesk/config.go
@@ -1,0 +1,373 @@
+package servicedesk
+
+import (
+	"fmt"
+	"time"
+
+	"cosmossdk.io/errors"
+)
+
+// Config holds the bridge service configuration
+type Config struct {
+	// Enabled enables the bridge service
+	Enabled bool `json:"enabled"`
+
+	// JiraConfig is the Jira configuration
+	JiraConfig *JiraConfig `json:"jira,omitempty"`
+
+	// WaldurConfig is the Waldur configuration
+	WaldurConfig *WaldurConfig `json:"waldur,omitempty"`
+
+	// MappingSchema is the field mapping schema
+	MappingSchema *MappingSchema `json:"mapping_schema,omitempty"`
+
+	// SyncConfig is the sync configuration
+	SyncConfig SyncConfig `json:"sync"`
+
+	// RetryConfig is the retry configuration
+	RetryConfig RetryConfig `json:"retry"`
+
+	// WebhookConfig is the webhook configuration
+	WebhookConfig WebhookServerConfig `json:"webhook"`
+
+	// AuditConfig is the audit configuration
+	AuditConfig AuditConfig `json:"audit"`
+}
+
+// DefaultConfig returns a default configuration
+func DefaultConfig() *Config {
+	return &Config{
+		Enabled:       false,
+		MappingSchema: DefaultMappingSchema(),
+		SyncConfig:    DefaultSyncConfig(),
+		RetryConfig:   DefaultRetryConfig(),
+		WebhookConfig: DefaultWebhookServerConfig(),
+		AuditConfig:   DefaultAuditConfig(),
+	}
+}
+
+// Validate validates the configuration
+func (c *Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	if c.JiraConfig == nil && c.WaldurConfig == nil {
+		return fmt.Errorf("at least one service desk must be configured")
+	}
+
+	if c.JiraConfig != nil {
+		if err := c.JiraConfig.Validate(); err != nil {
+			return fmt.Errorf("jira config: %w", err)
+		}
+	}
+
+	if c.WaldurConfig != nil {
+		if err := c.WaldurConfig.Validate(); err != nil {
+			return fmt.Errorf("waldur config: %w", err)
+		}
+	}
+
+	if err := c.SyncConfig.Validate(); err != nil {
+		return fmt.Errorf("sync config: %w", err)
+	}
+
+	if err := c.RetryConfig.Validate(); err != nil {
+		return fmt.Errorf("retry config: %w", err)
+	}
+
+	return nil
+}
+
+// JiraConfig holds Jira configuration
+type JiraConfig struct {
+	// BaseURL is the Jira instance URL
+	BaseURL string `json:"base_url"`
+
+	// Username is the Jira username (for basic auth)
+	Username string `json:"username"`
+
+	// APIToken is the API token (CRITICAL: never log)
+	APIToken string `json:"-"`
+
+	// ProjectKey is the Jira project key
+	ProjectKey string `json:"project_key"`
+
+	// IssueType is the default issue type
+	IssueType string `json:"issue_type"`
+
+	// WebhookSecret is the webhook secret (CRITICAL: never log)
+	WebhookSecret string `json:"-"`
+
+	// Timeout is the API timeout
+	Timeout time.Duration `json:"timeout"`
+}
+
+// Validate validates the Jira configuration
+func (c *JiraConfig) Validate() error {
+	if c.BaseURL == "" {
+		return fmt.Errorf("base_url is required")
+	}
+	if c.Username == "" {
+		return fmt.Errorf("username is required")
+	}
+	if c.APIToken == "" {
+		return fmt.Errorf("api_token is required")
+	}
+	if c.ProjectKey == "" {
+		return fmt.Errorf("project_key is required")
+	}
+	return nil
+}
+
+// WaldurConfig holds Waldur configuration
+type WaldurConfig struct {
+	// BaseURL is the Waldur API URL
+	BaseURL string `json:"base_url"`
+
+	// Token is the API token (CRITICAL: never log)
+	Token string `json:"-"`
+
+	// OrganizationUUID is the Waldur organization UUID
+	OrganizationUUID string `json:"organization_uuid"`
+
+	// ProjectUUID is the Waldur project UUID
+	ProjectUUID string `json:"project_uuid"`
+
+	// WebhookSecret is the webhook secret (CRITICAL: never log)
+	WebhookSecret string `json:"-"`
+
+	// Timeout is the API timeout
+	Timeout time.Duration `json:"timeout"`
+}
+
+// Validate validates the Waldur configuration
+func (c *WaldurConfig) Validate() error {
+	if c.BaseURL == "" {
+		return fmt.Errorf("base_url is required")
+	}
+	if c.Token == "" {
+		return fmt.Errorf("token is required")
+	}
+	if c.OrganizationUUID == "" {
+		return fmt.Errorf("organization_uuid is required")
+	}
+	return nil
+}
+
+// SyncConfig holds sync behavior configuration
+type SyncConfig struct {
+	// SyncInterval is the interval between sync cycles
+	SyncInterval time.Duration `json:"sync_interval"`
+
+	// BatchSize is the maximum events per sync batch
+	BatchSize int `json:"batch_size"`
+
+	// ConflictResolution is the default conflict resolution strategy
+	ConflictResolution ConflictResolution `json:"conflict_resolution"`
+
+	// EnableInbound enables inbound sync (external to on-chain)
+	EnableInbound bool `json:"enable_inbound"`
+
+	// EnableOutbound enables outbound sync (on-chain to external)
+	EnableOutbound bool `json:"enable_outbound"`
+
+	// SyncAttachments enables attachment sync
+	SyncAttachments bool `json:"sync_attachments"`
+}
+
+// DefaultSyncConfig returns a default sync configuration
+func DefaultSyncConfig() SyncConfig {
+	return SyncConfig{
+		SyncInterval:       30 * time.Second,
+		BatchSize:          50,
+		ConflictResolution: ConflictResolutionOnChainWins,
+		EnableInbound:      true,
+		EnableOutbound:     true,
+		SyncAttachments:    true,
+	}
+}
+
+// Validate validates the sync configuration
+func (c *SyncConfig) Validate() error {
+	if c.SyncInterval < 5*time.Second {
+		return fmt.Errorf("sync_interval must be at least 5 seconds")
+	}
+	if c.BatchSize < 1 {
+		return fmt.Errorf("batch_size must be at least 1")
+	}
+	if c.BatchSize > 500 {
+		return fmt.Errorf("batch_size must not exceed 500")
+	}
+	return nil
+}
+
+// RetryConfig holds retry behavior configuration
+type RetryConfig struct {
+	// MaxRetries is the maximum retry attempts
+	MaxRetries int `json:"max_retries"`
+
+	// InitialBackoff is the initial backoff duration
+	InitialBackoff time.Duration `json:"initial_backoff"`
+
+	// MaxBackoff is the maximum backoff duration
+	MaxBackoff time.Duration `json:"max_backoff"`
+
+	// BackoffMultiplier is the backoff multiplier
+	BackoffMultiplier float64 `json:"backoff_multiplier"`
+
+	// RetryableStatusCodes are HTTP status codes that should be retried
+	RetryableStatusCodes []int `json:"retryable_status_codes"`
+}
+
+// DefaultRetryConfig returns a default retry configuration
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries:           5,
+		InitialBackoff:       1 * time.Second,
+		MaxBackoff:           5 * time.Minute,
+		BackoffMultiplier:    2.0,
+		RetryableStatusCodes: []int{429, 500, 502, 503, 504},
+	}
+}
+
+// Validate validates the retry configuration
+func (c *RetryConfig) Validate() error {
+	if c.MaxRetries < 0 {
+		return fmt.Errorf("max_retries cannot be negative")
+	}
+	if c.InitialBackoff < 0 {
+		return fmt.Errorf("initial_backoff cannot be negative")
+	}
+	if c.MaxBackoff < c.InitialBackoff {
+		return fmt.Errorf("max_backoff must be >= initial_backoff")
+	}
+	if c.BackoffMultiplier < 1 {
+		return fmt.Errorf("backoff_multiplier must be >= 1")
+	}
+	return nil
+}
+
+// CalculateBackoff calculates the backoff duration for a given attempt
+func (c *RetryConfig) CalculateBackoff(attempt int) time.Duration {
+	if attempt <= 0 {
+		return c.InitialBackoff
+	}
+
+	backoff := float64(c.InitialBackoff)
+	for i := 0; i < attempt; i++ {
+		backoff *= c.BackoffMultiplier
+		if backoff > float64(c.MaxBackoff) {
+			backoff = float64(c.MaxBackoff)
+			break
+		}
+	}
+	return time.Duration(backoff)
+}
+
+// IsRetryable checks if an HTTP status code is retryable
+func (c *RetryConfig) IsRetryable(statusCode int) bool {
+	for _, code := range c.RetryableStatusCodes {
+		if code == statusCode {
+			return true
+		}
+	}
+	return false
+}
+
+// WebhookServerConfig holds webhook server configuration
+type WebhookServerConfig struct {
+	// Enabled enables the webhook server
+	Enabled bool `json:"enabled"`
+
+	// ListenAddr is the address to listen on
+	ListenAddr string `json:"listen_addr"`
+
+	// PathPrefix is the webhook path prefix
+	PathPrefix string `json:"path_prefix"`
+
+	// RequireSignature requires signature verification
+	RequireSignature bool `json:"require_signature"`
+
+	// AllowedIPs are allowed source IP addresses
+	AllowedIPs []string `json:"allowed_ips,omitempty"`
+
+	// RateLimitPerSecond is the rate limit per second
+	RateLimitPerSecond int `json:"rate_limit_per_second"`
+}
+
+// DefaultWebhookServerConfig returns a default webhook server configuration
+func DefaultWebhookServerConfig() WebhookServerConfig {
+	return WebhookServerConfig{
+		Enabled:            true,
+		ListenAddr:         ":8480",
+		PathPrefix:         "/webhooks",
+		RequireSignature:   true,
+		RateLimitPerSecond: 100,
+	}
+}
+
+// AuditConfig holds audit configuration
+type AuditConfig struct {
+	// Enabled enables audit logging
+	Enabled bool `json:"enabled"`
+
+	// LogLevel is the audit log level
+	LogLevel string `json:"log_level"`
+
+	// RetentionDays is the audit log retention period
+	RetentionDays int `json:"retention_days"`
+
+	// LogSensitive enables logging of sensitive operations
+	LogSensitive bool `json:"log_sensitive"`
+}
+
+// DefaultAuditConfig returns a default audit configuration
+func DefaultAuditConfig() AuditConfig {
+	return AuditConfig{
+		Enabled:       true,
+		LogLevel:      "info",
+		RetentionDays: 90,
+		LogSensitive:  false,
+	}
+}
+
+// LoadConfigFromEnv loads configuration from environment variables
+func LoadConfigFromEnv() (*Config, error) {
+	cfg := DefaultConfig()
+
+	// This is a placeholder - actual implementation would read from env
+	// and secrets management system (Vault, etc.)
+
+	return cfg, nil
+}
+
+// package-level errors using cosmossdk error pattern
+var (
+	// ErrConfigInvalid indicates an invalid configuration
+	ErrConfigInvalid = errors.Register("servicedesk", 1, "invalid configuration")
+
+	// ErrSyncFailed indicates a sync operation failed
+	ErrSyncFailed = errors.Register("servicedesk", 2, "sync failed")
+
+	// ErrExternalAPIError indicates an external API error
+	ErrExternalAPIError = errors.Register("servicedesk", 3, "external API error")
+
+	// ErrConflict indicates a sync conflict
+	ErrConflict = errors.Register("servicedesk", 4, "sync conflict detected")
+
+	// ErrTicketNotFound indicates the ticket was not found
+	ErrTicketNotFound = errors.Register("servicedesk", 5, "ticket not found")
+
+	// ErrSignatureInvalid indicates an invalid callback signature
+	ErrSignatureInvalid = errors.Register("servicedesk", 6, "invalid signature")
+
+	// ErrRateLimited indicates rate limiting
+	ErrRateLimited = errors.Register("servicedesk", 7, "rate limited")
+
+	// ErrAttachmentFailed indicates attachment sync failed
+	ErrAttachmentFailed = errors.Register("servicedesk", 8, "attachment sync failed")
+
+	// ErrAuditFailed indicates audit logging failed
+	ErrAuditFailed = errors.Register("servicedesk", 9, "audit logging failed")
+)

--- a/pkg/servicedesk/config_test.go
+++ b/pkg/servicedesk/config_test.go
@@ -1,0 +1,371 @@
+package servicedesk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Enabled {
+		t.Error("expected Enabled = false by default")
+	}
+
+	if cfg.MappingSchema == nil {
+		t.Error("expected MappingSchema to be set")
+	}
+
+	if cfg.SyncConfig.SyncInterval != 30*time.Second {
+		t.Errorf("expected SyncInterval = 30s, got %v", cfg.SyncConfig.SyncInterval)
+	}
+
+	if cfg.RetryConfig.MaxRetries != 5 {
+		t.Errorf("expected MaxRetries = 5, got %d", cfg.RetryConfig.MaxRetries)
+	}
+}
+
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr bool
+	}{
+		{
+			name:    "disabled config is valid",
+			cfg:     DefaultConfig(),
+			wantErr: false,
+		},
+		{
+			name: "enabled without service desk",
+			cfg: &Config{
+				Enabled:     true,
+				SyncConfig:  DefaultSyncConfig(),
+				RetryConfig: DefaultRetryConfig(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "enabled with jira",
+			cfg: &Config{
+				Enabled: true,
+				JiraConfig: &JiraConfig{
+					BaseURL:    "https://jira.example.com",
+					Username:   "user",
+					APIToken:   "token",
+					ProjectKey: "PROJ",
+				},
+				SyncConfig:  DefaultSyncConfig(),
+				RetryConfig: DefaultRetryConfig(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "enabled with waldur",
+			cfg: &Config{
+				Enabled: true,
+				WaldurConfig: &WaldurConfig{
+					BaseURL:          "https://waldur.example.com",
+					Token:            "token",
+					OrganizationUUID: "org-uuid",
+				},
+				SyncConfig:  DefaultSyncConfig(),
+				RetryConfig: DefaultRetryConfig(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "jira missing base url",
+			cfg: &Config{
+				Enabled: true,
+				JiraConfig: &JiraConfig{
+					Username:   "user",
+					APIToken:   "token",
+					ProjectKey: "PROJ",
+				},
+				SyncConfig:  DefaultSyncConfig(),
+				RetryConfig: DefaultRetryConfig(),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestJiraConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *JiraConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			cfg: &JiraConfig{
+				BaseURL:    "https://jira.example.com",
+				Username:   "user",
+				APIToken:   "token",
+				ProjectKey: "PROJ",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing base url",
+			cfg: &JiraConfig{
+				Username:   "user",
+				APIToken:   "token",
+				ProjectKey: "PROJ",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing username",
+			cfg: &JiraConfig{
+				BaseURL:    "https://jira.example.com",
+				APIToken:   "token",
+				ProjectKey: "PROJ",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing api token",
+			cfg: &JiraConfig{
+				BaseURL:    "https://jira.example.com",
+				Username:   "user",
+				ProjectKey: "PROJ",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing project key",
+			cfg: &JiraConfig{
+				BaseURL:  "https://jira.example.com",
+				Username: "user",
+				APIToken: "token",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWaldurConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *WaldurConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			cfg: &WaldurConfig{
+				BaseURL:          "https://waldur.example.com",
+				Token:            "token",
+				OrganizationUUID: "org-uuid",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing base url",
+			cfg: &WaldurConfig{
+				Token:            "token",
+				OrganizationUUID: "org-uuid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing token",
+			cfg: &WaldurConfig{
+				BaseURL:          "https://waldur.example.com",
+				OrganizationUUID: "org-uuid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing org uuid",
+			cfg: &WaldurConfig{
+				BaseURL: "https://waldur.example.com",
+				Token:   "token",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSyncConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     SyncConfig
+		wantErr bool
+	}{
+		{
+			name:    "default config is valid",
+			cfg:     DefaultSyncConfig(),
+			wantErr: false,
+		},
+		{
+			name: "sync interval too short",
+			cfg: SyncConfig{
+				SyncInterval: 1 * time.Second,
+				BatchSize:    50,
+			},
+			wantErr: true,
+		},
+		{
+			name: "batch size too small",
+			cfg: SyncConfig{
+				SyncInterval: 30 * time.Second,
+				BatchSize:    0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "batch size too large",
+			cfg: SyncConfig{
+				SyncInterval: 30 * time.Second,
+				BatchSize:    1000,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRetryConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     RetryConfig
+		wantErr bool
+	}{
+		{
+			name:    "default config is valid",
+			cfg:     DefaultRetryConfig(),
+			wantErr: false,
+		},
+		{
+			name: "negative max retries",
+			cfg: RetryConfig{
+				MaxRetries:        -1,
+				InitialBackoff:    1 * time.Second,
+				MaxBackoff:        1 * time.Minute,
+				BackoffMultiplier: 2.0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "max backoff less than initial",
+			cfg: RetryConfig{
+				MaxRetries:        5,
+				InitialBackoff:    1 * time.Minute,
+				MaxBackoff:        1 * time.Second,
+				BackoffMultiplier: 2.0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiplier less than 1",
+			cfg: RetryConfig{
+				MaxRetries:        5,
+				InitialBackoff:    1 * time.Second,
+				MaxBackoff:        1 * time.Minute,
+				BackoffMultiplier: 0.5,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCalculateBackoff(t *testing.T) {
+	cfg := RetryConfig{
+		InitialBackoff:    1 * time.Second,
+		MaxBackoff:        1 * time.Minute,
+		BackoffMultiplier: 2.0,
+	}
+
+	tests := []struct {
+		attempt  int
+		expected time.Duration
+	}{
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 4 * time.Second},
+		{3, 8 * time.Second},
+		{4, 16 * time.Second},
+		{5, 32 * time.Second},
+		{6, 1 * time.Minute}, // capped at max
+		{10, 1 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		backoff := cfg.CalculateBackoff(tt.attempt)
+		if backoff != tt.expected {
+			t.Errorf("CalculateBackoff(%d) = %v, want %v", tt.attempt, backoff, tt.expected)
+		}
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	cfg := DefaultRetryConfig()
+
+	tests := []struct {
+		statusCode int
+		retryable  bool
+	}{
+		{200, false},
+		{400, false},
+		{401, false},
+		{403, false},
+		{404, false},
+		{429, true},  // Rate limited
+		{500, true},  // Server error
+		{502, true},  // Bad gateway
+		{503, true},  // Service unavailable
+		{504, true},  // Gateway timeout
+	}
+
+	for _, tt := range tests {
+		if cfg.IsRetryable(tt.statusCode) != tt.retryable {
+			t.Errorf("IsRetryable(%d) = %v, want %v", tt.statusCode, cfg.IsRetryable(tt.statusCode), tt.retryable)
+		}
+	}
+}

--- a/pkg/servicedesk/doc.go
+++ b/pkg/servicedesk/doc.go
@@ -1,0 +1,16 @@
+// Package servicedesk provides bi-directional integration between VirtEngine
+// on-chain support tickets and external service desk systems (Jira/Waldur).
+//
+// VE-3E: Jira/Waldur Service Desk Sync
+//
+// This package implements:
+//   - Mapping schema from on-chain ticket fields to Jira/Waldur fields
+//   - Bridge service that listens to chain events and creates external tickets
+//   - Bi-directional status sync with signed callbacks
+//   - Attachment handling via artifact store with access controls
+//   - Conflict resolution for concurrent updates
+//   - Audit trail of external actions
+//   - Retry and backoff for API failures
+//
+// CRITICAL: Never log API tokens, webhook secrets, or sensitive ticket content.
+package servicedesk

--- a/pkg/servicedesk/retry.go
+++ b/pkg/servicedesk/retry.go
@@ -1,0 +1,168 @@
+package servicedesk
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"cosmossdk.io/log"
+)
+
+// RetryQueue manages failed sync events for retry
+type RetryQueue struct {
+	config RetryConfig
+	logger log.Logger
+
+	mu      sync.Mutex
+	queue   []*SyncEvent
+	failed  []*SyncEvent
+	running bool
+	stopCh  chan struct{}
+}
+
+// NewRetryQueue creates a new retry queue
+func NewRetryQueue(config RetryConfig, logger log.Logger) *RetryQueue {
+	return &RetryQueue{
+		config: config,
+		logger: logger.With("component", "retry_queue"),
+		queue:  make([]*SyncEvent, 0),
+		failed: make([]*SyncEvent, 0),
+		stopCh: make(chan struct{}),
+	}
+}
+
+// Add adds an event to the retry queue
+func (q *RetryQueue) Add(event *SyncEvent) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// Calculate next retry time
+	backoff := q.config.CalculateBackoff(event.RetryCount)
+	nextRetry := time.Now().Add(backoff)
+	event.NextRetryAt = &nextRetry
+
+	q.queue = append(q.queue, event)
+	q.logger.Debug("event added to retry queue",
+		"event_id", event.ID,
+		"retry_count", event.RetryCount,
+		"next_retry", nextRetry,
+	)
+}
+
+// Start starts the retry queue processor
+func (q *RetryQueue) Start(ctx context.Context, processor func(context.Context, *SyncEvent) error) {
+	q.mu.Lock()
+	if q.running {
+		q.mu.Unlock()
+		return
+	}
+	q.running = true
+	q.mu.Unlock()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-q.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			q.processReadyEvents(ctx, processor)
+		}
+	}
+}
+
+// Stop stops the retry queue
+func (q *RetryQueue) Stop() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.running {
+		close(q.stopCh)
+		q.running = false
+	}
+}
+
+// processReadyEvents processes events that are ready for retry
+func (q *RetryQueue) processReadyEvents(ctx context.Context, processor func(context.Context, *SyncEvent) error) {
+	q.mu.Lock()
+	now := time.Now()
+	ready := make([]*SyncEvent, 0)
+	remaining := make([]*SyncEvent, 0)
+
+	for _, event := range q.queue {
+		if event.NextRetryAt != nil && now.After(*event.NextRetryAt) {
+			ready = append(ready, event)
+		} else {
+			remaining = append(remaining, event)
+		}
+	}
+	q.queue = remaining
+	q.mu.Unlock()
+
+	// Process ready events
+	for _, event := range ready {
+		if err := processor(ctx, event); err != nil {
+			q.logger.Error("retry failed",
+				"event_id", event.ID,
+				"retry_count", event.RetryCount,
+				"error", err,
+			)
+
+			event.RetryCount++
+			event.Error = err.Error()
+
+			if event.CanRetry() {
+				q.Add(event)
+			} else {
+				q.mu.Lock()
+				event.Status = SyncStatusFailed
+				q.failed = append(q.failed, event)
+				q.mu.Unlock()
+				q.logger.Warn("event failed permanently",
+					"event_id", event.ID,
+					"ticket_id", event.TicketID,
+				)
+			}
+		} else {
+			event.Status = SyncStatusSynced
+			q.logger.Info("retry succeeded",
+				"event_id", event.ID,
+				"retry_count", event.RetryCount,
+			)
+		}
+	}
+}
+
+// FailedCount returns the number of permanently failed events
+func (q *RetryQueue) FailedCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.failed)
+}
+
+// GetFailed returns the failed events
+func (q *RetryQueue) GetFailed() []*SyncEvent {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	result := make([]*SyncEvent, len(q.failed))
+	copy(result, q.failed)
+	return result
+}
+
+// ClearFailed clears the failed events list
+func (q *RetryQueue) ClearFailed() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.failed = make([]*SyncEvent, 0)
+}
+
+// PendingCount returns the number of pending retry events
+func (q *RetryQueue) PendingCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.queue)
+}

--- a/pkg/servicedesk/retry_test.go
+++ b/pkg/servicedesk/retry_test.go
@@ -1,0 +1,209 @@
+package servicedesk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+)
+
+func TestRetryQueue(t *testing.T) {
+	config := DefaultRetryConfig()
+	queue := NewRetryQueue(config, log.NewNopLogger())
+
+	// Add an event
+	event := &SyncEvent{
+		ID:         "test-1",
+		TicketID:   "TKT-00000001",
+		MaxRetries: 3,
+		RetryCount: 0,
+		Status:     SyncStatusFailed,
+	}
+
+	queue.Add(event)
+
+	if queue.PendingCount() != 1 {
+		t.Errorf("expected 1 pending event, got %d", queue.PendingCount())
+	}
+
+	// Check that retry time was set
+	if event.NextRetryAt == nil {
+		t.Error("expected NextRetryAt to be set")
+	}
+}
+
+func TestRetryQueueProcessing(t *testing.T) {
+	config := RetryConfig{
+		MaxRetries:        3,
+		InitialBackoff:    10 * time.Millisecond,
+		MaxBackoff:        100 * time.Millisecond,
+		BackoffMultiplier: 2.0,
+	}
+	queue := NewRetryQueue(config, log.NewNopLogger())
+
+	// Track processing
+	processed := make(chan string, 10)
+	processor := func(ctx context.Context, event *SyncEvent) error {
+		processed <- event.ID
+		return nil
+	}
+
+	// Add an event with immediate retry
+	event := &SyncEvent{
+		ID:         "test-1",
+		TicketID:   "TKT-00000001",
+		MaxRetries: 3,
+		RetryCount: 0,
+		Status:     SyncStatusFailed,
+	}
+	now := time.Now().Add(-1 * time.Second) // Already due
+	event.NextRetryAt = &now
+	
+	queue.mu.Lock()
+	queue.queue = append(queue.queue, event)
+	queue.mu.Unlock()
+
+	// Process ready events
+	ctx := context.Background()
+	queue.processReadyEvents(ctx, processor)
+
+	// Check it was processed
+	select {
+	case id := <-processed:
+		if id != "test-1" {
+			t.Errorf("expected test-1, got %s", id)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected event to be processed")
+	}
+
+	// Should no longer be pending
+	if queue.PendingCount() != 0 {
+		t.Errorf("expected 0 pending after processing, got %d", queue.PendingCount())
+	}
+}
+
+func TestRetryQueueRequeue(t *testing.T) {
+	config := RetryConfig{
+		MaxRetries:        3,
+		InitialBackoff:    10 * time.Millisecond,
+		MaxBackoff:        100 * time.Millisecond,
+		BackoffMultiplier: 2.0,
+	}
+	queue := NewRetryQueue(config, log.NewNopLogger())
+
+	// Processor that always fails
+	failCount := 0
+	processor := func(ctx context.Context, event *SyncEvent) error {
+		failCount++
+		return ErrSyncFailed.Wrap("test error")
+	}
+
+	// Add an event with immediate retry
+	event := &SyncEvent{
+		ID:         "test-1",
+		TicketID:   "TKT-00000001",
+		MaxRetries: 3,
+		RetryCount: 0,
+		Status:     SyncStatusPending,
+	}
+	now := time.Now().Add(-1 * time.Second)
+	event.NextRetryAt = &now
+
+	queue.mu.Lock()
+	queue.queue = append(queue.queue, event)
+	queue.mu.Unlock()
+
+	// Process - should fail and requeue
+	ctx := context.Background()
+	queue.processReadyEvents(ctx, processor)
+
+	if failCount != 1 {
+		t.Errorf("expected 1 fail, got %d", failCount)
+	}
+
+	// Should be requeued
+	if queue.PendingCount() != 1 {
+		t.Errorf("expected 1 pending after failed processing, got %d", queue.PendingCount())
+	}
+
+	// Check retry count was incremented
+	queue.mu.Lock()
+	if len(queue.queue) > 0 && queue.queue[0].RetryCount != 1 {
+		t.Errorf("expected RetryCount 1, got %d", queue.queue[0].RetryCount)
+	}
+	queue.mu.Unlock()
+}
+
+func TestRetryQueuePermanentFailure(t *testing.T) {
+	config := RetryConfig{
+		MaxRetries:        2,
+		InitialBackoff:    10 * time.Millisecond,
+		MaxBackoff:        100 * time.Millisecond,
+		BackoffMultiplier: 2.0,
+	}
+	queue := NewRetryQueue(config, log.NewNopLogger())
+
+	// Processor that always fails
+	processor := func(ctx context.Context, event *SyncEvent) error {
+		return ErrSyncFailed.Wrap("test error")
+	}
+
+	// Add an event that has already exhausted retries
+	event := &SyncEvent{
+		ID:         "test-1",
+		TicketID:   "TKT-00000001",
+		MaxRetries: 2,
+		RetryCount: 2, // Already at max
+		Status:     SyncStatusFailed,
+	}
+	now := time.Now().Add(-1 * time.Second)
+	event.NextRetryAt = &now
+
+	queue.mu.Lock()
+	queue.queue = append(queue.queue, event)
+	queue.mu.Unlock()
+
+	// Process - should fail permanently
+	ctx := context.Background()
+	queue.processReadyEvents(ctx, processor)
+
+	// Should be in failed list, not pending
+	if queue.PendingCount() != 0 {
+		t.Errorf("expected 0 pending, got %d", queue.PendingCount())
+	}
+	if queue.FailedCount() != 1 {
+		t.Errorf("expected 1 failed, got %d", queue.FailedCount())
+	}
+
+	// Check failed event
+	failed := queue.GetFailed()
+	if len(failed) != 1 {
+		t.Fatalf("expected 1 failed event, got %d", len(failed))
+	}
+	if failed[0].Status != SyncStatusFailed {
+		t.Errorf("expected status Failed, got %s", failed[0].Status)
+	}
+}
+
+func TestRetryQueueClearFailed(t *testing.T) {
+	config := DefaultRetryConfig()
+	queue := NewRetryQueue(config, log.NewNopLogger())
+
+	// Add some failed events
+	queue.mu.Lock()
+	queue.failed = append(queue.failed, &SyncEvent{ID: "failed-1"})
+	queue.failed = append(queue.failed, &SyncEvent{ID: "failed-2"})
+	queue.mu.Unlock()
+
+	if queue.FailedCount() != 2 {
+		t.Errorf("expected 2 failed, got %d", queue.FailedCount())
+	}
+
+	queue.ClearFailed()
+
+	if queue.FailedCount() != 0 {
+		t.Errorf("expected 0 failed after clear, got %d", queue.FailedCount())
+	}
+}

--- a/pkg/servicedesk/sync.go
+++ b/pkg/servicedesk/sync.go
@@ -1,0 +1,266 @@
+package servicedesk
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"cosmossdk.io/log"
+)
+
+// SyncManager manages ticket synchronization state and operations
+type SyncManager struct {
+	bridge *Bridge
+	config SyncConfig
+	logger log.Logger
+
+	// In-memory sync state (would use persistent storage in production)
+	mu          sync.RWMutex
+	syncRecords map[string]*TicketSyncRecord
+	lastSync    time.Time
+}
+
+// Conflict represents a detected sync conflict
+type Conflict struct {
+	// TicketID is the conflicting ticket
+	TicketID string `json:"ticket_id"`
+
+	// OnChainValue is the on-chain value
+	OnChainValue interface{} `json:"on_chain_value"`
+
+	// ExternalValue is the external value
+	ExternalValue interface{} `json:"external_value"`
+
+	// Field is the conflicting field
+	Field string `json:"field"`
+
+	// OnChainTimestamp is when the on-chain update occurred
+	OnChainTimestamp time.Time `json:"on_chain_timestamp"`
+
+	// ExternalTimestamp is when the external update occurred
+	ExternalTimestamp time.Time `json:"external_timestamp"`
+}
+
+// NewSyncManager creates a new sync manager
+func NewSyncManager(bridge *Bridge, config SyncConfig) *SyncManager {
+	return &SyncManager{
+		bridge:      bridge,
+		config:      config,
+		logger:      bridge.logger.With("component", "sync_manager"),
+		syncRecords: make(map[string]*TicketSyncRecord),
+	}
+}
+
+// GetSyncRecord returns the sync record for a ticket
+func (m *SyncManager) GetSyncRecord(ctx context.Context, ticketID string) (*TicketSyncRecord, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	record, ok := m.syncRecords[ticketID]
+	if !ok {
+		return nil, nil
+	}
+	return record, nil
+}
+
+// UpdateExternalRef updates the external reference for a ticket
+func (m *SyncManager) UpdateExternalRef(ctx context.Context, ticketID string, ref ExternalTicketRef) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	record, ok := m.syncRecords[ticketID]
+	if !ok {
+		record = &TicketSyncRecord{
+			TicketID:           ticketID,
+			ExternalRefs:       []ExternalTicketRef{},
+			ConflictResolution: m.config.ConflictResolution,
+		}
+		m.syncRecords[ticketID] = record
+	}
+
+	// Update or add the external ref
+	found := false
+	for i, existing := range record.ExternalRefs {
+		if existing.Type == ref.Type {
+			record.ExternalRefs[i] = ref
+			found = true
+			break
+		}
+	}
+	if !found {
+		record.ExternalRefs = append(record.ExternalRefs, ref)
+	}
+}
+
+// CheckConflict checks for sync conflicts
+func (m *SyncManager) CheckConflict(ctx context.Context, event *SyncEvent) (*Conflict, error) {
+	m.mu.RLock()
+	record, ok := m.syncRecords[event.TicketID]
+	m.mu.RUnlock()
+
+	if !ok {
+		return nil, nil
+	}
+
+	// Check if there's a pending on-chain update newer than this external update
+	if record.PendingSync && record.LastOnChainUpdate.After(event.Timestamp) {
+		return &Conflict{
+			TicketID:          event.TicketID,
+			OnChainTimestamp:  record.LastOnChainUpdate,
+			ExternalTimestamp: event.Timestamp,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+// ProcessInboundUpdate processes an inbound update from external system
+func (m *SyncManager) ProcessInboundUpdate(ctx context.Context, event *SyncEvent) error {
+	m.logger.Debug("processing inbound update",
+		"ticket_id", event.TicketID,
+		"event_type", event.Type,
+	)
+
+	// In a full implementation, this would:
+	// 1. Validate the update against on-chain state
+	// 2. Create a transaction to update on-chain state
+	// 3. Wait for confirmation
+	// 4. Update sync record
+
+	// For now, just update the sync record
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	record, ok := m.syncRecords[event.TicketID]
+	if ok {
+		for i, ref := range record.ExternalRefs {
+			now := time.Now()
+			record.ExternalRefs[i].LastSyncAt = &now
+			record.ExternalRefs[i].SyncStatus = SyncStatusSynced
+			record.ExternalRefs[i].SyncVersion = ref.SyncVersion + 1
+		}
+	}
+
+	return nil
+}
+
+// SyncTicket syncs a specific ticket
+func (m *SyncManager) SyncTicket(ctx context.Context, ticketID string, direction SyncDirection) error {
+	m.logger.Info("syncing ticket", "ticket_id", ticketID, "direction", direction)
+
+	switch direction {
+	case SyncDirectionOutbound:
+		// Would fetch on-chain ticket and sync to external
+		return m.syncOutbound(ctx, ticketID)
+	case SyncDirectionInbound:
+		// Would fetch external ticket and sync to on-chain
+		return m.syncInbound(ctx, ticketID)
+	default:
+		// Sync both directions
+		if err := m.syncOutbound(ctx, ticketID); err != nil {
+			return err
+		}
+		return m.syncInbound(ctx, ticketID)
+	}
+}
+
+// RunSync runs a sync cycle for all pending tickets
+func (m *SyncManager) RunSync(ctx context.Context) error {
+	m.mu.Lock()
+	m.lastSync = time.Now()
+	m.mu.Unlock()
+
+	m.logger.Debug("running sync cycle")
+
+	// Find tickets needing sync
+	m.mu.RLock()
+	ticketsToSync := make([]string, 0)
+	for ticketID, record := range m.syncRecords {
+		if record.PendingSync {
+			ticketsToSync = append(ticketsToSync, ticketID)
+		}
+	}
+	m.mu.RUnlock()
+
+	// Sync each ticket
+	for _, ticketID := range ticketsToSync {
+		if err := m.SyncTicket(ctx, ticketID, ""); err != nil {
+			m.logger.Error("failed to sync ticket", "ticket_id", ticketID, "error", err)
+		}
+	}
+
+	return nil
+}
+
+// LastSyncTime returns the last sync time
+func (m *SyncManager) LastSyncTime() time.Time {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.lastSync
+}
+
+// syncOutbound syncs from on-chain to external
+func (m *SyncManager) syncOutbound(ctx context.Context, ticketID string) error {
+	// In full implementation:
+	// 1. Fetch on-chain ticket state
+	// 2. Compare with external state
+	// 3. Update external if different
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if record, ok := m.syncRecords[ticketID]; ok {
+		record.PendingSync = false
+		for i := range record.ExternalRefs {
+			now := time.Now()
+			record.ExternalRefs[i].LastSyncAt = &now
+			record.ExternalRefs[i].SyncStatus = SyncStatusSynced
+		}
+	}
+
+	return nil
+}
+
+// syncInbound syncs from external to on-chain
+func (m *SyncManager) syncInbound(ctx context.Context, ticketID string) error {
+	// In full implementation:
+	// 1. Fetch external ticket state
+	// 2. Compare with on-chain state
+	// 3. Create tx to update on-chain if different
+
+	return nil
+}
+
+// MarkPendingSync marks a ticket as needing sync
+func (m *SyncManager) MarkPendingSync(ticketID string, onChainUpdate time.Time, version int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	record, ok := m.syncRecords[ticketID]
+	if !ok {
+		record = &TicketSyncRecord{
+			TicketID:           ticketID,
+			ExternalRefs:       []ExternalTicketRef{},
+			ConflictResolution: m.config.ConflictResolution,
+		}
+		m.syncRecords[ticketID] = record
+	}
+
+	record.PendingSync = true
+	record.LastOnChainUpdate = onChainUpdate
+	record.LastOnChainVersion = version
+}
+
+// GetPendingCount returns the number of pending syncs
+func (m *SyncManager) GetPendingCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	count := 0
+	for _, record := range m.syncRecords {
+		if record.PendingSync {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/servicedesk/types.go
+++ b/pkg/servicedesk/types.go
@@ -1,0 +1,456 @@
+package servicedesk
+
+import (
+	"fmt"
+	"time"
+)
+
+// ServiceDeskType identifies the external service desk system
+type ServiceDeskType string
+
+const (
+	// ServiceDeskJira represents Jira Service Desk
+	ServiceDeskJira ServiceDeskType = "jira"
+
+	// ServiceDeskWaldur represents Waldur service desk
+	ServiceDeskWaldur ServiceDeskType = "waldur"
+)
+
+// String returns the string representation
+func (t ServiceDeskType) String() string {
+	return string(t)
+}
+
+// IsValid checks if the service desk type is valid
+func (t ServiceDeskType) IsValid() bool {
+	return t == ServiceDeskJira || t == ServiceDeskWaldur
+}
+
+// SyncDirection indicates the direction of synchronization
+type SyncDirection string
+
+const (
+	// SyncDirectionOutbound is from VirtEngine to external
+	SyncDirectionOutbound SyncDirection = "outbound"
+
+	// SyncDirectionInbound is from external to VirtEngine
+	SyncDirectionInbound SyncDirection = "inbound"
+)
+
+// SyncStatus represents the synchronization status
+type SyncStatus string
+
+const (
+	// SyncStatusPending indicates sync is pending
+	SyncStatusPending SyncStatus = "pending"
+
+	// SyncStatusSynced indicates successful sync
+	SyncStatusSynced SyncStatus = "synced"
+
+	// SyncStatusFailed indicates sync failed
+	SyncStatusFailed SyncStatus = "failed"
+
+	// SyncStatusConflict indicates a conflict was detected
+	SyncStatusConflict SyncStatus = "conflict"
+)
+
+// TicketFieldMapping defines the mapping between on-chain and external fields
+type TicketFieldMapping struct {
+	// OnChainField is the VirtEngine ticket field name
+	OnChainField string `json:"on_chain_field"`
+
+	// ExternalField is the external service desk field name
+	ExternalField string `json:"external_field"`
+
+	// Transform is an optional transformation function name
+	Transform string `json:"transform,omitempty"`
+
+	// Direction specifies sync direction (both, outbound, inbound)
+	Direction string `json:"direction"`
+}
+
+// StatusMapping maps on-chain ticket status to external status
+type StatusMapping struct {
+	// OnChainStatus is the VirtEngine ticket status
+	OnChainStatus string `json:"on_chain_status"`
+
+	// JiraStatus is the corresponding Jira status
+	JiraStatus string `json:"jira_status"`
+
+	// WaldurStatus is the corresponding Waldur status
+	WaldurStatus string `json:"waldur_status"`
+}
+
+// PriorityMapping maps on-chain ticket priority to external priority
+type PriorityMapping struct {
+	// OnChainPriority is the VirtEngine ticket priority
+	OnChainPriority string `json:"on_chain_priority"`
+
+	// JiraPriority is the corresponding Jira priority
+	JiraPriority string `json:"jira_priority"`
+
+	// WaldurPriority is the corresponding Waldur priority
+	WaldurPriority string `json:"waldur_priority"`
+}
+
+// CategoryMapping maps on-chain ticket category to external fields
+type CategoryMapping struct {
+	// OnChainCategory is the VirtEngine ticket category
+	OnChainCategory string `json:"on_chain_category"`
+
+	// JiraComponent is the corresponding Jira component
+	JiraComponent string `json:"jira_component"`
+
+	// JiraLabels are additional Jira labels
+	JiraLabels []string `json:"jira_labels,omitempty"`
+
+	// WaldurType is the corresponding Waldur issue type
+	WaldurType string `json:"waldur_type"`
+}
+
+// MappingSchema defines the complete mapping configuration
+type MappingSchema struct {
+	// Version is the schema version
+	Version string `json:"version"`
+
+	// FieldMappings are field-level mappings
+	FieldMappings []TicketFieldMapping `json:"field_mappings"`
+
+	// StatusMappings are status mappings
+	StatusMappings []StatusMapping `json:"status_mappings"`
+
+	// PriorityMappings are priority mappings
+	PriorityMappings []PriorityMapping `json:"priority_mappings"`
+
+	// CategoryMappings are category mappings
+	CategoryMappings []CategoryMapping `json:"category_mappings"`
+
+	// CustomFieldMappings maps VirtEngine fields to external custom fields
+	CustomFieldMappings map[string]string `json:"custom_field_mappings"`
+}
+
+// DefaultMappingSchema returns the default mapping schema
+func DefaultMappingSchema() *MappingSchema {
+	return &MappingSchema{
+		Version: "1.0",
+		FieldMappings: []TicketFieldMapping{
+			{OnChainField: "ticket_id", ExternalField: "virtengine_ticket_id", Direction: "outbound"},
+			{OnChainField: "customer_address", ExternalField: "virtengine_customer", Direction: "outbound"},
+			{OnChainField: "category", ExternalField: "component", Direction: "outbound"},
+			{OnChainField: "priority", ExternalField: "priority", Direction: "both"},
+			{OnChainField: "status", ExternalField: "status", Direction: "both"},
+			{OnChainField: "assigned_to", ExternalField: "assignee", Direction: "both"},
+		},
+		StatusMappings: []StatusMapping{
+			{OnChainStatus: "open", JiraStatus: "Open", WaldurStatus: "new"},
+			{OnChainStatus: "assigned", JiraStatus: "In Progress", WaldurStatus: "in_progress"},
+			{OnChainStatus: "in_progress", JiraStatus: "In Progress", WaldurStatus: "in_progress"},
+			{OnChainStatus: "pending_customer", JiraStatus: "Waiting for Customer", WaldurStatus: "waiting"},
+			{OnChainStatus: "resolved", JiraStatus: "Resolved", WaldurStatus: "resolved"},
+			{OnChainStatus: "closed", JiraStatus: "Closed", WaldurStatus: "closed"},
+		},
+		PriorityMappings: []PriorityMapping{
+			{OnChainPriority: "low", JiraPriority: "Low", WaldurPriority: "low"},
+			{OnChainPriority: "normal", JiraPriority: "Medium", WaldurPriority: "medium"},
+			{OnChainPriority: "high", JiraPriority: "High", WaldurPriority: "high"},
+			{OnChainPriority: "urgent", JiraPriority: "Highest", WaldurPriority: "critical"},
+		},
+		CategoryMappings: []CategoryMapping{
+			{OnChainCategory: "account", JiraComponent: "Account Management", WaldurType: "account"},
+			{OnChainCategory: "identity", JiraComponent: "Identity & VEID", WaldurType: "identity"},
+			{OnChainCategory: "billing", JiraComponent: "Billing & Payments", WaldurType: "billing"},
+			{OnChainCategory: "provider", JiraComponent: "Provider Services", WaldurType: "provider"},
+			{OnChainCategory: "marketplace", JiraComponent: "Marketplace", WaldurType: "marketplace"},
+			{OnChainCategory: "technical", JiraComponent: "Technical Support", WaldurType: "technical"},
+			{OnChainCategory: "security", JiraComponent: "Security", WaldurType: "security"},
+		},
+		CustomFieldMappings: map[string]string{
+			"ticket_id":         "customfield_10100",
+			"ticket_number":     "customfield_10101",
+			"customer_address":  "customfield_10102",
+			"related_entity":    "customfield_10103",
+			"provider_address":  "customfield_10104",
+			"blockchain_tx":     "customfield_10105",
+		},
+	}
+}
+
+// MapOnChainStatusToJira maps on-chain status to Jira status
+func (s *MappingSchema) MapOnChainStatusToJira(onChainStatus string) string {
+	for _, m := range s.StatusMappings {
+		if m.OnChainStatus == onChainStatus {
+			return m.JiraStatus
+		}
+	}
+	return "Open" // default
+}
+
+// MapOnChainStatusToWaldur maps on-chain status to Waldur status
+func (s *MappingSchema) MapOnChainStatusToWaldur(onChainStatus string) string {
+	for _, m := range s.StatusMappings {
+		if m.OnChainStatus == onChainStatus {
+			return m.WaldurStatus
+		}
+	}
+	return "new" // default
+}
+
+// MapJiraStatusToOnChain maps Jira status to on-chain status
+func (s *MappingSchema) MapJiraStatusToOnChain(jiraStatus string) string {
+	for _, m := range s.StatusMappings {
+		if m.JiraStatus == jiraStatus {
+			return m.OnChainStatus
+		}
+	}
+	return "open" // default
+}
+
+// MapWaldurStatusToOnChain maps Waldur status to on-chain status
+func (s *MappingSchema) MapWaldurStatusToOnChain(waldurStatus string) string {
+	for _, m := range s.StatusMappings {
+		if m.WaldurStatus == waldurStatus {
+			return m.OnChainStatus
+		}
+	}
+	return "open" // default
+}
+
+// MapPriorityToJira maps on-chain priority to Jira priority
+func (s *MappingSchema) MapPriorityToJira(onChainPriority string) string {
+	for _, m := range s.PriorityMappings {
+		if m.OnChainPriority == onChainPriority {
+			return m.JiraPriority
+		}
+	}
+	return "Medium" // default
+}
+
+// MapPriorityToWaldur maps on-chain priority to Waldur priority
+func (s *MappingSchema) MapPriorityToWaldur(onChainPriority string) string {
+	for _, m := range s.PriorityMappings {
+		if m.OnChainPriority == onChainPriority {
+			return m.WaldurPriority
+		}
+	}
+	return "medium" // default
+}
+
+// MapCategoryToJiraComponent maps on-chain category to Jira component
+func (s *MappingSchema) MapCategoryToJiraComponent(category string) string {
+	for _, m := range s.CategoryMappings {
+		if m.OnChainCategory == category {
+			return m.JiraComponent
+		}
+	}
+	return "General" // default
+}
+
+// ExternalTicketRef represents a reference to an external ticket
+type ExternalTicketRef struct {
+	// Type is the service desk type
+	Type ServiceDeskType `json:"type"`
+
+	// ExternalID is the external ticket ID (e.g., JIRA-123)
+	ExternalID string `json:"external_id"`
+
+	// ExternalURL is the URL to the external ticket
+	ExternalURL string `json:"external_url"`
+
+	// ProjectKey is the external project key
+	ProjectKey string `json:"project_key"`
+
+	// SyncStatus is the current sync status
+	SyncStatus SyncStatus `json:"sync_status"`
+
+	// LastSyncAt is the last successful sync timestamp
+	LastSyncAt *time.Time `json:"last_sync_at,omitempty"`
+
+	// LastSyncError is the last sync error message
+	LastSyncError string `json:"last_sync_error,omitempty"`
+
+	// SyncVersion is used for optimistic locking
+	SyncVersion int64 `json:"sync_version"`
+
+	// CreatedAt is when the external ticket was created
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Validate validates the external ticket reference
+func (r *ExternalTicketRef) Validate() error {
+	if !r.Type.IsValid() {
+		return fmt.Errorf("invalid service desk type: %s", r.Type)
+	}
+	if r.ExternalID == "" {
+		return fmt.Errorf("external ID is required")
+	}
+	return nil
+}
+
+// TicketSyncRecord tracks sync state for a ticket
+type TicketSyncRecord struct {
+	// TicketID is the on-chain ticket ID
+	TicketID string `json:"ticket_id"`
+
+	// ExternalRefs are references to external tickets
+	ExternalRefs []ExternalTicketRef `json:"external_refs"`
+
+	// LastOnChainUpdate is the last on-chain update timestamp
+	LastOnChainUpdate time.Time `json:"last_on_chain_update"`
+
+	// LastOnChainVersion is the last on-chain version (block height)
+	LastOnChainVersion int64 `json:"last_on_chain_version"`
+
+	// PendingSync indicates if there's a pending sync operation
+	PendingSync bool `json:"pending_sync"`
+
+	// ConflictResolution is the conflict resolution strategy
+	ConflictResolution ConflictResolution `json:"conflict_resolution"`
+}
+
+// GetExternalRef returns the external reference for the given type
+func (r *TicketSyncRecord) GetExternalRef(t ServiceDeskType) *ExternalTicketRef {
+	for i := range r.ExternalRefs {
+		if r.ExternalRefs[i].Type == t {
+			return &r.ExternalRefs[i]
+		}
+	}
+	return nil
+}
+
+// ConflictResolution defines how to resolve conflicts
+type ConflictResolution string
+
+const (
+	// ConflictResolutionOnChainWins uses on-chain data as source of truth
+	ConflictResolutionOnChainWins ConflictResolution = "on_chain_wins"
+
+	// ConflictResolutionExternalWins uses external data as source of truth
+	ConflictResolutionExternalWins ConflictResolution = "external_wins"
+
+	// ConflictResolutionNewestWins uses the newest update
+	ConflictResolutionNewestWins ConflictResolution = "newest_wins"
+
+	// ConflictResolutionManual requires manual resolution
+	ConflictResolutionManual ConflictResolution = "manual"
+)
+
+// SyncEvent represents an event that needs to be synced
+type SyncEvent struct {
+	// ID is the unique event ID
+	ID string `json:"id"`
+
+	// Type is the event type
+	Type string `json:"type"`
+
+	// TicketID is the on-chain ticket ID
+	TicketID string `json:"ticket_id"`
+
+	// Direction is the sync direction
+	Direction SyncDirection `json:"direction"`
+
+	// Payload is the event payload
+	Payload map[string]interface{} `json:"payload"`
+
+	// Timestamp is when the event occurred
+	Timestamp time.Time `json:"timestamp"`
+
+	// BlockHeight is the block height (for on-chain events)
+	BlockHeight int64 `json:"block_height,omitempty"`
+
+	// RetryCount is the number of retry attempts
+	RetryCount int `json:"retry_count"`
+
+	// MaxRetries is the maximum retry attempts
+	MaxRetries int `json:"max_retries"`
+
+	// NextRetryAt is when to retry next
+	NextRetryAt *time.Time `json:"next_retry_at,omitempty"`
+
+	// Status is the processing status
+	Status SyncStatus `json:"status"`
+
+	// Error is the last error message
+	Error string `json:"error,omitempty"`
+}
+
+// CanRetry checks if the event can be retried
+func (e *SyncEvent) CanRetry() bool {
+	return e.RetryCount < e.MaxRetries
+}
+
+// AttachmentSync represents an attachment sync request
+type AttachmentSync struct {
+	// TicketID is the on-chain ticket ID
+	TicketID string `json:"ticket_id"`
+
+	// ArtifactAddress is the artifact store content address
+	ArtifactAddress string `json:"artifact_address"`
+
+	// FileName is the original file name
+	FileName string `json:"file_name"`
+
+	// ContentType is the MIME content type
+	ContentType string `json:"content_type"`
+
+	// Size is the file size in bytes
+	Size int64 `json:"size"`
+
+	// ExternalAttachmentID is the external attachment ID after sync
+	ExternalAttachmentID string `json:"external_attachment_id,omitempty"`
+
+	// AccessToken is a temporary access token for the attachment
+	AccessToken string `json:"access_token,omitempty"`
+
+	// ExpiresAt is when the access token expires
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+// CallbackPayload is the payload for signed callbacks from external systems
+type CallbackPayload struct {
+	// EventType is the external event type
+	EventType string `json:"event_type"`
+
+	// ServiceDeskType is the service desk type
+	ServiceDeskType ServiceDeskType `json:"service_desk_type"`
+
+	// ExternalID is the external ticket ID
+	ExternalID string `json:"external_id"`
+
+	// OnChainTicketID is the VirtEngine ticket ID
+	OnChainTicketID string `json:"on_chain_ticket_id"`
+
+	// Changes are the field changes
+	Changes map[string]interface{} `json:"changes"`
+
+	// Timestamp is when the event occurred
+	Timestamp time.Time `json:"timestamp"`
+
+	// Signature is the HMAC signature
+	Signature string `json:"signature"`
+
+	// Nonce is a unique nonce to prevent replay attacks
+	Nonce string `json:"nonce"`
+}
+
+// Validate validates the callback payload
+func (p *CallbackPayload) Validate() error {
+	if p.EventType == "" {
+		return fmt.Errorf("event_type is required")
+	}
+	if !p.ServiceDeskType.IsValid() {
+		return fmt.Errorf("invalid service_desk_type: %s", p.ServiceDeskType)
+	}
+	if p.ExternalID == "" {
+		return fmt.Errorf("external_id is required")
+	}
+	if p.OnChainTicketID == "" {
+		return fmt.Errorf("on_chain_ticket_id is required")
+	}
+	if p.Signature == "" {
+		return fmt.Errorf("signature is required")
+	}
+	if p.Nonce == "" {
+		return fmt.Errorf("nonce is required")
+	}
+	return nil
+}

--- a/pkg/servicedesk/types_test.go
+++ b/pkg/servicedesk/types_test.go
@@ -1,0 +1,300 @@
+package servicedesk
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultMappingSchema(t *testing.T) {
+	schema := DefaultMappingSchema()
+
+	if schema.Version != "1.0" {
+		t.Errorf("expected version 1.0, got %s", schema.Version)
+	}
+
+	// Test status mappings
+	tests := []struct {
+		onChain string
+		jira    string
+		waldur  string
+	}{
+		{"open", "Open", "new"},
+		{"assigned", "In Progress", "in_progress"},
+		{"in_progress", "In Progress", "in_progress"},
+		{"pending_customer", "Waiting for Customer", "waiting"},
+		{"resolved", "Resolved", "resolved"},
+		{"closed", "Closed", "closed"},
+	}
+
+	for _, tt := range tests {
+		jira := schema.MapOnChainStatusToJira(tt.onChain)
+		if jira != tt.jira {
+			t.Errorf("MapOnChainStatusToJira(%s) = %s, want %s", tt.onChain, jira, tt.jira)
+		}
+
+		waldur := schema.MapOnChainStatusToWaldur(tt.onChain)
+		if waldur != tt.waldur {
+			t.Errorf("MapOnChainStatusToWaldur(%s) = %s, want %s", tt.onChain, waldur, tt.waldur)
+		}
+	}
+}
+
+func TestMapStatusRoundTrip(t *testing.T) {
+	schema := DefaultMappingSchema()
+
+	// Test Jira round trip
+	jiraStatus := schema.MapOnChainStatusToJira("open")
+	onChain := schema.MapJiraStatusToOnChain(jiraStatus)
+	if onChain != "open" {
+		t.Errorf("Jira round trip failed: open -> %s -> %s", jiraStatus, onChain)
+	}
+
+	// Test Waldur round trip
+	waldurStatus := schema.MapOnChainStatusToWaldur("resolved")
+	onChain = schema.MapWaldurStatusToOnChain(waldurStatus)
+	if onChain != "resolved" {
+		t.Errorf("Waldur round trip failed: resolved -> %s -> %s", waldurStatus, onChain)
+	}
+}
+
+func TestPriorityMapping(t *testing.T) {
+	schema := DefaultMappingSchema()
+
+	tests := []struct {
+		onChain string
+		jira    string
+		waldur  string
+	}{
+		{"low", "Low", "low"},
+		{"normal", "Medium", "medium"},
+		{"high", "High", "high"},
+		{"urgent", "Highest", "critical"},
+	}
+
+	for _, tt := range tests {
+		jira := schema.MapPriorityToJira(tt.onChain)
+		if jira != tt.jira {
+			t.Errorf("MapPriorityToJira(%s) = %s, want %s", tt.onChain, jira, tt.jira)
+		}
+
+		waldur := schema.MapPriorityToWaldur(tt.onChain)
+		if waldur != tt.waldur {
+			t.Errorf("MapPriorityToWaldur(%s) = %s, want %s", tt.onChain, waldur, tt.waldur)
+		}
+	}
+}
+
+func TestCategoryMapping(t *testing.T) {
+	schema := DefaultMappingSchema()
+
+	tests := []struct {
+		category  string
+		component string
+	}{
+		{"account", "Account Management"},
+		{"identity", "Identity & VEID"},
+		{"billing", "Billing & Payments"},
+		{"provider", "Provider Services"},
+		{"marketplace", "Marketplace"},
+		{"technical", "Technical Support"},
+		{"security", "Security"},
+	}
+
+	for _, tt := range tests {
+		component := schema.MapCategoryToJiraComponent(tt.category)
+		if component != tt.component {
+			t.Errorf("MapCategoryToJiraComponent(%s) = %s, want %s", tt.category, component, tt.component)
+		}
+	}
+}
+
+func TestExternalTicketRefValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     ExternalTicketRef
+		wantErr bool
+	}{
+		{
+			name: "valid jira ref",
+			ref: ExternalTicketRef{
+				Type:       ServiceDeskJira,
+				ExternalID: "PROJ-123",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid waldur ref",
+			ref: ExternalTicketRef{
+				Type:       ServiceDeskWaldur,
+				ExternalID: "abc-123",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid type",
+			ref: ExternalTicketRef{
+				Type:       "invalid",
+				ExternalID: "123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing external ID",
+			ref: ExternalTicketRef{
+				Type:       ServiceDeskJira,
+				ExternalID: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.ref.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCallbackPayloadValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload CallbackPayload
+		wantErr bool
+	}{
+		{
+			name: "valid payload",
+			payload: CallbackPayload{
+				EventType:       "status_changed",
+				ServiceDeskType: ServiceDeskJira,
+				ExternalID:      "PROJ-123",
+				OnChainTicketID: "TKT-00000001",
+				Signature:       "abc123",
+				Nonce:           "nonce123",
+				Timestamp:       time.Now(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing event type",
+			payload: CallbackPayload{
+				ServiceDeskType: ServiceDeskJira,
+				ExternalID:      "PROJ-123",
+				OnChainTicketID: "TKT-00000001",
+				Signature:       "abc123",
+				Nonce:           "nonce123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing signature",
+			payload: CallbackPayload{
+				EventType:       "status_changed",
+				ServiceDeskType: ServiceDeskJira,
+				ExternalID:      "PROJ-123",
+				OnChainTicketID: "TKT-00000001",
+				Nonce:           "nonce123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing nonce",
+			payload: CallbackPayload{
+				EventType:       "status_changed",
+				ServiceDeskType: ServiceDeskJira,
+				ExternalID:      "PROJ-123",
+				OnChainTicketID: "TKT-00000001",
+				Signature:       "abc123",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.payload.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSyncEventCanRetry(t *testing.T) {
+	event := &SyncEvent{
+		ID:         "test-1",
+		MaxRetries: 3,
+		RetryCount: 0,
+	}
+
+	if !event.CanRetry() {
+		t.Error("expected CanRetry() = true for RetryCount 0")
+	}
+
+	event.RetryCount = 2
+	if !event.CanRetry() {
+		t.Error("expected CanRetry() = true for RetryCount 2")
+	}
+
+	event.RetryCount = 3
+	if event.CanRetry() {
+		t.Error("expected CanRetry() = false for RetryCount 3")
+	}
+
+	event.RetryCount = 5
+	if event.CanRetry() {
+		t.Error("expected CanRetry() = false for RetryCount 5")
+	}
+}
+
+func TestTicketSyncRecordGetExternalRef(t *testing.T) {
+	record := &TicketSyncRecord{
+		TicketID: "TKT-00000001",
+		ExternalRefs: []ExternalTicketRef{
+			{Type: ServiceDeskJira, ExternalID: "PROJ-123"},
+			{Type: ServiceDeskWaldur, ExternalID: "waldur-456"},
+		},
+	}
+
+	jiraRef := record.GetExternalRef(ServiceDeskJira)
+	if jiraRef == nil {
+		t.Fatal("expected to find Jira ref")
+	}
+	if jiraRef.ExternalID != "PROJ-123" {
+		t.Errorf("expected ExternalID PROJ-123, got %s", jiraRef.ExternalID)
+	}
+
+	waldurRef := record.GetExternalRef(ServiceDeskWaldur)
+	if waldurRef == nil {
+		t.Fatal("expected to find Waldur ref")
+	}
+	if waldurRef.ExternalID != "waldur-456" {
+		t.Errorf("expected ExternalID waldur-456, got %s", waldurRef.ExternalID)
+	}
+
+	// Test non-existent
+	unknownRef := record.GetExternalRef("unknown")
+	if unknownRef != nil {
+		t.Error("expected nil for unknown service desk type")
+	}
+}
+
+func TestServiceDeskTypeIsValid(t *testing.T) {
+	tests := []struct {
+		t       ServiceDeskType
+		isValid bool
+	}{
+		{ServiceDeskJira, true},
+		{ServiceDeskWaldur, true},
+		{"invalid", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if tt.t.IsValid() != tt.isValid {
+			t.Errorf("ServiceDeskType(%s).IsValid() = %v, want %v", tt.t, tt.t.IsValid(), tt.isValid)
+		}
+	}
+}

--- a/x/support/types/errors.go
+++ b/x/support/types/errors.go
@@ -27,4 +27,14 @@ var (
 	ErrInvalidCategory      = errors.Register(ModuleName, 19, "invalid ticket category")
 	ErrTicketNotResolved    = errors.Register(ModuleName, 20, "ticket is not resolved")
 	ErrSelfAssignment       = errors.Register(ModuleName, 21, "cannot assign ticket to self")
+
+	// External sync errors
+	ErrExternalSyncFailed   = errors.Register(ModuleName, 30, "external sync failed")
+	ErrExternalRefNotFound  = errors.Register(ModuleName, 31, "external ticket reference not found")
+	ErrSyncConflict         = errors.Register(ModuleName, 32, "sync conflict detected")
+	ErrInvalidSyncConfig    = errors.Register(ModuleName, 33, "invalid sync configuration")
+	ErrInvalidSignature     = errors.Register(ModuleName, 34, "invalid callback signature")
+	ErrDuplicateNonce       = errors.Register(ModuleName, 35, "duplicate callback nonce")
+	ErrAttachmentFailed     = errors.Register(ModuleName, 36, "attachment operation failed")
+	ErrExternalAPIError     = errors.Register(ModuleName, 37, "external API error")
 )

--- a/x/support/types/external_sync.go
+++ b/x/support/types/external_sync.go
@@ -1,0 +1,259 @@
+package types
+
+import (
+	"fmt"
+	"time"
+)
+
+// External sync store key prefixes
+var (
+	// PrefixExternalTicketRef is the prefix for external ticket references
+	// Key: PrefixExternalTicketRef | ticket_id | service_desk_type -> ExternalTicketRef
+	PrefixExternalTicketRef = []byte{0x10}
+
+	// PrefixSyncRecord is the prefix for sync records
+	// Key: PrefixSyncRecord | ticket_id -> TicketSyncRecord
+	PrefixSyncRecord = []byte{0x11}
+
+	// PrefixExternalCallback is the prefix for external callback nonce tracking
+	// Key: PrefixExternalCallback | nonce -> timestamp
+	PrefixExternalCallback = []byte{0x12}
+
+	// PrefixSyncAudit is the prefix for sync audit log
+	// Key: PrefixSyncAudit | timestamp | sequence -> SyncAuditEntry
+	PrefixSyncAudit = []byte{0x13}
+)
+
+// ServiceDeskType identifies the external service desk system
+type ServiceDeskType string
+
+const (
+	// ServiceDeskJira represents Jira Service Desk
+	ServiceDeskJira ServiceDeskType = "jira"
+
+	// ServiceDeskWaldur represents Waldur service desk
+	ServiceDeskWaldur ServiceDeskType = "waldur"
+)
+
+// IsValid checks if the service desk type is valid
+func (t ServiceDeskType) IsValid() bool {
+	return t == ServiceDeskJira || t == ServiceDeskWaldur
+}
+
+// ExternalSyncStatus represents the synchronization status
+type ExternalSyncStatus string
+
+const (
+	// ExternalSyncPending indicates sync is pending
+	ExternalSyncPending ExternalSyncStatus = "pending"
+
+	// ExternalSyncSynced indicates successful sync
+	ExternalSyncSynced ExternalSyncStatus = "synced"
+
+	// ExternalSyncFailed indicates sync failed
+	ExternalSyncFailed ExternalSyncStatus = "failed"
+
+	// ExternalSyncConflict indicates a conflict was detected
+	ExternalSyncConflict ExternalSyncStatus = "conflict"
+)
+
+// ExternalTicketRef represents a reference to an external service desk ticket
+type ExternalTicketRef struct {
+	// TicketID is the on-chain ticket ID
+	TicketID string `json:"ticket_id"`
+
+	// ServiceDeskType is the external service desk type
+	ServiceDeskType ServiceDeskType `json:"service_desk_type"`
+
+	// ExternalID is the external ticket ID (e.g., JIRA-123)
+	ExternalID string `json:"external_id"`
+
+	// ExternalURL is the URL to the external ticket
+	ExternalURL string `json:"external_url"`
+
+	// ProjectKey is the external project key
+	ProjectKey string `json:"project_key"`
+
+	// SyncStatus is the current sync status
+	SyncStatus ExternalSyncStatus `json:"sync_status"`
+
+	// LastSyncAt is the last successful sync timestamp
+	LastSyncAt *time.Time `json:"last_sync_at,omitempty"`
+
+	// LastSyncError is the last sync error message
+	LastSyncError string `json:"last_sync_error,omitempty"`
+
+	// SyncVersion is used for optimistic locking
+	SyncVersion int64 `json:"sync_version"`
+
+	// CreatedAt is when the external ticket was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// LastExternalUpdate is the last external update timestamp
+	LastExternalUpdate *time.Time `json:"last_external_update,omitempty"`
+}
+
+// Validate validates the external ticket reference
+func (r *ExternalTicketRef) Validate() error {
+	if r.TicketID == "" {
+		return ErrInvalidTicketID.Wrap("ticket_id is required")
+	}
+	if !r.ServiceDeskType.IsValid() {
+		return ErrInvalidSyncConfig.Wrapf("invalid service desk type: %s", r.ServiceDeskType)
+	}
+	if r.ExternalID == "" {
+		return ErrInvalidSyncConfig.Wrap("external_id is required")
+	}
+	return nil
+}
+
+// TicketSyncRecord tracks the complete sync state for a ticket
+type TicketSyncRecord struct {
+	// TicketID is the on-chain ticket ID
+	TicketID string `json:"ticket_id"`
+
+	// ExternalRefs are references to external tickets
+	ExternalRefs []ExternalTicketRef `json:"external_refs"`
+
+	// LastOnChainUpdate is the last on-chain update block height
+	LastOnChainBlockHeight int64 `json:"last_on_chain_block_height"`
+
+	// LastOnChainTxHash is the last on-chain transaction hash
+	LastOnChainTxHash string `json:"last_on_chain_tx_hash"`
+
+	// PendingSync indicates if there's a pending sync operation
+	PendingSync bool `json:"pending_sync"`
+
+	// PendingSyncDirection indicates the pending sync direction
+	PendingSyncDirection string `json:"pending_sync_direction,omitempty"`
+
+	// ConflictResolution is the conflict resolution strategy
+	ConflictResolution string `json:"conflict_resolution"`
+
+	// CreatedAt is when the sync record was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is when the sync record was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// GetExternalRef returns the external reference for the given service desk type
+func (r *TicketSyncRecord) GetExternalRef(t ServiceDeskType) *ExternalTicketRef {
+	for i := range r.ExternalRefs {
+		if r.ExternalRefs[i].ServiceDeskType == t {
+			return &r.ExternalRefs[i]
+		}
+	}
+	return nil
+}
+
+// Validate validates the sync record
+func (r *TicketSyncRecord) Validate() error {
+	if r.TicketID == "" {
+		return ErrInvalidTicketID.Wrap("ticket_id is required")
+	}
+	for _, ref := range r.ExternalRefs {
+		if err := ref.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SyncAuditEntry represents an entry in the sync audit log
+type SyncAuditEntry struct {
+	// ID is the unique entry ID
+	ID string `json:"id"`
+
+	// TicketID is the on-chain ticket ID
+	TicketID string `json:"ticket_id"`
+
+	// ServiceDeskType is the external service desk type
+	ServiceDeskType ServiceDeskType `json:"service_desk_type"`
+
+	// ExternalID is the external ticket ID
+	ExternalID string `json:"external_id"`
+
+	// EventType is the type of sync event
+	EventType string `json:"event_type"`
+
+	// Direction is the sync direction (inbound/outbound)
+	Direction string `json:"direction"`
+
+	// Status is the sync status
+	Status ExternalSyncStatus `json:"status"`
+
+	// Details contains additional event details
+	Details string `json:"details,omitempty"`
+
+	// Error contains error information
+	Error string `json:"error,omitempty"`
+
+	// BlockHeight is the on-chain block height
+	BlockHeight int64 `json:"block_height"`
+
+	// TxHash is the related transaction hash
+	TxHash string `json:"tx_hash,omitempty"`
+
+	// Timestamp is when the event occurred
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// Validate validates the sync audit entry
+func (e *SyncAuditEntry) Validate() error {
+	if e.TicketID == "" {
+		return ErrInvalidTicketID.Wrap("ticket_id is required")
+	}
+	if e.EventType == "" {
+		return ErrInvalidSyncConfig.Wrap("event_type is required")
+	}
+	return nil
+}
+
+// ExternalTicketRefKey returns the store key for an external ticket reference
+func ExternalTicketRefKey(ticketID string, serviceDeskType ServiceDeskType) []byte {
+	key := make([]byte, 0, len(PrefixExternalTicketRef)+len(ticketID)+len(serviceDeskType)+2)
+	key = append(key, PrefixExternalTicketRef...)
+	key = append(key, []byte(ticketID)...)
+	key = append(key, '/')
+	key = append(key, []byte(serviceDeskType)...)
+	return key
+}
+
+// ExternalTicketRefPrefixKey returns the prefix for a ticket's external references
+func ExternalTicketRefPrefixKey(ticketID string) []byte {
+	key := make([]byte, 0, len(PrefixExternalTicketRef)+len(ticketID)+1)
+	key = append(key, PrefixExternalTicketRef...)
+	key = append(key, []byte(ticketID)...)
+	key = append(key, '/')
+	return key
+}
+
+// SyncRecordKey returns the store key for a sync record
+func SyncRecordKey(ticketID string) []byte {
+	key := make([]byte, 0, len(PrefixSyncRecord)+len(ticketID))
+	key = append(key, PrefixSyncRecord...)
+	key = append(key, []byte(ticketID)...)
+	return key
+}
+
+// ExternalCallbackNonceKey returns the store key for callback nonce tracking
+func ExternalCallbackNonceKey(nonce string) []byte {
+	key := make([]byte, 0, len(PrefixExternalCallback)+len(nonce))
+	key = append(key, PrefixExternalCallback...)
+	key = append(key, []byte(nonce)...)
+	return key
+}
+
+// Proto message interface stubs
+func (*ExternalTicketRef) ProtoMessage()   {}
+func (r *ExternalTicketRef) Reset()        { *r = ExternalTicketRef{} }
+func (r *ExternalTicketRef) String() string { return fmt.Sprintf("%+v", *r) }
+
+func (*TicketSyncRecord) ProtoMessage()    {}
+func (r *TicketSyncRecord) Reset()         { *r = TicketSyncRecord{} }
+func (r *TicketSyncRecord) String() string { return fmt.Sprintf("%+v", *r) }
+
+func (*SyncAuditEntry) ProtoMessage()      {}
+func (e *SyncAuditEntry) Reset()           { *e = SyncAuditEntry{} }
+func (e *SyncAuditEntry) String() string   { return fmt.Sprintf("%+v", *e) }


### PR DESCRIPTION
Objective:
Bridge on-chain support tickets to Jira/Waldur service desk systems with bi-directional sync.

Prerequisites:
- 2F feat(app): add encrypted on-chain support request module

Needs to be done (A–I):
A. Define mapping from on-chain ticket fields to Jira/Waldur fields.
B. Implement bridge service that listens to chain events and creates tickets.
C. Sync status updates from Jira/Waldur back on-chain with signed callbacks.
D. Handle attachments via artifact store with access controls.
E. Add conflict resolution for concurrent updates.
F. Provide audit trail of external actions.
G. Implement retry and backoff for API failures.
H. Add integration tests using sandbox Jira/Waldur.
I. Document operational flow and credentials management.

Acceptance criteria:
- On-chain ticket creates external ticket automatically.
- Status changes sync both directions with audit logs.
- Attachments handled securely.
- Failures are retried and surfaced in monitoring.

How it can be done:
- Use pkg/jira and pkg/waldur clients in bridge service.
- Add signed callback handling to x/support.
- Use artifact store for attachments.

MCP guidance:
- Use Context7 for Jira/Waldur client APIs.
- Use Exa for service desk integration patterns.

Deliverables:
- Bridge service, mapping schema, sync logic, tests.