### PR TITLE
perf(ci): move go mod tidy to pre-commit, speed up pre-push

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# VirtEngine Pre-Commit Hook
+#
+# Runs fast checks on staged files before commit.
+# Only runs go mod tidy/vendor when go.mod or go.sum are staged.
+#
+# Bypass: git commit --no-verify
+# Skip mod check: VE_HOOK_SKIP_MOD=1 git commit
+
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$HOOK_DIR/common.sh"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Check if go.mod or go.sum are staged
+if git diff --cached --name-only | grep -qE '^go\.(mod|sum)$'; then
+    if [ "${VE_HOOK_SKIP_MOD:-}" = "1" ]; then
+        hook_warn "[pre-commit] Skipping go mod checks (VE_HOOK_SKIP_MOD=1)"
+        exit 0
+    fi
+
+    hook_header "[pre-commit] go.mod/go.sum changed - syncing modules..."
+    
+    # Run go mod tidy
+    hook_step "Running 'go mod tidy'..."
+    if ! go mod tidy 2>&1; then
+        hook_fail "go mod tidy failed"
+        exit 1
+    fi
+
+    # Check if tidy changed anything
+    if ! git diff --quiet go.mod go.sum 2>/dev/null; then
+        hook_warn "go mod tidy made changes. Adding to commit..."
+        git add go.mod go.sum
+    fi
+
+    # Sync vendor directory
+    hook_step "Running 'go mod vendor'..."
+    if ! go mod vendor 2>&1; then
+        hook_fail "go mod vendor failed"
+        exit 1
+    fi
+
+    hook_pass "[pre-commit] Module sync complete"
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,18 +2,17 @@
 # VirtEngine Pre-Push Hook
 #
 # Prevents pushing code that doesn't pass critical quality gates.
-# Mirrors CI required checks: vet, mod sync, lint, build, tests.
+# Mirrors CI required checks: vet, lint, build, tests.
 #
-# Auto-fix mode (default): Automatically runs 'go mod tidy' and 'go mod vendor'
-# to sync dependencies and amends the last commit if changes are needed.
+# NOTE: go mod tidy/vendor are handled by pre-commit hook (only when go.mod changes).
+# This keeps pre-push fast.
 #
 # Bypass:       git push --no-verify
 # Quick mode:   VE_HOOK_QUICK=1 git push     (vet + build only)
-# No auto-fix:  VE_HOOK_NO_AUTOFIX=1 git push
 #
 # Skip individual checks:
 #   VE_HOOK_SKIP_VET=1      Skip go vet
-#   VE_HOOK_SKIP_MOD=1      Skip go mod tidy/vendor checks
+#   VE_HOOK_SKIP_MOD=1      Skip go mod vendor sync
 #   VE_HOOK_SKIP_LINT=1     Skip golangci-lint
 #   VE_HOOK_SKIP_BUILD=1    Skip build
 #   VE_HOOK_SKIP_TEST=1     Skip unit tests
@@ -50,8 +49,7 @@ TOTAL_START=$(hook_time_start)
 FAILED=0
 PASSED=0
 SKIPPED=0
-TOTAL_CHECKS=6
-NEEDS_AMEND=0  # Track if we staged changes that need to be committed
+TOTAL_CHECKS=5  # Reduced from 6 - mod tidy moved to pre-commit
 
 # Helper to run a check
 run_check() {
@@ -108,42 +106,16 @@ check_vet() {
 }
 
 # =========================================================================
-# Check 2: go mod tidy (with auto-fix)
-# =========================================================================
-check_mod_tidy() {
-    # Run go mod tidy and auto-stage if files changed
-    hook_step "Running 'go mod tidy'..."
-    go mod tidy 2>&1
-
-    # Check if go.mod or go.sum have uncommitted changes
-    if git diff --quiet go.mod go.sum 2>/dev/null; then
-        return 0
-    else
-        if [ "${VE_HOOK_NO_AUTOFIX:-}" = "1" ]; then
-            hook_fail "go.mod or go.sum is out of sync. Run 'go mod tidy' and commit."
-            return 1
-        fi
-        # Files changed - stage them for commit
-        hook_warn "go.mod or go.sum updated. Staging changes..."
-        git add go.mod go.sum
-        NEEDS_AMEND=1
-        hook_step "Module files staged."
-        return 0
-    fi
-}
-
-# =========================================================================
-# Check 3: go mod vendor (auto-sync for local build)
+# Check 2: go mod vendor (fast sync - only if needed)
 # =========================================================================
 check_mod_vendor() {
-    # Vendor sync check with auto-fix capability.
-    # Since vendor/ is gitignored, we just need to ensure it's synced locally
-    # for the build and test steps to work correctly.
+    # Quick vendor sync - only runs go mod vendor if vendor is missing or stale.
+    # Full go mod tidy is handled by pre-commit hook when go.mod changes.
 
-    # Quick check: if vendor exists and looks correct, skip the expensive sync
+    # Quick check: if vendor exists and is in sync, skip
     if [ -f vendor/modules.txt ]; then
-        # Fast consistency check using go command (validates without copying)
-        if go mod verify -mod=vendor 2>/dev/null; then
+        # Use go list to verify vendor consistency (faster than go mod verify)
+        if go list -mod=vendor ./... >/dev/null 2>&1; then
             hook_step "Vendor directory already in sync"
             return 0
         fi
@@ -156,13 +128,7 @@ check_mod_vendor() {
         return 1
     fi
 
-    # Verify vendor/modules.txt exists after sync
-    if [ ! -f vendor/modules.txt ]; then
-        hook_fail "vendor/modules.txt not found after go mod vendor."
-        return 1
-    fi
-
-    hook_step "Vendor directory synced successfully"
+    hook_step "Vendor directory synced"
     return 0
 }
 
@@ -227,22 +193,6 @@ check_test() {
 # Run checks
 # =========================================================================
 
-# Helper function to amend commit with staged changes
-amend_commit_if_needed() {
-    if [ "$NEEDS_AMEND" -eq 1 ] && [ "$FAILED" -eq 0 ]; then
-        hook_header "-----------------------------------------"
-        hook_warn "Auto-fix: Amending last commit with vendor/module changes..."
-        if git commit --amend --no-edit 2>&1; then
-            hook_pass "Commit amended successfully with auto-fixed changes"
-            NEEDS_AMEND=0
-        else
-            hook_fail "Failed to amend commit. Please commit manually."
-            FAILED=$((FAILED + 1))
-        fi
-        hook_header "-----------------------------------------"
-    fi
-}
-
 # Quick mode: only vet + build
 if [ "${VE_HOOK_QUICK:-}" = "1" ]; then
     TOTAL_CHECKS=2
@@ -250,15 +200,10 @@ if [ "${VE_HOOK_QUICK:-}" = "1" ]; then
     run_check 2 "Build binaries" VE_HOOK_SKIP_BUILD check_build || true
 else
     run_check 1 "go vet" VE_HOOK_SKIP_VET check_vet || true
-    run_check 2 "go mod tidy (auto-sync)" VE_HOOK_SKIP_MOD check_mod_tidy || true
-    run_check 3 "go mod vendor (auto-sync)" VE_HOOK_SKIP_MOD check_mod_vendor || true
-
-    # Amend commit if we staged any auto-fix changes (before build/test)
-    amend_commit_if_needed
-
-    run_check 4 "golangci-lint" VE_HOOK_SKIP_LINT check_lint || true
-    run_check 5 "Build binaries" VE_HOOK_SKIP_BUILD check_build || true
-    run_check 6 "Unit tests" VE_HOOK_SKIP_TEST check_test || true
+    run_check 2 "go mod vendor (sync)" VE_HOOK_SKIP_MOD check_mod_vendor || true
+    run_check 3 "golangci-lint" VE_HOOK_SKIP_LINT check_lint || true
+    run_check 4 "Build binaries" VE_HOOK_SKIP_BUILD check_build || true
+    run_check 5 "Unit tests" VE_HOOK_SKIP_TEST check_test || true
 fi
 
 # =========================================================================
@@ -279,7 +224,6 @@ if [ "$FAILED" -gt 0 ]; then
     hook_info "Bypass:       git push --no-verify"
     hook_info "Quick mode:   VE_HOOK_QUICK=1 git push"
     hook_info "Skip one:     VE_HOOK_SKIP_LINT=1 git push"
-    hook_info "No auto-fix:  VE_HOOK_NO_AUTOFIX=1 git push"
     exit 1
 else
     hook_header "========================================="


### PR DESCRIPTION
- Create pre-commit hook that runs go mod tidy only when go.mod changes
- Remove expensive go mod tidy from pre-push (was taking ~15s)
- Pre-push now only syncs vendor if needed (instant if already synced)
- Reduce pre-push checks from 6 to 5

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/virtengine/node/blob/main/CONTRIBUTING.md#paperwork-for-pull-requests))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/virtengine/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
