### PR TITLE
fix(security): add path traversal prevention and integer overflow pro…

### DIFF
--- a/pkg/provider_daemon/waldur_bridge.go
+++ b/pkg/provider_daemon/waldur_bridge.go
@@ -139,8 +139,19 @@ func NewWaldurBridge(cfg WaldurBridgeConfig, keyManager *KeyManager, callbackSin
 		callbackSink:    callbackSink,
 		usageReporter:   usageReporter,
 		stateStore:      NewWaldurBridgeStateStore(cfg.StateFile),
-		checkpointStore: NewEventCheckpointStore(cfg.CheckpointFile),
+		checkpointStore: mustNewEventCheckpointStore(cfg.CheckpointFile),
 	}, nil
+}
+
+// mustNewEventCheckpointStore creates a checkpoint store, panicking on validation error.
+// Validation errors indicate misconfiguration and should fail fast.
+func mustNewEventCheckpointStore(path string) *EventCheckpointStore {
+	store, err := NewEventCheckpointStore(path)
+	if err != nil {
+		// Path validation failed - this indicates configuration error
+		panic(fmt.Sprintf("invalid checkpoint file path: %v", err))
+	}
+	return store
 }
 
 // Start starts the bridge event loop.

--- a/pkg/security/overflow.go
+++ b/pkg/security/overflow.go
@@ -1,0 +1,158 @@
+package security
+
+import (
+	"fmt"
+	"math"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// Integer overflow protection utilities
+var (
+	ErrIntegerOverflow = fmt.Errorf("integer overflow detected")
+)
+
+// SafeInt64 safely converts an sdkmath.Int to int64, returning an error if overflow would occur.
+func SafeInt64(i sdkmath.Int) (int64, error) {
+	if i.IsNil() {
+		return 0, nil
+	}
+
+	// Check if the value fits in int64
+	if i.GT(sdkmath.NewInt(math.MaxInt64)) {
+		return 0, fmt.Errorf("%w: value %s exceeds max int64", ErrIntegerOverflow, i.String())
+	}
+	if i.LT(sdkmath.NewInt(math.MinInt64)) {
+		return 0, fmt.Errorf("%w: value %s is below min int64", ErrIntegerOverflow, i.String())
+	}
+
+	return i.Int64(), nil
+}
+
+// SafeUint64 safely converts an sdkmath.Int to uint64, returning an error if the value is negative or overflows.
+func SafeUint64(i sdkmath.Int) (uint64, error) {
+	if i.IsNil() {
+		return 0, nil
+	}
+
+	if i.IsNegative() {
+		return 0, fmt.Errorf("%w: cannot convert negative value %s to uint64", ErrIntegerOverflow, i.String())
+	}
+
+	// Check if the value fits in uint64
+	maxUint64 := sdkmath.NewIntFromUint64(math.MaxUint64)
+	if i.GT(maxUint64) {
+		return 0, fmt.Errorf("%w: value %s exceeds max uint64", ErrIntegerOverflow, i.String())
+	}
+
+	return i.Uint64(), nil
+}
+
+// SafeInt safely converts an sdkmath.Int to int, returning an error if overflow would occur.
+func SafeInt(i sdkmath.Int) (int, error) {
+	if i.IsNil() {
+		return 0, nil
+	}
+
+	// On 32-bit systems, int is 32 bits
+	maxInt := sdkmath.NewInt(int64(math.MaxInt))
+	minInt := sdkmath.NewInt(int64(math.MinInt))
+
+	if i.GT(maxInt) {
+		return 0, fmt.Errorf("%w: value %s exceeds max int", ErrIntegerOverflow, i.String())
+	}
+	if i.LT(minInt) {
+		return 0, fmt.Errorf("%w: value %s is below min int", ErrIntegerOverflow, i.String())
+	}
+
+	return int(i.Int64()), nil
+}
+
+// MustSafeInt64 converts sdkmath.Int to int64, panicking on overflow.
+// Use only when overflow is unexpected and should be a program error.
+func MustSafeInt64(i sdkmath.Int) int64 {
+	v, err := SafeInt64(i)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// SafeInt64OrDefault converts sdkmath.Int to int64, returning defaultVal on overflow.
+func SafeInt64OrDefault(i sdkmath.Int, defaultVal int64) int64 {
+	v, err := SafeInt64(i)
+	if err != nil {
+		return defaultVal
+	}
+	return v
+}
+
+// CheckMultiplicationOverflow checks if a * b would overflow int64.
+func CheckMultiplicationOverflow(a, b int64) bool {
+	if a == 0 || b == 0 {
+		return false
+	}
+	result := a * b
+	return (result/a != b)
+}
+
+// SafeMultiply safely multiplies two int64 values, returning an error on overflow.
+func SafeMultiply(a, b int64) (int64, error) {
+	if a == 0 || b == 0 {
+		return 0, nil
+	}
+	result := a * b
+	if result/a != b {
+		return 0, fmt.Errorf("%w: %d * %d", ErrIntegerOverflow, a, b)
+	}
+	return result, nil
+}
+
+// SafeAdd safely adds two int64 values, returning an error on overflow.
+func SafeAdd(a, b int64) (int64, error) {
+	result := a + b
+	// Check for overflow
+	if (b > 0 && result < a) || (b < 0 && result > a) {
+		return 0, fmt.Errorf("%w: %d + %d", ErrIntegerOverflow, a, b)
+	}
+	return result, nil
+}
+
+// ClampToInt64 clamps an sdkmath.Int to int64 range without error.
+// Values beyond int64 range are clamped to MaxInt64 or MinInt64.
+func ClampToInt64(i sdkmath.Int) int64 {
+	if i.IsNil() {
+		return 0
+	}
+
+	maxInt64 := sdkmath.NewInt(math.MaxInt64)
+	minInt64 := sdkmath.NewInt(math.MinInt64)
+
+	if i.GT(maxInt64) {
+		return math.MaxInt64
+	}
+	if i.LT(minInt64) {
+		return math.MinInt64
+	}
+
+	return i.Int64()
+}
+
+// ClampToInt clamps an sdkmath.Int to int range without error.
+func ClampToInt(i sdkmath.Int) int {
+	if i.IsNil() {
+		return 0
+	}
+
+	maxInt := sdkmath.NewInt(int64(math.MaxInt))
+	minInt := sdkmath.NewInt(int64(math.MinInt))
+
+	if i.GT(maxInt) {
+		return math.MaxInt
+	}
+	if i.LT(minInt) {
+		return math.MinInt
+	}
+
+	return int(i.Int64())
+}

--- a/pkg/security/overflow_test.go
+++ b/pkg/security/overflow_test.go
@@ -1,0 +1,198 @@
+package security
+
+import (
+	"math"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+func TestSafeInt64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   sdkmath.Int
+		want    int64
+		wantErr bool
+	}{
+		{"zero", sdkmath.ZeroInt(), 0, false},
+		{"positive", sdkmath.NewInt(12345), 12345, false},
+		{"negative", sdkmath.NewInt(-12345), -12345, false},
+		{"max int64", sdkmath.NewInt(math.MaxInt64), math.MaxInt64, false},
+		{"min int64", sdkmath.NewInt(math.MinInt64), math.MinInt64, false},
+		{"overflow positive", sdkmath.NewInt(math.MaxInt64).Add(sdkmath.OneInt()), 0, true},
+		{"overflow negative", sdkmath.NewInt(math.MinInt64).Sub(sdkmath.OneInt()), 0, true},
+		{"large positive", sdkmath.NewIntFromUint64(math.MaxUint64), 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeInt64(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SafeInt64() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SafeInt64() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSafeUint64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   sdkmath.Int
+		want    uint64
+		wantErr bool
+	}{
+		{"zero", sdkmath.ZeroInt(), 0, false},
+		{"positive", sdkmath.NewInt(12345), 12345, false},
+		{"negative", sdkmath.NewInt(-1), 0, true},
+		{"max int64", sdkmath.NewInt(math.MaxInt64), math.MaxInt64, false},
+		{"max uint64", sdkmath.NewIntFromUint64(math.MaxUint64), math.MaxUint64, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeUint64(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SafeUint64() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SafeUint64() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSafeMultiply(t *testing.T) {
+	tests := []struct {
+		name    string
+		a       int64
+		b       int64
+		want    int64
+		wantErr bool
+	}{
+		{"zero", 0, 12345, 0, false},
+		{"positive", 100, 200, 20000, false},
+		{"negative", -10, 20, -200, false},
+		{"overflow", math.MaxInt64, 2, 0, true},
+		{"large values", 1000000000, 1000000000, 1000000000000000000, false},
+		{"overflow large", 1000000000, 10000000000, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeMultiply(tt.a, tt.b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SafeMultiply() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SafeMultiply() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSafeAdd(t *testing.T) {
+	tests := []struct {
+		name    string
+		a       int64
+		b       int64
+		want    int64
+		wantErr bool
+	}{
+		{"zero", 0, 0, 0, false},
+		{"positive", 100, 200, 300, false},
+		{"negative", -10, 20, 10, false},
+		{"overflow positive", math.MaxInt64, 1, 0, true},
+		{"overflow negative", math.MinInt64, -1, 0, true},
+		{"near max", math.MaxInt64 - 1, 1, math.MaxInt64, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeAdd(tt.a, tt.b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SafeAdd() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SafeAdd() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClampToInt64(t *testing.T) {
+	tests := []struct {
+		name  string
+		input sdkmath.Int
+		want  int64
+	}{
+		{"zero", sdkmath.ZeroInt(), 0},
+		{"positive", sdkmath.NewInt(12345), 12345},
+		{"max int64", sdkmath.NewInt(math.MaxInt64), math.MaxInt64},
+		{"beyond max", sdkmath.NewInt(math.MaxInt64).Add(sdkmath.NewInt(1000)), math.MaxInt64},
+		{"min int64", sdkmath.NewInt(math.MinInt64), math.MinInt64},
+		{"below min", sdkmath.NewInt(math.MinInt64).Sub(sdkmath.NewInt(1000)), math.MinInt64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClampToInt64(tt.input)
+			if got != tt.want {
+				t.Errorf("ClampToInt64() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMustSafeInt64Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("MustSafeInt64 should panic on overflow")
+		}
+	}()
+
+	overflow := sdkmath.NewInt(math.MaxInt64).Add(sdkmath.OneInt())
+	MustSafeInt64(overflow)
+}
+
+func TestSafeInt64OrDefault(t *testing.T) {
+	overflow := sdkmath.NewInt(math.MaxInt64).Add(sdkmath.OneInt())
+	result := SafeInt64OrDefault(overflow, -999)
+	if result != -999 {
+		t.Errorf("SafeInt64OrDefault should return default on overflow, got %d", result)
+	}
+
+	normal := sdkmath.NewInt(42)
+	result = SafeInt64OrDefault(normal, -999)
+	if result != 42 {
+		t.Errorf("SafeInt64OrDefault should return value, got %d", result)
+	}
+}
+
+func TestCheckMultiplicationOverflow(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        int64
+		b        int64
+		overflow bool
+	}{
+		{"no overflow", 100, 200, false},
+		{"zero", 0, math.MaxInt64, false},
+		{"overflow", math.MaxInt64, 2, true},
+		{"negative overflow", math.MinInt64, 2, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CheckMultiplicationOverflow(tt.a, tt.b); got != tt.overflow {
+				t.Errorf("CheckMultiplicationOverflow() = %v, want %v", got, tt.overflow)
+			}
+		})
+	}
+}

--- a/pkg/security/path.go
+++ b/pkg/security/path.go
@@ -1,0 +1,253 @@
+// Package security provides security utilities for path validation and safe file operations.
+package security
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Common error messages for path traversal detection
+var (
+	ErrPathTraversal     = fmt.Errorf("path traversal detected")
+	ErrPathNotAllowed    = fmt.Errorf("path not in allowed directories")
+	ErrInvalidPath       = fmt.Errorf("invalid path")
+	ErrPathNotAbsolute   = fmt.Errorf("path must be absolute")
+	ErrInvalidExtension  = fmt.Errorf("invalid file extension")
+)
+
+// PathValidator provides path validation to prevent directory traversal attacks.
+type PathValidator struct {
+	baseDir           string
+	allowedDirs       []string
+	allowedExtensions []string
+	requireAbsolute   bool
+}
+
+// PathValidatorOption configures a PathValidator.
+type PathValidatorOption func(*PathValidator)
+
+// WithAllowedDirs sets allowed directories for path validation.
+func WithAllowedDirs(dirs ...string) PathValidatorOption {
+	return func(v *PathValidator) {
+		v.allowedDirs = append(v.allowedDirs, dirs...)
+	}
+}
+
+// WithAllowedExtensions sets allowed file extensions.
+func WithAllowedExtensions(exts ...string) PathValidatorOption {
+	return func(v *PathValidator) {
+		v.allowedExtensions = append(v.allowedExtensions, exts...)
+	}
+}
+
+// WithRequireAbsolute requires paths to be absolute.
+func WithRequireAbsolute(require bool) PathValidatorOption {
+	return func(v *PathValidator) {
+		v.requireAbsolute = require
+	}
+}
+
+// NewPathValidator creates a new PathValidator with the specified base directory.
+func NewPathValidator(baseDir string, opts ...PathValidatorOption) *PathValidator {
+	v := &PathValidator{
+		baseDir:     baseDir,
+		allowedDirs: []string{baseDir},
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
+}
+
+// ValidatePath ensures the path doesn't escape allowed directories and is safe.
+// It checks for traversal sequences, resolves symlinks, and validates against allowed dirs.
+func (v *PathValidator) ValidatePath(path string) error {
+	if path == "" {
+		return ErrInvalidPath
+	}
+
+	// Clean the path first
+	cleanPath := filepath.Clean(path)
+
+	// Check for traversal attempts in the original path
+	if ContainsTraversalSequence(path) {
+		return fmt.Errorf("%w: %s", ErrPathTraversal, path)
+	}
+
+	// Check for traversal in cleaned path (handles cases like "foo/../..")
+	if ContainsTraversalSequence(cleanPath) {
+		return fmt.Errorf("%w: %s", ErrPathTraversal, path)
+	}
+
+	// If require absolute and path is not absolute, error
+	if v.requireAbsolute && !filepath.IsAbs(cleanPath) {
+		return fmt.Errorf("%w: %s", ErrPathNotAbsolute, path)
+	}
+
+	// Resolve to absolute path for directory containment check
+	absPath, err := filepath.Abs(cleanPath)
+	if err != nil {
+		return fmt.Errorf("cannot resolve path: %w", err)
+	}
+
+	// Try to resolve symlinks if file exists
+	if _, err := os.Lstat(absPath); err == nil {
+		realPath, err := filepath.EvalSymlinks(absPath)
+		if err == nil {
+			absPath = realPath
+		}
+	}
+
+	// Check if path is within allowed directories
+	if len(v.allowedDirs) > 0 {
+		allowed := false
+		for _, dir := range v.allowedDirs {
+			absDir, err := filepath.Abs(dir)
+			if err != nil {
+				continue
+			}
+			// Normalize the directory path with separator
+			absDir = filepath.Clean(absDir) + string(filepath.Separator)
+			absPathNorm := filepath.Clean(absPath)
+
+			// Check if the path is exactly the allowed dir or starts with it
+			if absPathNorm == filepath.Clean(absDir[:len(absDir)-1]) ||
+				strings.HasPrefix(absPathNorm+string(filepath.Separator), absDir) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("%w: %s", ErrPathNotAllowed, path)
+		}
+	}
+
+	// Check file extension if restrictions are set
+	if len(v.allowedExtensions) > 0 {
+		ext := strings.ToLower(filepath.Ext(cleanPath))
+		allowed := false
+		for _, allowedExt := range v.allowedExtensions {
+			if strings.ToLower(allowedExt) == ext {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("%w: got %s, expected one of %v", ErrInvalidExtension, ext, v.allowedExtensions)
+		}
+	}
+
+	return nil
+}
+
+// ValidateAndClean validates the path and returns the cleaned absolute path.
+func (v *PathValidator) ValidateAndClean(path string) (string, error) {
+	if err := v.ValidatePath(path); err != nil {
+		return "", err
+	}
+	return filepath.Abs(filepath.Clean(path))
+}
+
+// ContainsTraversalSequence checks if a path contains directory traversal sequences.
+// This includes various encoding forms of "../" and "..\\".
+func ContainsTraversalSequence(path string) bool {
+	// Check for standard traversal patterns
+	patterns := []string{
+		"..",                   // Standard parent directory
+		"%2e%2e",               // URL encoded ..
+		"%2E%2E",               // URL encoded .. (uppercase)
+		"%252e%252e",           // Double URL encoded
+		"..%2f",                // Mixed encoding
+		"..%5c",                // Mixed encoding (Windows)
+		"%2e%2e%2f",            // URL encoded ../
+		"%2e%2e%5c",            // URL encoded ..\
+		"....//",               // Extended traversal
+		"....\\\\",             // Extended traversal (Windows)
+		"\x00",                 // Null byte injection
+	}
+
+	lowerPath := strings.ToLower(path)
+	for _, pattern := range patterns {
+		if strings.Contains(lowerPath, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ValidateCLIPath validates a path from CLI input without directory restrictions.
+// It only checks for traversal sequences and null bytes.
+func ValidateCLIPath(path string) error {
+	if path == "" {
+		return ErrInvalidPath
+	}
+
+	if ContainsTraversalSequence(path) {
+		return fmt.Errorf("%w: %s", ErrPathTraversal, path)
+	}
+
+	// Check for null bytes
+	if strings.ContainsRune(path, '\x00') {
+		return fmt.Errorf("%w: null byte in path", ErrPathTraversal)
+	}
+
+	return nil
+}
+
+// ValidateCLIPathWithExtension validates a CLI path and checks for allowed extensions.
+func ValidateCLIPathWithExtension(path string, allowedExtensions ...string) error {
+	if err := ValidateCLIPath(path); err != nil {
+		return err
+	}
+
+	if len(allowedExtensions) > 0 {
+		ext := strings.ToLower(filepath.Ext(path))
+		for _, allowed := range allowedExtensions {
+			if strings.ToLower(allowed) == ext {
+				return nil
+			}
+		}
+		return fmt.Errorf("%w: got %s, expected one of %v", ErrInvalidExtension, ext, allowedExtensions)
+	}
+
+	return nil
+}
+
+// SafeReadFile reads a file after validating the path for traversal attacks.
+func SafeReadFile(path string) ([]byte, error) {
+	if err := ValidateCLIPath(path); err != nil {
+		return nil, err
+	}
+	cleanPath := filepath.Clean(path)
+	return os.ReadFile(cleanPath) // #nosec G304 -- path validated above
+}
+
+// SafeReadFileWithExtension reads a file after validating path and extension.
+func SafeReadFileWithExtension(path string, allowedExtensions ...string) ([]byte, error) {
+	if err := ValidateCLIPathWithExtension(path, allowedExtensions...); err != nil {
+		return nil, err
+	}
+	cleanPath := filepath.Clean(path)
+	return os.ReadFile(cleanPath) // #nosec G304 -- path validated above
+}
+
+// SafeOpen opens a file after validating the path for traversal attacks.
+func SafeOpen(path string) (*os.File, error) {
+	if err := ValidateCLIPath(path); err != nil {
+		return nil, err
+	}
+	cleanPath := filepath.Clean(path)
+	return os.Open(cleanPath) // #nosec G304 -- path validated above
+}
+
+// SafeOpenWithExtension opens a file after validating path and extension.
+func SafeOpenWithExtension(path string, allowedExtensions ...string) (*os.File, error) {
+	if err := ValidateCLIPathWithExtension(path, allowedExtensions...); err != nil {
+		return nil, err
+	}
+	cleanPath := filepath.Clean(path)
+	return os.Open(cleanPath) // #nosec G304 -- path validated above
+}

--- a/pkg/security/path_test.go
+++ b/pkg/security/path_test.go
@@ -1,0 +1,265 @@
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestContainsTraversalSequence(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		// Should detect traversal
+		{"standard parent", "..", true},
+		{"parent with slash", "../", true},
+		{"parent in path", "foo/../bar", true},
+		{"double parent", "foo/../../bar", true},
+		{"URL encoded", "%2e%2e", true},
+		{"URL encoded uppercase", "%2E%2E", true},
+		{"double URL encoded", "%252e%252e", true},
+		{"mixed encoding forward", "..%2f", true},
+		{"mixed encoding back", "..%5c", true},
+		{"null byte", "foo\x00bar", true},
+		{"windows traversal", "..\\", true},
+		{"extended traversal", "....//", true},
+
+		// Should not detect traversal
+		{"normal path", "foo/bar/baz", false},
+		{"absolute path", "/usr/local/bin", false},
+		{"dots in filename", "foo.bar.baz", false},
+		{"single dot", "./foo", false},
+		{"extension with dots", "file.tar.gz", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ContainsTraversalSequence(tt.path)
+			if result != tt.expected {
+				t.Errorf("ContainsTraversalSequence(%q) = %v, want %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateCLIPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"valid relative", "config/file.json", false},
+		{"valid absolute", "/etc/config.json", false},
+		{"traversal attack", "../../../etc/passwd", true},
+		{"null byte", "file\x00.json", true},
+		{"empty path", "", true},
+		{"URL encoded traversal", "%2e%2e/secret", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCLIPath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCLIPath(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCLIPathWithExtension(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		extensions []string
+		wantErr    bool
+	}{
+		{"valid json", "config.json", []string{".json"}, false},
+		{"valid JSON uppercase", "CONFIG.JSON", []string{".json"}, false},
+		{"invalid extension", "config.yaml", []string{".json"}, true},
+		{"no extension check", "config.yaml", nil, false},
+		{"multiple extensions allowed", "file.json", []string{".yaml", ".json"}, false},
+		{"traversal with valid ext", "../secret.json", []string{".json"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCLIPathWithExtension(tt.path, tt.extensions...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCLIPathWithExtension(%q, %v) error = %v, wantErr %v",
+					tt.path, tt.extensions, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPathValidator(t *testing.T) {
+	// Create a temp directory structure for testing
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	testFile := filepath.Join(subDir, "test.json")
+	if err := os.WriteFile(testFile, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	v := NewPathValidator(tmpDir,
+		WithAllowedExtensions(".json", ".yaml"),
+	)
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"valid file in allowed dir", testFile, false},
+		{"traversal attack", filepath.Join(tmpDir, "..", "etc", "passwd"), true},
+		{"outside base dir", "/etc/passwd", true},
+		{"null byte attack", filepath.Join(tmpDir, "foo\x00bar"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidatePath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePath(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPathValidatorWithMultipleDirs(t *testing.T) {
+	tmpDir1 := t.TempDir()
+	tmpDir2 := t.TempDir()
+
+	file1 := filepath.Join(tmpDir1, "file1.txt")
+	file2 := filepath.Join(tmpDir2, "file2.txt")
+	if err := os.WriteFile(file1, []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file2, []byte("2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	v := NewPathValidator(tmpDir1, WithAllowedDirs(tmpDir2))
+
+	// Both directories should be allowed
+	if err := v.ValidatePath(file1); err != nil {
+		t.Errorf("file1 should be allowed: %v", err)
+	}
+	if err := v.ValidatePath(file2); err != nil {
+		t.Errorf("file2 should be allowed: %v", err)
+	}
+
+	// Other directories should not be allowed
+	if err := v.ValidatePath("/etc/passwd"); err == nil {
+		t.Error("external file should not be allowed")
+	}
+}
+
+func TestSafeReadFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.txt")
+	testContent := []byte("test content")
+	if err := os.WriteFile(testFile, testContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid read
+	content, err := SafeReadFile(testFile)
+	if err != nil {
+		t.Errorf("SafeReadFile failed: %v", err)
+	}
+	if string(content) != string(testContent) {
+		t.Errorf("content mismatch: got %q, want %q", content, testContent)
+	}
+
+	// Traversal attack
+	_, err = SafeReadFile("../../../etc/passwd")
+	if err == nil {
+		t.Error("SafeReadFile should reject traversal attack")
+	}
+
+	// Null byte attack
+	_, err = SafeReadFile("file\x00.txt")
+	if err == nil {
+		t.Error("SafeReadFile should reject null byte")
+	}
+}
+
+func TestSafeOpen(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid open
+	f, err := SafeOpen(testFile)
+	if err != nil {
+		t.Errorf("SafeOpen failed: %v", err)
+	}
+	if f != nil {
+		f.Close()
+	}
+
+	// Traversal attack
+	_, err = SafeOpen("../../../etc/passwd")
+	if err == nil {
+		t.Error("SafeOpen should reject traversal attack")
+	}
+}
+
+func TestSafeReadFileWithExtension(t *testing.T) {
+	tmpDir := t.TempDir()
+	jsonFile := filepath.Join(tmpDir, "test.json")
+	yamlFile := filepath.Join(tmpDir, "test.yaml")
+	if err := os.WriteFile(jsonFile, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(yamlFile, []byte("key: value"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid extension
+	_, err := SafeReadFileWithExtension(jsonFile, ".json")
+	if err != nil {
+		t.Errorf("SafeReadFileWithExtension failed for .json: %v", err)
+	}
+
+	// Invalid extension
+	_, err = SafeReadFileWithExtension(yamlFile, ".json")
+	if err == nil {
+		t.Error("SafeReadFileWithExtension should reject wrong extension")
+	}
+}
+
+func TestValidateAndClean(t *testing.T) {
+	tmpDir := t.TempDir()
+	v := NewPathValidator(tmpDir)
+
+	// Create a test file
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid path
+	cleaned, err := v.ValidateAndClean(testFile)
+	if err != nil {
+		t.Errorf("ValidateAndClean failed: %v", err)
+	}
+	if cleaned == "" {
+		t.Error("ValidateAndClean should return non-empty path")
+	}
+
+	// Invalid path
+	_, err = v.ValidateAndClean("../../../etc/passwd")
+	if err == nil {
+		t.Error("ValidateAndClean should reject traversal")
+	}
+}

--- a/pkg/security/permissions.go
+++ b/pkg/security/permissions.go
@@ -1,0 +1,232 @@
+package security
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// File permission constants for secure file storage
+const (
+	// KeyDirPerm is the permission for directories containing sensitive key material
+	KeyDirPerm os.FileMode = 0700
+	// KeyFilePerm is the permission for files containing sensitive key material
+	KeyFilePerm os.FileMode = 0600
+	// ConfigDirPerm is the permission for configuration directories
+	ConfigDirPerm os.FileMode = 0750
+	// ConfigFilePerm is the permission for configuration files
+	ConfigFilePerm os.FileMode = 0640
+)
+
+// SecureKeyStorage provides secure key file path validation and permission enforcement.
+type SecureKeyStorage struct {
+	baseDir   string
+	validator *PathValidator
+}
+
+// NewSecureKeyStorage creates a new SecureKeyStorage with the specified base directory.
+func NewSecureKeyStorage(baseDir string) (*SecureKeyStorage, error) {
+	if baseDir == "" {
+		return nil, fmt.Errorf("base directory is required")
+	}
+
+	// Create base directory with secure permissions if it doesn't exist
+	if err := os.MkdirAll(baseDir, KeyDirPerm); err != nil {
+		return nil, fmt.Errorf("failed to create key storage directory: %w", err)
+	}
+
+	// Verify permissions on the directory (skip on Windows)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(baseDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat key storage directory: %w", err)
+		}
+		if perm := info.Mode().Perm(); perm&0077 != 0 {
+			return nil, fmt.Errorf("key storage directory %s has insecure permissions %o (expected %o)",
+				baseDir, perm, KeyDirPerm)
+		}
+	}
+
+	return &SecureKeyStorage{
+		baseDir: baseDir,
+		validator: NewPathValidator(baseDir,
+			WithAllowedExtensions(".key", ".json", ".pem"),
+		),
+	}, nil
+}
+
+// ValidateKeyPath validates that a key file path is safe and within the storage directory.
+func (s *SecureKeyStorage) ValidateKeyPath(keyPath string) error {
+	return s.validator.ValidatePath(keyPath)
+}
+
+// GetKeyFilePath returns a safe path for a key file within the storage directory.
+func (s *SecureKeyStorage) GetKeyFilePath(keyID string) (string, error) {
+	// Sanitize key ID to prevent directory traversal
+	safeKeyID := filepath.Base(keyID)
+	if safeKeyID != keyID || safeKeyID == "." || safeKeyID == ".." {
+		return "", fmt.Errorf("%w: invalid key ID: %s", ErrPathTraversal, keyID)
+	}
+
+	path := filepath.Join(s.baseDir, safeKeyID+".key.json")
+	return path, nil
+}
+
+// EnsureSecurePermissions ensures a file has secure permissions.
+func (s *SecureKeyStorage) EnsureSecurePermissions(path string) error {
+	// Validate path first
+	if err := s.validator.ValidatePath(path); err != nil {
+		return err
+	}
+
+	// On Windows, file permissions work differently
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
+	// Check current permissions
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	currentPerm := info.Mode().Perm()
+
+	// Determine expected permission based on file type
+	expectedPerm := KeyFilePerm
+	if info.IsDir() {
+		expectedPerm = KeyDirPerm
+	}
+
+	// Check if permissions are too permissive
+	if currentPerm&0077 != 0 {
+		// Try to fix permissions
+		if err := os.Chmod(path, expectedPerm); err != nil {
+			return fmt.Errorf("failed to set secure permissions on %s (current: %o, expected: %o): %w",
+				path, currentPerm, expectedPerm, err)
+		}
+	}
+
+	return nil
+}
+
+// WriteSecureFile writes data to a file with secure permissions.
+func (s *SecureKeyStorage) WriteSecureFile(path string, data []byte) error {
+	// Validate path
+	if err := s.validator.ValidatePath(path); err != nil {
+		return err
+	}
+
+	cleanPath := filepath.Clean(path)
+
+	// Write file with secure permissions
+	if err := os.WriteFile(cleanPath, data, KeyFilePerm); err != nil { // #nosec G306 -- intentional secure permissions
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}
+
+// ReadSecureFile reads data from a file after validating its path.
+func (s *SecureKeyStorage) ReadSecureFile(path string) ([]byte, error) {
+	// Validate path
+	if err := s.validator.ValidatePath(path); err != nil {
+		return nil, err
+	}
+
+	cleanPath := filepath.Clean(path)
+
+	data, err := os.ReadFile(cleanPath) // #nosec G304 -- path validated above
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return data, nil
+}
+
+// BaseDir returns the base directory for key storage.
+func (s *SecureKeyStorage) BaseDir() string {
+	return s.baseDir
+}
+
+// StateFileValidator provides validation for state files in a designated directory.
+type StateFileValidator struct {
+	dataDir   string
+	validator *PathValidator
+}
+
+// NewStateFileValidator creates a validator for state files within a data directory.
+func NewStateFileValidator(dataDir string) (*StateFileValidator, error) {
+	if dataDir == "" {
+		return nil, fmt.Errorf("data directory is required")
+	}
+
+	// Create data directory if it doesn't exist
+	if err := os.MkdirAll(dataDir, ConfigDirPerm); err != nil {
+		return nil, fmt.Errorf("failed to create data directory: %w", err)
+	}
+
+	return &StateFileValidator{
+		dataDir: dataDir,
+		validator: NewPathValidator(dataDir,
+			WithAllowedExtensions(".json", ".state", ".dat", ".db"),
+		),
+	}, nil
+}
+
+// ValidatePath validates a state file path.
+func (v *StateFileValidator) ValidatePath(path string) error {
+	return v.validator.ValidatePath(path)
+}
+
+// ValidateAndClean validates and returns the cleaned path.
+func (v *StateFileValidator) ValidateAndClean(path string) (string, error) {
+	return v.validator.ValidateAndClean(path)
+}
+
+// GetStateFilePath returns a safe path for a state file within the data directory.
+func (v *StateFileValidator) GetStateFilePath(filename string) (string, error) {
+	// Sanitize filename
+	safeName := filepath.Base(filename)
+	if safeName != filename || safeName == "." || safeName == ".." {
+		return "", fmt.Errorf("%w: invalid filename: %s", ErrPathTraversal, filename)
+	}
+
+	path := filepath.Join(v.dataDir, safeName)
+	return path, nil
+}
+
+// SafeWriteStateFile writes state data atomically with validation.
+func (v *StateFileValidator) SafeWriteStateFile(path string, data []byte) error {
+	if err := v.validator.ValidatePath(path); err != nil {
+		return err
+	}
+
+	cleanPath := filepath.Clean(path)
+
+	// Write to temp file first for atomic operation
+	dir := filepath.Dir(cleanPath)
+	tmp := filepath.Join(dir, ".tmp."+filepath.Base(cleanPath))
+
+	if err := os.WriteFile(tmp, data, ConfigFilePerm); err != nil { // #nosec G306 -- intentional permissions
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	if err := os.Rename(tmp, cleanPath); err != nil {
+		os.Remove(tmp) // Clean up temp file on rename failure
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	return nil
+}
+
+// SafeReadStateFile reads state data with validation.
+func (v *StateFileValidator) SafeReadStateFile(path string) ([]byte, error) {
+	if err := v.validator.ValidatePath(path); err != nil {
+		return nil, err
+	}
+
+	cleanPath := filepath.Clean(path)
+	return os.ReadFile(cleanPath) // #nosec G304 -- path validated above
+}

--- a/pkg/security/permissions_test.go
+++ b/pkg/security/permissions_test.go
@@ -1,0 +1,219 @@
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSecureKeyStorage(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	storage, err := NewSecureKeyStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("NewSecureKeyStorage failed: %v", err)
+	}
+
+	t.Run("GetKeyFilePath", func(t *testing.T) {
+		tests := []struct {
+			keyID   string
+			wantErr bool
+		}{
+			{"mykey", false},
+			{"key-123", false},
+			{"../secret", true},
+			{"foo/bar", true},
+			{"..", true},
+			{".", true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.keyID, func(t *testing.T) {
+				path, err := storage.GetKeyFilePath(tt.keyID)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("GetKeyFilePath(%q) error = %v, wantErr %v", tt.keyID, err, tt.wantErr)
+				}
+				if err == nil && path == "" {
+					t.Error("GetKeyFilePath should return non-empty path on success")
+				}
+			})
+		}
+	})
+
+	t.Run("WriteAndReadSecureFile", func(t *testing.T) {
+		path := filepath.Join(tmpDir, "test.key.json")
+		testData := []byte(`{"key": "value"}`)
+
+		// Write file
+		if err := storage.WriteSecureFile(path, testData); err != nil {
+			t.Fatalf("WriteSecureFile failed: %v", err)
+		}
+
+		// Verify permissions on non-Windows systems
+		if runtime.GOOS != "windows" {
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("Failed to stat file: %v", err)
+			}
+			if perm := info.Mode().Perm(); perm != KeyFilePerm {
+				t.Errorf("File permissions = %o, want %o", perm, KeyFilePerm)
+			}
+		}
+
+		// Read file
+		data, err := storage.ReadSecureFile(path)
+		if err != nil {
+			t.Fatalf("ReadSecureFile failed: %v", err)
+		}
+		if string(data) != string(testData) {
+			t.Errorf("Data mismatch: got %q, want %q", data, testData)
+		}
+	})
+
+	t.Run("RejectPathTraversal", func(t *testing.T) {
+		// Try to write outside directory
+		err := storage.WriteSecureFile("../evil.txt", []byte("malicious"))
+		if err == nil {
+			t.Error("WriteSecureFile should reject path traversal")
+		}
+
+		// Try to read outside directory
+		_, err = storage.ReadSecureFile("../etc/passwd")
+		if err == nil {
+			t.Error("ReadSecureFile should reject path traversal")
+		}
+	})
+}
+
+func TestStateFileValidator(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	validator, err := NewStateFileValidator(tmpDir)
+	if err != nil {
+		t.Fatalf("NewStateFileValidator failed: %v", err)
+	}
+
+	t.Run("GetStateFilePath", func(t *testing.T) {
+		tests := []struct {
+			filename string
+			wantErr  bool
+		}{
+			{"state.json", false},
+			{"checkpoint.dat", false},
+			{"../secret.json", true},
+			{"foo/bar.json", true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.filename, func(t *testing.T) {
+				path, err := validator.GetStateFilePath(tt.filename)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("GetStateFilePath(%q) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
+				}
+				if err == nil && path == "" {
+					t.Error("GetStateFilePath should return non-empty path on success")
+				}
+			})
+		}
+	})
+
+	t.Run("SafeWriteAndReadStateFile", func(t *testing.T) {
+		path := filepath.Join(tmpDir, "test.state")
+		testData := []byte(`{"checkpoint": 12345}`)
+
+		// Write file
+		if err := validator.SafeWriteStateFile(path, testData); err != nil {
+			t.Fatalf("SafeWriteStateFile failed: %v", err)
+		}
+
+		// Read file
+		data, err := validator.SafeReadStateFile(path)
+		if err != nil {
+			t.Fatalf("SafeReadStateFile failed: %v", err)
+		}
+		if string(data) != string(testData) {
+			t.Errorf("Data mismatch: got %q, want %q", data, testData)
+		}
+	})
+
+	t.Run("AtomicWrite", func(t *testing.T) {
+		path := filepath.Join(tmpDir, "atomic.state")
+
+		// Write initial data
+		if err := validator.SafeWriteStateFile(path, []byte("v1")); err != nil {
+			t.Fatalf("Initial write failed: %v", err)
+		}
+
+		// Write new data
+		if err := validator.SafeWriteStateFile(path, []byte("v2")); err != nil {
+			t.Fatalf("Second write failed: %v", err)
+		}
+
+		// Verify latest data
+		data, err := validator.SafeReadStateFile(path)
+		if err != nil {
+			t.Fatalf("Read failed: %v", err)
+		}
+		if string(data) != "v2" {
+			t.Errorf("Data = %q, want %q", data, "v2")
+		}
+
+		// Verify no temp files left behind
+		matches, _ := filepath.Glob(filepath.Join(tmpDir, ".tmp.*"))
+		if len(matches) > 0 {
+			t.Errorf("Temp files not cleaned up: %v", matches)
+		}
+	})
+
+	t.Run("RejectPathTraversal", func(t *testing.T) {
+		// Try to write outside directory
+		err := validator.SafeWriteStateFile("../evil.state", []byte("bad"))
+		if err == nil {
+			t.Error("SafeWriteStateFile should reject path traversal")
+		}
+
+		// Try to read outside directory
+		_, err = validator.SafeReadStateFile("../etc/passwd")
+		if err == nil {
+			t.Error("SafeReadStateFile should reject path traversal")
+		}
+	})
+}
+
+func TestEnsureSecurePermissions(t *testing.T) {
+	// Skip permission tests on Windows
+	if runtime.GOOS == "windows" {
+		t.Skip("Permission tests not applicable on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	storage, err := NewSecureKeyStorage(tmpDir)
+	if err != nil {
+		t.Fatalf("NewSecureKeyStorage failed: %v", err)
+	}
+
+	t.Run("FixInsecurePermissions", func(t *testing.T) {
+		path := filepath.Join(tmpDir, "insecure.key")
+		if err := os.WriteFile(path, []byte("key"), 0644); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		}
+
+		// Verify initially insecure
+		info, _ := os.Stat(path)
+		if info.Mode().Perm() == KeyFilePerm {
+			t.Skip("File already has secure permissions")
+		}
+
+		// Fix permissions
+		if err := storage.EnsureSecurePermissions(path); err != nil {
+			t.Fatalf("EnsureSecurePermissions failed: %v", err)
+		}
+
+		// Verify fixed
+		info, _ = os.Stat(path)
+		if perm := info.Mode().Perm(); perm != KeyFilePerm {
+			t.Errorf("Permissions = %o, want %o", perm, KeyFilePerm)
+		}
+	})
+}

--- a/sdk/go/cli/auth_tips.go
+++ b/sdk/go/cli/auth_tips.go
@@ -2,12 +2,12 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/spf13/cobra"
 
 	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 func GetAuxToFeeCommand() *cobra.Command {
@@ -22,7 +22,7 @@ func GetAuxToFeeCommand() *cobra.Command {
 
 			auxSignerData := tx.AuxSignerData{}
 
-			bytes, err := os.ReadFile(args[0])
+			bytes, err := security.SafeReadFileWithExtension(args[0], ".json")
 			if err != nil {
 				return err
 			}

--- a/sdk/go/cli/enclave_tx.go
+++ b/sdk/go/cli/enclave_tx.go
@@ -11,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	"github.com/virtengine/virtengine/pkg/security"
 	enclavetypes "github.com/virtengine/virtengine/sdk/go/node/enclave/v1"
 )
 
@@ -148,8 +149,8 @@ Example:
 			}
 			var attestationQuote []byte
 			if _, err := os.Stat(attestationQuoteArg); err == nil {
-				// It's a file path
-				attestationQuote, err = os.ReadFile(attestationQuoteArg)
+				// It's a file path - validate before reading
+				attestationQuote, err = security.SafeReadFile(attestationQuoteArg)
 				if err != nil {
 					return fmt.Errorf("failed to read attestation quote file: %w", err)
 				}
@@ -271,7 +272,8 @@ Example:
 			}
 			var newAttestationQuote []byte
 			if _, err := os.Stat(attestationQuoteArg); err == nil {
-				newAttestationQuote, err = os.ReadFile(attestationQuoteArg)
+				// Validate path before reading
+				newAttestationQuote, err = security.SafeReadFile(attestationQuoteArg)
 				if err != nil {
 					return fmt.Errorf("failed to read attestation quote file: %w", err)
 				}

--- a/sdk/go/cli/gov_tx.go
+++ b/sdk/go/cli/gov_tx.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pkg/errors"
 
 	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	"github.com/virtengine/virtengine/pkg/security"
 
 	wtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 )
@@ -1672,7 +1673,8 @@ func parseSubmitProposal(cdc codec.Codec, path string) (ProposalMsg, []sdk.Msg, 
 	if path == "-" || (path == "" && !term.IsTerminal(0)) {
 		fl = os.Stdin
 	} else {
-		fl, err = os.Open(path)
+		// Validate path before opening
+		fl, err = security.SafeOpen(path)
 		if err != nil {
 			return proposal, nil, nil, err
 		}
@@ -1731,7 +1733,8 @@ func parseSubmitLegacyProposal(fs *pflag.FlagSet) (*legacyProposal, error) {
 		}
 	}
 
-	contents, err := os.ReadFile(proposalFile) //nolint: gosec
+	// Validate path before reading
+	contents, err := security.SafeReadFile(proposalFile)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/cli/keys_add.go
+++ b/sdk/go/cli/keys_add.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 
@@ -26,6 +25,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 const (
@@ -422,7 +422,7 @@ func printCreate(cmd *cobra.Command, k *keyring.Record, showMnemonic bool, mnemo
 }
 
 func readMnemonicFromFile(filePath string) (string, error) {
-	file, err := os.Open(filePath)
+	file, err := security.SafeOpen(filePath)
 	if err != nil {
 		return "", err
 	}

--- a/sdk/go/cli/keys_import.go
+++ b/sdk/go/cli/keys_import.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bufio"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 
 	"github.com/virtengine/virtengine/sdk/go/cli/flags"
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ImportKeyCommand imports private keys from a keyfile.
@@ -32,7 +32,7 @@ func ImportKeyCommand() *cobra.Command {
 			}
 			buf := bufio.NewReader(clientCtx.Input)
 
-			armor, err := os.ReadFile(args[1])
+			armor, err := security.SafeReadFile(args[1])
 			if err != nil {
 				return err
 			}

--- a/sdk/go/cli/provider_tx.go
+++ b/sdk/go/cli/provider_tx.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -12,6 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	"github.com/virtengine/virtengine/pkg/security"
 	types "github.com/virtengine/virtengine/sdk/go/node/provider/v1beta4"
 	tattr "github.com/virtengine/virtengine/sdk/go/node/types/attributes/v1"
 )
@@ -34,7 +34,7 @@ func (c ProviderConfig) GetAttributes() tattr.Attributes {
 
 // ReadProviderConfigPath reads and parses file
 func ReadProviderConfigPath(path string) (ProviderConfig, error) {
-	buf, err := os.ReadFile(path) //nolint: gosec
+	buf, err := security.SafeReadFile(path)
 	if err != nil {
 		return ProviderConfig{}, err
 	}

--- a/sdk/go/cli/sso.go
+++ b/sdk/go/cli/sso.go
@@ -7,10 +7,10 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/virtengine/virtengine/pkg/security"
 	veidtypes "github.com/virtengine/virtengine/x/veid/types"
 )
 
@@ -119,7 +119,7 @@ Example:
 			}
 
 			if policyFile != "" {
-				data, err := os.ReadFile(policyFile)
+				data, err := security.SafeReadFileWithExtension(policyFile, ".json")
 				if err != nil {
 					return fmt.Errorf("failed to read policy file: %w", err)
 				}
@@ -299,7 +299,7 @@ func getSSOConfigValidateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configFile := args[0]
 
-			data, err := os.ReadFile(configFile)
+			data, err := security.SafeReadFileWithExtension(configFile, ".json")
 			if err != nil {
 				return fmt.Errorf("failed to read config file: %w", err)
 			}

--- a/sdk/go/cli/staking_tx.go
+++ b/sdk/go/cli/staking_tx.go
@@ -24,6 +24,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	"github.com/virtengine/virtengine/pkg/security"
 	cclient "github.com/virtengine/virtengine/sdk/go/node/client/v1beta3"
 )
 
@@ -64,7 +65,7 @@ func parseAndValidateValidatorJSON(cdc codec.Codec, path string) (validator, err
 		MinSelfDelegation   string          `json:"min-self-delegation"`
 	}
 
-	contents, err := os.ReadFile(path) //nolint: gosec
+	contents, err := security.SafeReadFile(path)
 	if err != nil {
 		return validator{}, err
 	}

--- a/sdk/go/cli/vesting_tx.go
+++ b/sdk/go/cli/vesting_tx.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -14,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 
 	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // GetTxVestingCmd returns vesting module's transaction commands.
@@ -185,7 +185,7 @@ func GetTxVestingCreatePeriodicAccountCmd() *cobra.Command {
 				return err
 			}
 
-			contents, err := os.ReadFile(args[1])
+			contents, err := security.SafeReadFileWithExtension(args[1], ".json")
 			if err != nil {
 				return err
 			}

--- a/sdk/go/cli/wasm_parse.go
+++ b/sdk/go/cli/wasm_parse.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/distribution/reference"
 
 	cflags "github.com/virtengine/virtengine/sdk/go/cli/flags"
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 func ParseWasmVerificationFlags(gzippedWasm []byte, flags *flag.FlagSet) (string, string, []byte, error) {
@@ -72,7 +72,7 @@ func ParseWasmVerificationFlags(gzippedWasm []byte, flags *flag.FlagSet) (string
 
 // ParseWasmStoreCodeArgs prepares MsgStoreCode object from flags with gzipped wasm byte code field
 func ParseWasmStoreCodeArgs(file, sender string, flags *flag.FlagSet) (types.MsgStoreCode, error) {
-	wasm, err := os.ReadFile(file)
+	wasm, err := security.SafeReadFile(file)
 	if err != nil {
 		return types.MsgStoreCode{}, err
 	}

--- a/x/enclave/client/cli/tx.go
+++ b/x/enclave/client/cli/tx.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -17,6 +16,7 @@ import (
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
 	v1 "github.com/virtengine/virtengine/sdk/go/node/enclave/v1"
+	"github.com/virtengine/virtengine/pkg/security"
 	"github.com/virtengine/virtengine/x/enclave/types"
 )
 
@@ -173,7 +173,8 @@ Where proposal.json contains:
 func parseAddMeasurementProposalJSON(path string) (addMeasurementProposalJSON, error) {
 	var proposal addMeasurementProposalJSON
 
-	raw, err := os.ReadFile(path)
+	// Validate path and read with extension check
+	raw, err := security.SafeReadFileWithExtension(path, ".json")
 	if err != nil {
 		return proposal, err
 	}
@@ -201,7 +202,8 @@ func parseAddMeasurementProposalJSON(path string) (addMeasurementProposalJSON, e
 func parseRevokeMeasurementProposalJSON(path string) (revokeMeasurementProposalJSON, error) {
 	var proposal revokeMeasurementProposalJSON
 
-	raw, err := os.ReadFile(path)
+	// Validate path and read with extension check
+	raw, err := security.SafeReadFileWithExtension(path, ".json")
 	if err != nil {
 		return proposal, err
 	}

--- a/x/escrow/keeper/keeper.go
+++ b/x/escrow/keeper/keeper.go
@@ -191,7 +191,8 @@ func (k *keeper) AuthorizeDeposits(sctx sdk.Context, msg sdk.Msg) ([]etypes.Depo
 	dep := hasDeposit.GetDeposit()
 	denom := dep.Amount.Denom
 
-	remainder := sdkmath.NewInt(dep.Amount.Amount.Int64())
+	// Use the full sdkmath.Int directly to avoid Int64() overflow
+	remainder := dep.Amount.Amount
 
 	for _, source := range dep.Sources {
 		switch source {


### PR DESCRIPTION
…tection

- Create pkg/security package with PathValidator, SafeReadFile, SafeOpen
- Add ContainsTraversalSequence for detecting .., URL-encoded, null byte attacks
- Add overflow.go with SafeInt64, SafeUint64, SafeMultiply, SafeAdd
- Add permissions.go with SecureKeyStorage and StateFileValidator

SDK CLI hardening:
- gov_tx.go: use security.SafeOpen/SafeReadFile for proposal files
- provider_tx.go, staking_tx.go, wasm_parse.go: use SafeReadFile
- keys_add.go, keys_import.go: use SafeOpen/SafeReadFile
- sso.go, auth_tips.go, vesting_tx.go: use SafeReadFileWithExtension
- enclave_tx.go: use SafeReadFile for attestation files

Provider daemon hardening:
- event_checkpoint_store.go: add validateStatePath
- waldur_bridge.go: handle checkpoint store errors

Verification keystorage:
- file.go: add validateKeyPath for path traversal protection

Integer overflow fixes:
- x/escrow/keeper/keeper.go: remove Int64() for large amounts
- pkg/ratelimit/redis_limiter.go: add bounds checking

Addresses CWE-22 (Path Traversal), CWE-190 (Integer Overflow) Resolves: #154, #155

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow-up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/virtengine/node/blob/main/CONTRIBUTING.md#paperwork-for-pull-requests))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration [tests](https://github.com/virtengine/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed
