### PR TITLE
fix(provider): 1D - Fix InsecureSkipVerify TLS bypass in client 

### DIFF
--- a/sdk/go/provider/client/client.go
+++ b/sdk/go/provider/client/client.go
@@ -159,7 +159,7 @@ func NewClient(ctx context.Context, addr sdk.Address, opts ...ClientOption) (Cli
 		MinVersion:            tls.VersionTLS13,
 		RootCAs:               certPool,
 		VerifyPeerCertificate: cl.verifyPeerCertificate,
-		InsecureSkipVerify:    true, // nolint: gosec
+		InsecureSkipVerify:    cl.opts.insecureSkipVerify, //nolint:gosec // G402: Controlled by explicit opt-in via WithInsecureSkipVerify option
 	}
 
 	// must use Hostname rather than Host field as a certificate is issued for host without port

--- a/sdk/go/provider/client/client_test.go
+++ b/sdk/go/provider/client/client_test.go
@@ -69,4 +69,31 @@ func TestNewClientWithProviderURL(t *testing.T) {
 		require.Empty(t, c.opts.token) // Should be empty when no token provided
 	})
 
+	t.Run("TLS verification enabled by default", func(t *testing.T) {
+		cl, err := NewClient(ctx, addr, WithProviderURL(providerURL))
+		require.NoError(t, err)
+
+		c := cl.(*client)
+		require.False(t, c.tlsCfg.InsecureSkipVerify, "TLS verification should be enabled by default")
+		require.False(t, c.opts.insecureSkipVerify, "insecureSkipVerify option should be false by default")
+	})
+
+	t.Run("TLS verification can be disabled with option", func(t *testing.T) {
+		cl, err := NewClient(ctx, addr, WithProviderURL(providerURL), WithInsecureSkipVerify(true))
+		require.NoError(t, err)
+
+		c := cl.(*client)
+		require.True(t, c.tlsCfg.InsecureSkipVerify, "TLS verification should be disabled when opted in")
+		require.True(t, c.opts.insecureSkipVerify, "insecureSkipVerify option should be true when set")
+	})
+
+	t.Run("TLS verification remains enabled when option is false", func(t *testing.T) {
+		cl, err := NewClient(ctx, addr, WithProviderURL(providerURL), WithInsecureSkipVerify(false))
+		require.NoError(t, err)
+
+		c := cl.(*client)
+		require.False(t, c.tlsCfg.InsecureSkipVerify, "TLS verification should remain enabled")
+		require.False(t, c.opts.insecureSkipVerify, "insecureSkipVerify option should be false")
+	})
+
 }

--- a/sdk/go/provider/client/options.go
+++ b/sdk/go/provider/client/options.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"crypto/tls"
 	"fmt"
+	"log"
 
 	ajwt "github.com/virtengine/virtengine/sdk/go/util/jwt"
 	atls "github.com/virtengine/virtengine/sdk/go/util/tls"
@@ -14,6 +15,9 @@ type clientOptions struct {
 	token       string
 	providerURL string
 	certQuerier atls.CertificateQuerier
+	// insecureSkipVerify disables TLS certificate verification.
+	// This should only be used in development/testing environments.
+	insecureSkipVerify bool
 }
 
 // ClientOption is a function type that modifies a clientOptions struct and returns an error.
@@ -70,6 +74,22 @@ func WithCertQuerier(certQuerier atls.CertificateQuerier) ClientOption {
 		}
 
 		options.certQuerier = certQuerier
+		return nil
+	}
+}
+
+// WithInsecureSkipVerify configures the client to skip TLS certificate verification.
+// WARNING: This option disables certificate verification, making the connection
+// vulnerable to man-in-the-middle attacks. USE WITH CAUTION.
+// This should only be used in development/testing environments where the provider
+// uses self-signed certificates that cannot be verified through standard PKI or on-chain validation.
+func WithInsecureSkipVerify(skip bool) ClientOption {
+	return func(options *clientOptions) error {
+		if skip {
+			log.Println("WARNING: TLS certificate verification disabled - NOT RECOMMENDED FOR PRODUCTION. " +
+				"This makes the connection vulnerable to man-in-the-middle attacks.")
+		}
+		options.insecureSkipVerify = skip
 		return nil
 	}
 }


### PR DESCRIPTION
## 🔴 HIGH - TLS Security

### Issue Reference
GitHub Issue: #158 (TLS/HTTP security - G402)

### Problem
The provider client in `sdk/go/provider/client.go` has `InsecureSkipVerify: true` which disables TLS certificate verification, enabling man-in-the-middle attacks.

### Files to Modify
- `sdk/go/provider/client.go`
  - Line with `InsecureSkipVerify: true, // nolint: gosec`

### Required Changes
1. Remove `InsecureSkipVerify: true` as default
2. Add configuration option for explicit opt-in with warnings
3. Implement proper certificate verification
4. Add client option: `WithInsecureSkipVerify(bool)` that logs security warning
5. Default to secure mode (verify certificates)

### Code Pattern
```go
type ClientOptions struct {
    // InsecureSkipVerify disables TLS cert verification. USE WITH CAUTION.
    // This should only be used in development/testing environments.
    InsecureSkipVerify bool
}

func NewClient(opts ClientOptions) *Client {
    if opts.InsecureSkipVerify {
        log.Warn("TLS certificate verification disabled - NOT RECOMMENDED FOR PRODUCTION")
    }
    // ...
}
```

### Security Impact
- **Current Risk**: MITM attacks on provider communication
- **After Fix**: Secure TLS with explicit opt-out only

### Acceptance Criteria
- [ ] Default is secure (verify TLS certs)
- [ ] Explicit opt-in required for insecure mode
- [ ] Warning logged when insecure mode used
- [ ] All provider client tests pass
- [ ] gosec scan passes

### Batch
**1D** - Can run in parallel with 1A, 1B, 1C, 1E (different module)