### PR TITLE
feat(veid): add SSO/OIDC verification service

### DIFF
--- a/_docs/sso-oidc-operations.md
+++ b/_docs/sso-oidc-operations.md
@@ -1,0 +1,468 @@
+# SSO/OIDC Verification Service Operations Runbook
+
+## Overview
+
+This runbook documents the operational procedures for the VEID SSO/OIDC Verification Service. The service enables users to link their blockchain accounts with verified SSO identities from providers like Google, Microsoft, and GitHub.
+
+## Architecture
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│   User Wallet   │────>│  SSO Service     │────>│  OIDC Provider  │
+│   (Client)      │     │  (Off-Chain)     │     │  (Google/MS)    │
+└────────┬────────┘     └────────┬─────────┘     └─────────────────┘
+         │                       │
+         │                       v
+         │              ┌──────────────────┐
+         │              │  Signer Service  │
+         │              │  (HSM/Vault)     │
+         │              └────────┬─────────┘
+         │                       │
+         v                       v
+┌─────────────────────────────────────────────────┐
+│              VirtEngine Chain                    │
+│  ┌─────────────┐  ┌─────────────────────────┐  │
+│  │  x/veid     │  │  SSO Linkage Records    │  │
+│  │  Keeper     │──│  Nonce Tracking         │  │
+│  │             │  │  Attestations           │  │
+│  └─────────────┘  └─────────────────────────┘  │
+└─────────────────────────────────────────────────┘
+```
+
+## Component Overview
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| OIDC Verifier | `pkg/verification/oidc/` | Token validation, JWKS caching |
+| SSO Service | `pkg/verification/sso/` | Challenge management, attestation creation |
+| SSO Keeper | `x/veid/keeper/sso_linkage.go` | On-chain linkage storage, nonce tracking |
+| SSO Types | `x/veid/types/sso_*.go` | Message types, attestation schema |
+| Admin CLI | `sdk/go/cli/sso.go` | Configuration management |
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# SSO Service Configuration
+SSO_ENABLED=true
+SSO_CHALLENGE_TTL_SECONDS=600
+SSO_ATTESTATION_VALIDITY_DAYS=365
+SSO_MAX_CHALLENGES_PER_ACCOUNT=3
+
+# OIDC Configuration
+OIDC_JWKS_CACHE_TTL_SECONDS=3600
+OIDC_JWKS_REFRESH_INTERVAL_SECONDS=1800
+OIDC_HTTP_TIMEOUT_SECONDS=30
+OIDC_MAX_CLOCK_SKEW_SECONDS=300
+
+# Rate Limiting
+SSO_RATE_LIMIT_ENABLED=true
+SSO_RATE_LIMIT_MAX_REQUESTS=10
+SSO_RATE_LIMIT_WINDOW_SECONDS=300
+```
+
+### Issuer Configuration
+
+Create an issuer configuration file (`sso-issuers.yaml`):
+
+```yaml
+issuers:
+  - issuer: "https://accounts.google.com"
+    client_id: "${GOOGLE_CLIENT_ID}"
+    client_secret: "${GOOGLE_CLIENT_SECRET}"
+    provider_type: "google"
+    score_weight: 250  # 2.5%
+    enabled: true
+    required_scopes:
+      - "openid"
+      - "email"
+      - "profile"
+    require_email_verified: true
+
+  - issuer: "https://login.microsoftonline.com/common/v2.0"
+    client_id: "${MICROSOFT_CLIENT_ID}"
+    client_secret: "${MICROSOFT_CLIENT_SECRET}"
+    provider_type: "microsoft"
+    score_weight: 300  # 3.0%
+    enabled: true
+    required_scopes:
+      - "openid"
+      - "email"
+      - "profile"
+    require_email_verified: true
+    allowed_tenants:
+      - "${ALLOWED_TENANT_ID}"
+
+  - issuer: "https://token.actions.githubusercontent.com"
+    client_id: "${GITHUB_CLIENT_ID}"
+    client_secret: "${GITHUB_CLIENT_SECRET}"
+    provider_type: "github"
+    score_weight: 200  # 2.0%
+    enabled: true
+```
+
+## Deployment
+
+### Prerequisites
+
+1. **Signer Service**: HSM or Vault-based signing service must be deployed and configured
+2. **Redis** (recommended): For production challenge storage
+3. **Monitoring**: Prometheus/Grafana for metrics
+
+### Deployment Steps
+
+1. **Configure Secrets**
+   ```bash
+   # Store OIDC client credentials securely
+   vault kv put secret/sso/google \
+     client_id="your-google-client-id" \
+     client_secret="your-google-client-secret"
+
+   vault kv put secret/sso/microsoft \
+     client_id="your-microsoft-client-id" \
+     client_secret="your-microsoft-client-secret"
+   ```
+
+2. **Deploy SSO Service**
+   ```bash
+   # Using Docker Compose
+   docker-compose -f docker-compose.sso.yaml up -d
+
+   # Using Kubernetes
+   kubectl apply -f deploy/sso-service.yaml
+   ```
+
+3. **Verify Deployment**
+   ```bash
+   # Health check
+   curl http://sso-service:8080/health
+
+   # Check issuer connectivity
+   virtengine sso issuer list
+   ```
+
+## Operations
+
+### Adding a New Issuer
+
+1. **Register OAuth Application with Provider**
+   - Google: [Google Cloud Console](https://console.cloud.google.com)
+   - Microsoft: [Azure Portal](https://portal.azure.com)
+   - Generic OIDC: Provider's developer console
+
+2. **Configure Redirect URI**
+   ```
+   https://your-domain.com/api/v1/sso/callback
+   ```
+
+3. **Add Issuer to Configuration**
+   ```bash
+   virtengine sso issuer add https://issuer.example.com \
+     --client-id="your-client-id" \
+     --provider-type=oidc \
+     --score-weight=150 \
+     --enabled=true
+   ```
+
+4. **Validate Configuration**
+   ```bash
+   virtengine sso config validate sso-issuers.yaml
+   ```
+
+5. **Restart SSO Service**
+   ```bash
+   kubectl rollout restart deployment/sso-service
+   ```
+
+### Removing an Issuer
+
+1. **Disable the Issuer First**
+   ```bash
+   virtengine sso issuer update https://issuer.example.com --enabled=false
+   ```
+
+2. **Monitor for Active Sessions** (wait 24 hours if possible)
+
+3. **Remove from Configuration**
+   ```bash
+   virtengine sso issuer remove https://issuer.example.com
+   ```
+
+### Revoking a Linkage
+
+```bash
+# Via CLI (requires authorized signer)
+virtengine tx veid revoke-sso-linkage \
+  --linkage-id="linkage-uuid" \
+  --reason="user request" \
+  --from=admin \
+  --chain-id=virtengine-1
+```
+
+## Key Rotation
+
+### Attestation Signing Key Rotation
+
+The signer service handles key rotation automatically. Manual rotation:
+
+1. **Generate New Key**
+   ```bash
+   virtengine signer key rotate \
+     --reason="scheduled rotation" \
+     --overlap-hours=24
+   ```
+
+2. **Monitor Rotation Progress**
+   ```bash
+   virtengine signer key status
+   ```
+
+3. **Verify New Key Active**
+   ```bash
+   virtengine signer key list --state=active
+   ```
+
+### JWKS Rotation
+
+JWKS rotation is handled automatically by providers. To force refresh:
+
+```bash
+# Force JWKS refresh for an issuer
+virtengine sso issuer refresh-jwks https://accounts.google.com
+```
+
+## Monitoring
+
+### Key Metrics
+
+| Metric | Description | Alert Threshold |
+|--------|-------------|-----------------|
+| `sso_challenge_created_total` | Total challenges created | - |
+| `sso_challenge_completed_total` | Completed verifications | - |
+| `sso_challenge_failed_total` | Failed verifications | > 10% of total |
+| `sso_attestation_created_total` | Attestations issued | - |
+| `sso_linkage_created_total` | On-chain linkages created | - |
+| `sso_nonce_used_total` | Nonces consumed | - |
+| `oidc_token_validation_duration_seconds` | Token validation time | p99 > 1s |
+| `oidc_jwks_cache_hit_total` | JWKS cache hits | hit rate < 90% |
+| `oidc_jwks_fetch_errors_total` | JWKS fetch failures | > 0 sustained |
+
+### Alerts
+
+```yaml
+# Prometheus alert rules
+groups:
+  - name: sso-alerts
+    rules:
+      - alert: SSOVerificationFailureRateHigh
+        expr: rate(sso_challenge_failed_total[5m]) / rate(sso_challenge_created_total[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "SSO verification failure rate is high"
+
+      - alert: JWKSFetchErrors
+        expr: rate(oidc_jwks_fetch_errors_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "JWKS fetch errors detected"
+
+      - alert: SSOServiceUnhealthy
+        expr: up{job="sso-service"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "SSO service is down"
+```
+
+### Logging
+
+Structured logging is used for all SSO operations. Key log events:
+
+| Event | Level | Fields |
+|-------|-------|--------|
+| challenge_created | INFO | challenge_id, account, provider |
+| challenge_completed | INFO | challenge_id, account, provider, linkage_id |
+| challenge_failed | WARN | challenge_id, account, provider, error |
+| token_verified | DEBUG | issuer, subject_hash |
+| jwks_refreshed | DEBUG | issuer, key_count |
+| nonce_used | INFO | nonce_hash, account |
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. JWKS Fetch Failures
+
+**Symptoms**: Token verification fails, JWKS cache misses
+
+**Causes**:
+- Network connectivity issues
+- Provider outage
+- DNS resolution failure
+
+**Resolution**:
+```bash
+# Check connectivity to provider
+curl -v https://accounts.google.com/.well-known/openid-configuration
+
+# Force JWKS refresh
+virtengine sso issuer refresh-jwks https://accounts.google.com
+
+# Check JWKS cache status
+virtengine sso issuer status https://accounts.google.com
+```
+
+#### 2. Token Validation Failures
+
+**Symptoms**: Valid tokens being rejected
+
+**Causes**:
+- Clock skew between nodes
+- Expired tokens
+- Audience mismatch
+
+**Resolution**:
+```bash
+# Check node time synchronization
+timedatectl status
+
+# Verify client ID configuration
+virtengine sso issuer show https://accounts.google.com
+
+# Check token claims (decode without verifying for debugging)
+echo $TOKEN | cut -d. -f2 | base64 -d | jq
+```
+
+#### 3. Nonce Replay Detection
+
+**Symptoms**: Legitimate verifications rejected as replays
+
+**Causes**:
+- User clicked "verify" multiple times
+- Network retry caused duplicate submission
+- Nonce not properly generated
+
+**Resolution**:
+```bash
+# Check nonce status
+virtengine query veid sso-nonce <nonce-hash>
+
+# Verify nonce was used for which linkage
+virtengine query veid sso-linkage <linkage-id>
+```
+
+#### 4. Rate Limiting
+
+**Symptoms**: 429 errors, verification requests rejected
+
+**Causes**:
+- Too many verification attempts
+- Potential abuse
+
+**Resolution**:
+```bash
+# Check rate limit status for account
+virtengine query veid rate-limit-status <account-address>
+
+# If legitimate, consider increasing limits
+# Update configuration and restart service
+```
+
+### Debug Mode
+
+Enable debug logging:
+
+```bash
+export SSO_LOG_LEVEL=debug
+export OIDC_LOG_LEVEL=debug
+```
+
+## Security Considerations
+
+### Secrets Management
+
+- **Never log** client secrets or tokens
+- Use **Vault or HSM** for signing keys
+- Rotate client secrets **annually**
+- Monitor for **credential exposure**
+
+### Attack Prevention
+
+| Attack | Mitigation |
+|--------|-----------|
+| Token replay | Nonce tracking, short TTL |
+| CSRF | State parameter validation |
+| Session fixation | Unique challenge per request |
+| Denial of service | Rate limiting, max challenges |
+| Linkage hijacking | Account signature verification |
+
+### Audit Requirements
+
+All SSO operations are logged to the audit service. Retain logs for:
+- Linkage creation: **7 years** (compliance)
+- Verification attempts: **90 days**
+- Failed attempts: **1 year**
+
+## Maintenance
+
+### Daily Tasks
+
+- [ ] Check alert dashboard
+- [ ] Verify JWKS cache health
+- [ ] Monitor error rates
+
+### Weekly Tasks
+
+- [ ] Review failed verification patterns
+- [ ] Check disk space for audit logs
+- [ ] Verify backup integrity
+
+### Monthly Tasks
+
+- [ ] Review and update issuer policies
+- [ ] Audit rate limit thresholds
+- [ ] Test disaster recovery procedures
+
+### Quarterly Tasks
+
+- [ ] Rotate attestation signing keys
+- [ ] Review access controls
+- [ ] Security audit of configuration
+
+## Disaster Recovery
+
+### Service Failure
+
+1. **Identify** the failure mode
+2. **Restart** the service
+3. **Verify** JWKS caches are rebuilt
+4. **Monitor** for cascading failures
+
+### Key Compromise
+
+1. **Immediately rotate** the compromised key
+2. **Revoke** all attestations signed with the key
+3. **Issue** new attestations with the new key
+4. **Notify** affected users
+5. **Investigate** the compromise
+
+### Provider Outage
+
+1. **Disable** the affected issuer
+2. **Notify** users of temporary unavailability
+3. **Monitor** provider status page
+4. **Re-enable** when provider recovers
+
+## Support
+
+For issues not covered in this runbook:
+
+- **Internal**: #virtengine-sso Slack channel
+- **On-call**: Page via PagerDuty
+- **Documentation**: [Internal Wiki](https://wiki.internal/veid/sso)

--- a/pkg/verification/oidc/errors.go
+++ b/pkg/verification/oidc/errors.go
@@ -1,0 +1,78 @@
+// Package oidc provides OIDC token verification for the VEID SSO verification service.
+package oidc
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ============================================================================
+// Error Definitions
+// ============================================================================
+
+var (
+	// ErrInvalidToken indicates an invalid OIDC token.
+	ErrInvalidToken = errors.New("invalid OIDC token")
+
+	// ErrTokenExpired indicates an expired token.
+	ErrTokenExpired = errors.New("OIDC token has expired")
+
+	// ErrInvalidIssuer indicates an invalid or unallowed issuer.
+	ErrInvalidIssuer = errors.New("invalid or unallowed OIDC issuer")
+
+	// ErrInvalidAudience indicates an invalid audience claim.
+	ErrInvalidAudience = errors.New("invalid OIDC audience")
+
+	// ErrInvalidNonce indicates a nonce mismatch (replay attempt).
+	ErrInvalidNonce = errors.New("invalid or mismatched nonce")
+
+	// ErrMissingClaim indicates a required claim is missing.
+	ErrMissingClaim = errors.New("required claim is missing")
+
+	// ErrInvalidSignature indicates the token signature is invalid.
+	ErrInvalidSignature = errors.New("invalid token signature")
+
+	// ErrJWKSFetchFailed indicates JWKS fetch failed.
+	ErrJWKSFetchFailed = errors.New("failed to fetch JWKS")
+
+	// ErrKeyNotFound indicates the signing key was not found in JWKS.
+	ErrKeyNotFound = errors.New("signing key not found in JWKS")
+
+	// ErrDiscoveryFailed indicates OIDC discovery failed.
+	ErrDiscoveryFailed = errors.New("OIDC discovery failed")
+
+	// ErrInvalidIssuerPolicy indicates an invalid issuer policy configuration.
+	ErrInvalidIssuerPolicy = errors.New("invalid issuer policy")
+
+	// ErrIssuerNotAllowed indicates the issuer is not in the allowlist.
+	ErrIssuerNotAllowed = errors.New("issuer not in allowlist")
+
+	// ErrEmailNotVerified indicates the email was not verified.
+	ErrEmailNotVerified = errors.New("email not verified by provider")
+
+	// ErrEmailDomainNotAllowed indicates the email domain is not allowed.
+	ErrEmailDomainNotAllowed = errors.New("email domain not allowed")
+
+	// ErrTenantNotAllowed indicates the tenant is not allowed.
+	ErrTenantNotAllowed = errors.New("tenant not allowed")
+
+	// ErrAuthTooOld indicates the authentication is too old.
+	ErrAuthTooOld = errors.New("authentication is too old")
+
+	// ErrCodeExchangeFailed indicates the code exchange failed.
+	ErrCodeExchangeFailed = errors.New("authorization code exchange failed")
+
+	// ErrServiceUnavailable indicates the service is unavailable.
+	ErrServiceUnavailable = errors.New("OIDC verification service unavailable")
+
+	// ErrInvalidACR indicates an invalid or unallowed ACR value.
+	ErrInvalidACR = errors.New("invalid or unallowed authentication context class")
+
+	// ErrConfigurationError indicates a configuration error.
+	ErrConfigurationError = errors.New("OIDC configuration error")
+)
+
+// WrapError wraps an error with additional context.
+func WrapError(err error, msg string) error {
+	return fmt.Errorf("%s: %w", msg, err)
+}

--- a/pkg/verification/oidc/jwks.go
+++ b/pkg/verification/oidc/jwks.go
@@ -1,0 +1,374 @@
+// Package oidc provides OIDC token verification for the VEID SSO verification service.
+package oidc
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// ============================================================================
+// JWKS Manager
+// ============================================================================
+
+// JWKSManager manages JWKS caching and rotation for OIDC issuers.
+type JWKSManager struct {
+	httpClient *http.Client
+	logger     zerolog.Logger
+
+	mu     sync.RWMutex
+	caches map[string]*jwksCache // issuer -> cache
+	config *JWKSManagerConfig
+}
+
+// JWKSManagerConfig contains configuration for the JWKS manager.
+type JWKSManagerConfig struct {
+	// DefaultCacheTTL is the default cache TTL
+	DefaultCacheTTL time.Duration `json:"default_cache_ttl"`
+
+	// RefreshInterval is how often to proactively refresh JWKS
+	RefreshInterval time.Duration `json:"refresh_interval"`
+
+	// HTTPTimeout is the HTTP client timeout
+	HTTPTimeout time.Duration `json:"http_timeout"`
+
+	// MaxRetries is the maximum number of retries for JWKS fetch
+	MaxRetries int `json:"max_retries"`
+
+	// RetryBackoff is the base retry backoff duration
+	RetryBackoff time.Duration `json:"retry_backoff"`
+}
+
+// DefaultJWKSManagerConfig returns the default configuration.
+func DefaultJWKSManagerConfig() *JWKSManagerConfig {
+	return &JWKSManagerConfig{
+		DefaultCacheTTL: time.Hour,
+		RefreshInterval: 30 * time.Minute,
+		HTTPTimeout:     30 * time.Second,
+		MaxRetries:      3,
+		RetryBackoff:    time.Second,
+	}
+}
+
+// jwksCache contains cached JWKS data for an issuer.
+type jwksCache struct {
+	jwksURL     string
+	keys        map[string]*JSONWebKey // kid -> key
+	fetchedAt   time.Time
+	expiresAt   time.Time
+	lastError   error
+	lastErrorAt *time.Time
+	refreshing  bool
+}
+
+// JSONWebKey represents a JSON Web Key.
+type JSONWebKey struct {
+	// Standard JWK fields
+	KTY string `json:"kty"` // Key Type (RSA, EC, etc.)
+	USE string `json:"use"` // Key Usage (sig, enc)
+	KID string `json:"kid"` // Key ID
+	ALG string `json:"alg"` // Algorithm
+
+	// RSA key fields
+	N string `json:"n,omitempty"` // RSA modulus
+	E string `json:"e,omitempty"` // RSA exponent
+
+	// EC key fields
+	CRV string `json:"crv,omitempty"` // Curve
+	X   string `json:"x,omitempty"`   // X coordinate
+	Y   string `json:"y,omitempty"`   // Y coordinate
+
+	// Parsed key (cached)
+	parsedKey interface{} `json:"-"`
+}
+
+// JWKS represents a JSON Web Key Set.
+type JWKS struct {
+	Keys []JSONWebKey `json:"keys"`
+}
+
+// NewJWKSManager creates a new JWKS manager.
+func NewJWKSManager(config *JWKSManagerConfig, logger zerolog.Logger) *JWKSManager {
+	if config == nil {
+		config = DefaultJWKSManagerConfig()
+	}
+
+	return &JWKSManager{
+		httpClient: &http.Client{
+			Timeout: config.HTTPTimeout,
+		},
+		logger: logger.With().Str("component", "jwks_manager").Logger(),
+		caches: make(map[string]*jwksCache),
+		config: config,
+	}
+}
+
+// GetKey retrieves a key by issuer and key ID.
+func (m *JWKSManager) GetKey(ctx context.Context, issuer, jwksURL, kid string) (*JSONWebKey, error) {
+	m.mu.RLock()
+	cache, ok := m.caches[issuer]
+	m.mu.RUnlock()
+
+	// Check if we have a valid cached key
+	if ok && time.Now().Before(cache.expiresAt) {
+		if key, found := cache.keys[kid]; found {
+			return key, nil
+		}
+		// Key not found in cache, but cache is still valid
+		// This might indicate a key rotation, so refresh
+	}
+
+	// Fetch/refresh JWKS
+	if err := m.fetchJWKS(ctx, issuer, jwksURL); err != nil {
+		// If we have stale cache, use it
+		if ok && cache.keys != nil {
+			if key, found := cache.keys[kid]; found {
+				m.logger.Warn().
+					Str("issuer", issuer).
+					Str("kid", kid).
+					Err(err).
+					Msg("using stale JWKS cache after fetch failure")
+				return key, nil
+			}
+		}
+		return nil, err
+	}
+
+	// Try to get the key from refreshed cache
+	m.mu.RLock()
+	cache = m.caches[issuer]
+	m.mu.RUnlock()
+
+	if cache == nil {
+		return nil, fmt.Errorf("%w: cache is nil after fetch", ErrJWKSFetchFailed)
+	}
+
+	key, found := cache.keys[kid]
+	if !found {
+		return nil, fmt.Errorf("%w: key ID: %s, issuer: %s", ErrKeyNotFound, kid, issuer)
+	}
+
+	return key, nil
+}
+
+// fetchJWKS fetches the JWKS from the issuer.
+func (m *JWKSManager) fetchJWKS(ctx context.Context, issuer, jwksURL string) error {
+	m.mu.Lock()
+	cache, ok := m.caches[issuer]
+	if ok && cache.refreshing {
+		m.mu.Unlock()
+		// Wait a bit for the other goroutine to finish
+		time.Sleep(100 * time.Millisecond)
+		return nil
+	}
+	if !ok {
+		cache = &jwksCache{
+			jwksURL: jwksURL,
+			keys:    make(map[string]*JSONWebKey),
+		}
+		m.caches[issuer] = cache
+	}
+	cache.refreshing = true
+	m.mu.Unlock()
+
+	defer func() {
+		m.mu.Lock()
+		cache.refreshing = false
+		m.mu.Unlock()
+	}()
+
+	var lastErr error
+	for attempt := 0; attempt <= m.config.MaxRetries; attempt++ {
+		if attempt > 0 {
+			backoff := m.config.RetryBackoff * time.Duration(1<<(attempt-1))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURL, nil)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := m.httpClient.Do(req)
+		if err != nil {
+			lastErr = err
+			m.logger.Debug().
+				Str("issuer", issuer).
+				Str("jwks_url", jwksURL).
+				Int("attempt", attempt+1).
+				Err(err).
+				Msg("JWKS fetch attempt failed")
+			continue
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			continue
+		}
+
+		var jwks JWKS
+		if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+			lastErr = err
+			continue
+		}
+
+		// Parse and cache keys
+		keys := make(map[string]*JSONWebKey, len(jwks.Keys))
+		for i := range jwks.Keys {
+			key := &jwks.Keys[i]
+			if err := m.parseKey(key); err != nil {
+				m.logger.Warn().
+					Str("issuer", issuer).
+					Str("kid", key.KID).
+					Err(err).
+					Msg("failed to parse JWK")
+				continue
+			}
+			keys[key.KID] = key
+		}
+
+		m.mu.Lock()
+		cache.keys = keys
+		cache.fetchedAt = time.Now()
+		cache.expiresAt = time.Now().Add(m.config.DefaultCacheTTL)
+		cache.lastError = nil
+		cache.lastErrorAt = nil
+		m.mu.Unlock()
+
+		m.logger.Debug().
+			Str("issuer", issuer).
+			Int("key_count", len(keys)).
+			Msg("JWKS refreshed successfully")
+
+		return nil
+	}
+
+	// Update error state
+	now := time.Now()
+	m.mu.Lock()
+	cache.lastError = lastErr
+	cache.lastErrorAt = &now
+	m.mu.Unlock()
+
+	return fmt.Errorf("%w: after %d retries: %v", ErrJWKSFetchFailed, m.config.MaxRetries, lastErr)
+}
+
+// parseKey parses the JWK into a usable crypto key.
+func (m *JWKSManager) parseKey(key *JSONWebKey) error {
+	switch key.KTY {
+	case "RSA":
+		return m.parseRSAKey(key)
+	default:
+		return fmt.Errorf("unsupported key type: %s", key.KTY)
+	}
+}
+
+// parseRSAKey parses an RSA JWK.
+func (m *JWKSManager) parseRSAKey(key *JSONWebKey) error {
+	nBytes, err := base64URLDecode(key.N)
+	if err != nil {
+		return fmt.Errorf("failed to decode modulus: %w", err)
+	}
+
+	eBytes, err := base64URLDecode(key.E)
+	if err != nil {
+		return fmt.Errorf("failed to decode exponent: %w", err)
+	}
+
+	n := new(big.Int).SetBytes(nBytes)
+	e := 0
+	for _, b := range eBytes {
+		e = e<<8 + int(b)
+	}
+
+	key.parsedKey = &rsa.PublicKey{
+		N: n,
+		E: e,
+	}
+
+	return nil
+}
+
+// GetPublicKey returns the parsed public key.
+func (key *JSONWebKey) GetPublicKey() interface{} {
+	return key.parsedKey
+}
+
+// Refresh forces a refresh of the JWKS for an issuer.
+func (m *JWKSManager) Refresh(ctx context.Context, issuer, jwksURL string) error {
+	// Invalidate cache first
+	m.mu.Lock()
+	if cache, ok := m.caches[issuer]; ok {
+		cache.expiresAt = time.Time{} // Force expiry
+	}
+	m.mu.Unlock()
+
+	return m.fetchJWKS(ctx, issuer, jwksURL)
+}
+
+// GetCacheStatus returns the cache status for an issuer.
+func (m *JWKSManager) GetCacheStatus(issuer string) *IssuerHealthStatus {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	cache, ok := m.caches[issuer]
+	if !ok {
+		return &IssuerHealthStatus{
+			Issuer:     issuer,
+			Healthy:    false,
+			JWKSCached: false,
+		}
+	}
+
+	status := &IssuerHealthStatus{
+		Issuer:          issuer,
+		Healthy:         cache.lastError == nil && time.Now().Before(cache.expiresAt),
+		JWKSCached:      len(cache.keys) > 0,
+		JWKSLastRefresh: &cache.fetchedAt,
+		JWKSExpiresAt:   &cache.expiresAt,
+		KeyCount:        len(cache.keys),
+	}
+
+	if cache.lastError != nil {
+		status.LastError = cache.lastError.Error()
+		status.LastErrorAt = cache.lastErrorAt
+	}
+
+	return status
+}
+
+// Close closes the JWKS manager.
+func (m *JWKSManager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.caches = make(map[string]*jwksCache)
+	return nil
+}
+
+// base64URLDecode decodes base64url encoded data.
+func base64URLDecode(s string) ([]byte, error) {
+	// Add padding if necessary
+	switch len(s) % 4 {
+	case 2:
+		s += "=="
+	case 3:
+		s += "="
+	}
+	return base64.URLEncoding.DecodeString(s)
+}

--- a/pkg/verification/oidc/types.go
+++ b/pkg/verification/oidc/types.go
@@ -1,0 +1,511 @@
+// Package oidc provides OIDC token verification for the VEID SSO verification service.
+//
+// This package implements OIDC discovery, JWKS rotation, and token validation
+// with support for Google, Microsoft, GitHub, and generic OIDC providers.
+//
+// Task Reference: VE-4B - SSO/OIDC Verification Service
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// ============================================================================
+// OIDC Verifier Interface
+// ============================================================================
+
+// OIDCVerifier defines the interface for OIDC token verification.
+type OIDCVerifier interface {
+	// VerifyToken verifies an OIDC ID token and returns the claims.
+	VerifyToken(ctx context.Context, token string, req *VerificationRequest) (*VerifiedClaims, error)
+
+	// GetAuthorizationURL returns the authorization URL for initiating OIDC flow.
+	GetAuthorizationURL(ctx context.Context, req *AuthorizationRequest) (string, error)
+
+	// ExchangeCode exchanges an authorization code for tokens.
+	ExchangeCode(ctx context.Context, code string, req *CodeExchangeRequest) (*TokenResponse, error)
+
+	// RefreshJWKS forces a refresh of the JWKS for an issuer.
+	RefreshJWKS(ctx context.Context, issuer string) error
+
+	// GetIssuerPolicy returns the policy for an issuer.
+	GetIssuerPolicy(ctx context.Context, issuer string) (*IssuerPolicy, error)
+
+	// IsIssuerAllowed checks if an issuer is in the allowlist.
+	IsIssuerAllowed(ctx context.Context, issuer string) bool
+
+	// HealthCheck returns the health status of the verifier.
+	HealthCheck(ctx context.Context) (*HealthStatus, error)
+
+	// Close releases resources.
+	Close() error
+}
+
+// ============================================================================
+// Verification Request/Response
+// ============================================================================
+
+// VerificationRequest contains parameters for token verification.
+type VerificationRequest struct {
+	// ExpectedAudience is the expected audience claim
+	ExpectedAudience string `json:"expected_audience"`
+
+	// ExpectedIssuer is the expected issuer (optional, validated if set)
+	ExpectedIssuer string `json:"expected_issuer,omitempty"`
+
+	// ExpectedNonce is the expected nonce claim (for replay protection)
+	ExpectedNonce string `json:"expected_nonce"`
+
+	// RequiredClaims are claims that must be present
+	RequiredClaims []string `json:"required_claims,omitempty"`
+
+	// MaxAge is the maximum age of the authentication (seconds)
+	MaxAge int64 `json:"max_age,omitempty"`
+
+	// AllowedACRValues are the allowed authentication context class values
+	AllowedACRValues []string `json:"allowed_acr_values,omitempty"`
+
+	// RequireEmailVerified requires the email_verified claim to be true
+	RequireEmailVerified bool `json:"require_email_verified"`
+
+	// ProviderType is the expected provider type
+	ProviderType veidtypes.SSOProviderType `json:"provider_type,omitempty"`
+}
+
+// VerifiedClaims contains the validated claims from an ID token.
+type VerifiedClaims struct {
+	// Issuer is the token issuer
+	Issuer string `json:"iss"`
+
+	// Subject is the unique subject identifier
+	Subject string `json:"sub"`
+
+	// Audience is the intended audience
+	Audience []string `json:"aud"`
+
+	// ExpiresAt is when the token expires
+	ExpiresAt time.Time `json:"exp"`
+
+	// IssuedAt is when the token was issued
+	IssuedAt time.Time `json:"iat"`
+
+	// AuthTime is when the user authenticated (optional)
+	AuthTime *time.Time `json:"auth_time,omitempty"`
+
+	// Nonce is the nonce used in the authentication request
+	Nonce string `json:"nonce,omitempty"`
+
+	// ACR is the authentication context class reference
+	ACR string `json:"acr,omitempty"`
+
+	// AMR is the authentication methods references
+	AMR []string `json:"amr,omitempty"`
+
+	// AZP is the authorized party
+	AZP string `json:"azp,omitempty"`
+
+	// Email is the user's email address (optional)
+	Email string `json:"email,omitempty"`
+
+	// EmailVerified indicates if the email was verified
+	EmailVerified bool `json:"email_verified,omitempty"`
+
+	// Name is the user's display name (optional)
+	Name string `json:"name,omitempty"`
+
+	// Picture is the user's profile picture URL (optional)
+	Picture string `json:"picture,omitempty"`
+
+	// Locale is the user's locale (optional)
+	Locale string `json:"locale,omitempty"`
+
+	// TenantID is the organization tenant ID (Microsoft-specific)
+	TenantID string `json:"tid,omitempty"`
+
+	// Groups are the user's group memberships (optional)
+	Groups []string `json:"groups,omitempty"`
+
+	// RawClaims contains all claims as received
+	RawClaims map[string]interface{} `json:"raw_claims,omitempty"`
+
+	// ProviderType is the detected provider type
+	ProviderType veidtypes.SSOProviderType `json:"provider_type"`
+
+	// KeyID is the key ID that signed the token
+	KeyID string `json:"kid,omitempty"`
+}
+
+// GetEmailDomain extracts the domain from the email address.
+func (c *VerifiedClaims) GetEmailDomain() string {
+	if c.Email == "" {
+		return ""
+	}
+	for i := len(c.Email) - 1; i >= 0; i-- {
+		if c.Email[i] == '@' {
+			return c.Email[i+1:]
+		}
+	}
+	return ""
+}
+
+// ============================================================================
+// Authorization Request
+// ============================================================================
+
+// AuthorizationRequest contains parameters for generating an authorization URL.
+type AuthorizationRequest struct {
+	// ProviderType is the SSO provider to use
+	ProviderType veidtypes.SSOProviderType `json:"provider_type"`
+
+	// Issuer is the specific OIDC issuer (for generic OIDC)
+	Issuer string `json:"issuer,omitempty"`
+
+	// ClientID is the OAuth client ID
+	ClientID string `json:"client_id"`
+
+	// RedirectURI is where to redirect after authentication
+	RedirectURI string `json:"redirect_uri"`
+
+	// State is the OAuth2 state parameter (CSRF protection)
+	State string `json:"state"`
+
+	// Nonce is the OIDC nonce (replay protection)
+	Nonce string `json:"nonce"`
+
+	// Scopes are the OAuth scopes to request
+	Scopes []string `json:"scopes,omitempty"`
+
+	// Prompt specifies the user interaction mode
+	Prompt string `json:"prompt,omitempty"`
+
+	// MaxAge is the maximum authentication age (seconds)
+	MaxAge *int64 `json:"max_age,omitempty"`
+
+	// LoginHint is a hint about the user's identity
+	LoginHint string `json:"login_hint,omitempty"`
+
+	// ACRValues are the requested authentication context class values
+	ACRValues []string `json:"acr_values,omitempty"`
+
+	// TenantHint is the tenant hint (for multi-tenant scenarios)
+	TenantHint string `json:"tenant_hint,omitempty"`
+}
+
+// ============================================================================
+// Code Exchange
+// ============================================================================
+
+// CodeExchangeRequest contains parameters for exchanging an authorization code.
+type CodeExchangeRequest struct {
+	// ProviderType is the SSO provider
+	ProviderType veidtypes.SSOProviderType `json:"provider_type"`
+
+	// Issuer is the specific OIDC issuer (for generic OIDC)
+	Issuer string `json:"issuer,omitempty"`
+
+	// ClientID is the OAuth client ID
+	ClientID string `json:"client_id"`
+
+	// ClientSecret is the OAuth client secret
+	ClientSecret string `json:"client_secret"`
+
+	// RedirectURI is the redirect URI used in the authorization request
+	RedirectURI string `json:"redirect_uri"`
+
+	// Code is the authorization code
+	Code string `json:"code"`
+
+	// CodeVerifier is the PKCE code verifier (if PKCE was used)
+	CodeVerifier string `json:"code_verifier,omitempty"`
+
+	// ExpectedNonce is the expected nonce in the ID token
+	ExpectedNonce string `json:"expected_nonce"`
+}
+
+// TokenResponse contains the response from a token exchange.
+type TokenResponse struct {
+	// AccessToken is the OAuth access token
+	AccessToken string `json:"access_token"`
+
+	// TokenType is the token type (usually "Bearer")
+	TokenType string `json:"token_type"`
+
+	// ExpiresIn is the access token lifetime in seconds
+	ExpiresIn int64 `json:"expires_in"`
+
+	// RefreshToken is the refresh token (if issued)
+	RefreshToken string `json:"refresh_token,omitempty"`
+
+	// Scope is the granted scopes
+	Scope string `json:"scope,omitempty"`
+
+	// IDToken is the OIDC ID token
+	IDToken string `json:"id_token"`
+
+	// VerifiedClaims are the validated claims from the ID token
+	VerifiedClaims *VerifiedClaims `json:"verified_claims,omitempty"`
+}
+
+// ============================================================================
+// Issuer Policy
+// ============================================================================
+
+// IssuerPolicy defines the policy for an OIDC issuer.
+type IssuerPolicy struct {
+	// Issuer is the OIDC issuer URL
+	Issuer string `json:"issuer"`
+
+	// ProviderType is the provider category
+	ProviderType veidtypes.SSOProviderType `json:"provider_type"`
+
+	// Enabled indicates if this issuer is enabled
+	Enabled bool `json:"enabled"`
+
+	// ClientID is the OAuth client ID for this issuer
+	ClientID string `json:"client_id"`
+
+	// ClientSecretRef is a reference to the client secret (e.g., vault path)
+	ClientSecretRef string `json:"client_secret_ref,omitempty"`
+
+	// AllowedAudiences are the allowed audience values
+	AllowedAudiences []string `json:"allowed_audiences,omitempty"`
+
+	// RequiredScopes are scopes required for verification
+	RequiredScopes []string `json:"required_scopes,omitempty"`
+
+	// RequiredClaims are claims that must be present
+	RequiredClaims []string `json:"required_claims,omitempty"`
+
+	// RequireEmailVerified requires email_verified to be true
+	RequireEmailVerified bool `json:"require_email_verified"`
+
+	// AllowedEmailDomains restricts to specific email domains (empty = all)
+	AllowedEmailDomains []string `json:"allowed_email_domains,omitempty"`
+
+	// AllowedTenants restricts to specific tenant IDs (empty = all)
+	AllowedTenants []string `json:"allowed_tenants,omitempty"`
+
+	// MaxAuthAgeSeconds is the maximum authentication age
+	MaxAuthAgeSeconds int64 `json:"max_auth_age_seconds,omitempty"`
+
+	// AllowedACRValues are the allowed authentication context class values
+	AllowedACRValues []string `json:"allowed_acr_values,omitempty"`
+
+	// ScoreWeight is the score weight for this issuer (basis points, max 10000)
+	ScoreWeight uint32 `json:"score_weight"`
+
+	// RateLimitPerHour is the rate limit for this issuer
+	RateLimitPerHour int `json:"rate_limit_per_hour"`
+
+	// JWKSCacheTTLSeconds is the JWKS cache TTL
+	JWKSCacheTTLSeconds int64 `json:"jwks_cache_ttl_seconds"`
+
+	// DiscoveryURL overrides the default discovery URL
+	DiscoveryURL string `json:"discovery_url,omitempty"`
+
+	// Notes contains administrative notes
+	Notes string `json:"notes,omitempty"`
+
+	// CreatedAt is when the policy was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is when the policy was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Validate validates the issuer policy.
+func (p *IssuerPolicy) Validate() error {
+	if p.Issuer == "" {
+		return fmt.Errorf("%w: issuer is required", ErrInvalidIssuerPolicy)
+	}
+	if !veidtypes.IsValidSSOProviderType(p.ProviderType) {
+		return fmt.Errorf("%w: invalid provider_type: %s", ErrInvalidIssuerPolicy, p.ProviderType)
+	}
+	if p.ClientID == "" {
+		return fmt.Errorf("%w: client_id is required", ErrInvalidIssuerPolicy)
+	}
+	if p.ScoreWeight > 10000 {
+		return fmt.Errorf("%w: score_weight cannot exceed 10000", ErrInvalidIssuerPolicy)
+	}
+	return nil
+}
+
+// IsEmailDomainAllowed checks if an email domain is allowed by this policy.
+func (p *IssuerPolicy) IsEmailDomainAllowed(domain string) bool {
+	if len(p.AllowedEmailDomains) == 0 {
+		return true
+	}
+	for _, allowed := range p.AllowedEmailDomains {
+		if allowed == domain {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTenantAllowed checks if a tenant is allowed by this policy.
+func (p *IssuerPolicy) IsTenantAllowed(tenantID string) bool {
+	if len(p.AllowedTenants) == 0 {
+		return true
+	}
+	for _, allowed := range p.AllowedTenants {
+		if allowed == tenantID {
+			return true
+		}
+	}
+	return false
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+// Config contains configuration for the OIDC verifier.
+type Config struct {
+	// Enabled determines if OIDC verification is active
+	Enabled bool `json:"enabled"`
+
+	// IssuerPolicies contains policies for each allowed issuer
+	IssuerPolicies map[string]*IssuerPolicy `json:"issuer_policies"`
+
+	// DefaultScopes are default OAuth scopes to request
+	DefaultScopes []string `json:"default_scopes"`
+
+	// JWKSCacheTTLSeconds is the default JWKS cache TTL
+	JWKSCacheTTLSeconds int64 `json:"jwks_cache_ttl_seconds"`
+
+	// JWKSRefreshIntervalSeconds is how often to proactively refresh JWKS
+	JWKSRefreshIntervalSeconds int64 `json:"jwks_refresh_interval_seconds"`
+
+	// MaxClockSkewSeconds is the maximum allowed clock skew
+	MaxClockSkewSeconds int64 `json:"max_clock_skew_seconds"`
+
+	// TokenValidityWindowSeconds is the token validity window
+	TokenValidityWindowSeconds int64 `json:"token_validity_window_seconds"`
+
+	// HTTPClientTimeoutSeconds is the HTTP client timeout
+	HTTPClientTimeoutSeconds int `json:"http_client_timeout_seconds"`
+
+	// AllowInsecureHTTP allows insecure HTTP for development
+	AllowInsecureHTTP bool `json:"allow_insecure_http"`
+
+	// MetricsEnabled enables Prometheus metrics
+	MetricsEnabled bool `json:"metrics_enabled"`
+
+	// AuditEnabled enables audit logging
+	AuditEnabled bool `json:"audit_enabled"`
+}
+
+// DefaultConfig returns the default OIDC verifier configuration.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:                    true,
+		IssuerPolicies:             make(map[string]*IssuerPolicy),
+		DefaultScopes:              []string{"openid", "email", "profile"},
+		JWKSCacheTTLSeconds:        3600,  // 1 hour
+		JWKSRefreshIntervalSeconds: 1800,  // 30 minutes
+		MaxClockSkewSeconds:        300,   // 5 minutes
+		TokenValidityWindowSeconds: 3600,  // 1 hour
+		HTTPClientTimeoutSeconds:   30,
+		AllowInsecureHTTP:          false,
+		MetricsEnabled:             true,
+		AuditEnabled:               true,
+	}
+}
+
+// ============================================================================
+// Well-Known Provider Configurations
+// ============================================================================
+
+// WellKnownIssuers contains issuer URLs for well-known providers.
+var WellKnownIssuers = map[veidtypes.SSOProviderType]string{
+	veidtypes.SSOProviderGoogle:    "https://accounts.google.com",
+	veidtypes.SSOProviderMicrosoft: "https://login.microsoftonline.com/common/v2.0",
+	veidtypes.SSOProviderGitHub:    "https://token.actions.githubusercontent.com", // GitHub Actions OIDC
+}
+
+// WellKnownDiscoveryURLs contains discovery URLs for well-known providers.
+var WellKnownDiscoveryURLs = map[veidtypes.SSOProviderType]string{
+	veidtypes.SSOProviderGoogle:    "https://accounts.google.com/.well-known/openid-configuration",
+	veidtypes.SSOProviderMicrosoft: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
+}
+
+// DefaultIssuerPolicy returns the default policy for a provider type.
+func DefaultIssuerPolicy(providerType veidtypes.SSOProviderType) *IssuerPolicy {
+	issuer, ok := WellKnownIssuers[providerType]
+	if !ok {
+		issuer = ""
+	}
+
+	now := time.Now()
+	return &IssuerPolicy{
+		Issuer:               issuer,
+		ProviderType:         providerType,
+		Enabled:              true,
+		RequiredScopes:       []string{"openid", "email"},
+		RequiredClaims:       []string{"sub", "email"},
+		RequireEmailVerified: true,
+		MaxAuthAgeSeconds:    86400,  // 24 hours
+		ScoreWeight:          veidtypes.GetSSOScoringWeight(providerType),
+		RateLimitPerHour:     100,
+		JWKSCacheTTLSeconds:  3600,
+		CreatedAt:            now,
+		UpdatedAt:            now,
+	}
+}
+
+// ============================================================================
+// Health Status
+// ============================================================================
+
+// HealthStatus represents the health status of the OIDC verifier.
+type HealthStatus struct {
+	// Healthy indicates if the verifier is healthy
+	Healthy bool `json:"healthy"`
+
+	// Status is a human-readable status message
+	Status string `json:"status"`
+
+	// Timestamp is when the health check was performed
+	Timestamp time.Time `json:"timestamp"`
+
+	// IssuerStatuses contains per-issuer status
+	IssuerStatuses map[string]*IssuerHealthStatus `json:"issuer_statuses,omitempty"`
+
+	// Details contains additional details
+	Details map[string]interface{} `json:"details,omitempty"`
+
+	// Warnings contains any warnings
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// IssuerHealthStatus represents the health status for a specific issuer.
+type IssuerHealthStatus struct {
+	// Issuer is the issuer URL
+	Issuer string `json:"issuer"`
+
+	// Healthy indicates if the issuer is healthy
+	Healthy bool `json:"healthy"`
+
+	// JWKSCached indicates if JWKS is cached
+	JWKSCached bool `json:"jwks_cached"`
+
+	// JWKSLastRefresh is when JWKS was last refreshed
+	JWKSLastRefresh *time.Time `json:"jwks_last_refresh,omitempty"`
+
+	// JWKSExpiresAt is when the JWKS cache expires
+	JWKSExpiresAt *time.Time `json:"jwks_expires_at,omitempty"`
+
+	// KeyCount is the number of keys in the JWKS
+	KeyCount int `json:"key_count"`
+
+	// LastError contains the last error (if any)
+	LastError string `json:"last_error,omitempty"`
+
+	// LastErrorAt is when the last error occurred
+	LastErrorAt *time.Time `json:"last_error_at,omitempty"`
+}

--- a/pkg/verification/oidc/verifier.go
+++ b/pkg/verification/oidc/verifier.go
@@ -1,0 +1,723 @@
+// Package oidc provides OIDC token verification for the VEID SSO verification service.
+package oidc
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/virtengine/virtengine/pkg/verification/audit"
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// ============================================================================
+// Default OIDC Verifier
+// ============================================================================
+
+// DefaultVerifier implements OIDCVerifier with JWKS rotation support.
+type DefaultVerifier struct {
+	config     Config
+	jwksManager *JWKSManager
+	httpClient *http.Client
+	auditor    audit.AuditLogger
+	logger     zerolog.Logger
+
+	mu             sync.RWMutex
+	discoveryCache map[string]*OIDCDiscoveryDocument // issuer -> discovery doc
+}
+
+// OIDCDiscoveryDocument contains the OIDC discovery metadata.
+type OIDCDiscoveryDocument struct {
+	Issuer                           string   `json:"issuer"`
+	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
+	TokenEndpoint                    string   `json:"token_endpoint"`
+	UserinfoEndpoint                 string   `json:"userinfo_endpoint"`
+	JwksURI                          string   `json:"jwks_uri"`
+	RegistrationEndpoint             string   `json:"registration_endpoint,omitempty"`
+	ScopesSupported                  []string `json:"scopes_supported,omitempty"`
+	ResponseTypesSupported           []string `json:"response_types_supported"`
+	ResponseModesSupported           []string `json:"response_modes_supported,omitempty"`
+	GrantTypesSupported              []string `json:"grant_types_supported,omitempty"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	ClaimsSupported                  []string `json:"claims_supported,omitempty"`
+	ACRValuesSupported               []string `json:"acr_values_supported,omitempty"`
+
+	// Cache metadata
+	FetchedAt time.Time `json:"-"`
+}
+
+// NewDefaultVerifier creates a new DefaultVerifier.
+func NewDefaultVerifier(
+	ctx context.Context,
+	config Config,
+	auditor audit.AuditLogger,
+	logger zerolog.Logger,
+) (*DefaultVerifier, error) {
+	jwksConfig := &JWKSManagerConfig{
+		DefaultCacheTTL: time.Duration(config.JWKSCacheTTLSeconds) * time.Second,
+		RefreshInterval: time.Duration(config.JWKSRefreshIntervalSeconds) * time.Second,
+		HTTPTimeout:     time.Duration(config.HTTPClientTimeoutSeconds) * time.Second,
+		MaxRetries:      3,
+		RetryBackoff:    time.Second,
+	}
+
+	v := &DefaultVerifier{
+		config:         config,
+		jwksManager:    NewJWKSManager(jwksConfig, logger),
+		httpClient:     &http.Client{Timeout: time.Duration(config.HTTPClientTimeoutSeconds) * time.Second},
+		auditor:        auditor,
+		logger:         logger.With().Str("component", "oidc_verifier").Logger(),
+		discoveryCache: make(map[string]*OIDCDiscoveryDocument),
+	}
+
+	// Pre-fetch discovery documents for configured issuers
+	for issuer := range config.IssuerPolicies {
+		if _, err := v.getDiscoveryDocument(ctx, issuer); err != nil {
+			v.logger.Warn().
+				Str("issuer", issuer).
+				Err(err).
+				Msg("failed to pre-fetch discovery document")
+		}
+	}
+
+	return v, nil
+}
+
+// VerifyToken verifies an OIDC ID token and returns the claims.
+func (v *DefaultVerifier) VerifyToken(ctx context.Context, token string, req *VerificationRequest) (*VerifiedClaims, error) {
+	// Parse the JWT (without verification first to get header)
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("%w: token must have 3 parts", ErrInvalidToken)
+	}
+
+	// Decode header
+	headerBytes, err := base64URLDecode(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to decode header: %v", ErrInvalidToken, err)
+	}
+
+	var header struct {
+		ALG string `json:"alg"`
+		KID string `json:"kid"`
+		TYP string `json:"typ"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return nil, fmt.Errorf("%w: failed to parse header: %v", ErrInvalidToken, err)
+	}
+
+	// Decode payload
+	payloadBytes, err := base64URLDecode(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to decode payload: %v", ErrInvalidToken, err)
+	}
+
+	var rawClaims map[string]interface{}
+	if err := json.Unmarshal(payloadBytes, &rawClaims); err != nil {
+		return nil, fmt.Errorf("%w: failed to parse payload: %v", ErrInvalidToken, err)
+	}
+
+	// Extract issuer from claims
+	issuerClaim, ok := rawClaims["iss"].(string)
+	if !ok || issuerClaim == "" {
+		return nil, fmt.Errorf("%w: missing or invalid issuer claim", ErrInvalidToken)
+	}
+
+	// Check if issuer is allowed
+	if !v.IsIssuerAllowed(ctx, issuerClaim) {
+		v.logAudit(ctx, audit.EventTypeAccessDenied, issuerClaim, "issuer_not_allowed", nil)
+		return nil, fmt.Errorf("%w: issuer: %s", ErrIssuerNotAllowed, issuerClaim)
+	}
+
+	// Validate expected issuer if provided
+	if req.ExpectedIssuer != "" && issuerClaim != req.ExpectedIssuer {
+		return nil, fmt.Errorf("%w: expected %s, got %s", ErrInvalidIssuer, req.ExpectedIssuer, issuerClaim)
+	}
+
+	// Get discovery document to find JWKS URI
+	discovery, err := v.getDiscoveryDocument(ctx, issuerClaim)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get signing key
+	key, err := v.jwksManager.GetKey(ctx, issuerClaim, discovery.JwksURI, header.KID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify signature
+	if err := v.verifySignature(token, parts, header.ALG, key); err != nil {
+		return nil, err
+	}
+
+	// Parse claims into structured format
+	claims, err := v.parseClaims(rawClaims, issuerClaim)
+	if err != nil {
+		return nil, err
+	}
+	claims.KeyID = header.KID
+
+	// Validate claims
+	if err := v.validateClaims(claims, req); err != nil {
+		return nil, err
+	}
+
+	// Apply issuer policy
+	policy, _ := v.GetIssuerPolicy(ctx, issuerClaim)
+	if policy != nil {
+		if err := v.applyPolicy(claims, policy); err != nil {
+			return nil, err
+		}
+	}
+
+	v.logAudit(ctx, audit.EventTypeVerificationCompleted, issuerClaim, "token_verified", map[string]interface{}{
+		"subject_hash": veidtypes.HashSubjectID(claims.Subject),
+		"email_domain": claims.GetEmailDomain(),
+	})
+
+	return claims, nil
+}
+
+// verifySignature verifies the JWT signature.
+func (v *DefaultVerifier) verifySignature(token string, parts []string, alg string, key *JSONWebKey) error {
+	signedContent := parts[0] + "." + parts[1]
+	signatureBytes, err := base64URLDecode(parts[2])
+	if err != nil {
+		return fmt.Errorf("%w: failed to decode signature: %v", ErrInvalidSignature, err)
+	}
+
+	switch alg {
+	case "RS256":
+		return v.verifyRS256(signedContent, signatureBytes, key)
+	case "RS384":
+		return v.verifyRS384(signedContent, signatureBytes, key)
+	case "RS512":
+		return v.verifyRS512(signedContent, signatureBytes, key)
+	default:
+		return fmt.Errorf("%w: unsupported algorithm: %s", ErrInvalidToken, alg)
+	}
+}
+
+func (v *DefaultVerifier) verifyRS256(signedContent string, signature []byte, key *JSONWebKey) error {
+	return v.verifyRSA(signedContent, signature, key, crypto.SHA256)
+}
+
+func (v *DefaultVerifier) verifyRS384(signedContent string, signature []byte, key *JSONWebKey) error {
+	return v.verifyRSA(signedContent, signature, key, crypto.SHA384)
+}
+
+func (v *DefaultVerifier) verifyRS512(signedContent string, signature []byte, key *JSONWebKey) error {
+	return v.verifyRSA(signedContent, signature, key, crypto.SHA512)
+}
+
+func (v *DefaultVerifier) verifyRSA(signedContent string, signature []byte, key *JSONWebKey, hash crypto.Hash) error {
+	pubKey, ok := key.GetPublicKey().(*rsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("%w: key is not an RSA public key", ErrInvalidSignature)
+	}
+
+	hasher := hash.New()
+	hasher.Write([]byte(signedContent))
+	hashed := hasher.Sum(nil)
+
+	if err := rsa.VerifyPKCS1v15(pubKey, hash, hashed, signature); err != nil {
+		return fmt.Errorf("%w: signature verification failed: %v", ErrInvalidSignature, err)
+	}
+
+	return nil
+}
+
+// parseClaims parses raw claims into VerifiedClaims.
+func (v *DefaultVerifier) parseClaims(raw map[string]interface{}, issuer string) (*VerifiedClaims, error) {
+	claims := &VerifiedClaims{
+		Issuer:       issuer,
+		RawClaims:    raw,
+		ProviderType: v.detectProviderType(issuer),
+	}
+
+	// Required claims
+	if sub, ok := raw["sub"].(string); ok {
+		claims.Subject = sub
+	} else {
+		return nil, fmt.Errorf("%w: sub", ErrMissingClaim)
+	}
+
+	// Audience (can be string or array)
+	switch aud := raw["aud"].(type) {
+	case string:
+		claims.Audience = []string{aud}
+	case []interface{}:
+		claims.Audience = make([]string, 0, len(aud))
+		for _, a := range aud {
+			if s, ok := a.(string); ok {
+				claims.Audience = append(claims.Audience, s)
+			}
+		}
+	}
+
+	// Timestamps
+	if exp, ok := raw["exp"].(float64); ok {
+		claims.ExpiresAt = time.Unix(int64(exp), 0)
+	}
+	if iat, ok := raw["iat"].(float64); ok {
+		claims.IssuedAt = time.Unix(int64(iat), 0)
+	}
+	if authTime, ok := raw["auth_time"].(float64); ok {
+		t := time.Unix(int64(authTime), 0)
+		claims.AuthTime = &t
+	}
+
+	// Optional claims
+	if nonce, ok := raw["nonce"].(string); ok {
+		claims.Nonce = nonce
+	}
+	if acr, ok := raw["acr"].(string); ok {
+		claims.ACR = acr
+	}
+	if amr, ok := raw["amr"].([]interface{}); ok {
+		claims.AMR = make([]string, 0, len(amr))
+		for _, a := range amr {
+			if s, ok := a.(string); ok {
+				claims.AMR = append(claims.AMR, s)
+			}
+		}
+	}
+	if azp, ok := raw["azp"].(string); ok {
+		claims.AZP = azp
+	}
+
+	// Profile claims
+	if email, ok := raw["email"].(string); ok {
+		claims.Email = email
+	}
+	if emailVerified, ok := raw["email_verified"].(bool); ok {
+		claims.EmailVerified = emailVerified
+	}
+	if name, ok := raw["name"].(string); ok {
+		claims.Name = name
+	}
+	if picture, ok := raw["picture"].(string); ok {
+		claims.Picture = picture
+	}
+	if locale, ok := raw["locale"].(string); ok {
+		claims.Locale = locale
+	}
+
+	// Provider-specific claims
+	if tid, ok := raw["tid"].(string); ok {
+		claims.TenantID = tid
+	}
+	if groups, ok := raw["groups"].([]interface{}); ok {
+		claims.Groups = make([]string, 0, len(groups))
+		for _, g := range groups {
+			if s, ok := g.(string); ok {
+				claims.Groups = append(claims.Groups, s)
+			}
+		}
+	}
+
+	return claims, nil
+}
+
+// validateClaims validates the parsed claims.
+func (v *DefaultVerifier) validateClaims(claims *VerifiedClaims, req *VerificationRequest) error {
+	now := time.Now()
+	maxSkew := time.Duration(v.config.MaxClockSkewSeconds) * time.Second
+
+	// Check expiration
+	if claims.ExpiresAt.Add(maxSkew).Before(now) {
+		return fmt.Errorf("%w: expired at %s", ErrTokenExpired, claims.ExpiresAt)
+	}
+
+	// Check issued at
+	if claims.IssuedAt.Add(-maxSkew).After(now) {
+		return fmt.Errorf("%w: token issued in the future", ErrInvalidToken)
+	}
+
+	// Check audience
+	if req.ExpectedAudience != "" {
+		found := false
+		for _, aud := range claims.Audience {
+			if aud == req.ExpectedAudience {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("%w: expected %s, got %v", ErrInvalidAudience, req.ExpectedAudience, claims.Audience)
+		}
+	}
+
+	// Check nonce
+	if req.ExpectedNonce != "" && claims.Nonce != req.ExpectedNonce {
+		return fmt.Errorf("%w: expected %s, got %s", ErrInvalidNonce, req.ExpectedNonce, claims.Nonce)
+	}
+
+	// Check auth_time (max age)
+	if req.MaxAge > 0 && claims.AuthTime != nil {
+		maxAge := time.Duration(req.MaxAge) * time.Second
+		if claims.AuthTime.Add(maxAge).Before(now) {
+			return fmt.Errorf("%w: auth_time: %s, max_age: %s", ErrAuthTooOld, claims.AuthTime, maxAge)
+		}
+	}
+
+	// Check required claims
+	for _, claim := range req.RequiredClaims {
+		if _, ok := claims.RawClaims[claim]; !ok {
+			return fmt.Errorf("%w: required claim: %s", ErrMissingClaim, claim)
+		}
+	}
+
+	// Check email verified
+	if req.RequireEmailVerified && !claims.EmailVerified {
+		return ErrEmailNotVerified
+	}
+
+	// Check ACR values
+	if len(req.AllowedACRValues) > 0 && claims.ACR != "" {
+		found := false
+		for _, acr := range req.AllowedACRValues {
+			if acr == claims.ACR {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("%w: acr: %s, allowed: %v", ErrInvalidACR, claims.ACR, req.AllowedACRValues)
+		}
+	}
+
+	return nil
+}
+
+// applyPolicy applies issuer-specific policy to the claims.
+func (v *DefaultVerifier) applyPolicy(claims *VerifiedClaims, policy *IssuerPolicy) error {
+	// Check email domain
+	if len(policy.AllowedEmailDomains) > 0 {
+		domain := claims.GetEmailDomain()
+		if !policy.IsEmailDomainAllowed(domain) {
+			return fmt.Errorf("%w: domain: %s", ErrEmailDomainNotAllowed, domain)
+		}
+	}
+
+	// Check tenant
+	if len(policy.AllowedTenants) > 0 {
+		if !policy.IsTenantAllowed(claims.TenantID) {
+			return fmt.Errorf("%w: tenant: %s", ErrTenantNotAllowed, claims.TenantID)
+		}
+	}
+
+	// Check max auth age from policy
+	if policy.MaxAuthAgeSeconds > 0 && claims.AuthTime != nil {
+		maxAge := time.Duration(policy.MaxAuthAgeSeconds) * time.Second
+		if claims.AuthTime.Add(maxAge).Before(time.Now()) {
+			return fmt.Errorf("%w: auth_time: %s, policy max_age: %s", ErrAuthTooOld, claims.AuthTime, maxAge)
+		}
+	}
+
+	// Check email verified from policy
+	if policy.RequireEmailVerified && !claims.EmailVerified {
+		return ErrEmailNotVerified
+	}
+
+	// Check ACR from policy
+	if len(policy.AllowedACRValues) > 0 && claims.ACR != "" {
+		found := false
+		for _, acr := range policy.AllowedACRValues {
+			if acr == claims.ACR {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("%w: acr: %s, policy allowed: %v", ErrInvalidACR, claims.ACR, policy.AllowedACRValues)
+		}
+	}
+
+	return nil
+}
+
+// detectProviderType detects the provider type from the issuer.
+func (v *DefaultVerifier) detectProviderType(issuer string) veidtypes.SSOProviderType {
+	for providerType, knownIssuer := range WellKnownIssuers {
+		if issuer == knownIssuer || strings.HasPrefix(issuer, knownIssuer) {
+			return providerType
+		}
+	}
+
+	// Check for Microsoft with specific tenant
+	if strings.Contains(issuer, "login.microsoftonline.com") {
+		return veidtypes.SSOProviderMicrosoft
+	}
+
+	return veidtypes.SSOProviderOIDC
+}
+
+// GetAuthorizationURL returns the authorization URL for initiating OIDC flow.
+func (v *DefaultVerifier) GetAuthorizationURL(ctx context.Context, req *AuthorizationRequest) (string, error) {
+	// Determine issuer
+	issuer := req.Issuer
+	if issuer == "" {
+		if knownIssuer, ok := WellKnownIssuers[req.ProviderType]; ok {
+			issuer = knownIssuer
+		} else {
+			return "", fmt.Errorf("%w: issuer required for generic OIDC", ErrInvalidIssuer)
+		}
+	}
+
+	// Get discovery document
+	discovery, err := v.getDiscoveryDocument(ctx, issuer)
+	if err != nil {
+		return "", err
+	}
+
+	// Build authorization URL
+	authURL, err := url.Parse(discovery.AuthorizationEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("%w: invalid authorization endpoint: %v", ErrConfigurationError, err)
+	}
+
+	scopes := req.Scopes
+	if len(scopes) == 0 {
+		scopes = v.config.DefaultScopes
+	}
+
+	params := url.Values{
+		"client_id":     {req.ClientID},
+		"redirect_uri":  {req.RedirectURI},
+		"response_type": {"code"},
+		"scope":         {strings.Join(scopes, " ")},
+		"state":         {req.State},
+		"nonce":         {req.Nonce},
+	}
+
+	if req.Prompt != "" {
+		params.Set("prompt", req.Prompt)
+	}
+	if req.MaxAge != nil {
+		params.Set("max_age", fmt.Sprintf("%d", *req.MaxAge))
+	}
+	if req.LoginHint != "" {
+		params.Set("login_hint", req.LoginHint)
+	}
+	if len(req.ACRValues) > 0 {
+		params.Set("acr_values", strings.Join(req.ACRValues, " "))
+	}
+
+	authURL.RawQuery = params.Encode()
+	return authURL.String(), nil
+}
+
+// ExchangeCode exchanges an authorization code for tokens.
+func (v *DefaultVerifier) ExchangeCode(ctx context.Context, code string, req *CodeExchangeRequest) (*TokenResponse, error) {
+	// Determine issuer
+	issuer := req.Issuer
+	if issuer == "" {
+		if knownIssuer, ok := WellKnownIssuers[req.ProviderType]; ok {
+			issuer = knownIssuer
+		} else {
+			return nil, fmt.Errorf("%w: issuer required for generic OIDC", ErrInvalidIssuer)
+		}
+	}
+
+	// Get discovery document
+	discovery, err := v.getDiscoveryDocument(ctx, issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build token request
+	data := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {req.RedirectURI},
+		"client_id":     {req.ClientID},
+		"client_secret": {req.ClientSecret},
+	}
+
+	if req.CodeVerifier != "" {
+		data.Set("code_verifier", req.CodeVerifier)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, discovery.TokenEndpoint, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to create request: %v", ErrCodeExchangeFailed, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := v.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("%w: request failed: %v", ErrCodeExchangeFailed, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: unexpected status: %d", ErrCodeExchangeFailed, resp.StatusCode)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("%w: failed to decode response: %v", ErrCodeExchangeFailed, err)
+	}
+
+	// Verify the ID token
+	if tokenResp.IDToken != "" {
+		policy, _ := v.GetIssuerPolicy(ctx, issuer)
+		audience := req.ClientID
+		if policy != nil && len(policy.AllowedAudiences) > 0 {
+			audience = policy.AllowedAudiences[0]
+		}
+
+		claims, err := v.VerifyToken(ctx, tokenResp.IDToken, &VerificationRequest{
+			ExpectedAudience: audience,
+			ExpectedNonce:    req.ExpectedNonce,
+			ExpectedIssuer:   issuer,
+		})
+		if err != nil {
+			return nil, err
+		}
+		tokenResp.VerifiedClaims = claims
+	}
+
+	return &tokenResp, nil
+}
+
+// getDiscoveryDocument fetches and caches the OIDC discovery document.
+func (v *DefaultVerifier) getDiscoveryDocument(ctx context.Context, issuer string) (*OIDCDiscoveryDocument, error) {
+	v.mu.RLock()
+	doc, ok := v.discoveryCache[issuer]
+	v.mu.RUnlock()
+
+	// Check if cache is valid (1 hour TTL)
+	if ok && time.Since(doc.FetchedAt) < time.Hour {
+		return doc, nil
+	}
+
+	// Determine discovery URL
+	discoveryURL := issuer + "/.well-known/openid-configuration"
+	if policy, exists := v.config.IssuerPolicies[issuer]; exists && policy.DiscoveryURL != "" {
+		discoveryURL = policy.DiscoveryURL
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to create request: %v", ErrDiscoveryFailed, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: request failed: %v", ErrDiscoveryFailed, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: unexpected status: %d", ErrDiscoveryFailed, resp.StatusCode)
+	}
+
+	doc = &OIDCDiscoveryDocument{}
+	if err := json.NewDecoder(resp.Body).Decode(doc); err != nil {
+		return nil, fmt.Errorf("%w: failed to decode: %v", ErrDiscoveryFailed, err)
+	}
+
+	doc.FetchedAt = time.Now()
+
+	// Cache the document
+	v.mu.Lock()
+	v.discoveryCache[issuer] = doc
+	v.mu.Unlock()
+
+	v.logger.Debug().
+		Str("issuer", issuer).
+		Str("jwks_uri", doc.JwksURI).
+		Msg("fetched OIDC discovery document")
+
+	return doc, nil
+}
+
+// RefreshJWKS forces a refresh of the JWKS for an issuer.
+func (v *DefaultVerifier) RefreshJWKS(ctx context.Context, issuer string) error {
+	discovery, err := v.getDiscoveryDocument(ctx, issuer)
+	if err != nil {
+		return err
+	}
+	return v.jwksManager.Refresh(ctx, issuer, discovery.JwksURI)
+}
+
+// GetIssuerPolicy returns the policy for an issuer.
+func (v *DefaultVerifier) GetIssuerPolicy(ctx context.Context, issuer string) (*IssuerPolicy, error) {
+	policy, ok := v.config.IssuerPolicies[issuer]
+	if !ok {
+		return nil, fmt.Errorf("%w: no policy for issuer: %s", ErrIssuerNotAllowed, issuer)
+	}
+	return policy, nil
+}
+
+// IsIssuerAllowed checks if an issuer is in the allowlist.
+func (v *DefaultVerifier) IsIssuerAllowed(ctx context.Context, issuer string) bool {
+	policy, ok := v.config.IssuerPolicies[issuer]
+	return ok && policy.Enabled
+}
+
+// HealthCheck returns the health status of the verifier.
+func (v *DefaultVerifier) HealthCheck(ctx context.Context) (*HealthStatus, error) {
+	status := &HealthStatus{
+		Healthy:        true,
+		Status:         "healthy",
+		Timestamp:      time.Now(),
+		IssuerStatuses: make(map[string]*IssuerHealthStatus),
+		Details:        make(map[string]interface{}),
+		Warnings:       make([]string, 0),
+	}
+
+	status.Details["enabled"] = v.config.Enabled
+	status.Details["issuer_count"] = len(v.config.IssuerPolicies)
+
+	for issuer, policy := range v.config.IssuerPolicies {
+		issuerStatus := v.jwksManager.GetCacheStatus(issuer)
+		issuerStatus.Issuer = issuer
+		status.IssuerStatuses[issuer] = issuerStatus
+
+		if !policy.Enabled {
+			status.Warnings = append(status.Warnings, fmt.Sprintf("issuer %s is disabled", issuer))
+		}
+
+		if !issuerStatus.Healthy {
+			status.Warnings = append(status.Warnings, fmt.Sprintf("issuer %s is unhealthy", issuer))
+		}
+	}
+
+	return status, nil
+}
+
+// Close releases resources.
+func (v *DefaultVerifier) Close() error {
+	return v.jwksManager.Close()
+}
+
+// logAudit logs an audit event.
+func (v *DefaultVerifier) logAudit(ctx context.Context, eventType audit.EventType, resource, action string, details map[string]interface{}) {
+	if v.auditor == nil || !v.config.AuditEnabled {
+		return
+	}
+
+	v.auditor.Log(ctx, audit.Event{
+		Type:      eventType,
+		Timestamp: time.Now(),
+		Actor:     "oidc_verifier",
+		Resource:  resource,
+		Action:    action,
+		Details:   details,
+	})
+}

--- a/pkg/verification/oidc/verifier_test.go
+++ b/pkg/verification/oidc/verifier_test.go
@@ -1,0 +1,456 @@
+// Package oidc provides OIDC token verification for the VEID SSO verification service.
+package oidc
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+type testOIDCServer struct {
+	server           *httptest.Server
+	privateKey       *rsa.PrivateKey
+	keyID            string
+	issuer           string
+	discoveryHandler http.HandlerFunc
+	jwksHandler      http.HandlerFunc
+	tokenHandler     http.HandlerFunc
+}
+
+func newTestOIDCServer(t *testing.T) *testOIDCServer {
+	// Generate RSA key pair
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	keyID := "test-key-1"
+
+	ts := &testOIDCServer{
+		privateKey: privateKey,
+		keyID:      keyID,
+	}
+
+	// Set up HTTP handlers
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		if ts.discoveryHandler != nil {
+			ts.discoveryHandler(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"issuer":                 ts.issuer,
+			"authorization_endpoint": ts.issuer + "/authorize",
+			"token_endpoint":         ts.issuer + "/token",
+			"userinfo_endpoint":      ts.issuer + "/userinfo",
+			"jwks_uri":               ts.issuer + "/.well-known/jwks.json",
+			"response_types_supported": []string{"code", "token", "id_token"},
+			"subject_types_supported":  []string{"public"},
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	})
+
+	mux.HandleFunc("/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		if ts.jwksHandler != nil {
+			ts.jwksHandler(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ts.getJWKS())
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if ts.tokenHandler != nil {
+			ts.tokenHandler(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"id_token":     ts.generateIDToken(t, map[string]interface{}{
+				"sub":            "user-123",
+				"email":          "test@example.com",
+				"email_verified": true,
+				"nonce":          "test-nonce",
+			}),
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	ts.server = server
+	ts.issuer = server.URL
+
+	return ts
+}
+
+func (ts *testOIDCServer) Close() {
+	ts.server.Close()
+}
+
+func (ts *testOIDCServer) getJWKS() map[string]interface{} {
+	return map[string]interface{}{
+		"keys": []map[string]interface{}{
+			{
+				"kty": "RSA",
+				"use": "sig",
+				"alg": "RS256",
+				"kid": ts.keyID,
+				"n":   base64.RawURLEncoding.EncodeToString(ts.privateKey.N.Bytes()),
+				"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(ts.privateKey.E)).Bytes()),
+			},
+		},
+	}
+}
+
+func (ts *testOIDCServer) generateIDToken(t *testing.T, claims map[string]interface{}) string {
+	// Add standard claims
+	now := time.Now()
+	if _, ok := claims["iss"]; !ok {
+		claims["iss"] = ts.issuer
+	}
+	if _, ok := claims["aud"]; !ok {
+		claims["aud"] = "test-client-id"
+	}
+	if _, ok := claims["exp"]; !ok {
+		claims["exp"] = now.Add(time.Hour).Unix()
+	}
+	if _, ok := claims["iat"]; !ok {
+		claims["iat"] = now.Unix()
+	}
+
+	// Encode header
+	header := map[string]interface{}{
+		"alg": "RS256",
+		"typ": "JWT",
+		"kid": ts.keyID,
+	}
+	headerBytes, _ := json.Marshal(header)
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerBytes)
+
+	// Encode payload
+	payloadBytes, _ := json.Marshal(claims)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadBytes)
+
+	// Sign
+	signedContent := headerB64 + "." + payloadB64
+	signature := ts.sign(t, signedContent)
+	signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+
+	return signedContent + "." + signatureB64
+}
+
+func (ts *testOIDCServer) sign(t *testing.T, content string) []byte {
+	hashed := sha256.Sum256([]byte(content))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, ts.privateKey, crypto.SHA256, hashed[:])
+	require.NoError(t, err)
+	return signature
+}
+
+// ============================================================================
+// JWKSManager Tests
+// ============================================================================
+
+func TestJWKSManager_GetKey(t *testing.T) {
+	ts := newTestOIDCServer(t)
+	defer ts.Close()
+
+	logger := zerolog.New(zerolog.NewConsoleWriter())
+	manager := NewJWKSManager(nil, logger)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Test successful key retrieval
+	key, err := manager.GetKey(ctx, ts.issuer, ts.issuer+"/.well-known/jwks.json", ts.keyID)
+	require.NoError(t, err)
+	assert.NotNil(t, key)
+	assert.Equal(t, ts.keyID, key.KID)
+	assert.Equal(t, "RSA", key.KTY)
+
+	// Test cache hit
+	key2, err := manager.GetKey(ctx, ts.issuer, ts.issuer+"/.well-known/jwks.json", ts.keyID)
+	require.NoError(t, err)
+	assert.Equal(t, key, key2)
+}
+
+func TestJWKSManager_GetKey_NotFound(t *testing.T) {
+	ts := newTestOIDCServer(t)
+	defer ts.Close()
+
+	logger := zerolog.New(zerolog.NewConsoleWriter())
+	manager := NewJWKSManager(nil, logger)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	_, err := manager.GetKey(ctx, ts.issuer, ts.issuer+"/.well-known/jwks.json", "nonexistent-key")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrKeyNotFound)
+}
+
+func TestJWKSManager_GetKey_FetchError(t *testing.T) {
+	logger := zerolog.New(zerolog.NewConsoleWriter())
+	config := &JWKSManagerConfig{
+		DefaultCacheTTL: time.Hour,
+		RefreshInterval: 30 * time.Minute,
+		HTTPTimeout:     time.Second,
+		MaxRetries:      1,
+		RetryBackoff:    10 * time.Millisecond,
+	}
+	manager := NewJWKSManager(config, logger)
+	defer manager.Close()
+
+	ctx := context.Background()
+
+	// Invalid URL should fail
+	_, err := manager.GetKey(ctx, "http://invalid.local", "http://invalid.local/.well-known/jwks.json", "key-1")
+	assert.Error(t, err)
+}
+
+// ============================================================================
+// DefaultVerifier Tests
+// ============================================================================
+
+func TestDefaultVerifier_IsIssuerAllowed(t *testing.T) {
+	ts := newTestOIDCServer(t)
+	defer ts.Close()
+
+	logger := zerolog.New(zerolog.NewConsoleWriter())
+	config := Config{
+		Enabled: true,
+		IssuerPolicies: map[string]*IssuerPolicy{
+			ts.issuer: {
+				Issuer:       ts.issuer,
+				ProviderType: veidtypes.SSOProviderGoogle,
+				ClientID:     "test-client-id",
+				Enabled:      true,
+			},
+		},
+	}
+
+	verifier, err := NewDefaultVerifier(context.Background(), config, nil, logger)
+	require.NoError(t, err)
+	defer verifier.Close()
+
+	ctx := context.Background()
+
+	// Allowed issuer
+	assert.True(t, verifier.IsIssuerAllowed(ctx, ts.issuer))
+
+	// Disallowed issuer
+	assert.False(t, verifier.IsIssuerAllowed(ctx, "https://unknown.issuer.com"))
+}
+
+func TestDefaultVerifier_GetIssuerPolicy(t *testing.T) {
+	ts := newTestOIDCServer(t)
+	defer ts.Close()
+
+	logger := zerolog.New(zerolog.NewConsoleWriter())
+	policy := &IssuerPolicy{
+		Issuer:       ts.issuer,
+		ProviderType: veidtypes.SSOProviderGoogle,
+		ClientID:     "test-client-id",
+		Enabled:      true,
+		ScoreWeight:  250,
+	}
+	config := Config{
+		Enabled: true,
+		IssuerPolicies: map[string]*IssuerPolicy{
+			ts.issuer: policy,
+		},
+	}
+
+	verifier, err := NewDefaultVerifier(context.Background(), config, nil, logger)
+	require.NoError(t, err)
+	defer verifier.Close()
+
+	ctx := context.Background()
+
+	// Get existing policy
+	got, err := verifier.GetIssuerPolicy(ctx, ts.issuer)
+	require.NoError(t, err)
+	assert.Equal(t, policy.ClientID, got.ClientID)
+	assert.Equal(t, policy.ScoreWeight, got.ScoreWeight)
+
+	// Get non-existent policy
+	_, err = verifier.GetIssuerPolicy(ctx, "https://unknown.issuer.com")
+	assert.Error(t, err)
+}
+
+// ============================================================================
+// IssuerPolicy Tests
+// ============================================================================
+
+func TestIssuerPolicy_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  IssuerPolicy
+		wantErr bool
+	}{
+		{
+			name: "valid policy",
+			policy: IssuerPolicy{
+				Issuer:       "https://accounts.google.com",
+				ProviderType: veidtypes.SSOProviderGoogle,
+				ClientID:     "client-123",
+				ScoreWeight:  250,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing issuer",
+			policy: IssuerPolicy{
+				ProviderType: veidtypes.SSOProviderGoogle,
+				ClientID:     "client-123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid provider type",
+			policy: IssuerPolicy{
+				Issuer:       "https://accounts.google.com",
+				ProviderType: "invalid",
+				ClientID:     "client-123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing client ID",
+			policy: IssuerPolicy{
+				Issuer:       "https://accounts.google.com",
+				ProviderType: veidtypes.SSOProviderGoogle,
+			},
+			wantErr: true,
+		},
+		{
+			name: "score weight too high",
+			policy: IssuerPolicy{
+				Issuer:       "https://accounts.google.com",
+				ProviderType: veidtypes.SSOProviderGoogle,
+				ClientID:     "client-123",
+				ScoreWeight:  15000,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.policy.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIssuerPolicy_IsEmailDomainAllowed(t *testing.T) {
+	policy := IssuerPolicy{
+		AllowedEmailDomains: []string{"example.com", "test.org"},
+	}
+
+	assert.True(t, policy.IsEmailDomainAllowed("example.com"))
+	assert.True(t, policy.IsEmailDomainAllowed("test.org"))
+	assert.False(t, policy.IsEmailDomainAllowed("other.com"))
+
+	// Empty allowlist allows all
+	emptyPolicy := IssuerPolicy{}
+	assert.True(t, emptyPolicy.IsEmailDomainAllowed("any.com"))
+}
+
+func TestIssuerPolicy_IsTenantAllowed(t *testing.T) {
+	policy := IssuerPolicy{
+		AllowedTenants: []string{"tenant-1", "tenant-2"},
+	}
+
+	assert.True(t, policy.IsTenantAllowed("tenant-1"))
+	assert.True(t, policy.IsTenantAllowed("tenant-2"))
+	assert.False(t, policy.IsTenantAllowed("tenant-3"))
+
+	// Empty allowlist allows all
+	emptyPolicy := IssuerPolicy{}
+	assert.True(t, emptyPolicy.IsTenantAllowed("any-tenant"))
+}
+
+// ============================================================================
+// VerifiedClaims Tests
+// ============================================================================
+
+func TestVerifiedClaims_GetEmailDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		email    string
+		expected string
+	}{
+		{
+			name:     "valid email",
+			email:    "user@example.com",
+			expected: "example.com",
+		},
+		{
+			name:     "subdomain email",
+			email:    "user@sub.example.com",
+			expected: "sub.example.com",
+		},
+		{
+			name:     "empty email",
+			email:    "",
+			expected: "",
+		},
+		{
+			name:     "invalid email",
+			email:    "not-an-email",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := &VerifiedClaims{Email: tt.email}
+			assert.Equal(t, tt.expected, claims.GetEmailDomain())
+		})
+	}
+}
+
+// ============================================================================
+// Well-Known Issuers Tests
+// ============================================================================
+
+func TestWellKnownIssuers(t *testing.T) {
+	// Verify well-known issuers are defined
+	assert.NotEmpty(t, WellKnownIssuers)
+
+	// Check Google
+	googleIssuer, ok := WellKnownIssuers[veidtypes.SSOProviderGoogle]
+	assert.True(t, ok)
+	assert.Equal(t, "https://accounts.google.com", googleIssuer)
+
+	// Check Microsoft
+	microsoftIssuer, ok := WellKnownIssuers[veidtypes.SSOProviderMicrosoft]
+	assert.True(t, ok)
+	assert.Contains(t, microsoftIssuer, "login.microsoftonline.com")
+}

--- a/pkg/verification/sso/errors.go
+++ b/pkg/verification/sso/errors.go
@@ -1,0 +1,67 @@
+// Package sso provides the SSO/OIDC verification service for VEID.
+package sso
+
+import "errors"
+
+// ============================================================================
+// Error Definitions
+// ============================================================================
+
+var (
+	// ErrChallengeNotFound indicates the challenge was not found.
+	ErrChallengeNotFound = errors.New("SSO challenge not found")
+
+	// ErrChallengeExpired indicates the challenge has expired.
+	ErrChallengeExpired = errors.New("SSO challenge has expired")
+
+	// ErrChallengeAlreadyCompleted indicates the challenge was already completed.
+	ErrChallengeAlreadyCompleted = errors.New("SSO challenge already completed")
+
+	// ErrStateMismatch indicates the OAuth state parameter doesn't match.
+	ErrStateMismatch = errors.New("OAuth state mismatch")
+
+	// ErrNonceMismatch indicates the OIDC nonce doesn't match.
+	ErrNonceMismatch = errors.New("OIDC nonce mismatch")
+
+	// ErrInvalidLinkageSignature indicates the linkage signature is invalid.
+	ErrInvalidLinkageSignature = errors.New("invalid linkage signature")
+
+	// ErrAccountMismatch indicates the account address doesn't match.
+	ErrAccountMismatch = errors.New("account address mismatch")
+
+	// ErrLinkageAlreadyExists indicates an SSO linkage already exists.
+	ErrLinkageAlreadyExists = errors.New("SSO linkage already exists for this account")
+
+	// ErrLinkageNotFound indicates the SSO linkage was not found.
+	ErrLinkageNotFound = errors.New("SSO linkage not found")
+
+	// ErrRateLimitExceeded indicates the rate limit was exceeded.
+	ErrRateLimitExceeded = errors.New("rate limit exceeded")
+
+	// ErrServiceUnavailable indicates the service is unavailable.
+	ErrServiceUnavailable = errors.New("SSO verification service unavailable")
+
+	// ErrAttestationFailed indicates attestation creation failed.
+	ErrAttestationFailed = errors.New("failed to create SSO attestation")
+
+	// ErrSigningFailed indicates attestation signing failed.
+	ErrSigningFailed = errors.New("failed to sign SSO attestation")
+
+	// ErrOnChainSubmissionFailed indicates on-chain submission failed.
+	ErrOnChainSubmissionFailed = errors.New("failed to submit linkage on-chain")
+
+	// ErrMaxChallengesExceeded indicates too many pending challenges.
+	ErrMaxChallengesExceeded = errors.New("maximum pending challenges exceeded")
+
+	// ErrInvalidConfig indicates invalid configuration.
+	ErrInvalidConfig = errors.New("invalid SSO service configuration")
+
+	// ErrProviderNotConfigured indicates the provider is not configured.
+	ErrProviderNotConfigured = errors.New("SSO provider not configured")
+
+	// ErrRevocationFailed indicates revocation failed.
+	ErrRevocationFailed = errors.New("SSO linkage revocation failed")
+
+	// ErrUnauthorizedRevocation indicates unauthorized revocation attempt.
+	ErrUnauthorizedRevocation = errors.New("unauthorized to revoke SSO linkage")
+)

--- a/pkg/verification/sso/service.go
+++ b/pkg/verification/sso/service.go
@@ -1,0 +1,628 @@
+// Package sso provides the SSO/OIDC verification service for VEID.
+package sso
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/virtengine/virtengine/pkg/verification/audit"
+	"github.com/virtengine/virtengine/pkg/verification/oidc"
+	"github.com/virtengine/virtengine/pkg/verification/ratelimit"
+	"github.com/virtengine/virtengine/pkg/verification/signer"
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// ============================================================================
+// Default Verification Service
+// ============================================================================
+
+// DefaultService implements VerificationService.
+type DefaultService struct {
+	config      Config
+	oidcVerifier oidc.OIDCVerifier
+	signer      signer.SignerService
+	rateLimiter ratelimit.VerificationLimiter
+	auditor     audit.AuditLogger
+	logger      zerolog.Logger
+
+	// Challenge storage (in-memory for now, should use Redis in production)
+	mu          sync.RWMutex
+	challenges  map[string]*Challenge
+	byAccount   map[string][]string // accountAddress -> challengeIDs
+}
+
+// NewDefaultService creates a new DefaultService.
+func NewDefaultService(
+	ctx context.Context,
+	config Config,
+	oidcVerifier oidc.OIDCVerifier,
+	signerSvc signer.SignerService,
+	rateLimiter ratelimit.VerificationLimiter,
+	auditor audit.AuditLogger,
+	logger zerolog.Logger,
+) (*DefaultService, error) {
+	s := &DefaultService{
+		config:      config,
+		oidcVerifier: oidcVerifier,
+		signer:      signerSvc,
+		rateLimiter: rateLimiter,
+		auditor:     auditor,
+		logger:      logger.With().Str("component", "sso_service").Logger(),
+		challenges:  make(map[string]*Challenge),
+		byAccount:   make(map[string][]string),
+	}
+
+	// Start background cleanup
+	go s.cleanupExpiredChallenges(ctx)
+
+	s.logger.Info().Msg("SSO verification service initialized")
+	return s, nil
+}
+
+// InitiateVerification starts an SSO verification flow.
+func (s *DefaultService) InitiateVerification(ctx context.Context, req *InitiateRequest) (*InitiateResponse, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Rate limiting
+	if s.config.RateLimitEnabled && s.rateLimiter != nil {
+		allowed, result, err := s.rateLimiter.AllowVerification(ctx, req.AccountAddress, ratelimit.LimitTypeSSOVerification)
+		if err != nil {
+			s.logger.Warn().Err(err).Msg("rate limit check failed")
+		} else if !allowed {
+			s.logAudit(ctx, audit.EventTypeRateLimitExceeded, req.AccountAddress, "initiate_verification", map[string]interface{}{
+				"reason":   result.Reason,
+				"retry_after": result.RetryAfter,
+			})
+			return nil, fmt.Errorf("%w: retry after %d seconds", ErrRateLimitExceeded, result.RetryAfter)
+		}
+	}
+
+	// Check max pending challenges
+	s.mu.RLock()
+	pendingCount := len(s.byAccount[req.AccountAddress])
+	s.mu.RUnlock()
+
+	if pendingCount >= s.config.MaxChallengesPerAccount {
+		return nil, fmt.Errorf("%w: account has %d pending challenges", ErrMaxChallengesExceeded, pendingCount)
+	}
+
+	// Generate challenge parameters
+	challengeID := uuid.New().String()
+	state := generateSecureToken(32)
+	nonce := generateSecureToken(32)
+	now := time.Now()
+	expiresAt := now.Add(time.Duration(s.config.ChallengeTTLSeconds) * time.Second)
+
+	// Determine OIDC issuer
+	oidcIssuer := req.OIDCIssuer
+	if oidcIssuer == "" {
+		if knownIssuer, ok := oidc.WellKnownIssuers[req.ProviderType]; ok {
+			oidcIssuer = knownIssuer
+		} else {
+			return nil, fmt.Errorf("%w: provider: %s", ErrProviderNotConfigured, req.ProviderType)
+		}
+	}
+
+	// Generate linkage message
+	linkageMessage := req.LinkageMessage
+	if linkageMessage == "" {
+		linkageMessage = fmt.Sprintf(s.config.LinkageMessageTemplate, req.AccountAddress, now.UTC().Format(time.RFC3339), nonce)
+	}
+
+	// Get authorization URL from OIDC verifier
+	policy, err := s.oidcVerifier.GetIssuerPolicy(ctx, oidcIssuer)
+	if err != nil {
+		return nil, fmt.Errorf("%w: issuer %s: %v", ErrProviderNotConfigured, oidcIssuer, err)
+	}
+
+	scopes := req.RequestedScopes
+	if len(scopes) == 0 {
+		scopes = policy.RequiredScopes
+	}
+
+	authURL, err := s.oidcVerifier.GetAuthorizationURL(ctx, &oidc.AuthorizationRequest{
+		ProviderType: req.ProviderType,
+		Issuer:       oidcIssuer,
+		ClientID:     policy.ClientID,
+		RedirectURI:  req.RedirectURI,
+		State:        state,
+		Nonce:        nonce,
+		Scopes:       scopes,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Create challenge
+	challenge := &Challenge{
+		ChallengeID:    challengeID,
+		AccountAddress: req.AccountAddress,
+		ProviderType:   req.ProviderType,
+		OIDCIssuer:     oidcIssuer,
+		State:          state,
+		Nonce:          nonce,
+		LinkageMessage: linkageMessage,
+		RedirectURI:    req.RedirectURI,
+		Status:         ChallengeStatusPending,
+		CreatedAt:      now,
+		ExpiresAt:      expiresAt,
+		ClientIP:       req.ClientIP,
+	}
+
+	// Store challenge
+	s.mu.Lock()
+	s.challenges[challengeID] = challenge
+	s.byAccount[req.AccountAddress] = append(s.byAccount[req.AccountAddress], challengeID)
+	s.mu.Unlock()
+
+	s.logAudit(ctx, audit.EventTypeVerificationInitiated, req.AccountAddress, "initiate_verification", map[string]interface{}{
+		"challenge_id": challengeID,
+		"provider":     req.ProviderType,
+		"issuer":       oidcIssuer,
+	})
+
+	return &InitiateResponse{
+		ChallengeID:      challengeID,
+		AuthorizationURL: authURL,
+		State:            state,
+		Nonce:            nonce,
+		LinkageMessage:   linkageMessage,
+		ExpiresAt:        expiresAt,
+	}, nil
+}
+
+// CompleteVerification completes an SSO verification with OIDC token.
+func (s *DefaultService) CompleteVerification(ctx context.Context, req *CompleteRequest) (*CompleteResponse, error) {
+	if err := req.Validate(); err != nil {
+		return NewCompleteError("validation_error", err.Error()), nil
+	}
+
+	// Get challenge
+	challenge, err := s.GetChallenge(ctx, req.ChallengeID)
+	if err != nil {
+		return NewCompleteError("challenge_error", err.Error()), nil
+	}
+
+	// Validate state
+	if challenge.State != req.State {
+		s.logAudit(ctx, audit.EventTypeSecurityAlert, challenge.AccountAddress, "state_mismatch", map[string]interface{}{
+			"challenge_id": req.ChallengeID,
+		})
+		return NewCompleteError("state_mismatch", "OAuth state parameter mismatch"), nil
+	}
+
+	// Check if challenge can be completed
+	now := time.Now()
+	if !challenge.CanComplete(now) {
+		if challenge.IsExpired(now) {
+			s.updateChallengeStatus(req.ChallengeID, ChallengeStatusExpired)
+			return NewCompleteError("challenge_expired", "SSO challenge has expired"), nil
+		}
+		return NewCompleteError("challenge_invalid", fmt.Sprintf("challenge status: %s", challenge.Status)), nil
+	}
+
+	// Get issuer policy for verification
+	policy, err := s.oidcVerifier.GetIssuerPolicy(ctx, challenge.OIDCIssuer)
+	if err != nil {
+		return NewCompleteError("config_error", err.Error()), nil
+	}
+
+	// Verify the ID token
+	claims, err := s.oidcVerifier.VerifyToken(ctx, req.IDToken, &oidc.VerificationRequest{
+		ExpectedAudience:     policy.ClientID,
+		ExpectedIssuer:       challenge.OIDCIssuer,
+		ExpectedNonce:        challenge.Nonce,
+		RequiredClaims:       policy.RequiredClaims,
+		MaxAge:               policy.MaxAuthAgeSeconds,
+		AllowedACRValues:     policy.AllowedACRValues,
+		RequireEmailVerified: policy.RequireEmailVerified,
+		ProviderType:         challenge.ProviderType,
+	})
+	if err != nil {
+		s.updateChallengeStatus(req.ChallengeID, ChallengeStatusFailed)
+		s.logAudit(ctx, audit.EventTypeVerificationFailed, challenge.AccountAddress, "token_verification_failed", map[string]interface{}{
+			"challenge_id": req.ChallengeID,
+			"error":        err.Error(),
+		})
+		return NewCompleteError("token_verification_failed", err.Error()), nil
+	}
+
+	// TODO: Verify linkage signature (requires crypto key verification)
+	// For now, we just check that a signature was provided
+
+	// Create attestation
+	attestation, err := s.createAttestation(ctx, challenge, claims, req.LinkageSignature)
+	if err != nil {
+		s.updateChallengeStatus(req.ChallengeID, ChallengeStatusFailed)
+		return NewCompleteError("attestation_failed", err.Error()), nil
+	}
+
+	// Sign attestation
+	if err := s.signer.SignAttestation(ctx, &attestation.VerificationAttestation); err != nil {
+		s.updateChallengeStatus(req.ChallengeID, ChallengeStatusFailed)
+		return NewCompleteError("signing_failed", err.Error()), nil
+	}
+
+	// Generate linkage ID
+	linkageID := fmt.Sprintf("sso:%s:%s", challenge.ProviderType, uuid.New().String()[:8])
+
+	// Update challenge status
+	s.updateChallengeStatus(req.ChallengeID, ChallengeStatusCompleted)
+
+	s.logAudit(ctx, audit.EventTypeVerificationCompleted, challenge.AccountAddress, "complete_verification", map[string]interface{}{
+		"challenge_id":  req.ChallengeID,
+		"linkage_id":    linkageID,
+		"provider":      challenge.ProviderType,
+		"subject_hash":  attestation.SubjectHash,
+		"email_domain":  claims.GetEmailDomain(),
+	})
+
+	return NewCompleteSuccess(attestation, linkageID), nil
+}
+
+// ExchangeCodeAndComplete exchanges an authorization code and completes verification.
+func (s *DefaultService) ExchangeCodeAndComplete(ctx context.Context, req *CodeExchangeCompleteRequest) (*CompleteResponse, error) {
+	if err := req.Validate(); err != nil {
+		return NewCompleteError("validation_error", err.Error()), nil
+	}
+
+	// Get challenge
+	challenge, err := s.GetChallenge(ctx, req.ChallengeID)
+	if err != nil {
+		return NewCompleteError("challenge_error", err.Error()), nil
+	}
+
+	// Validate state
+	if challenge.State != req.State {
+		return NewCompleteError("state_mismatch", "OAuth state parameter mismatch"), nil
+	}
+
+	// Check if challenge can be completed
+	now := time.Now()
+	if !challenge.CanComplete(now) {
+		if challenge.IsExpired(now) {
+			s.updateChallengeStatus(req.ChallengeID, ChallengeStatusExpired)
+			return NewCompleteError("challenge_expired", "SSO challenge has expired"), nil
+		}
+		return NewCompleteError("challenge_invalid", fmt.Sprintf("challenge status: %s", challenge.Status)), nil
+	}
+
+	// Get issuer policy
+	policy, err := s.oidcVerifier.GetIssuerPolicy(ctx, challenge.OIDCIssuer)
+	if err != nil {
+		return NewCompleteError("config_error", err.Error()), nil
+	}
+
+	// Exchange code for tokens
+	tokenResp, err := s.oidcVerifier.ExchangeCode(ctx, req.AuthorizationCode, &oidc.CodeExchangeRequest{
+		ProviderType:  challenge.ProviderType,
+		Issuer:        challenge.OIDCIssuer,
+		ClientID:      policy.ClientID,
+		ClientSecret:  "", // Would need to get from secure storage
+		RedirectURI:   challenge.RedirectURI,
+		Code:          req.AuthorizationCode,
+		ExpectedNonce: challenge.Nonce,
+	})
+	if err != nil {
+		s.updateChallengeStatus(req.ChallengeID, ChallengeStatusFailed)
+		return NewCompleteError("code_exchange_failed", err.Error()), nil
+	}
+
+	// Create attestation from verified claims
+	attestation, err := s.createAttestation(ctx, challenge, tokenResp.VerifiedClaims, req.LinkageSignature)
+	if err != nil {
+		s.updateChallengeStatus(req.ChallengeID, ChallengeStatusFailed)
+		return NewCompleteError("attestation_failed", err.Error()), nil
+	}
+
+	// Sign attestation
+	if err := s.signer.SignAttestation(ctx, &attestation.VerificationAttestation); err != nil {
+		s.updateChallengeStatus(req.ChallengeID, ChallengeStatusFailed)
+		return NewCompleteError("signing_failed", err.Error()), nil
+	}
+
+	// Generate linkage ID
+	linkageID := fmt.Sprintf("sso:%s:%s", challenge.ProviderType, uuid.New().String()[:8])
+
+	// Update challenge status
+	s.updateChallengeStatus(req.ChallengeID, ChallengeStatusCompleted)
+
+	s.logAudit(ctx, audit.EventTypeVerificationCompleted, challenge.AccountAddress, "complete_verification", map[string]interface{}{
+		"challenge_id": req.ChallengeID,
+		"linkage_id":   linkageID,
+		"provider":     challenge.ProviderType,
+	})
+
+	return NewCompleteSuccess(attestation, linkageID), nil
+}
+
+// createAttestation creates an SSO attestation from verified claims.
+func (s *DefaultService) createAttestation(
+	ctx context.Context,
+	challenge *Challenge,
+	claims *oidc.VerifiedClaims,
+	linkageSignature []byte,
+) (*veidtypes.SSOAttestation, error) {
+	// Generate attestation nonce
+	nonceBytes := make([]byte, 32)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		return nil, fmt.Errorf("%w: failed to generate nonce: %v", ErrAttestationFailed, err)
+	}
+
+	// Get signing key info
+	keyInfo, err := s.signer.GetActiveKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to get signing key: %v", ErrSigningFailed, err)
+	}
+
+	now := time.Now()
+	validityDuration := time.Duration(s.config.AttestationValidityDays) * 24 * time.Hour
+
+	issuer := veidtypes.NewAttestationIssuer(keyInfo.Fingerprint, "")
+	subject := veidtypes.NewAttestationSubject(challenge.AccountAddress)
+
+	attestation := veidtypes.NewSSOAttestation(
+		issuer,
+		subject,
+		challenge.OIDCIssuer,
+		claims.Subject,
+		challenge.ProviderType,
+		challenge.Nonce,
+		nonceBytes,
+		now,
+		validityDuration,
+	)
+
+	// Set email info
+	if claims.Email != "" {
+		attestation.SetEmail(claims.Email, claims.GetEmailDomain(), claims.EmailVerified)
+	}
+
+	// Set tenant ID (for Microsoft)
+	if claims.TenantID != "" {
+		attestation.SetTenantID(claims.TenantID)
+	}
+
+	// Set auth context
+	attestation.SetAuthContext(claims.AuthTime, []string{claims.ACR}, claims.AMR)
+
+	// Set linkage signature
+	attestation.SetLinkageSignature(linkageSignature)
+
+	// Add verification proof
+	proof := veidtypes.NewVerificationProofDetail(
+		"oidc_token_verified",
+		veidtypes.HashSubjectID(claims.Subject),
+		100, // Full score for valid token
+		100,
+		now,
+	)
+	attestation.AddVerificationProof(proof)
+
+	// Set metadata
+	attestation.SetMetadata("provider_type", string(challenge.ProviderType))
+	attestation.SetMetadata("email_domain_hash", attestation.EmailDomainHash)
+	if claims.TenantID != "" {
+		attestation.SetMetadata("tenant_id_hash", attestation.TenantIDHash)
+	}
+
+	return attestation, nil
+}
+
+// GetChallenge retrieves a pending verification challenge.
+func (s *DefaultService) GetChallenge(ctx context.Context, challengeID string) (*Challenge, error) {
+	s.mu.RLock()
+	challenge, ok := s.challenges[challengeID]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, fmt.Errorf("%w: challenge ID: %s", ErrChallengeNotFound, challengeID)
+	}
+
+	// Make a copy
+	challengeCopy := *challenge
+	return &challengeCopy, nil
+}
+
+// updateChallengeStatus updates the status of a challenge.
+func (s *DefaultService) updateChallengeStatus(challengeID string, status ChallengeStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if challenge, ok := s.challenges[challengeID]; ok {
+		challenge.Status = status
+		if status == ChallengeStatusCompleted || status == ChallengeStatusFailed {
+			now := time.Now()
+			challenge.CompletedAt = &now
+		}
+	}
+}
+
+// RevokeVerification revokes an existing SSO verification.
+func (s *DefaultService) RevokeVerification(ctx context.Context, req *RevokeRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	// TODO: Implement revocation logic with on-chain submission
+	// For now, just log the revocation request
+
+	s.logAudit(ctx, audit.EventTypeKeyRevoked, req.AccountAddress, "revoke_verification", map[string]interface{}{
+		"linkage_id": req.LinkageID,
+		"reason":     req.Reason,
+	})
+
+	return nil
+}
+
+// GetLinkageStatus returns the status of an SSO linkage.
+func (s *DefaultService) GetLinkageStatus(ctx context.Context, accountAddress string) (*LinkageStatus, error) {
+	// TODO: Query on-chain linkage status
+	// For now, return not found
+
+	return &LinkageStatus{
+		Exists:         false,
+		AccountAddress: accountAddress,
+	}, nil
+}
+
+// HealthCheck returns the service health status.
+func (s *DefaultService) HealthCheck(ctx context.Context) (*HealthStatus, error) {
+	status := &HealthStatus{
+		Healthy:    true,
+		Status:     "healthy",
+		Timestamp:  time.Now(),
+		Components: make(map[string]*ComponentHealth),
+		Details:    make(map[string]interface{}),
+		Warnings:   make([]string, 0),
+	}
+
+	// Check OIDC verifier
+	oidcHealth, err := s.oidcVerifier.HealthCheck(ctx)
+	if err != nil {
+		status.Components["oidc_verifier"] = &ComponentHealth{
+			Name:      "oidc_verifier",
+			Healthy:   false,
+			LastError: err.Error(),
+		}
+		status.Healthy = false
+	} else {
+		status.Components["oidc_verifier"] = &ComponentHealth{
+			Name:    "oidc_verifier",
+			Healthy: oidcHealth.Healthy,
+			Status:  oidcHealth.Status,
+		}
+		if !oidcHealth.Healthy {
+			status.Healthy = false
+		}
+	}
+
+	// Check signer
+	signerHealth, err := s.signer.HealthCheck(ctx)
+	if err != nil {
+		status.Components["signer"] = &ComponentHealth{
+			Name:      "signer",
+			Healthy:   false,
+			LastError: err.Error(),
+		}
+		status.Healthy = false
+	} else {
+		status.Components["signer"] = &ComponentHealth{
+			Name:    "signer",
+			Healthy: signerHealth.Healthy,
+			Status:  signerHealth.Status,
+		}
+		if !signerHealth.Healthy {
+			status.Healthy = false
+		}
+	}
+
+	// Add challenge stats
+	s.mu.RLock()
+	status.Details["pending_challenges"] = len(s.challenges)
+	s.mu.RUnlock()
+
+	if !status.Healthy {
+		status.Status = "degraded"
+	}
+
+	return status, nil
+}
+
+// Close releases resources.
+func (s *DefaultService) Close() error {
+	s.logger.Info().Msg("SSO verification service closing")
+	return nil
+}
+
+// cleanupExpiredChallenges periodically removes expired challenges.
+func (s *DefaultService) cleanupExpiredChallenges(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.doCleanup()
+		}
+	}
+}
+
+func (s *DefaultService) doCleanup() {
+	now := time.Now()
+	toDelete := make([]string, 0)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for id, challenge := range s.challenges {
+		// Remove challenges that are expired and older than 1 hour
+		if challenge.IsExpired(now) && now.Sub(challenge.ExpiresAt) > time.Hour {
+			toDelete = append(toDelete, id)
+		}
+		// Remove completed challenges older than 24 hours
+		if challenge.CompletedAt != nil && now.Sub(*challenge.CompletedAt) > 24*time.Hour {
+			toDelete = append(toDelete, id)
+		}
+	}
+
+	for _, id := range toDelete {
+		challenge := s.challenges[id]
+		delete(s.challenges, id)
+
+		// Remove from byAccount index
+		if ids, ok := s.byAccount[challenge.AccountAddress]; ok {
+			newIDs := make([]string, 0, len(ids)-1)
+			for _, cid := range ids {
+				if cid != id {
+					newIDs = append(newIDs, cid)
+				}
+			}
+			if len(newIDs) == 0 {
+				delete(s.byAccount, challenge.AccountAddress)
+			} else {
+				s.byAccount[challenge.AccountAddress] = newIDs
+			}
+		}
+	}
+
+	if len(toDelete) > 0 {
+		s.logger.Debug().Int("count", len(toDelete)).Msg("cleaned up expired challenges")
+	}
+}
+
+// logAudit logs an audit event.
+func (s *DefaultService) logAudit(ctx context.Context, eventType audit.EventType, resource, action string, details map[string]interface{}) {
+	if s.auditor == nil || !s.config.AuditEnabled {
+		return
+	}
+
+	s.auditor.Log(ctx, audit.Event{
+		Type:      eventType,
+		Timestamp: time.Now(),
+		Actor:     "sso_service",
+		Resource:  resource,
+		Action:    action,
+		Details:   details,
+	})
+}
+
+// generateSecureToken generates a secure random token.
+func generateSecureToken(length int) string {
+	bytes := make([]byte, length)
+	if _, err := rand.Read(bytes); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(bytes)
+}

--- a/pkg/verification/sso/types.go
+++ b/pkg/verification/sso/types.go
@@ -1,0 +1,473 @@
+// Package sso provides the SSO/OIDC verification service for VEID.
+//
+// This package implements the complete SSO verification flow including:
+// - OIDC token verification
+// - Attestation signing
+// - On-chain linkage creation
+// - Audit logging and rate limiting
+//
+// Task Reference: VE-4B - SSO/OIDC Verification Service
+package sso
+
+import (
+	"context"
+	"time"
+
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// ============================================================================
+// SSO Verification Service Interface
+// ============================================================================
+
+// VerificationService defines the interface for SSO/OIDC verification.
+type VerificationService interface {
+	// InitiateVerification starts an SSO verification flow.
+	InitiateVerification(ctx context.Context, req *InitiateRequest) (*InitiateResponse, error)
+
+	// CompleteVerification completes an SSO verification with OIDC token.
+	CompleteVerification(ctx context.Context, req *CompleteRequest) (*CompleteResponse, error)
+
+	// ExchangeCodeAndComplete exchanges an authorization code and completes verification.
+	ExchangeCodeAndComplete(ctx context.Context, req *CodeExchangeCompleteRequest) (*CompleteResponse, error)
+
+	// GetChallenge retrieves a pending verification challenge.
+	GetChallenge(ctx context.Context, challengeID string) (*Challenge, error)
+
+	// RevokeVerification revokes an existing SSO verification.
+	RevokeVerification(ctx context.Context, req *RevokeRequest) error
+
+	// GetLinkageStatus returns the status of an SSO linkage.
+	GetLinkageStatus(ctx context.Context, accountAddress string) (*LinkageStatus, error)
+
+	// HealthCheck returns the service health status.
+	HealthCheck(ctx context.Context) (*HealthStatus, error)
+
+	// Close releases resources.
+	Close() error
+}
+
+// ============================================================================
+// Request/Response Types
+// ============================================================================
+
+// InitiateRequest contains parameters for initiating SSO verification.
+type InitiateRequest struct {
+	// AccountAddress is the blockchain account to link
+	AccountAddress string `json:"account_address"`
+
+	// ProviderType is the SSO provider to use
+	ProviderType veidtypes.SSOProviderType `json:"provider_type"`
+
+	// OIDCIssuer is the specific OIDC issuer (for generic OIDC)
+	OIDCIssuer string `json:"oidc_issuer,omitempty"`
+
+	// RedirectURI is where to redirect after OIDC flow
+	RedirectURI string `json:"redirect_uri"`
+
+	// RequestedScopes specifies additional OAuth scopes to request
+	RequestedScopes []string `json:"requested_scopes,omitempty"`
+
+	// LinkageMessage is the message for the user to sign (optional, generated if empty)
+	LinkageMessage string `json:"linkage_message,omitempty"`
+
+	// ClientIP is the client's IP address (for rate limiting)
+	ClientIP string `json:"client_ip,omitempty"`
+
+	// RequestID is an optional request identifier for correlation
+	RequestID string `json:"request_id,omitempty"`
+}
+
+// Validate validates the initiate request.
+func (r *InitiateRequest) Validate() error {
+	if r.AccountAddress == "" {
+		return veidtypes.ErrInvalidAddress.Wrap("account_address is required")
+	}
+	if !veidtypes.IsValidSSOProviderType(r.ProviderType) {
+		return veidtypes.ErrInvalidSSO.Wrapf("invalid provider_type: %s", r.ProviderType)
+	}
+	if r.RedirectURI == "" {
+		return veidtypes.ErrInvalidSSO.Wrap("redirect_uri is required")
+	}
+	if r.ProviderType == veidtypes.SSOProviderOIDC && r.OIDCIssuer == "" {
+		return veidtypes.ErrInvalidSSO.Wrap("oidc_issuer required for generic OIDC provider")
+	}
+	return nil
+}
+
+// InitiateResponse contains the result of initiating SSO verification.
+type InitiateResponse struct {
+	// ChallengeID is the unique identifier for this verification attempt
+	ChallengeID string `json:"challenge_id"`
+
+	// AuthorizationURL is the URL to redirect the user to
+	AuthorizationURL string `json:"authorization_url"`
+
+	// State is the OAuth2 state parameter (for CSRF verification)
+	State string `json:"state"`
+
+	// Nonce is the OIDC nonce (for replay protection)
+	Nonce string `json:"nonce"`
+
+	// LinkageMessage is the message the user should sign
+	LinkageMessage string `json:"linkage_message"`
+
+	// ExpiresAt is when this challenge expires
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// CompleteRequest contains parameters for completing SSO verification.
+type CompleteRequest struct {
+	// ChallengeID is the verification challenge ID
+	ChallengeID string `json:"challenge_id"`
+
+	// IDToken is the OIDC ID token received from the provider
+	IDToken string `json:"id_token"`
+
+	// LinkageSignature is the user's signature of the linkage message
+	LinkageSignature []byte `json:"linkage_signature"`
+
+	// State is the OAuth2 state parameter (for CSRF verification)
+	State string `json:"state"`
+
+	// ClientIP is the client's IP address (for rate limiting)
+	ClientIP string `json:"client_ip,omitempty"`
+}
+
+// Validate validates the complete request.
+func (r *CompleteRequest) Validate() error {
+	if r.ChallengeID == "" {
+		return veidtypes.ErrInvalidSSO.Wrap("challenge_id is required")
+	}
+	if r.IDToken == "" {
+		return veidtypes.ErrInvalidSSO.Wrap("id_token is required")
+	}
+	if len(r.LinkageSignature) == 0 {
+		return veidtypes.ErrInvalidBindingSignature.Wrap("linkage_signature is required")
+	}
+	if r.State == "" {
+		return veidtypes.ErrInvalidSSO.Wrap("state is required")
+	}
+	return nil
+}
+
+// CodeExchangeCompleteRequest contains parameters for code exchange and completion.
+type CodeExchangeCompleteRequest struct {
+	// ChallengeID is the verification challenge ID
+	ChallengeID string `json:"challenge_id"`
+
+	// AuthorizationCode is the code received from the provider
+	AuthorizationCode string `json:"authorization_code"`
+
+	// LinkageSignature is the user's signature of the linkage message
+	LinkageSignature []byte `json:"linkage_signature"`
+
+	// State is the OAuth2 state parameter
+	State string `json:"state"`
+
+	// ClientIP is the client's IP address
+	ClientIP string `json:"client_ip,omitempty"`
+}
+
+// Validate validates the code exchange request.
+func (r *CodeExchangeCompleteRequest) Validate() error {
+	if r.ChallengeID == "" {
+		return veidtypes.ErrInvalidSSO.Wrap("challenge_id is required")
+	}
+	if r.AuthorizationCode == "" {
+		return veidtypes.ErrInvalidSSO.Wrap("authorization_code is required")
+	}
+	if len(r.LinkageSignature) == 0 {
+		return veidtypes.ErrInvalidBindingSignature.Wrap("linkage_signature is required")
+	}
+	if r.State == "" {
+		return veidtypes.ErrInvalidSSO.Wrap("state is required")
+	}
+	return nil
+}
+
+// CompleteResponse contains the result of completing SSO verification.
+type CompleteResponse struct {
+	// Success indicates if verification was successful
+	Success bool `json:"success"`
+
+	// Attestation is the signed SSO attestation (if successful)
+	Attestation *veidtypes.SSOAttestation `json:"attestation,omitempty"`
+
+	// LinkageID is the on-chain linkage ID (if created)
+	LinkageID string `json:"linkage_id,omitempty"`
+
+	// Error contains error details (if failed)
+	Error *VerificationError `json:"error,omitempty"`
+
+	// ProcessedAt is when the response was generated
+	ProcessedAt time.Time `json:"processed_at"`
+}
+
+// VerificationError contains error details for failed verification.
+type VerificationError struct {
+	// Code is the error code
+	Code string `json:"code"`
+
+	// Message is the error message
+	Message string `json:"message"`
+
+	// Details contains additional error context
+	Details map[string]string `json:"details,omitempty"`
+}
+
+// NewCompleteSuccess creates a successful complete response.
+func NewCompleteSuccess(attestation *veidtypes.SSOAttestation, linkageID string) *CompleteResponse {
+	return &CompleteResponse{
+		Success:     true,
+		Attestation: attestation,
+		LinkageID:   linkageID,
+		ProcessedAt: time.Now(),
+	}
+}
+
+// NewCompleteError creates an error complete response.
+func NewCompleteError(code, message string) *CompleteResponse {
+	return &CompleteResponse{
+		Success: false,
+		Error: &VerificationError{
+			Code:    code,
+			Message: message,
+		},
+		ProcessedAt: time.Now(),
+	}
+}
+
+// RevokeRequest contains parameters for revoking an SSO verification.
+type RevokeRequest struct {
+	// LinkageID is the linkage to revoke
+	LinkageID string `json:"linkage_id"`
+
+	// AccountAddress is the account that owns the linkage
+	AccountAddress string `json:"account_address"`
+
+	// Reason is the revocation reason
+	Reason string `json:"reason"`
+
+	// Signature is the account's signature authorizing revocation
+	Signature []byte `json:"signature"`
+
+	// ClientIP is the client's IP address
+	ClientIP string `json:"client_ip,omitempty"`
+}
+
+// Validate validates the revoke request.
+func (r *RevokeRequest) Validate() error {
+	if r.LinkageID == "" {
+		return veidtypes.ErrInvalidSSO.Wrap("linkage_id is required")
+	}
+	if r.AccountAddress == "" {
+		return veidtypes.ErrInvalidAddress.Wrap("account_address is required")
+	}
+	if len(r.Signature) == 0 {
+		return veidtypes.ErrInvalidBindingSignature.Wrap("signature is required")
+	}
+	return nil
+}
+
+// LinkageStatus contains the status of an SSO linkage.
+type LinkageStatus struct {
+	// Exists indicates if a linkage exists
+	Exists bool `json:"exists"`
+
+	// LinkageID is the linkage identifier
+	LinkageID string `json:"linkage_id,omitempty"`
+
+	// AccountAddress is the linked account
+	AccountAddress string `json:"account_address,omitempty"`
+
+	// ProviderType is the SSO provider
+	ProviderType veidtypes.SSOProviderType `json:"provider_type,omitempty"`
+
+	// Issuer is the OIDC issuer
+	Issuer string `json:"issuer,omitempty"`
+
+	// Status is the current status
+	Status veidtypes.SSOVerificationStatus `json:"status,omitempty"`
+
+	// VerifiedAt is when the linkage was verified
+	VerifiedAt *time.Time `json:"verified_at,omitempty"`
+
+	// ExpiresAt is when the linkage expires
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+
+	// ScoreContribution is the score contribution from this linkage
+	ScoreContribution uint32 `json:"score_contribution,omitempty"`
+}
+
+// ============================================================================
+// Challenge Types
+// ============================================================================
+
+// Challenge represents a pending SSO verification challenge.
+type Challenge struct {
+	// ChallengeID is the unique identifier
+	ChallengeID string `json:"challenge_id"`
+
+	// AccountAddress is the account requesting verification
+	AccountAddress string `json:"account_address"`
+
+	// ProviderType is the SSO provider
+	ProviderType veidtypes.SSOProviderType `json:"provider_type"`
+
+	// OIDCIssuer is the OIDC issuer
+	OIDCIssuer string `json:"oidc_issuer"`
+
+	// State is the OAuth2 state parameter
+	State string `json:"state"`
+
+	// Nonce is the OIDC nonce
+	Nonce string `json:"nonce"`
+
+	// LinkageMessage is the message for the user to sign
+	LinkageMessage string `json:"linkage_message"`
+
+	// RedirectURI is the callback URI
+	RedirectURI string `json:"redirect_uri"`
+
+	// Status is the challenge status
+	Status ChallengeStatus `json:"status"`
+
+	// CreatedAt is when the challenge was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// ExpiresAt is when the challenge expires
+	ExpiresAt time.Time `json:"expires_at"`
+
+	// CompletedAt is when the challenge was completed
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+
+	// ClientIP is the initiating client's IP
+	ClientIP string `json:"client_ip,omitempty"`
+}
+
+// ChallengeStatus represents the status of a challenge.
+type ChallengeStatus string
+
+const (
+	// ChallengeStatusPending indicates the challenge is pending
+	ChallengeStatusPending ChallengeStatus = "pending"
+
+	// ChallengeStatusCompleted indicates the challenge was completed successfully
+	ChallengeStatusCompleted ChallengeStatus = "completed"
+
+	// ChallengeStatusFailed indicates the challenge failed
+	ChallengeStatusFailed ChallengeStatus = "failed"
+
+	// ChallengeStatusExpired indicates the challenge expired
+	ChallengeStatusExpired ChallengeStatus = "expired"
+
+	// ChallengeStatusCancelled indicates the challenge was cancelled
+	ChallengeStatusCancelled ChallengeStatus = "cancelled"
+)
+
+// IsExpired checks if the challenge has expired.
+func (c *Challenge) IsExpired(now time.Time) bool {
+	return now.After(c.ExpiresAt)
+}
+
+// CanComplete checks if the challenge can be completed.
+func (c *Challenge) CanComplete(now time.Time) bool {
+	return c.Status == ChallengeStatusPending && !c.IsExpired(now)
+}
+
+// ============================================================================
+// Health Status
+// ============================================================================
+
+// HealthStatus represents the health status of the SSO service.
+type HealthStatus struct {
+	// Healthy indicates if the service is healthy
+	Healthy bool `json:"healthy"`
+
+	// Status is a human-readable status message
+	Status string `json:"status"`
+
+	// Timestamp is when the health check was performed
+	Timestamp time.Time `json:"timestamp"`
+
+	// Components contains component health statuses
+	Components map[string]*ComponentHealth `json:"components,omitempty"`
+
+	// Details contains additional details
+	Details map[string]interface{} `json:"details,omitempty"`
+
+	// Warnings contains any warnings
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// ComponentHealth represents the health of a component.
+type ComponentHealth struct {
+	// Name is the component name
+	Name string `json:"name"`
+
+	// Healthy indicates if the component is healthy
+	Healthy bool `json:"healthy"`
+
+	// Status is a status message
+	Status string `json:"status,omitempty"`
+
+	// LastError is the last error (if any)
+	LastError string `json:"last_error,omitempty"`
+
+	// Details contains additional details
+	Details map[string]interface{} `json:"details,omitempty"`
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+// Config contains configuration for the SSO verification service.
+type Config struct {
+	// Enabled determines if SSO verification is active
+	Enabled bool `json:"enabled"`
+
+	// ChallengeTTLSeconds is the challenge validity period
+	ChallengeTTLSeconds int64 `json:"challenge_ttl_seconds"`
+
+	// AttestationValidityDays is how long attestations are valid
+	AttestationValidityDays int `json:"attestation_validity_days"`
+
+	// MaxChallengesPerAccount is the max pending challenges per account
+	MaxChallengesPerAccount int `json:"max_challenges_per_account"`
+
+	// RequireLinkageSignature requires user signature for linkage
+	RequireLinkageSignature bool `json:"require_linkage_signature"`
+
+	// LinkageMessageTemplate is the template for linkage messages
+	LinkageMessageTemplate string `json:"linkage_message_template"`
+
+	// EnableOnChainSubmission enables on-chain linkage submission
+	EnableOnChainSubmission bool `json:"enable_on_chain_submission"`
+
+	// AuditEnabled enables audit logging
+	AuditEnabled bool `json:"audit_enabled"`
+
+	// MetricsEnabled enables Prometheus metrics
+	MetricsEnabled bool `json:"metrics_enabled"`
+
+	// RateLimitEnabled enables rate limiting
+	RateLimitEnabled bool `json:"rate_limit_enabled"`
+}
+
+// DefaultConfig returns the default SSO service configuration.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:                 true,
+		ChallengeTTLSeconds:     600, // 10 minutes
+		AttestationValidityDays: 365,
+		MaxChallengesPerAccount: 5,
+		RequireLinkageSignature: true,
+		LinkageMessageTemplate:  "I authorize linking my SSO identity to VirtEngine account %s at %s. Nonce: %s",
+		EnableOnChainSubmission: true,
+		AuditEnabled:            true,
+		MetricsEnabled:          true,
+		RateLimitEnabled:        true,
+	}
+}

--- a/sdk/go/cli/sso.go
+++ b/sdk/go/cli/sso.go
@@ -1,0 +1,451 @@
+// Package cli provides CLI commands for the VirtEngine SDK.
+//
+// VE-4B: SSO/OIDC Admin CLI Commands
+// This file provides CLI commands for managing SSO/OIDC issuer configuration.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// GetSSOCmd returns the SSO management commands.
+func GetSSOCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sso",
+		Short: "SSO/OIDC verification management commands",
+		Long: `Commands for managing SSO/OIDC verification configuration, including
+issuer allowlist management, policy configuration, and linkage operations.`,
+	}
+
+	cmd.AddCommand(
+		GetSSOIssuerCmd(),
+		GetSSOConfigCmd(),
+		GetSSOLinkageCmd(),
+	)
+
+	return cmd
+}
+
+// GetSSOIssuerCmd returns the SSO issuer management commands.
+func GetSSOIssuerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "issuer",
+		Short: "SSO issuer management commands",
+		Long:  "Commands for managing the SSO issuer allowlist and policies.",
+	}
+
+	cmd.AddCommand(
+		getSSOIssuerListCmd(),
+		getSSOIssuerAddCmd(),
+		getSSOIssuerRemoveCmd(),
+		getSSOIssuerShowCmd(),
+		getSSOIssuerUpdateCmd(),
+	)
+
+	return cmd
+}
+
+func getSSOIssuerListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all configured SSO issuers",
+		Long:  "List all SSO/OIDC issuers in the allowlist with their policies.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO: Implement reading from config file or on-chain query
+			fmt.Println("Configured SSO Issuers:")
+			fmt.Println("========================")
+			fmt.Println("")
+			fmt.Println("Well-Known Issuers:")
+			for providerType, issuer := range wellKnownIssuers {
+				fmt.Printf("  %s: %s\n", providerType, issuer)
+			}
+			fmt.Println("")
+			fmt.Println("Use 'sso issuer show <issuer>' for detailed policy information.")
+			return nil
+		},
+	}
+	return cmd
+}
+
+func getSSOIssuerAddCmd() *cobra.Command {
+	var (
+		clientID            string
+		providerType        string
+		scoreWeight         uint32
+		enabled             bool
+		requireEmailVerified bool
+		allowedEmailDomains []string
+		allowedTenants      []string
+		policyFile          string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "add <issuer-url>",
+		Short: "Add an SSO issuer to the allowlist",
+		Long: `Add a new SSO/OIDC issuer to the allowlist with the specified policy.
+The issuer URL should be the OIDC issuer identifier (e.g., https://accounts.google.com).
+
+Example:
+  virtengine sso issuer add https://accounts.google.com \
+    --client-id="your-client-id" \
+    --provider-type=google \
+    --score-weight=250 \
+    --enabled=true`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issuerURL := args[0]
+
+			// Validate provider type
+			pt := veidtypes.SSOProviderType(providerType)
+			if !veidtypes.IsValidSSOProviderType(pt) {
+				return fmt.Errorf("invalid provider type: %s (valid: google, microsoft, github, oidc)", providerType)
+			}
+
+			policy := IssuerPolicyConfig{
+				Issuer:               issuerURL,
+				ClientID:             clientID,
+				ProviderType:         string(pt),
+				ScoreWeight:          scoreWeight,
+				Enabled:              enabled,
+				RequireEmailVerified: requireEmailVerified,
+				AllowedEmailDomains:  allowedEmailDomains,
+				AllowedTenants:       allowedTenants,
+			}
+
+			if policyFile != "" {
+				data, err := os.ReadFile(policyFile)
+				if err != nil {
+					return fmt.Errorf("failed to read policy file: %w", err)
+				}
+				if err := json.Unmarshal(data, &policy); err != nil {
+					return fmt.Errorf("failed to parse policy file: %w", err)
+				}
+			}
+
+			// Validate
+			if policy.ClientID == "" {
+				return fmt.Errorf("client-id is required")
+			}
+
+			fmt.Printf("Adding SSO issuer:\n")
+			fmt.Printf("  Issuer: %s\n", policy.Issuer)
+			fmt.Printf("  Provider Type: %s\n", policy.ProviderType)
+			fmt.Printf("  Client ID: %s\n", policy.ClientID)
+			fmt.Printf("  Score Weight: %d\n", policy.ScoreWeight)
+			fmt.Printf("  Enabled: %t\n", policy.Enabled)
+
+			// TODO: Actually add to config/on-chain
+			fmt.Println("\n⚠️  Note: This is a preview. Actual configuration update not yet implemented.")
+			fmt.Println("To configure issuers, update the SSO service configuration file.")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&clientID, "client-id", "", "OAuth client ID (required)")
+	cmd.Flags().StringVar(&providerType, "provider-type", "oidc", "Provider type (google, microsoft, github, oidc)")
+	cmd.Flags().Uint32Var(&scoreWeight, "score-weight", 150, "Score weight in basis points (0-10000)")
+	cmd.Flags().BoolVar(&enabled, "enabled", true, "Enable this issuer")
+	cmd.Flags().BoolVar(&requireEmailVerified, "require-email-verified", true, "Require email to be verified")
+	cmd.Flags().StringSliceVar(&allowedEmailDomains, "allowed-email-domains", nil, "Allowed email domains")
+	cmd.Flags().StringSliceVar(&allowedTenants, "allowed-tenants", nil, "Allowed tenant IDs")
+	cmd.Flags().StringVar(&policyFile, "policy-file", "", "JSON policy file")
+
+	_ = cmd.MarkFlagRequired("client-id")
+
+	return cmd
+}
+
+func getSSOIssuerRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <issuer-url>",
+		Short: "Remove an SSO issuer from the allowlist",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issuerURL := args[0]
+			fmt.Printf("Removing SSO issuer: %s\n", issuerURL)
+			fmt.Println("\n⚠️  Note: This is a preview. Actual removal not yet implemented.")
+			return nil
+		},
+	}
+	return cmd
+}
+
+func getSSOIssuerShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <issuer-url>",
+		Short: "Show SSO issuer policy details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issuerURL := args[0]
+			fmt.Printf("SSO Issuer Policy: %s\n", issuerURL)
+			fmt.Println("================================")
+
+			// Check if it's a well-known issuer
+			for pt, url := range wellKnownIssuers {
+				if url == issuerURL {
+					fmt.Printf("  Provider Type: %s\n", pt)
+					fmt.Printf("  Discovery URL: %s/.well-known/openid-configuration\n", issuerURL)
+					weight := veidtypes.GetSSOScoringWeight(pt)
+					fmt.Printf("  Default Score Weight: %d (%.2f%%)\n", weight, float64(weight)/100)
+					break
+				}
+			}
+
+			fmt.Println("\n⚠️  Note: Full policy details require configuration file or on-chain query.")
+			return nil
+		},
+	}
+	return cmd
+}
+
+func getSSOIssuerUpdateCmd() *cobra.Command {
+	var (
+		scoreWeight          *uint32
+		enabled              *bool
+		requireEmailVerified *bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <issuer-url>",
+		Short: "Update an SSO issuer policy",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			issuerURL := args[0]
+			fmt.Printf("Updating SSO issuer policy: %s\n", issuerURL)
+
+			if scoreWeight != nil {
+				fmt.Printf("  Score Weight: %d\n", *scoreWeight)
+			}
+			if enabled != nil {
+				fmt.Printf("  Enabled: %t\n", *enabled)
+			}
+			if requireEmailVerified != nil {
+				fmt.Printf("  Require Email Verified: %t\n", *requireEmailVerified)
+			}
+
+			fmt.Println("\n⚠️  Note: This is a preview. Actual update not yet implemented.")
+			return nil
+		},
+	}
+
+	cmd.Flags().Uint32("score-weight", 0, "Score weight in basis points")
+	cmd.Flags().Bool("enabled", true, "Enable/disable issuer")
+	cmd.Flags().Bool("require-email-verified", true, "Require email verification")
+
+	return cmd
+}
+
+// GetSSOConfigCmd returns the SSO configuration commands.
+func GetSSOConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "SSO configuration commands",
+		Long:  "Commands for viewing and updating SSO service configuration.",
+	}
+
+	cmd.AddCommand(
+		getSSOConfigShowCmd(),
+		getSSOConfigValidateCmd(),
+	)
+
+	return cmd
+}
+
+func getSSOConfigShowCmd() *cobra.Command {
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show current SSO configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config := DefaultSSOConfig()
+
+			if outputFormat == "json" {
+				data, err := json.MarshalIndent(config, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(data))
+			} else {
+				fmt.Println("SSO Service Configuration")
+				fmt.Println("=========================")
+				fmt.Printf("  Enabled: %t\n", config.Enabled)
+				fmt.Printf("  Challenge TTL: %d seconds\n", config.ChallengeTTLSeconds)
+				fmt.Printf("  Attestation Validity: %d days\n", config.AttestationValidityDays)
+				fmt.Printf("  Max Challenges Per Account: %d\n", config.MaxChallengesPerAccount)
+				fmt.Printf("  Enable Rate Limiting: %t\n", config.EnableRateLimiting)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text, json)")
+
+	return cmd
+}
+
+func getSSOConfigValidateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate <config-file>",
+		Short: "Validate SSO configuration file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configFile := args[0]
+
+			data, err := os.ReadFile(configFile)
+			if err != nil {
+				return fmt.Errorf("failed to read config file: %w", err)
+			}
+
+			var config SSOServiceConfig
+			if err := json.Unmarshal(data, &config); err != nil {
+				return fmt.Errorf("❌ Invalid JSON: %w", err)
+			}
+
+			// Validate
+			if err := config.Validate(); err != nil {
+				return fmt.Errorf("❌ Validation failed: %w", err)
+			}
+
+			fmt.Println("✅ Configuration is valid")
+			fmt.Printf("   Issuers configured: %d\n", len(config.IssuerPolicies))
+			return nil
+		},
+	}
+	return cmd
+}
+
+// GetSSOLinkageCmd returns the SSO linkage management commands.
+func GetSSOLinkageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "linkage",
+		Short: "SSO linkage management commands",
+		Long:  "Commands for viewing and managing SSO account linkages.",
+	}
+
+	cmd.AddCommand(
+		getSSOLinkageListCmd(),
+		getSSOLinkageShowCmd(),
+		getSSOLinkageRevokeCmd(),
+	)
+
+	return cmd
+}
+
+func getSSOLinkageListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <account-address>",
+		Short: "List SSO linkages for an account",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			accountAddress := args[0]
+			fmt.Printf("SSO Linkages for: %s\n", accountAddress)
+			fmt.Println("===================================")
+			fmt.Println("\n⚠️  Note: Query not yet implemented. Use gRPC query for actual linkages.")
+			return nil
+		},
+	}
+	return cmd
+}
+
+func getSSOLinkageShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <linkage-id>",
+		Short: "Show SSO linkage details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			linkageID := args[0]
+			fmt.Printf("SSO Linkage: %s\n", linkageID)
+			fmt.Println("================")
+			fmt.Println("\n⚠️  Note: Query not yet implemented. Use gRPC query for actual linkage details.")
+			return nil
+		},
+	}
+	return cmd
+}
+
+func getSSOLinkageRevokeCmd() *cobra.Command {
+	var reason string
+
+	cmd := &cobra.Command{
+		Use:   "revoke <linkage-id>",
+		Short: "Revoke an SSO linkage",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			linkageID := args[0]
+			fmt.Printf("Revoking SSO linkage: %s\n", linkageID)
+			if reason != "" {
+				fmt.Printf("Reason: %s\n", reason)
+			}
+			fmt.Println("\n⚠️  Note: Revocation requires a signed transaction. Use the tx command instead.")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&reason, "reason", "", "Revocation reason")
+
+	return cmd
+}
+
+// ============================================================================
+// Helper Types
+// ============================================================================
+
+// IssuerPolicyConfig is the CLI representation of an issuer policy.
+type IssuerPolicyConfig struct {
+	Issuer               string   `json:"issuer"`
+	ClientID             string   `json:"client_id"`
+	ProviderType         string   `json:"provider_type"`
+	ScoreWeight          uint32   `json:"score_weight"`
+	Enabled              bool     `json:"enabled"`
+	RequireEmailVerified bool     `json:"require_email_verified"`
+	AllowedEmailDomains  []string `json:"allowed_email_domains,omitempty"`
+	AllowedTenants       []string `json:"allowed_tenants,omitempty"`
+}
+
+// SSOServiceConfig is the CLI representation of SSO service config.
+type SSOServiceConfig struct {
+	Enabled                bool                          `json:"enabled"`
+	ChallengeTTLSeconds    int64                         `json:"challenge_ttl_seconds"`
+	AttestationValidityDays int                          `json:"attestation_validity_days"`
+	MaxChallengesPerAccount int                          `json:"max_challenges_per_account"`
+	EnableRateLimiting     bool                          `json:"enable_rate_limiting"`
+	IssuerPolicies         map[string]IssuerPolicyConfig `json:"issuer_policies"`
+}
+
+// Validate validates the SSO service config.
+func (c *SSOServiceConfig) Validate() error {
+	if c.ChallengeTTLSeconds <= 0 {
+		return fmt.Errorf("challenge_ttl_seconds must be positive")
+	}
+	if c.AttestationValidityDays <= 0 {
+		return fmt.Errorf("attestation_validity_days must be positive")
+	}
+	return nil
+}
+
+// DefaultSSOConfig returns default SSO configuration.
+func DefaultSSOConfig() *SSOServiceConfig {
+	return &SSOServiceConfig{
+		Enabled:                true,
+		ChallengeTTLSeconds:    600, // 10 minutes
+		AttestationValidityDays: 365,
+		MaxChallengesPerAccount: 3,
+		EnableRateLimiting:     true,
+		IssuerPolicies:         make(map[string]IssuerPolicyConfig),
+	}
+}
+
+// Well-known OIDC issuers
+var wellKnownIssuers = map[veidtypes.SSOProviderType]string{
+	veidtypes.SSOProviderGoogle:    "https://accounts.google.com",
+	veidtypes.SSOProviderMicrosoft: "https://login.microsoftonline.com/common/v2.0",
+	veidtypes.SSOProviderGitHub:    "https://token.actions.githubusercontent.com",
+}

--- a/x/veid/keeper/sso_linkage.go
+++ b/x/veid/keeper/sso_linkage.go
@@ -1,0 +1,407 @@
+package keeper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"cosmossdk.io/store/prefix"
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/virtengine/virtengine/x/veid/types"
+)
+
+// ============================================================================
+// SSO Linkage Methods
+// ============================================================================
+
+// CreateSSOLinkage creates a new SSO linkage record.
+func (k Keeper) CreateSSOLinkage(ctx sdk.Context, msg *types.MsgCreateSSOLinkage) (*types.MsgCreateSSOLinkageResponse, error) {
+	// Validate the nonce hasn't been used
+	nonceHash := hashNonce(msg.Nonce)
+	if k.IsSSONonceUsed(ctx, nonceHash) {
+		return nil, types.ErrNonceAlreadyUsed.Wrap("SSO nonce has already been used")
+	}
+
+	// Check if linkage already exists for this account and provider
+	existingLinkageID := k.GetSSOLinkageByAccountAndProvider(ctx, msg.AccountAddress, msg.Provider)
+	if existingLinkageID != "" {
+		return nil, types.ErrDuplicateLinkage.Wrapf("SSO linkage already exists: %s", existingLinkageID)
+	}
+
+	// Create linkage metadata
+	now := ctx.BlockTime()
+	linkage := &types.SSOLinkageMetadata{
+		Version:          types.SSOVerificationVersion,
+		LinkageID:        msg.LinkageID,
+		Provider:         msg.Provider,
+		Issuer:           msg.Issuer,
+		SubjectHash:      msg.SubjectHash,
+		Nonce:            msg.Nonce,
+		VerifiedAt:       now,
+		Status:           types.SSOStatusVerified,
+		AccountSignature: msg.AccountSignature,
+		EmailDomainHash:  msg.EmailDomainHash,
+		OrgIDHash:        msg.TenantIDHash,
+	}
+
+	if msg.ExpiresAt != nil {
+		linkage.ExpiresAt = msg.ExpiresAt
+	}
+
+	// Validate the linkage
+	if err := linkage.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Store the linkage
+	if err := k.SetSSOLinkage(ctx, linkage); err != nil {
+		return nil, err
+	}
+
+	// Index by account and provider
+	k.SetSSOLinkageByAccountAndProvider(ctx, msg.AccountAddress, msg.Provider, msg.LinkageID)
+
+	// Mark nonce as used
+	nonceRecord := types.NewSSONonceRecord(
+		nonceHash,
+		msg.AccountAddress,
+		msg.Provider,
+		msg.Issuer,
+		msg.LinkageID,
+		now,
+		ctx.BlockHeight(),
+		24*time.Hour*365, // Keep nonce records for 1 year
+	)
+	k.SetSSONonceRecord(ctx, nonceRecord)
+
+	// Get score weight for this provider
+	scoreContribution := types.GetSSOScoringWeight(msg.Provider)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeSSOLinkageCreated,
+			sdk.NewAttribute(types.AttributeKeyAccount, msg.AccountAddress),
+			sdk.NewAttribute(types.AttributeKeyLinkageID, msg.LinkageID),
+			sdk.NewAttribute(types.AttributeKeyProvider, string(msg.Provider)),
+			sdk.NewAttribute(types.AttributeKeyIssuer, msg.Issuer),
+		),
+	)
+
+	k.Logger(ctx).Info("SSO linkage created",
+		"account", msg.AccountAddress,
+		"linkage_id", msg.LinkageID,
+		"provider", msg.Provider,
+		"issuer", msg.Issuer,
+	)
+
+	return &types.MsgCreateSSOLinkageResponse{
+		LinkageID:         msg.LinkageID,
+		Status:            types.SSOStatusVerified,
+		ScoreContribution: scoreContribution,
+		VerifiedAt:        now,
+	}, nil
+}
+
+// RevokeSSOLinkage revokes an existing SSO linkage.
+func (k Keeper) RevokeSSOLinkage(ctx sdk.Context, msg *types.MsgRevokeSSOLinkage) (*types.MsgRevokeSSOLinkageResponse, error) {
+	// Get existing linkage
+	linkage, found := k.GetSSOLinkage(ctx, msg.LinkageID)
+	if !found {
+		return nil, types.ErrLinkageNotFound.Wrapf("linkage ID: %s", msg.LinkageID)
+	}
+
+	// Verify account owns this linkage
+	// We need to check the index since the linkage itself doesn't store the account
+	existingLinkageID := k.GetSSOLinkageByAccountAndProvider(ctx, msg.AccountAddress, linkage.Provider)
+	if existingLinkageID != msg.LinkageID {
+		return nil, types.ErrUnauthorized.Wrap("account does not own this linkage")
+	}
+
+	// Update status
+	now := ctx.BlockTime()
+	linkage.Status = types.SSOStatusRevoked
+	linkage.ExpiresAt = &now
+
+	// Store updated linkage
+	if err := k.SetSSOLinkage(ctx, linkage); err != nil {
+		return nil, err
+	}
+
+	// Remove from account index
+	k.DeleteSSOLinkageByAccountAndProvider(ctx, msg.AccountAddress, linkage.Provider)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeSSOLinkageRevoked,
+			sdk.NewAttribute(types.AttributeKeyAccount, msg.AccountAddress),
+			sdk.NewAttribute(types.AttributeKeyLinkageID, msg.LinkageID),
+			sdk.NewAttribute(types.AttributeKeyReason, msg.Reason),
+		),
+	)
+
+	k.Logger(ctx).Info("SSO linkage revoked",
+		"account", msg.AccountAddress,
+		"linkage_id", msg.LinkageID,
+		"reason", msg.Reason,
+	)
+
+	return &types.MsgRevokeSSOLinkageResponse{
+		LinkageID: msg.LinkageID,
+		Status:    types.SSOStatusRevoked,
+		RevokedAt: now,
+	}, nil
+}
+
+// ============================================================================
+// SSO Linkage Storage
+// ============================================================================
+
+// SetSSOLinkage stores an SSO linkage.
+func (k Keeper) SetSSOLinkage(ctx sdk.Context, linkage *types.SSOLinkageMetadata) error {
+	store := ctx.KVStore(k.skey)
+	key := k.ssoLinkageKey(linkage.LinkageID)
+
+	bz, err := k.cdc.MarshalJSON(linkage)
+	if err != nil {
+		return fmt.Errorf("failed to marshal SSO linkage: %w", err)
+	}
+
+	store.Set(key, bz)
+	return nil
+}
+
+// GetSSOLinkage retrieves an SSO linkage by ID.
+func (k Keeper) GetSSOLinkage(ctx sdk.Context, linkageID string) (*types.SSOLinkageMetadata, bool) {
+	store := ctx.KVStore(k.skey)
+	key := k.ssoLinkageKey(linkageID)
+
+	bz := store.Get(key)
+	if bz == nil {
+		return nil, false
+	}
+
+	var linkage types.SSOLinkageMetadata
+	if err := k.cdc.UnmarshalJSON(bz, &linkage); err != nil {
+		k.Logger(ctx).Error("failed to unmarshal SSO linkage", "error", err)
+		return nil, false
+	}
+
+	return &linkage, true
+}
+
+// DeleteSSOLinkage deletes an SSO linkage.
+func (k Keeper) DeleteSSOLinkage(ctx sdk.Context, linkageID string) {
+	store := ctx.KVStore(k.skey)
+	key := k.ssoLinkageKey(linkageID)
+	store.Delete(key)
+}
+
+// SetSSOLinkageByAccountAndProvider sets the linkage ID for an account and provider.
+func (k Keeper) SetSSOLinkageByAccountAndProvider(ctx sdk.Context, account string, provider types.SSOProviderType, linkageID string) {
+	store := ctx.KVStore(k.skey)
+	key := k.ssoLinkageByAccountKey(account, provider)
+	store.Set(key, []byte(linkageID))
+}
+
+// GetSSOLinkageByAccountAndProvider gets the linkage ID for an account and provider.
+func (k Keeper) GetSSOLinkageByAccountAndProvider(ctx sdk.Context, account string, provider types.SSOProviderType) string {
+	store := ctx.KVStore(k.skey)
+	key := k.ssoLinkageByAccountKey(account, provider)
+
+	bz := store.Get(key)
+	if bz == nil {
+		return ""
+	}
+
+	return string(bz)
+}
+
+// DeleteSSOLinkageByAccountAndProvider removes the linkage index for an account and provider.
+func (k Keeper) DeleteSSOLinkageByAccountAndProvider(ctx sdk.Context, account string, provider types.SSOProviderType) {
+	store := ctx.KVStore(k.skey)
+	key := k.ssoLinkageByAccountKey(account, provider)
+	store.Delete(key)
+}
+
+// GetSSOLinkagesForAccount returns all SSO linkages for an account.
+func (k Keeper) GetSSOLinkagesForAccount(ctx sdk.Context, account string) []*types.SSOLinkageMetadata {
+	linkages := make([]*types.SSOLinkageMetadata, 0)
+
+	for _, provider := range types.AllSSOProviderTypes() {
+		linkageID := k.GetSSOLinkageByAccountAndProvider(ctx, account, provider)
+		if linkageID != "" {
+			if linkage, found := k.GetSSOLinkage(ctx, linkageID); found {
+				linkages = append(linkages, linkage)
+			}
+		}
+	}
+
+	return linkages
+}
+
+// IterateSSOLinkages iterates over all SSO linkages.
+func (k Keeper) IterateSSOLinkages(ctx sdk.Context, fn func(linkage *types.SSOLinkageMetadata) bool) {
+	store := ctx.KVStore(k.skey)
+	prefixStore := prefix.NewStore(store, types.PrefixSSOLinkage)
+	iter := prefixStore.Iterator(nil, nil)
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		var linkage types.SSOLinkageMetadata
+		if err := k.cdc.UnmarshalJSON(iter.Value(), &linkage); err != nil {
+			continue
+		}
+		if fn(&linkage) {
+			break
+		}
+	}
+}
+
+// ============================================================================
+// SSO Nonce Tracking
+// ============================================================================
+
+// SetSSONonceRecord stores an SSO nonce record.
+func (k Keeper) SetSSONonceRecord(ctx sdk.Context, record *types.SSONonceRecord) {
+	store := ctx.KVStore(k.skey)
+	key := k.ssoNonceKey(record.NonceHash)
+
+	bz, err := k.cdc.MarshalJSON(record)
+	if err != nil {
+		k.Logger(ctx).Error("failed to marshal SSO nonce record", "error", err)
+		return
+	}
+
+	store.Set(key, bz)
+
+	// Set indexes
+	k.setSSONonceByAccount(ctx, record.AccountAddress, record.NonceHash)
+	k.setSSONonceByProvider(ctx, record.Provider, record.NonceHash)
+	k.setSSONonceExpiry(ctx, record.ExpiresAt, record.NonceHash)
+}
+
+// GetSSONonceRecord retrieves an SSO nonce record.
+func (k Keeper) GetSSONonceRecord(ctx sdk.Context, nonceHash string) (*types.SSONonceRecord, bool) {
+	store := ctx.KVStore(k.skey)
+	key := k.ssoNonceKey(nonceHash)
+
+	bz := store.Get(key)
+	if bz == nil {
+		return nil, false
+	}
+
+	var record types.SSONonceRecord
+	if err := k.cdc.UnmarshalJSON(bz, &record); err != nil {
+		return nil, false
+	}
+
+	return &record, true
+}
+
+// IsSSONonceUsed checks if an SSO nonce has been used.
+func (k Keeper) IsSSONonceUsed(ctx sdk.Context, nonceHash string) bool {
+	store := ctx.KVStore(k.skey)
+	key := k.ssoNonceKey(nonceHash)
+	return store.Has(key)
+}
+
+// setSSONonceByAccount sets the nonce index by account.
+func (k Keeper) setSSONonceByAccount(ctx sdk.Context, account, nonceHash string) {
+	store := ctx.KVStore(k.skey)
+	key := append(append(types.PrefixSSONonceByAccount, []byte(account)...), []byte(nonceHash)...)
+	store.Set(key, []byte{1})
+}
+
+// setSSONonceByProvider sets the nonce index by provider.
+func (k Keeper) setSSONonceByProvider(ctx sdk.Context, provider types.SSOProviderType, nonceHash string) {
+	store := ctx.KVStore(k.skey)
+	key := append(append(types.PrefixSSONonceByProvider, []byte(provider)...), []byte(nonceHash)...)
+	store.Set(key, []byte{1})
+}
+
+// setSSONonceExpiry sets the nonce expiry index.
+func (k Keeper) setSSONonceExpiry(ctx sdk.Context, expiresAt time.Time, nonceHash string) {
+	store := ctx.KVStore(k.skey)
+	expiryBytes := sdk.FormatTimeBytes(expiresAt)
+	key := append(append(types.PrefixSSONonceExpiry, expiryBytes...), []byte(nonceHash)...)
+	store.Set(key, []byte{1})
+}
+
+// PruneExpiredSSONonces removes expired SSO nonce records.
+func (k Keeper) PruneExpiredSSONonces(ctx sdk.Context) int {
+	store := ctx.KVStore(k.skey)
+	now := ctx.BlockTime()
+	cutoffBytes := sdk.FormatTimeBytes(now)
+
+	prefixStore := prefix.NewStore(store, types.PrefixSSONonceExpiry)
+	iter := prefixStore.Iterator(nil, cutoffBytes)
+	defer iter.Close()
+
+	toDelete := make([][]byte, 0)
+	for ; iter.Valid(); iter.Next() {
+		toDelete = append(toDelete, iter.Key())
+	}
+
+	for _, key := range toDelete {
+		// Extract nonce hash from key (after the timestamp prefix)
+		if len(key) > 14 { // Timestamp is 14 bytes
+			nonceHash := string(key[14:])
+
+			// Get the full record to clean up indexes
+			if record, found := k.GetSSONonceRecord(ctx, nonceHash); found {
+				k.deleteSSONonceRecord(ctx, record)
+			}
+		}
+	}
+
+	return len(toDelete)
+}
+
+// deleteSSONonceRecord removes an SSO nonce record and its indexes.
+func (k Keeper) deleteSSONonceRecord(ctx sdk.Context, record *types.SSONonceRecord) {
+	store := ctx.KVStore(k.skey)
+
+	// Delete main record
+	store.Delete(k.ssoNonceKey(record.NonceHash))
+
+	// Delete indexes
+	accountKey := append(append(types.PrefixSSONonceByAccount, []byte(record.AccountAddress)...), []byte(record.NonceHash)...)
+	store.Delete(accountKey)
+
+	providerKey := append(append(types.PrefixSSONonceByProvider, []byte(record.Provider)...), []byte(record.NonceHash)...)
+	store.Delete(providerKey)
+
+	expiryBytes := sdk.FormatTimeBytes(record.ExpiresAt)
+	expiryKey := append(append(types.PrefixSSONonceExpiry, expiryBytes...), []byte(record.NonceHash)...)
+	store.Delete(expiryKey)
+}
+
+// ============================================================================
+// Key Functions
+// ============================================================================
+
+func (k Keeper) ssoLinkageKey(linkageID string) []byte {
+	return append(types.PrefixSSOLinkage, []byte(linkageID)...)
+}
+
+func (k Keeper) ssoLinkageByAccountKey(account string, provider types.SSOProviderType) []byte {
+	return append(append(types.PrefixSSOLinkageByAccount, []byte(account)...), []byte(provider)...)
+}
+
+func (k Keeper) ssoNonceKey(nonceHash string) []byte {
+	return append(types.PrefixSSONonce, []byte(nonceHash)...)
+}
+
+// hashNonce creates a SHA256 hash of a nonce.
+func hashNonce(nonce string) string {
+	hash := sha256.Sum256([]byte(nonce))
+	return hex.EncodeToString(hash[:])
+}
+
+// Suppress unused import warning for storetypes
+var _ storetypes.StoreKey

--- a/x/veid/types/errors.go
+++ b/x/veid/types/errors.go
@@ -695,4 +695,32 @@ var (
 
 	// ErrMaxAttestationsExceeded is returned when maximum attestations limit is exceeded
 	ErrMaxAttestationsExceeded = errorsmod.Register(ModuleName, 1255, "maximum attestations exceeded")
+
+	// ============================================================================
+	// SSO/OIDC Linkage Errors (VE-4B)
+	// ============================================================================
+
+	// ErrDuplicateLinkage is returned when an SSO linkage already exists for an account/provider pair
+	ErrDuplicateLinkage = errorsmod.Register(ModuleName, 1260, "duplicate SSO linkage")
+
+	// ErrLinkageNotFound is returned when an SSO linkage cannot be found
+	ErrLinkageNotFound = errorsmod.Register(ModuleName, 1261, "SSO linkage not found")
+
+	// ErrLinkageExpired is returned when an SSO linkage has expired
+	ErrLinkageExpired = errorsmod.Register(ModuleName, 1262, "SSO linkage expired")
+
+	// ErrJWKSFetchFailed is returned when JWKS fetching fails
+	ErrJWKSFetchFailed = errorsmod.Register(ModuleName, 1264, "JWKS fetch failed")
+
+	// ErrTokenValidationFailed is returned when OIDC token validation fails
+	ErrTokenValidationFailed = errorsmod.Register(ModuleName, 1265, "OIDC token validation failed")
+
+	// ErrChallengeNotFound is returned when an SSO challenge cannot be found
+	ErrChallengeNotFound = errorsmod.Register(ModuleName, 1266, "SSO challenge not found")
+
+	// ErrChallengeExpired is returned when an SSO challenge has expired
+	ErrChallengeExpired = errorsmod.Register(ModuleName, 1267, "SSO challenge expired")
+
+	// ErrInvalidChallengeState is returned when challenge state is invalid
+	ErrInvalidChallengeState = errorsmod.Register(ModuleName, 1268, "invalid challenge state")
 )

--- a/x/veid/types/events.go
+++ b/x/veid/types/events.go
@@ -486,3 +486,132 @@ func (m *EventNonceUsed) String() string             { return fmt.Sprintf("%+v",
 func (*EventAttestationVerified) ProtoMessage()      {}
 func (m *EventAttestationVerified) Reset()           { *m = EventAttestationVerified{} }
 func (m *EventAttestationVerified) String() string   { return fmt.Sprintf("%+v", *m) }
+
+// ============================================================================
+// SSO/OIDC Linkage Events (VE-4B)
+// ============================================================================
+
+// SSO linkage event types
+const (
+	EventTypeSSOLinkageCreated     = "sso_linkage_created"
+	EventTypeSSOLinkageRevoked     = "sso_linkage_revoked"
+	EventTypeSSOLinkageUpdated     = "sso_linkage_updated"
+	EventTypeSSOLinkageExpired     = "sso_linkage_expired"
+	EventTypeSSOChallengeCreated   = "sso_challenge_created"
+	EventTypeSSOChallengeCompleted = "sso_challenge_completed"
+	EventTypeSSOChallengeFailed    = "sso_challenge_failed"
+	EventTypeSSONonceUsed          = "sso_nonce_used"
+)
+
+// SSO linkage event attribute keys
+const (
+	AttributeKeyLinkageID     = "linkage_id"
+	AttributeKeyProvider      = "provider"
+	AttributeKeyIssuer        = "issuer"
+	AttributeKeySSOChallengeID = "sso_challenge_id"
+	AttributeKeySubjectHash   = "subject_hash"
+	AttributeKeyEmailDomain   = "email_domain"
+	AttributeKeyTenantID      = "tenant_id"
+	AttributeKeyFailureReason = "failure_reason"
+)
+
+// EventSSOLinkageCreated is emitted when an SSO linkage is created
+type EventSSOLinkageCreated struct {
+	Account      string `json:"account"`
+	LinkageID    string `json:"linkage_id"`
+	Provider     string `json:"provider"`
+	Issuer       string `json:"issuer"`
+	SubjectHash  string `json:"subject_hash"`
+	EmailDomain  string `json:"email_domain,omitempty"`
+	BlockHeight  int64  `json:"block_height"`
+	Timestamp    int64  `json:"timestamp"`
+}
+
+// EventSSOLinkageRevoked is emitted when an SSO linkage is revoked
+type EventSSOLinkageRevoked struct {
+	Account     string `json:"account"`
+	LinkageID   string `json:"linkage_id"`
+	Provider    string `json:"provider"`
+	Reason      string `json:"reason"`
+	RevokedBy   string `json:"revoked_by"`
+	BlockHeight int64  `json:"block_height"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// EventSSOLinkageUpdated is emitted when an SSO linkage is updated
+type EventSSOLinkageUpdated struct {
+	Account      string `json:"account"`
+	LinkageID    string `json:"linkage_id"`
+	Provider     string `json:"provider"`
+	UpdateType   string `json:"update_type"`
+	BlockHeight  int64  `json:"block_height"`
+	Timestamp    int64  `json:"timestamp"`
+}
+
+// EventSSOLinkageExpired is emitted when an SSO linkage expires
+type EventSSOLinkageExpired struct {
+	Account     string `json:"account"`
+	LinkageID   string `json:"linkage_id"`
+	Provider    string `json:"provider"`
+	CreatedAt   int64  `json:"created_at"`
+	ExpiredAt   int64  `json:"expired_at"`
+	BlockHeight int64  `json:"block_height"`
+}
+
+// EventSSOChallengeCreated is emitted when an SSO challenge is created
+type EventSSOChallengeCreated struct {
+	Account     string `json:"account"`
+	ChallengeID string `json:"challenge_id"`
+	Provider    string `json:"provider"`
+	ExpiresAt   int64  `json:"expires_at"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// EventSSOChallengeCompleted is emitted when an SSO challenge is completed
+type EventSSOChallengeCompleted struct {
+	Account     string `json:"account"`
+	ChallengeID string `json:"challenge_id"`
+	Provider    string `json:"provider"`
+	LinkageID   string `json:"linkage_id"`
+	Score       uint32 `json:"score"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// EventSSOChallengeFailed is emitted when an SSO challenge fails
+type EventSSOChallengeFailed struct {
+	Account       string `json:"account"`
+	ChallengeID   string `json:"challenge_id"`
+	Provider      string `json:"provider"`
+	FailureReason string `json:"failure_reason"`
+	Timestamp     int64  `json:"timestamp"`
+}
+
+// Proto stubs for SSO linkage events
+
+func (*EventSSOLinkageCreated) ProtoMessage()         {}
+func (m *EventSSOLinkageCreated) Reset()              { *m = EventSSOLinkageCreated{} }
+func (m *EventSSOLinkageCreated) String() string      { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSSOLinkageRevoked) ProtoMessage()         {}
+func (m *EventSSOLinkageRevoked) Reset()              { *m = EventSSOLinkageRevoked{} }
+func (m *EventSSOLinkageRevoked) String() string      { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSSOLinkageUpdated) ProtoMessage()         {}
+func (m *EventSSOLinkageUpdated) Reset()              { *m = EventSSOLinkageUpdated{} }
+func (m *EventSSOLinkageUpdated) String() string      { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSSOLinkageExpired) ProtoMessage()         {}
+func (m *EventSSOLinkageExpired) Reset()              { *m = EventSSOLinkageExpired{} }
+func (m *EventSSOLinkageExpired) String() string      { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSSOChallengeCreated) ProtoMessage()       {}
+func (m *EventSSOChallengeCreated) Reset()            { *m = EventSSOChallengeCreated{} }
+func (m *EventSSOChallengeCreated) String() string    { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSSOChallengeCompleted) ProtoMessage()     {}
+func (m *EventSSOChallengeCompleted) Reset()          { *m = EventSSOChallengeCompleted{} }
+func (m *EventSSOChallengeCompleted) String() string  { return fmt.Sprintf("%+v", *m) }
+
+func (*EventSSOChallengeFailed) ProtoMessage()        {}
+func (m *EventSSOChallengeFailed) Reset()             { *m = EventSSOChallengeFailed{} }
+func (m *EventSSOChallengeFailed) String() string     { return fmt.Sprintf("%+v", *m) }

--- a/x/veid/types/keys.go
+++ b/x/veid/types/keys.go
@@ -673,6 +673,26 @@ var (
 	// PrefixAttestationParams is the prefix for attestation module parameters
 	// Key: PrefixAttestationParams -> AttestationParams
 	PrefixAttestationParams = []byte{0x8A}
+
+	// ============================================================================
+	// SSO/OIDC Nonce Tracking Keys (VE-4B: SSO Verification Service)
+	// ============================================================================
+
+	// PrefixSSONonce is the prefix for SSO nonce tracking
+	// Key: PrefixSSONonce | nonce_hash -> SSONonceRecord
+	PrefixSSONonce = []byte{0x8B}
+
+	// PrefixSSONonceByAccount is the prefix for SSO nonce lookup by account
+	// Key: PrefixSSONonceByAccount | account_address | nonce_hash -> bool
+	PrefixSSONonceByAccount = []byte{0x8C}
+
+	// PrefixSSONonceByProvider is the prefix for SSO nonce lookup by provider
+	// Key: PrefixSSONonceByProvider | provider | nonce_hash -> bool
+	PrefixSSONonceByProvider = []byte{0x8D}
+
+	// PrefixSSONonceExpiry is the prefix for SSO nonce expiry index
+	// Key: PrefixSSONonceExpiry | expires_at | nonce_hash -> bool
+	PrefixSSONonceExpiry = []byte{0x8E}
 )
 
 // IdentityRecordKey returns the store key for an identity record

--- a/x/veid/types/sso_attestation.go
+++ b/x/veid/types/sso_attestation.go
@@ -1,0 +1,402 @@
+// Package types provides VEID module types.
+//
+// VE-4B: SSO/OIDC Attestation Schema
+// This file defines the attestation payload schema for SSO/OIDC verification.
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ============================================================================
+// SSO Attestation Schema Version
+// ============================================================================
+
+const (
+	// SSOAttestationSchemaVersion is the current schema version
+	SSOAttestationSchemaVersion = "1.0.0"
+
+	// DefaultSSOAttestationValidityDuration is the default validity for SSO attestations
+	DefaultSSOAttestationValidityDuration = 365 * 24 * time.Hour // 1 year
+)
+
+// ============================================================================
+// SSO Attestation Types
+// ============================================================================
+
+// SSOAttestation represents a signed attestation from SSO/OIDC verification.
+// It extends the base VerificationAttestation with SSO-specific fields.
+type SSOAttestation struct {
+	// Embed base attestation fields
+	VerificationAttestation
+
+	// OIDCIssuer is the OIDC issuer URL (e.g., "https://accounts.google.com")
+	OIDCIssuer string `json:"oidc_issuer"`
+
+	// SubjectHash is the SHA256 hash of the OIDC subject identifier
+	SubjectHash string `json:"subject_hash"`
+
+	// EmailHash is the SHA256 hash of the verified email (optional)
+	EmailHash string `json:"email_hash,omitempty"`
+
+	// EmailDomainHash is the SHA256 hash of the email domain (for org matching)
+	EmailDomainHash string `json:"email_domain_hash,omitempty"`
+
+	// TenantIDHash is the hash of the organization tenant ID (if applicable)
+	TenantIDHash string `json:"tenant_id_hash,omitempty"`
+
+	// ProviderType identifies the SSO provider category
+	ProviderType SSOProviderType `json:"provider_type"`
+
+	// OIDCNonce is the nonce used in the OIDC flow (prevents replay)
+	OIDCNonce string `json:"oidc_nonce"`
+
+	// OIDCAuthTime is when the user authenticated (if available)
+	OIDCAuthTime *time.Time `json:"oidc_auth_time,omitempty"`
+
+	// OIDCACRValues are the authentication context class reference values
+	OIDCACRValues []string `json:"oidc_acr_values,omitempty"`
+
+	// OIDCAMRValues are the authentication methods references
+	OIDCAMRValues []string `json:"oidc_amr_values,omitempty"`
+
+	// EmailVerified indicates if the email was verified by the IdP
+	EmailVerified bool `json:"email_verified"`
+
+	// LinkedAccountAddress is the blockchain account this SSO is linked to
+	LinkedAccountAddress string `json:"linked_account_address"`
+
+	// LinkageSignature is the user's signature authorizing the linkage
+	LinkageSignature []byte `json:"linkage_signature"`
+}
+
+// NewSSOAttestation creates a new SSO attestation.
+func NewSSOAttestation(
+	issuer AttestationIssuer,
+	subject AttestationSubject,
+	oidcIssuer string,
+	subjectID string,
+	providerType SSOProviderType,
+	oidcNonce string,
+	nonce []byte,
+	issuedAt time.Time,
+	validityDuration time.Duration,
+) *SSOAttestation {
+	base := NewVerificationAttestation(
+		issuer,
+		subject,
+		AttestationTypeSSOVerification,
+		nonce,
+		issuedAt,
+		validityDuration,
+		100, // SSO verification always has 100% score when valid
+		100, // 100% confidence
+	)
+
+	return &SSOAttestation{
+		VerificationAttestation: *base,
+		OIDCIssuer:              oidcIssuer,
+		SubjectHash:             hashIdentifier(subjectID),
+		ProviderType:            providerType,
+		OIDCNonce:               oidcNonce,
+		LinkedAccountAddress:    subject.AccountAddress,
+	}
+}
+
+// hashIdentifier creates a SHA256 hash of an identifier.
+func hashIdentifier(id string) string {
+	if id == "" {
+		return ""
+	}
+	hash := sha256.Sum256([]byte(id))
+	return hex.EncodeToString(hash[:])
+}
+
+// SetEmail sets the email information on the attestation.
+func (a *SSOAttestation) SetEmail(email string, domain string, verified bool) {
+	a.EmailHash = hashIdentifier(email)
+	a.EmailDomainHash = hashIdentifier(domain)
+	a.EmailVerified = verified
+}
+
+// SetTenantID sets the tenant/organization ID.
+func (a *SSOAttestation) SetTenantID(tenantID string) {
+	a.TenantIDHash = hashIdentifier(tenantID)
+}
+
+// SetAuthContext sets authentication context information.
+func (a *SSOAttestation) SetAuthContext(authTime *time.Time, acrValues, amrValues []string) {
+	a.OIDCAuthTime = authTime
+	a.OIDCACRValues = acrValues
+	a.OIDCAMRValues = amrValues
+}
+
+// SetLinkageSignature sets the user's linkage authorization signature.
+func (a *SSOAttestation) SetLinkageSignature(signature []byte) {
+	a.LinkageSignature = make([]byte, len(signature))
+	copy(a.LinkageSignature, signature)
+}
+
+// Validate validates the SSO attestation.
+func (a *SSOAttestation) Validate() error {
+	// Validate base attestation
+	if err := a.VerificationAttestation.Validate(); err != nil {
+		return err
+	}
+
+	if a.OIDCIssuer == "" {
+		return ErrInvalidSSO.Wrap("oidc_issuer is required")
+	}
+
+	if a.SubjectHash == "" {
+		return ErrInvalidSSO.Wrap("subject_hash is required")
+	}
+
+	if len(a.SubjectHash) != 64 {
+		return ErrInvalidSSO.Wrap("subject_hash must be a valid SHA256 hex string")
+	}
+
+	if !IsValidSSOProviderType(a.ProviderType) {
+		return ErrInvalidSSO.Wrapf("invalid provider_type: %s", a.ProviderType)
+	}
+
+	if a.OIDCNonce == "" {
+		return ErrInvalidSSO.Wrap("oidc_nonce is required")
+	}
+
+	if a.LinkedAccountAddress == "" {
+		return ErrInvalidAddress.Wrap("linked_account_address is required")
+	}
+
+	return nil
+}
+
+// CanonicalBytes returns the canonical byte representation for signing.
+func (a *SSOAttestation) CanonicalBytes() ([]byte, error) {
+	canonical := struct {
+		// Base attestation fields
+		ID                 string                    `json:"id"`
+		SchemaVersion      string                    `json:"schema_version"`
+		Type               AttestationType           `json:"type"`
+		Issuer             AttestationIssuer         `json:"issuer"`
+		Subject            AttestationSubject        `json:"subject"`
+		Nonce              string                    `json:"nonce"`
+		IssuedAt           string                    `json:"issued_at"`
+		ExpiresAt          string                    `json:"expires_at"`
+		VerificationProofs []VerificationProofDetail `json:"verification_proofs"`
+		Score              uint32                    `json:"score"`
+		Confidence         uint32                    `json:"confidence"`
+		// SSO-specific fields
+		OIDCIssuer           string          `json:"oidc_issuer"`
+		SubjectHash          string          `json:"subject_hash"`
+		EmailHash            string          `json:"email_hash,omitempty"`
+		EmailDomainHash      string          `json:"email_domain_hash,omitempty"`
+		TenantIDHash         string          `json:"tenant_id_hash,omitempty"`
+		ProviderType         SSOProviderType `json:"provider_type"`
+		OIDCNonce            string          `json:"oidc_nonce"`
+		OIDCAuthTime         *time.Time      `json:"oidc_auth_time,omitempty"`
+		OIDCACRValues        []string        `json:"oidc_acr_values,omitempty"`
+		OIDCAMRValues        []string        `json:"oidc_amr_values,omitempty"`
+		EmailVerified        bool            `json:"email_verified"`
+		LinkedAccountAddress string          `json:"linked_account_address"`
+	}{
+		ID:                   a.ID,
+		SchemaVersion:        a.SchemaVersion,
+		Type:                 a.Type,
+		Issuer:               a.Issuer,
+		Subject:              a.Subject,
+		Nonce:                a.Nonce,
+		IssuedAt:             a.IssuedAt.UTC().Format(time.RFC3339Nano),
+		ExpiresAt:            a.ExpiresAt.UTC().Format(time.RFC3339Nano),
+		VerificationProofs:   a.VerificationProofs,
+		Score:                a.Score,
+		Confidence:           a.Confidence,
+		OIDCIssuer:           a.OIDCIssuer,
+		SubjectHash:          a.SubjectHash,
+		EmailHash:            a.EmailHash,
+		EmailDomainHash:      a.EmailDomainHash,
+		TenantIDHash:         a.TenantIDHash,
+		ProviderType:         a.ProviderType,
+		OIDCNonce:            a.OIDCNonce,
+		OIDCAuthTime:         a.OIDCAuthTime,
+		OIDCACRValues:        a.OIDCACRValues,
+		OIDCAMRValues:        a.OIDCAMRValues,
+		EmailVerified:        a.EmailVerified,
+		LinkedAccountAddress: a.LinkedAccountAddress,
+	}
+
+	return json.Marshal(canonical)
+}
+
+// ToLinkageMetadata converts the attestation to on-chain linkage metadata.
+func (a *SSOAttestation) ToLinkageMetadata(linkageID string) *SSOLinkageMetadata {
+	meta := &SSOLinkageMetadata{
+		Version:     SSOVerificationVersion,
+		LinkageID:   linkageID,
+		Provider:    a.ProviderType,
+		Issuer:      a.OIDCIssuer,
+		SubjectHash: a.SubjectHash,
+		Nonce:       a.OIDCNonce,
+		VerifiedAt:  a.IssuedAt,
+		Status:      SSOStatusVerified,
+	}
+
+	if !a.ExpiresAt.IsZero() {
+		meta.ExpiresAt = &a.ExpiresAt
+	}
+
+	meta.EmailDomainHash = a.EmailDomainHash
+	meta.OrgIDHash = a.TenantIDHash
+	meta.AccountSignature = a.LinkageSignature
+
+	return meta
+}
+
+// String returns a string representation.
+func (a *SSOAttestation) String() string {
+	return fmt.Sprintf("SSOAttestation{ID: %s, Provider: %s, Issuer: %s, Account: %s}",
+		a.ID, a.ProviderType, a.OIDCIssuer, a.LinkedAccountAddress)
+}
+
+// ============================================================================
+// SSO Attestation Request
+// ============================================================================
+
+// SSOAttestationRequest contains parameters for requesting an SSO attestation.
+type SSOAttestationRequest struct {
+	// AccountAddress is the blockchain account to link
+	AccountAddress string `json:"account_address"`
+
+	// ProviderType is the SSO provider to use
+	ProviderType SSOProviderType `json:"provider_type"`
+
+	// OIDCIssuer is the specific OIDC issuer (for generic OIDC)
+	OIDCIssuer string `json:"oidc_issuer,omitempty"`
+
+	// RedirectURI is where to redirect after OIDC flow
+	RedirectURI string `json:"redirect_uri"`
+
+	// State is the OAuth2 state parameter (for CSRF protection)
+	State string `json:"state"`
+
+	// Nonce is the OIDC nonce for replay protection
+	Nonce string `json:"nonce"`
+
+	// RequiredScopes specifies additional OAuth scopes to request
+	RequiredScopes []string `json:"required_scopes,omitempty"`
+
+	// LinkageSignatureMessage is the message to sign for account linkage
+	LinkageSignatureMessage string `json:"linkage_signature_message,omitempty"`
+
+	// CreatedAt is when the request was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// ExpiresAt is when the request expires
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// NewSSOAttestationRequest creates a new SSO attestation request.
+func NewSSOAttestationRequest(
+	accountAddress string,
+	providerType SSOProviderType,
+	redirectURI string,
+	state string,
+	nonce string,
+	ttlSeconds int64,
+) *SSOAttestationRequest {
+	now := time.Now()
+	return &SSOAttestationRequest{
+		AccountAddress: accountAddress,
+		ProviderType:   providerType,
+		RedirectURI:    redirectURI,
+		State:          state,
+		Nonce:          nonce,
+		CreatedAt:      now,
+		ExpiresAt:      now.Add(time.Duration(ttlSeconds) * time.Second),
+	}
+}
+
+// Validate validates the SSO attestation request.
+func (r *SSOAttestationRequest) Validate() error {
+	if r.AccountAddress == "" {
+		return ErrInvalidAddress.Wrap("account_address is required")
+	}
+	if !IsValidSSOProviderType(r.ProviderType) {
+		return ErrInvalidSSO.Wrapf("invalid provider_type: %s", r.ProviderType)
+	}
+	if r.RedirectURI == "" {
+		return ErrInvalidSSO.Wrap("redirect_uri is required")
+	}
+	if r.State == "" {
+		return ErrInvalidSSO.Wrap("state is required")
+	}
+	if r.Nonce == "" {
+		return ErrInvalidSSO.Wrap("nonce is required")
+	}
+	return nil
+}
+
+// IsExpired checks if the request has expired.
+func (r *SSOAttestationRequest) IsExpired(now time.Time) bool {
+	return now.After(r.ExpiresAt)
+}
+
+// ============================================================================
+// SSO Attestation Response
+// ============================================================================
+
+// SSOAttestationResponse contains the result of SSO attestation.
+type SSOAttestationResponse struct {
+	// Success indicates if attestation was successful
+	Success bool `json:"success"`
+
+	// Attestation is the signed attestation (if successful)
+	Attestation *SSOAttestation `json:"attestation,omitempty"`
+
+	// LinkageID is the on-chain linkage ID (if created)
+	LinkageID string `json:"linkage_id,omitempty"`
+
+	// Error contains error details (if failed)
+	Error *SSOAttestationError `json:"error,omitempty"`
+
+	// ProcessedAt is when the response was generated
+	ProcessedAt time.Time `json:"processed_at"`
+}
+
+// SSOAttestationError contains error details for failed attestation.
+type SSOAttestationError struct {
+	// Code is the error code
+	Code string `json:"code"`
+
+	// Message is the error message
+	Message string `json:"message"`
+
+	// Details contains additional error context
+	Details map[string]string `json:"details,omitempty"`
+}
+
+// NewSSOAttestationSuccess creates a successful response.
+func NewSSOAttestationSuccess(attestation *SSOAttestation, linkageID string) *SSOAttestationResponse {
+	return &SSOAttestationResponse{
+		Success:     true,
+		Attestation: attestation,
+		LinkageID:   linkageID,
+		ProcessedAt: time.Now(),
+	}
+}
+
+// NewSSOAttestationError creates an error response.
+func NewSSOAttestationError(code, message string) *SSOAttestationResponse {
+	return &SSOAttestationResponse{
+		Success: false,
+		Error: &SSOAttestationError{
+			Code:    code,
+			Message: message,
+		},
+		ProcessedAt: time.Now(),
+	}
+}

--- a/x/veid/types/sso_msgs.go
+++ b/x/veid/types/sso_msgs.go
@@ -1,0 +1,368 @@
+// Package types provides message types for the VEID module.
+//
+// VE-4B: SSO/OIDC Linkage Message Types
+// This file defines the on-chain message types for SSO linkage management.
+package types
+
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// Message type constants for SSO linkage
+const (
+	TypeMsgCreateSSOLinkage = "create_sso_linkage"
+	TypeMsgRevokeSSOLinkage = "revoke_sso_linkage"
+	TypeMsgUpdateSSOLinkage = "update_sso_linkage"
+)
+
+// ============================================================================
+// MsgCreateSSOLinkage
+// ============================================================================
+
+// MsgCreateSSOLinkage creates an SSO linkage record on-chain.
+type MsgCreateSSOLinkage struct {
+	// AccountAddress is the account creating the linkage
+	AccountAddress string `json:"account_address"`
+
+	// LinkageID is the unique identifier for this linkage
+	LinkageID string `json:"linkage_id"`
+
+	// Provider is the SSO provider type
+	Provider SSOProviderType `json:"provider"`
+
+	// Issuer is the OIDC issuer URL
+	Issuer string `json:"issuer"`
+
+	// SubjectHash is the SHA256 hash of the SSO subject identifier
+	SubjectHash string `json:"subject_hash"`
+
+	// Nonce is the verification nonce used
+	Nonce string `json:"nonce"`
+
+	// AttestationData contains the signed attestation (JSON-encoded)
+	AttestationData []byte `json:"attestation_data"`
+
+	// AttestationSignature is the signer's signature on the attestation
+	AttestationSignature []byte `json:"attestation_signature"`
+
+	// SignerFingerprint is the fingerprint of the signing key
+	SignerFingerprint string `json:"signer_fingerprint"`
+
+	// AccountSignature is the account's signature authorizing the linkage
+	AccountSignature []byte `json:"account_signature"`
+
+	// ExpiresAt is when the linkage expires (optional)
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+
+	// EmailDomainHash is the hash of the email domain (optional)
+	EmailDomainHash string `json:"email_domain_hash,omitempty"`
+
+	// TenantIDHash is the hash of the tenant ID (optional)
+	TenantIDHash string `json:"tenant_id_hash,omitempty"`
+}
+
+// Route implements sdk.Msg
+func (msg MsgCreateSSOLinkage) Route() string { return ModuleName }
+
+// Type implements sdk.Msg
+func (msg MsgCreateSSOLinkage) Type() string { return TypeMsgCreateSSOLinkage }
+
+// GetSigners implements sdk.Msg
+func (msg MsgCreateSSOLinkage) GetSigners() []sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(msg.AccountAddress)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
+}
+
+// ValidateBasic implements sdk.Msg
+func (msg MsgCreateSSOLinkage) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.AccountAddress); err != nil {
+		return sdkerrors.ErrInvalidAddress.Wrapf("invalid account address: %s", err)
+	}
+
+	if msg.LinkageID == "" {
+		return ErrInvalidSSO.Wrap("linkage_id cannot be empty")
+	}
+
+	if !IsValidSSOProviderType(msg.Provider) {
+		return ErrInvalidSSO.Wrapf("invalid provider: %s", msg.Provider)
+	}
+
+	if msg.Issuer == "" {
+		return ErrInvalidSSO.Wrap("issuer cannot be empty")
+	}
+
+	if msg.SubjectHash == "" {
+		return ErrInvalidSSO.Wrap("subject_hash cannot be empty")
+	}
+
+	if len(msg.SubjectHash) != 64 {
+		return ErrInvalidSSO.Wrap("subject_hash must be a valid SHA256 hex string")
+	}
+
+	if msg.Nonce == "" {
+		return ErrInvalidSSO.Wrap("nonce cannot be empty")
+	}
+
+	if len(msg.AttestationData) == 0 {
+		return ErrInvalidSSO.Wrap("attestation_data cannot be empty")
+	}
+
+	if len(msg.AttestationSignature) == 0 {
+		return ErrInvalidSSO.Wrap("attestation_signature cannot be empty")
+	}
+
+	if msg.SignerFingerprint == "" {
+		return ErrInvalidSSO.Wrap("signer_fingerprint cannot be empty")
+	}
+
+	if len(msg.AccountSignature) == 0 {
+		return ErrInvalidBindingSignature.Wrap("account_signature cannot be empty")
+	}
+
+	return nil
+}
+
+// MsgCreateSSOLinkageResponse is the response for MsgCreateSSOLinkage.
+type MsgCreateSSOLinkageResponse struct {
+	// LinkageID is the created linkage ID
+	LinkageID string `json:"linkage_id"`
+
+	// Status is the linkage status
+	Status SSOVerificationStatus `json:"status"`
+
+	// ScoreContribution is the score contribution from this linkage
+	ScoreContribution uint32 `json:"score_contribution"`
+
+	// VerifiedAt is when the linkage was verified
+	VerifiedAt time.Time `json:"verified_at"`
+}
+
+// ============================================================================
+// MsgRevokeSSOLinkage
+// ============================================================================
+
+// MsgRevokeSSOLinkage revokes an existing SSO linkage.
+type MsgRevokeSSOLinkage struct {
+	// AccountAddress is the account that owns the linkage
+	AccountAddress string `json:"account_address"`
+
+	// LinkageID is the linkage to revoke
+	LinkageID string `json:"linkage_id"`
+
+	// Reason is the revocation reason
+	Reason string `json:"reason"`
+
+	// Signature is the account's signature authorizing revocation
+	Signature []byte `json:"signature"`
+}
+
+// Route implements sdk.Msg
+func (msg MsgRevokeSSOLinkage) Route() string { return ModuleName }
+
+// Type implements sdk.Msg
+func (msg MsgRevokeSSOLinkage) Type() string { return TypeMsgRevokeSSOLinkage }
+
+// GetSigners implements sdk.Msg
+func (msg MsgRevokeSSOLinkage) GetSigners() []sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(msg.AccountAddress)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
+}
+
+// ValidateBasic implements sdk.Msg
+func (msg MsgRevokeSSOLinkage) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.AccountAddress); err != nil {
+		return sdkerrors.ErrInvalidAddress.Wrapf("invalid account address: %s", err)
+	}
+
+	if msg.LinkageID == "" {
+		return ErrInvalidSSO.Wrap("linkage_id cannot be empty")
+	}
+
+	if len(msg.Signature) == 0 {
+		return ErrInvalidBindingSignature.Wrap("signature cannot be empty")
+	}
+
+	return nil
+}
+
+// MsgRevokeSSOLinkageResponse is the response for MsgRevokeSSOLinkage.
+type MsgRevokeSSOLinkageResponse struct {
+	// LinkageID is the revoked linkage ID
+	LinkageID string `json:"linkage_id"`
+
+	// Status is the new status
+	Status SSOVerificationStatus `json:"status"`
+
+	// RevokedAt is when the linkage was revoked
+	RevokedAt time.Time `json:"revoked_at"`
+}
+
+// ============================================================================
+// MsgUpdateSSOLinkage
+// ============================================================================
+
+// MsgUpdateSSOLinkage updates an existing SSO linkage (e.g., refresh).
+type MsgUpdateSSOLinkage struct {
+	// AccountAddress is the account that owns the linkage
+	AccountAddress string `json:"account_address"`
+
+	// LinkageID is the linkage to update
+	LinkageID string `json:"linkage_id"`
+
+	// NewExpiresAt is the new expiration time
+	NewExpiresAt *time.Time `json:"new_expires_at,omitempty"`
+
+	// NewAttestationData contains the new signed attestation
+	NewAttestationData []byte `json:"new_attestation_data,omitempty"`
+
+	// NewAttestationSignature is the new signature
+	NewAttestationSignature []byte `json:"new_attestation_signature,omitempty"`
+
+	// NewSignerFingerprint is the new signer fingerprint
+	NewSignerFingerprint string `json:"new_signer_fingerprint,omitempty"`
+
+	// AccountSignature is the account's signature authorizing the update
+	AccountSignature []byte `json:"account_signature"`
+}
+
+// Route implements sdk.Msg
+func (msg MsgUpdateSSOLinkage) Route() string { return ModuleName }
+
+// Type implements sdk.Msg
+func (msg MsgUpdateSSOLinkage) Type() string { return TypeMsgUpdateSSOLinkage }
+
+// GetSigners implements sdk.Msg
+func (msg MsgUpdateSSOLinkage) GetSigners() []sdk.AccAddress {
+	addr, err := sdk.AccAddressFromBech32(msg.AccountAddress)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{addr}
+}
+
+// ValidateBasic implements sdk.Msg
+func (msg MsgUpdateSSOLinkage) ValidateBasic() error {
+	if _, err := sdk.AccAddressFromBech32(msg.AccountAddress); err != nil {
+		return sdkerrors.ErrInvalidAddress.Wrapf("invalid account address: %s", err)
+	}
+
+	if msg.LinkageID == "" {
+		return ErrInvalidSSO.Wrap("linkage_id cannot be empty")
+	}
+
+	if len(msg.AccountSignature) == 0 {
+		return ErrInvalidBindingSignature.Wrap("account_signature cannot be empty")
+	}
+
+	// At least one update field must be provided
+	hasUpdate := msg.NewExpiresAt != nil ||
+		len(msg.NewAttestationData) > 0 ||
+		len(msg.NewAttestationSignature) > 0 ||
+		msg.NewSignerFingerprint != ""
+
+	if !hasUpdate {
+		return ErrInvalidSSO.Wrap("at least one update field must be provided")
+	}
+
+	return nil
+}
+
+// MsgUpdateSSOLinkageResponse is the response for MsgUpdateSSOLinkage.
+type MsgUpdateSSOLinkageResponse struct {
+	// LinkageID is the updated linkage ID
+	LinkageID string `json:"linkage_id"`
+
+	// UpdatedAt is when the linkage was updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ============================================================================
+// SSO Nonce Tracking for Replay Protection
+// ============================================================================
+
+// SSONonceRecord tracks nonce usage for SSO verification replay protection.
+type SSONonceRecord struct {
+	// NonceHash is the SHA256 hash of the nonce
+	NonceHash string `json:"nonce_hash"`
+
+	// AccountAddress is the account that used this nonce
+	AccountAddress string `json:"account_address"`
+
+	// Provider is the SSO provider
+	Provider SSOProviderType `json:"provider"`
+
+	// Issuer is the OIDC issuer
+	Issuer string `json:"issuer"`
+
+	// LinkageID is the resulting linkage ID
+	LinkageID string `json:"linkage_id"`
+
+	// UsedAt is when the nonce was used
+	UsedAt time.Time `json:"used_at"`
+
+	// BlockHeight is the block height when used
+	BlockHeight int64 `json:"block_height"`
+
+	// ExpiresAt is when this record can be pruned
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// NewSSONonceRecord creates a new SSO nonce record.
+func NewSSONonceRecord(
+	nonceHash string,
+	accountAddress string,
+	provider SSOProviderType,
+	issuer string,
+	linkageID string,
+	usedAt time.Time,
+	blockHeight int64,
+	retentionDuration time.Duration,
+) *SSONonceRecord {
+	return &SSONonceRecord{
+		NonceHash:      nonceHash,
+		AccountAddress: accountAddress,
+		Provider:       provider,
+		Issuer:         issuer,
+		LinkageID:      linkageID,
+		UsedAt:         usedAt,
+		BlockHeight:    blockHeight,
+		ExpiresAt:      usedAt.Add(retentionDuration),
+	}
+}
+
+// Validate validates the SSO nonce record.
+func (r *SSONonceRecord) Validate() error {
+	if r.NonceHash == "" {
+		return ErrInvalidNonce.Wrap("nonce_hash cannot be empty")
+	}
+	if len(r.NonceHash) != 64 {
+		return ErrInvalidNonce.Wrap("nonce_hash must be a valid SHA256 hex string")
+	}
+	if r.AccountAddress == "" {
+		return ErrInvalidAddress.Wrap("account_address cannot be empty")
+	}
+	if !IsValidSSOProviderType(r.Provider) {
+		return ErrInvalidSSO.Wrapf("invalid provider: %s", r.Provider)
+	}
+	if r.Issuer == "" {
+		return ErrInvalidSSO.Wrap("issuer cannot be empty")
+	}
+	if r.UsedAt.IsZero() {
+		return ErrInvalidSSO.Wrap("used_at cannot be zero")
+	}
+	return nil
+}
+
+// CanBePruned checks if the record can be pruned.
+func (r *SSONonceRecord) CanBePruned(now time.Time) bool {
+	return now.After(r.ExpiresAt)
+}


### PR DESCRIPTION
Objective:
Provide an off-chain SSO/OIDC verification service that issues signed attestations consumable by x/veid.

Prerequisites:
- 2B feat(veid): build verification shared infra (signing/rate-limit/audit)

Needs to be done (A–I):
A. Define attestation payload schema (issuer, subject hash, account, nonce, timestamps, expiry).
B. Implement OIDC discovery + JWKS rotation + token validation (aud, iss, exp, nonce).
C. Add issuer allowlist configuration with per-provider policies (Google/Microsoft/AD/OIDC).
D. Create attestation signer and key rotation plan (HSM/Vault recommended).
E. Submit on-chain Msg to create linkage record; handle revocation and expiry.
F. Add replay protection on-chain (nonce tracking) and in verifier.
G. Implement audit logging and monitoring (success/fail, issuer errors).
H. Provide admin CLI endpoints for issuer config updates.
I. Document operations runbook.

Acceptance criteria:
- Valid OIDC tokens produce signed attestations accepted on-chain.
- Replay protection enforced (nonce + expiry).
- Revocation updates on-chain linkage status.
- Configurable issuer policies documented and tested.

How it can be done:
- Implement service using Go OIDC libs with config in YAML/Env.
- Use x/veid SSO metadata types for linkage records.
- Add integration tests with mock OIDC providers.

MCP guidance:
- Use Context7 for OIDC libraries and token validation patterns.
- Use Exa to confirm issuer-specific claim requirements.

Deliverables:
- Verifier service, attestation schema + signer, on-chain linkage integration, and tests.