### PR TITLE
[P0] Fix x/veid Keeper Feature Extraction & Verification Tests 

### DIFF
--- a/x/veid/module.go
+++ b/x/veid/module.go
@@ -136,17 +136,13 @@ func (am AppModule) QuerierRoute() string {
 // RegisterServices registers the module's services
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
-	// TODO: Query server registration is temporarily disabled due to type incompatibility
-	// with Cosmos SDK's GRPCQueryRouter. The custom query types in grpc_handlers.go
-	// need to be migrated to use SDK-generated protobuf types.
-	// types.RegisterQueryServer(cfg.QueryServer(), keeper.NewGRPCQuerier(am.keeper))
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewGRPCQuerier(am.keeper))
 }
 
 // RegisterQueryService registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterQueryService(server grpc.Server) {
-	// TODO: Temporarily disabled - see RegisterServices comment
-	// types.RegisterQueryServer(server, keeper.NewGRPCQuerier(am.keeper))
+	types.RegisterQueryServer(server, keeper.NewGRPCQuerier(am.keeper))
 }
 
 // BeginBlock performs no-op

--- a/x/veid/types/grpc_handlers.go
+++ b/x/veid/types/grpc_handlers.go
@@ -343,6 +343,10 @@ var _Query_serviceDesc = struct {
 		{MethodName: "ConsentSettings", Handler: nil},
 		{MethodName: "DerivedFeatures", Handler: nil},
 		{MethodName: "DerivedFeatureHashes", Handler: nil},
+		{MethodName: "Appeal", Handler: nil},
+		{MethodName: "AppealsByAccount", Handler: nil},
+		{MethodName: "PendingAppeals", Handler: nil},
+		{MethodName: "AppealParams", Handler: nil},
 	},
 	Streams:  []struct{}{},
 	Metadata: "virtengine/veid/v1/query.proto",
@@ -369,6 +373,10 @@ var _Query_serviceDesc_grpc = ggrpc.ServiceDesc{
 		{MethodName: "ConsentSettings", Handler: _Query_ConsentSettings_Handler},
 		{MethodName: "DerivedFeatures", Handler: _Query_DerivedFeatures_Handler},
 		{MethodName: "DerivedFeatureHashes", Handler: _Query_DerivedFeatureHashes_Handler},
+		{MethodName: "Appeal", Handler: _Query_Appeal_Handler},
+		{MethodName: "AppealsByAccount", Handler: _Query_AppealsByAccount_Handler},
+		{MethodName: "PendingAppeals", Handler: _Query_PendingAppeals_Handler},
+		{MethodName: "AppealParams", Handler: _Query_AppealParams_Handler},
 	},
 	Streams:  []ggrpc.StreamDesc{},
 	Metadata: "virtengine/veid/v1/query.proto",
@@ -525,6 +533,62 @@ func _Query_DerivedFeatureHashes_Handler(srv interface{}, ctx context.Context, d
 	info := &ggrpc.UnaryServerInfo{Server: srv, FullMethod: "/virtengine.veid.v1.Query/DerivedFeatureHashes"}
 	return interceptor(ctx, in, info, func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(QueryServer).DerivedFeatureHashes(ctx, req.(*QueryDerivedFeatureHashesRequest))
+	})
+}
+
+func _Query_Appeal_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor ggrpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryAppealRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).Appeal(ctx, in)
+	}
+	info := &ggrpc.UnaryServerInfo{Server: srv, FullMethod: "/virtengine.veid.v1.Query/Appeal"}
+	return interceptor(ctx, in, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).Appeal(ctx, req.(*QueryAppealRequest))
+	})
+}
+
+func _Query_AppealsByAccount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor ggrpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryAppealsByAccountRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).AppealsByAccount(ctx, in)
+	}
+	info := &ggrpc.UnaryServerInfo{Server: srv, FullMethod: "/virtengine.veid.v1.Query/AppealsByAccount"}
+	return interceptor(ctx, in, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).AppealsByAccount(ctx, req.(*QueryAppealsByAccountRequest))
+	})
+}
+
+func _Query_PendingAppeals_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor ggrpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryPendingAppealsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).PendingAppeals(ctx, in)
+	}
+	info := &ggrpc.UnaryServerInfo{Server: srv, FullMethod: "/virtengine.veid.v1.Query/PendingAppeals"}
+	return interceptor(ctx, in, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).PendingAppeals(ctx, req.(*QueryPendingAppealsRequest))
+	})
+}
+
+func _Query_AppealParams_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor ggrpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryAppealParamsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).AppealParams(ctx, in)
+	}
+	info := &ggrpc.UnaryServerInfo{Server: srv, FullMethod: "/virtengine.veid.v1.Query/AppealParams"}
+	return interceptor(ctx, in, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).AppealParams(ctx, req.(*QueryAppealParamsRequest))
 	})
 }
 


### PR DESCRIPTION
## Priority: P0 - Critical

## Problem
The VEID module keeper tests are failing due to feature extraction logic issues, verification flow problems, and struct field mismatches between proto and local types.

## Failing Tests
- `x/veid/keeper/...` - Multiple test failures

## Root Cause Analysis Needed
1. Review `UploadMetadata` struct - `CaptureTimestamp` vs `UploadedAt` field
2. Check `EncryptedPayloadEnvelope` - `Ciphertext`/`Nonce` vs base64 encoded fields
3. Verify ML feature extraction scoring logic
4. Check verification status state transitions
5. Review gRPC query handler registration (currently disabled)

## Acceptance Criteria
- [ ] All `x/veid/keeper/...` tests pass
- [ ] Scope upload and verification flow works
- [ ] Feature extraction and scoring works correctly
- [ ] Identity wallet operations work
- [ ] Tier transitions work correctly
- [ ] Re-enable gRPC query handler registration

## Files to Investigate
- `x/veid/keeper/keeper.go` - Core keeper
- `x/veid/keeper/msg_server.go` - MsgServer implementation
- `x/veid/keeper/msg_server_test.go` - MsgServer tests
- `x/veid/keeper/verification_*.go` - Verification logic
- `x/veid/keeper/tier_transitions_test.go` - Tier transition tests
- `x/veid/types/scope.go` - Scope types
- `x/veid/types/wallet.go` - Wallet types
- `x/veid/module.go` - Query handler registration (currently disabled)

## Testing Command
```bash
go test ./x/veid/keeper/... -v -count=1
```

## Notes
The gRPC query handler registration in `x/veid/module.go` is currently disabled with TODO comments due to type incompatibility with Cosmos SDK's GRPCQueryRouter. The custom query types need to be migrated to use SDK-generated protobuf types.

## Task Reference
- VE-3020: Appeal system
- VE-3021: KYC/AML Compliance Interface