### PR TITLE
refactor(hpc): 13C - Complete HPC module proto generation + test fixes

### DIFF
--- a/sdk/proto/node/virtengine/hpc/v1/genesis.proto
+++ b/sdk/proto/node/virtengine/hpc/v1/genesis.proto
@@ -1,0 +1,103 @@
+syntax = "proto3";
+package virtengine.hpc.v1;
+
+import "gogoproto/gogo.proto";
+import "virtengine/hpc/v1/types.proto";
+
+option go_package = "github.com/virtengine/virtengine/sdk/go/node/hpc/v1";
+
+// GenesisState defines the hpc module's genesis state
+message GenesisState {
+  // Params are the module parameters
+  Params params = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "params",
+    (gogoproto.moretags) = "yaml:\"params\""
+  ];
+
+  // Clusters are the registered HPC clusters
+  repeated HPCCluster clusters = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "clusters",
+    (gogoproto.moretags) = "yaml:\"clusters\""
+  ];
+
+  // Offerings are the HPC offerings
+  repeated HPCOffering offerings = 3 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "offerings",
+    (gogoproto.moretags) = "yaml:\"offerings\""
+  ];
+
+  // Jobs are the HPC jobs
+  repeated HPCJob jobs = 4 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "jobs",
+    (gogoproto.moretags) = "yaml:\"jobs\""
+  ];
+
+  // JobAccountings are the job accounting records
+  repeated JobAccounting job_accountings = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "job_accountings",
+    (gogoproto.moretags) = "yaml:\"job_accountings\""
+  ];
+
+  // NodeMetadatas are the node metadata records
+  repeated NodeMetadata node_metadatas = 6 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "node_metadatas",
+    (gogoproto.moretags) = "yaml:\"node_metadatas\""
+  ];
+
+  // SchedulingDecisions are the scheduling decision records
+  repeated SchedulingDecision scheduling_decisions = 7 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "scheduling_decisions",
+    (gogoproto.moretags) = "yaml:\"scheduling_decisions\""
+  ];
+
+  // HPCRewards are the HPC reward records
+  repeated HPCRewardRecord hpc_rewards = 8 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "hpc_rewards",
+    (gogoproto.moretags) = "yaml:\"hpc_rewards\""
+  ];
+
+  // Disputes are the dispute records
+  repeated HPCDispute disputes = 9 [
+    (gogoproto.nullable) = false,
+    (gogoproto.jsontag) = "disputes",
+    (gogoproto.moretags) = "yaml:\"disputes\""
+  ];
+
+  // ClusterSequence is the next cluster sequence
+  uint64 cluster_sequence = 10 [
+    (gogoproto.jsontag) = "cluster_sequence",
+    (gogoproto.moretags) = "yaml:\"cluster_sequence\""
+  ];
+
+  // OfferingSequence is the next offering sequence
+  uint64 offering_sequence = 11 [
+    (gogoproto.jsontag) = "offering_sequence",
+    (gogoproto.moretags) = "yaml:\"offering_sequence\""
+  ];
+
+  // JobSequence is the next job sequence
+  uint64 job_sequence = 12 [
+    (gogoproto.jsontag) = "job_sequence",
+    (gogoproto.moretags) = "yaml:\"job_sequence\""
+  ];
+
+  // DecisionSequence is the next decision sequence
+  uint64 decision_sequence = 13 [
+    (gogoproto.jsontag) = "decision_sequence",
+    (gogoproto.moretags) = "yaml:\"decision_sequence\""
+  ];
+
+  // DisputeSequence is the next dispute sequence
+  uint64 dispute_sequence = 14 [
+    (gogoproto.jsontag) = "dispute_sequence",
+    (gogoproto.moretags) = "yaml:\"dispute_sequence\""
+  ];
+}

--- a/sdk/proto/node/virtengine/hpc/v1/query.proto
+++ b/sdk/proto/node/virtengine/hpc/v1/query.proto
@@ -3,167 +3,369 @@ package virtengine.hpc.v1;
 
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
+import "cosmos_proto/cosmos.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
-import "virtengine/hpc/v1/tx.proto";
+import "virtengine/hpc/v1/types.proto";
 
 option go_package = "github.com/virtengine/virtengine/sdk/go/node/hpc/v1";
 
 // Query defines the gRPC querier service for the hpc module
 service Query {
-  // Params queries the module parameters
-  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
-    option (google.api.http).get = "/virtengine/hpc/v1/params";
-  }
-
-  // Cluster queries a cluster by ID
+  // Cluster returns a cluster by ID
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc Cluster(QueryClusterRequest) returns (QueryClusterResponse) {
-    option (google.api.http).get = "/virtengine/hpc/v1/clusters/{cluster_id}";
+    option (google.api.http).get = "/virtengine/hpc/v1/cluster/{cluster_id}";
   }
 
-  // Clusters queries all clusters
+  // Clusters returns all clusters with optional filters
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc Clusters(QueryClustersRequest) returns (QueryClustersResponse) {
     option (google.api.http).get = "/virtengine/hpc/v1/clusters";
   }
 
-  // ClustersByOwner queries clusters by owner
-  rpc ClustersByOwner(QueryClustersByOwnerRequest) returns (QueryClustersByOwnerResponse) {
-    option (google.api.http).get = "/virtengine/hpc/v1/clusters/owner/{owner}";
+  // ClustersByProvider returns clusters owned by a provider
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc ClustersByProvider(QueryClustersByProviderRequest) returns (QueryClustersByProviderResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/clusters/provider/{provider_address}";
   }
 
-  // Offering queries an offering by ID
+  // Offering returns an offering by ID
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc Offering(QueryOfferingRequest) returns (QueryOfferingResponse) {
-    option (google.api.http).get = "/virtengine/hpc/v1/offerings/{offering_id}";
+    option (google.api.http).get = "/virtengine/hpc/v1/offering/{offering_id}";
   }
 
-  // Offerings queries all offerings
+  // Offerings returns all offerings with optional filters
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc Offerings(QueryOfferingsRequest) returns (QueryOfferingsResponse) {
     option (google.api.http).get = "/virtengine/hpc/v1/offerings";
   }
 
-  // OfferingsByCluster queries offerings by cluster
+  // OfferingsByCluster returns offerings for a cluster
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc OfferingsByCluster(QueryOfferingsByClusterRequest) returns (QueryOfferingsByClusterResponse) {
     option (google.api.http).get = "/virtengine/hpc/v1/offerings/cluster/{cluster_id}";
   }
 
-  // Job queries a job by ID
+  // Job returns a job by ID
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc Job(QueryJobRequest) returns (QueryJobResponse) {
-    option (google.api.http).get = "/virtengine/hpc/v1/jobs/{job_id}";
+    option (google.api.http).get = "/virtengine/hpc/v1/job/{job_id}";
   }
 
-  // Jobs queries all jobs
+  // Jobs returns all jobs with optional filters
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
   rpc Jobs(QueryJobsRequest) returns (QueryJobsResponse) {
     option (google.api.http).get = "/virtengine/hpc/v1/jobs";
   }
 
-  // JobsBySubmitter queries jobs by submitter
-  rpc JobsBySubmitter(QueryJobsBySubmitterRequest) returns (QueryJobsBySubmitterResponse) {
-    option (google.api.http).get = "/virtengine/hpc/v1/jobs/submitter/{submitter}";
+  // JobsByCustomer returns jobs submitted by a customer
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc JobsByCustomer(QueryJobsByCustomerRequest) returns (QueryJobsByCustomerResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/jobs/customer/{customer_address}";
+  }
+
+  // JobsByProvider returns jobs handled by a provider
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc JobsByProvider(QueryJobsByProviderRequest) returns (QueryJobsByProviderResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/jobs/provider/{provider_address}";
+  }
+
+  // JobAccounting returns accounting data for a job
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc JobAccounting(QueryJobAccountingRequest) returns (QueryJobAccountingResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/job/{job_id}/accounting";
+  }
+
+  // NodeMetadata returns metadata for a node
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc NodeMetadata(QueryNodeMetadataRequest) returns (QueryNodeMetadataResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/node/{node_id}";
+  }
+
+  // NodesByCluster returns nodes in a cluster
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc NodesByCluster(QueryNodesByClusterRequest) returns (QueryNodesByClusterResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/nodes/cluster/{cluster_id}";
+  }
+
+  // SchedulingDecision returns a scheduling decision by ID
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc SchedulingDecision(QuerySchedulingDecisionRequest) returns (QuerySchedulingDecisionResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/scheduling/{decision_id}";
+  }
+
+  // SchedulingDecisionByJob returns the scheduling decision for a job
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc SchedulingDecisionByJob(QuerySchedulingDecisionByJobRequest) returns (QuerySchedulingDecisionByJobResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/job/{job_id}/scheduling";
+  }
+
+  // Reward returns a reward record by ID
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc Reward(QueryRewardRequest) returns (QueryRewardResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/reward/{reward_id}";
+  }
+
+  // RewardsByJob returns rewards for a job
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc RewardsByJob(QueryRewardsByJobRequest) returns (QueryRewardsByJobResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/job/{job_id}/rewards";
+  }
+
+  // Dispute returns a dispute by ID
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc Dispute(QueryDisputeRequest) returns (QueryDisputeResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/dispute/{dispute_id}";
+  }
+
+  // Disputes returns all disputes with optional filters
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc Disputes(QueryDisputesRequest) returns (QueryDisputesResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/disputes";
+  }
+
+  // Params returns the module parameters
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+    option (google.api.http).get = "/virtengine/hpc/v1/params";
   }
 }
 
-// QueryParamsRequest is the request type for the Query/Params RPC method
+// QueryClusterRequest is the request for Query/Cluster
+message QueryClusterRequest {
+  string cluster_id = 1 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+}
+
+// QueryClusterResponse is the response for Query/Cluster
+message QueryClusterResponse {
+  HPCCluster cluster = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "cluster", (gogoproto.moretags) = "yaml:\"cluster\""];
+}
+
+// QueryClustersRequest is the request for Query/Clusters
+message QueryClustersRequest {
+  ClusterState state = 1 [(gogoproto.jsontag) = "state,omitempty", (gogoproto.moretags) = "yaml:\"state\""];
+  string region = 2 [(gogoproto.jsontag) = "region,omitempty", (gogoproto.moretags) = "yaml:\"region\""];
+  cosmos.base.query.v1beta1.PageRequest pagination = 3 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryClustersResponse is the response for Query/Clusters
+message QueryClustersResponse {
+  repeated HPCCluster clusters = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "clusters", (gogoproto.moretags) = "yaml:\"clusters\""];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryClustersByProviderRequest is the request for Query/ClustersByProvider
+message QueryClustersByProviderRequest {
+  string provider_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  cosmos.base.query.v1beta1.PageRequest pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryClustersByProviderResponse is the response for Query/ClustersByProvider
+message QueryClustersByProviderResponse {
+  repeated HPCCluster clusters = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "clusters", (gogoproto.moretags) = "yaml:\"clusters\""];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryOfferingRequest is the request for Query/Offering
+message QueryOfferingRequest {
+  string offering_id = 1 [(gogoproto.jsontag) = "offering_id", (gogoproto.moretags) = "yaml:\"offering_id\""];
+}
+
+// QueryOfferingResponse is the response for Query/Offering
+message QueryOfferingResponse {
+  HPCOffering offering = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "offering", (gogoproto.moretags) = "yaml:\"offering\""];
+}
+
+// QueryOfferingsRequest is the request for Query/Offerings
+message QueryOfferingsRequest {
+  bool active_only = 1 [(gogoproto.jsontag) = "active_only,omitempty", (gogoproto.moretags) = "yaml:\"active_only\""];
+  cosmos.base.query.v1beta1.PageRequest pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryOfferingsResponse is the response for Query/Offerings
+message QueryOfferingsResponse {
+  repeated HPCOffering offerings = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "offerings", (gogoproto.moretags) = "yaml:\"offerings\""];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryOfferingsByClusterRequest is the request for Query/OfferingsByCluster
+message QueryOfferingsByClusterRequest {
+  string cluster_id = 1 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  cosmos.base.query.v1beta1.PageRequest pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryOfferingsByClusterResponse is the response for Query/OfferingsByCluster
+message QueryOfferingsByClusterResponse {
+  repeated HPCOffering offerings = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "offerings", (gogoproto.moretags) = "yaml:\"offerings\""];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryJobRequest is the request for Query/Job
+message QueryJobRequest {
+  string job_id = 1 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+}
+
+// QueryJobResponse is the response for Query/Job
+message QueryJobResponse {
+  HPCJob job = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "job", (gogoproto.moretags) = "yaml:\"job\""];
+}
+
+// QueryJobsRequest is the request for Query/Jobs
+message QueryJobsRequest {
+  JobState state = 1 [(gogoproto.jsontag) = "state,omitempty", (gogoproto.moretags) = "yaml:\"state\""];
+  string cluster_id = 2 [(gogoproto.jsontag) = "cluster_id,omitempty", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  cosmos.base.query.v1beta1.PageRequest pagination = 3 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryJobsResponse is the response for Query/Jobs
+message QueryJobsResponse {
+  repeated HPCJob jobs = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "jobs", (gogoproto.moretags) = "yaml:\"jobs\""];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryJobsByCustomerRequest is the request for Query/JobsByCustomer
+message QueryJobsByCustomerRequest {
+  string customer_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "customer_address", (gogoproto.moretags) = "yaml:\"customer_address\""];
+  cosmos.base.query.v1beta1.PageRequest pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryJobsByCustomerResponse is the response for Query/JobsByCustomer
+message QueryJobsByCustomerResponse {
+  repeated HPCJob jobs = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "jobs", (gogoproto.moretags) = "yaml:\"jobs\""];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryJobsByProviderRequest is the request for Query/JobsByProvider
+message QueryJobsByProviderRequest {
+  string provider_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  cosmos.base.query.v1beta1.PageRequest pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryJobsByProviderResponse is the response for Query/JobsByProvider
+message QueryJobsByProviderResponse {
+  repeated HPCJob jobs = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "jobs", (gogoproto.moretags) = "yaml:\"jobs\""];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryJobAccountingRequest is the request for Query/JobAccounting
+message QueryJobAccountingRequest {
+  string job_id = 1 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+}
+
+// QueryJobAccountingResponse is the response for Query/JobAccounting
+message QueryJobAccountingResponse {
+  JobAccounting accounting = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "accounting", (gogoproto.moretags) = "yaml:\"accounting\""];
+}
+
+// QueryNodeMetadataRequest is the request for Query/NodeMetadata
+message QueryNodeMetadataRequest {
+  string node_id = 1 [(gogoproto.jsontag) = "node_id", (gogoproto.moretags) = "yaml:\"node_id\""];
+}
+
+// QueryNodeMetadataResponse is the response for Query/NodeMetadata
+message QueryNodeMetadataResponse {
+  NodeMetadata node = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "node", (gogoproto.moretags) = "yaml:\"node\""];
+}
+
+// QueryNodesByClusterRequest is the request for Query/NodesByCluster
+message QueryNodesByClusterRequest {
+  string cluster_id = 1 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  cosmos.base.query.v1beta1.PageRequest pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryNodesByClusterResponse is the response for Query/NodesByCluster
+message QueryNodesByClusterResponse {
+  repeated NodeMetadata nodes = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "nodes", (gogoproto.moretags) = "yaml:\"nodes\""];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QuerySchedulingDecisionRequest is the request for Query/SchedulingDecision
+message QuerySchedulingDecisionRequest {
+  string decision_id = 1 [(gogoproto.jsontag) = "decision_id", (gogoproto.moretags) = "yaml:\"decision_id\""];
+}
+
+// QuerySchedulingDecisionResponse is the response for Query/SchedulingDecision
+message QuerySchedulingDecisionResponse {
+  SchedulingDecision decision = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "decision", (gogoproto.moretags) = "yaml:\"decision\""];
+}
+
+// QuerySchedulingDecisionByJobRequest is the request for Query/SchedulingDecisionByJob
+message QuerySchedulingDecisionByJobRequest {
+  string job_id = 1 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+}
+
+// QuerySchedulingDecisionByJobResponse is the response for Query/SchedulingDecisionByJob
+message QuerySchedulingDecisionByJobResponse {
+  SchedulingDecision decision = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "decision", (gogoproto.moretags) = "yaml:\"decision\""];
+}
+
+// QueryRewardRequest is the request for Query/Reward
+message QueryRewardRequest {
+  string reward_id = 1 [(gogoproto.jsontag) = "reward_id", (gogoproto.moretags) = "yaml:\"reward_id\""];
+}
+
+// QueryRewardResponse is the response for Query/Reward
+message QueryRewardResponse {
+  HPCRewardRecord reward = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "reward", (gogoproto.moretags) = "yaml:\"reward\""];
+}
+
+// QueryRewardsByJobRequest is the request for Query/RewardsByJob
+message QueryRewardsByJobRequest {
+  string job_id = 1 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+}
+
+// QueryRewardsByJobResponse is the response for Query/RewardsByJob
+message QueryRewardsByJobResponse {
+  repeated HPCRewardRecord rewards = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "rewards", (gogoproto.moretags) = "yaml:\"rewards\""];
+}
+
+// QueryDisputeRequest is the request for Query/Dispute
+message QueryDisputeRequest {
+  string dispute_id = 1 [(gogoproto.jsontag) = "dispute_id", (gogoproto.moretags) = "yaml:\"dispute_id\""];
+}
+
+// QueryDisputeResponse is the response for Query/Dispute
+message QueryDisputeResponse {
+  HPCDispute dispute = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "dispute", (gogoproto.moretags) = "yaml:\"dispute\""];
+}
+
+// QueryDisputesRequest is the request for Query/Disputes
+message QueryDisputesRequest {
+  DisputeStatus status = 1 [(gogoproto.jsontag) = "status,omitempty", (gogoproto.moretags) = "yaml:\"status\""];
+  cosmos.base.query.v1beta1.PageRequest pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryDisputesResponse is the response for Query/Disputes
+message QueryDisputesResponse {
+  repeated HPCDispute disputes = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "disputes", (gogoproto.moretags) = "yaml:\"disputes\""];
+  cosmos.base.query.v1beta1.PageResponse pagination = 2 [(gogoproto.jsontag) = "pagination,omitempty", (gogoproto.moretags) = "yaml:\"pagination\""];
+}
+
+// QueryParamsRequest is the request for Query/Params
 message QueryParamsRequest {}
 
-// QueryParamsResponse is the response type for the Query/Params RPC method
+// QueryParamsResponse is the response for Query/Params
 message QueryParamsResponse {
-  Params params = 1 [(gogoproto.nullable) = false];
-}
-
-// QueryClusterRequest is the request type for the Query/Cluster RPC method
-message QueryClusterRequest {
-  string cluster_id = 1;
-}
-
-// QueryClusterResponse is the response type for the Query/Cluster RPC method
-message QueryClusterResponse {
-  Cluster cluster = 1 [(gogoproto.nullable) = false];
-}
-
-// QueryClustersRequest is the request type for the Query/Clusters RPC method
-message QueryClustersRequest {
-  cosmos.base.query.v1beta1.PageRequest pagination = 1;
-}
-
-// QueryClustersResponse is the response type for the Query/Clusters RPC method
-message QueryClustersResponse {
-  repeated Cluster clusters = 1 [(gogoproto.nullable) = false];
-  cosmos.base.query.v1beta1.PageResponse pagination = 2;
-}
-
-// QueryClustersByOwnerRequest is the request type for the Query/ClustersByOwner RPC method
-message QueryClustersByOwnerRequest {
-  string owner = 1;
-  cosmos.base.query.v1beta1.PageRequest pagination = 2;
-}
-
-// QueryClustersByOwnerResponse is the response type for the Query/ClustersByOwner RPC method
-message QueryClustersByOwnerResponse {
-  repeated Cluster clusters = 1 [(gogoproto.nullable) = false];
-  cosmos.base.query.v1beta1.PageResponse pagination = 2;
-}
-
-// QueryOfferingRequest is the request type for the Query/Offering RPC method
-message QueryOfferingRequest {
-  string offering_id = 1;
-}
-
-// QueryOfferingResponse is the response type for the Query/Offering RPC method
-message QueryOfferingResponse {
-  Offering offering = 1 [(gogoproto.nullable) = false];
-}
-
-// QueryOfferingsRequest is the request type for the Query/Offerings RPC method
-message QueryOfferingsRequest {
-  cosmos.base.query.v1beta1.PageRequest pagination = 1;
-}
-
-// QueryOfferingsResponse is the response type for the Query/Offerings RPC method
-message QueryOfferingsResponse {
-  repeated Offering offerings = 1 [(gogoproto.nullable) = false];
-  cosmos.base.query.v1beta1.PageResponse pagination = 2;
-}
-
-// QueryOfferingsByClusterRequest is the request type for the Query/OfferingsByCluster RPC method
-message QueryOfferingsByClusterRequest {
-  string cluster_id = 1;
-  cosmos.base.query.v1beta1.PageRequest pagination = 2;
-}
-
-// QueryOfferingsByClusterResponse is the response type for the Query/OfferingsByCluster RPC method
-message QueryOfferingsByClusterResponse {
-  repeated Offering offerings = 1 [(gogoproto.nullable) = false];
-  cosmos.base.query.v1beta1.PageResponse pagination = 2;
-}
-
-// QueryJobRequest is the request type for the Query/Job RPC method
-message QueryJobRequest {
-  string job_id = 1;
-}
-
-// QueryJobResponse is the response type for the Query/Job RPC method
-message QueryJobResponse {
-  Job job = 1 [(gogoproto.nullable) = false];
-}
-
-// QueryJobsRequest is the request type for the Query/Jobs RPC method
-message QueryJobsRequest {
-  cosmos.base.query.v1beta1.PageRequest pagination = 1;
-}
-
-// QueryJobsResponse is the response type for the Query/Jobs RPC method
-message QueryJobsResponse {
-  repeated Job jobs = 1 [(gogoproto.nullable) = false];
-  cosmos.base.query.v1beta1.PageResponse pagination = 2;
-}
-
-// QueryJobsBySubmitterRequest is the request type for the Query/JobsBySubmitter RPC method
-message QueryJobsBySubmitterRequest {
-  string submitter = 1;
-  cosmos.base.query.v1beta1.PageRequest pagination = 2;
-}
-
-// QueryJobsBySubmitterResponse is the response type for the Query/JobsBySubmitter RPC method
-message QueryJobsBySubmitterResponse {
-  repeated Job jobs = 1 [(gogoproto.nullable) = false];
-  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+  Params params = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "params", (gogoproto.moretags) = "yaml:\"params\""];
 }

--- a/sdk/proto/node/virtengine/hpc/v1/tx.proto
+++ b/sdk/proto/node/virtengine/hpc/v1/tx.proto
@@ -5,6 +5,8 @@ import "gogoproto/gogo.proto";
 import "cosmos_proto/cosmos.proto";
 import "cosmos/msg/v1/msg.proto";
 import "amino/amino.proto";
+import "cosmos/base/v1beta1/coin.proto";
+import "virtengine/hpc/v1/types.proto";
 
 option go_package = "github.com/virtengine/virtengine/sdk/go/node/hpc/v1";
 
@@ -15,82 +17,89 @@ service Msg {
   // RegisterCluster registers a new HPC cluster
   rpc RegisterCluster(MsgRegisterCluster) returns (MsgRegisterClusterResponse);
 
-  // UpdateCluster updates cluster information
+  // UpdateCluster updates an existing HPC cluster
   rpc UpdateCluster(MsgUpdateCluster) returns (MsgUpdateClusterResponse);
 
-  // DeregisterCluster removes a cluster
+  // DeregisterCluster deregisters an HPC cluster
   rpc DeregisterCluster(MsgDeregisterCluster) returns (MsgDeregisterClusterResponse);
 
   // CreateOffering creates a new HPC offering
   rpc CreateOffering(MsgCreateOffering) returns (MsgCreateOfferingResponse);
 
-  // UpdateOffering updates an offering
+  // UpdateOffering updates an existing HPC offering
   rpc UpdateOffering(MsgUpdateOffering) returns (MsgUpdateOfferingResponse);
 
   // SubmitJob submits a new HPC job
   rpc SubmitJob(MsgSubmitJob) returns (MsgSubmitJobResponse);
 
-  // CancelJob cancels a job
+  // CancelJob cancels an HPC job
   rpc CancelJob(MsgCancelJob) returns (MsgCancelJobResponse);
 
-  // ReportJobStatus reports job status
+  // ReportJobStatus reports job status from the provider daemon
   rpc ReportJobStatus(MsgReportJobStatus) returns (MsgReportJobStatusResponse);
 
   // UpdateNodeMetadata updates node metadata
   rpc UpdateNodeMetadata(MsgUpdateNodeMetadata) returns (MsgUpdateNodeMetadataResponse);
 
-  // FlagDispute flags a dispute for a job
+  // FlagDispute flags a dispute for moderation
   rpc FlagDispute(MsgFlagDispute) returns (MsgFlagDisputeResponse);
 
-  // ResolveDispute resolves a flagged dispute
+  // ResolveDispute resolves a dispute (moderator only)
   rpc ResolveDispute(MsgResolveDispute) returns (MsgResolveDisputeResponse);
+
+  // UpdateParams updates module parameters (governance only)
+  rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
 }
 
 // MsgRegisterCluster registers a new HPC cluster
 message MsgRegisterCluster {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "owner";
+  option (cosmos.msg.v1.signer) = "provider_address";
   option (amino.name) = "hpc/MsgRegisterCluster";
 
-  string owner = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string name = 2;
-  string cluster_type = 3;
-  string region = 4;
-  string endpoint = 5;
-  uint64 total_nodes = 6;
-  uint64 total_gpus = 7;
+  string provider_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string name = 2 [(gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
+  string description = 3 [(gogoproto.jsontag) = "description,omitempty", (gogoproto.moretags) = "yaml:\"description\""];
+  string region = 4 [(gogoproto.jsontag) = "region", (gogoproto.moretags) = "yaml:\"region\""];
+  repeated Partition partitions = 5 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "partitions", (gogoproto.moretags) = "yaml:\"partitions\""];
+  int32 total_nodes = 6 [(gogoproto.jsontag) = "total_nodes", (gogoproto.moretags) = "yaml:\"total_nodes\""];
+  ClusterMetadata cluster_metadata = 7 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "cluster_metadata", (gogoproto.moretags) = "yaml:\"cluster_metadata\""];
+  string slurm_version = 8 [(gogoproto.jsontag) = "slurm_version", (gogoproto.moretags) = "yaml:\"slurm_version\""];
 }
 
 // MsgRegisterClusterResponse is the response for MsgRegisterCluster
 message MsgRegisterClusterResponse {
-  string cluster_id = 1;
+  string cluster_id = 1 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
 }
 
-// MsgUpdateCluster updates cluster information
+// MsgUpdateCluster updates an existing HPC cluster
 message MsgUpdateCluster {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "owner";
+  option (cosmos.msg.v1.signer) = "provider_address";
   option (amino.name) = "hpc/MsgUpdateCluster";
 
-  string owner = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string cluster_id = 2;
-  string endpoint = 3;
-  uint64 total_nodes = 4;
-  uint64 total_gpus = 5;
-  bool active = 6;
+  string provider_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string cluster_id = 2 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  string name = 3 [(gogoproto.jsontag) = "name,omitempty", (gogoproto.moretags) = "yaml:\"name\""];
+  string description = 4 [(gogoproto.jsontag) = "description,omitempty", (gogoproto.moretags) = "yaml:\"description\""];
+  ClusterState state = 5 [(gogoproto.jsontag) = "state,omitempty", (gogoproto.moretags) = "yaml:\"state\""];
+  repeated Partition partitions = 6 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "partitions,omitempty", (gogoproto.moretags) = "yaml:\"partitions\""];
+  int32 total_nodes = 7 [(gogoproto.jsontag) = "total_nodes,omitempty", (gogoproto.moretags) = "yaml:\"total_nodes\""];
+  int32 available_nodes = 8 [(gogoproto.jsontag) = "available_nodes,omitempty", (gogoproto.moretags) = "yaml:\"available_nodes\""];
+  ClusterMetadata cluster_metadata = 9 [(gogoproto.jsontag) = "cluster_metadata,omitempty", (gogoproto.moretags) = "yaml:\"cluster_metadata\""];
 }
 
 // MsgUpdateClusterResponse is the response for MsgUpdateCluster
 message MsgUpdateClusterResponse {}
 
-// MsgDeregisterCluster removes a cluster
+// MsgDeregisterCluster deregisters an HPC cluster
 message MsgDeregisterCluster {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "owner";
+  option (cosmos.msg.v1.signer) = "provider_address";
   option (amino.name) = "hpc/MsgDeregisterCluster";
 
-  string owner = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string cluster_id = 2;
+  string provider_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string cluster_id = 2 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
 }
 
 // MsgDeregisterClusterResponse is the response for MsgDeregisterCluster
@@ -99,33 +108,43 @@ message MsgDeregisterClusterResponse {}
 // MsgCreateOffering creates a new HPC offering
 message MsgCreateOffering {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "provider";
+  option (cosmos.msg.v1.signer) = "provider_address";
   option (amino.name) = "hpc/MsgCreateOffering";
 
-  string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string cluster_id = 2;
-  string name = 3;
-  string resource_type = 4;
-  string price_per_hour = 5;
-  uint64 min_duration = 6;
-  uint64 max_duration = 7;
+  string provider_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string cluster_id = 2 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  string name = 3 [(gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
+  string description = 4 [(gogoproto.jsontag) = "description,omitempty", (gogoproto.moretags) = "yaml:\"description\""];
+  repeated QueueOption queue_options = 5 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "queue_options", (gogoproto.moretags) = "yaml:\"queue_options\""];
+  HPCPricing pricing = 6 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "pricing", (gogoproto.moretags) = "yaml:\"pricing\""];
+  int32 required_identity_threshold = 7 [(gogoproto.jsontag) = "required_identity_threshold", (gogoproto.moretags) = "yaml:\"required_identity_threshold\""];
+  int64 max_runtime_seconds = 8 [(gogoproto.jsontag) = "max_runtime_seconds", (gogoproto.moretags) = "yaml:\"max_runtime_seconds\""];
+  repeated PreconfiguredWorkload preconfigured_workloads = 9 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "preconfigured_workloads,omitempty", (gogoproto.moretags) = "yaml:\"preconfigured_workloads\""];
+  bool supports_custom_workloads = 10 [(gogoproto.jsontag) = "supports_custom_workloads", (gogoproto.moretags) = "yaml:\"supports_custom_workloads\""];
 }
 
 // MsgCreateOfferingResponse is the response for MsgCreateOffering
 message MsgCreateOfferingResponse {
-  string offering_id = 1;
+  string offering_id = 1 [(gogoproto.jsontag) = "offering_id", (gogoproto.moretags) = "yaml:\"offering_id\""];
 }
 
-// MsgUpdateOffering updates an offering
+// MsgUpdateOffering updates an existing HPC offering
 message MsgUpdateOffering {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "provider";
+  option (cosmos.msg.v1.signer) = "provider_address";
   option (amino.name) = "hpc/MsgUpdateOffering";
 
-  string provider = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string offering_id = 2;
-  string price_per_hour = 3;
-  bool active = 4;
+  string provider_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string offering_id = 2 [(gogoproto.jsontag) = "offering_id", (gogoproto.moretags) = "yaml:\"offering_id\""];
+  string name = 3 [(gogoproto.jsontag) = "name,omitempty", (gogoproto.moretags) = "yaml:\"name\""];
+  string description = 4 [(gogoproto.jsontag) = "description,omitempty", (gogoproto.moretags) = "yaml:\"description\""];
+  repeated QueueOption queue_options = 5 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "queue_options,omitempty", (gogoproto.moretags) = "yaml:\"queue_options\""];
+  HPCPricing pricing = 6 [(gogoproto.jsontag) = "pricing,omitempty", (gogoproto.moretags) = "yaml:\"pricing\""];
+  int32 required_identity_threshold = 7 [(gogoproto.jsontag) = "required_identity_threshold,omitempty", (gogoproto.moretags) = "yaml:\"required_identity_threshold\""];
+  int64 max_runtime_seconds = 8 [(gogoproto.jsontag) = "max_runtime_seconds,omitempty", (gogoproto.moretags) = "yaml:\"max_runtime_seconds\""];
+  repeated PreconfiguredWorkload preconfigured_workloads = 9 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "preconfigured_workloads,omitempty", (gogoproto.moretags) = "yaml:\"preconfigured_workloads\""];
+  bool supports_custom_workloads = 10 [(gogoproto.jsontag) = "supports_custom_workloads,omitempty", (gogoproto.moretags) = "yaml:\"supports_custom_workloads\""];
+  bool active = 11 [(gogoproto.jsontag) = "active,omitempty", (gogoproto.moretags) = "yaml:\"active\""];
 }
 
 // MsgUpdateOfferingResponse is the response for MsgUpdateOffering
@@ -134,49 +153,56 @@ message MsgUpdateOfferingResponse {}
 // MsgSubmitJob submits a new HPC job
 message MsgSubmitJob {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "submitter";
+  option (cosmos.msg.v1.signer) = "customer_address";
   option (amino.name) = "hpc/MsgSubmitJob";
 
-  string submitter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string offering_id = 2;
-  string job_script = 3;
-  uint64 requested_nodes = 4;
-  uint64 requested_gpus = 5;
-  uint64 max_duration = 6;
-  string max_budget = 7;
+  string customer_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "customer_address", (gogoproto.moretags) = "yaml:\"customer_address\""];
+  string offering_id = 2 [(gogoproto.jsontag) = "offering_id", (gogoproto.moretags) = "yaml:\"offering_id\""];
+  string queue_name = 3 [(gogoproto.jsontag) = "queue_name", (gogoproto.moretags) = "yaml:\"queue_name\""];
+  JobWorkloadSpec workload_spec = 4 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "workload_spec", (gogoproto.moretags) = "yaml:\"workload_spec\""];
+  JobResources resources = 5 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "resources", (gogoproto.moretags) = "yaml:\"resources\""];
+  repeated DataReference data_references = 6 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "data_references,omitempty", (gogoproto.moretags) = "yaml:\"data_references\""];
+  string encrypted_inputs_pointer = 7 [(gogoproto.jsontag) = "encrypted_inputs_pointer,omitempty", (gogoproto.moretags) = "yaml:\"encrypted_inputs_pointer\""];
+  string encrypted_outputs_pointer = 8 [(gogoproto.jsontag) = "encrypted_outputs_pointer,omitempty", (gogoproto.moretags) = "yaml:\"encrypted_outputs_pointer\""];
+  int64 max_runtime_seconds = 9 [(gogoproto.jsontag) = "max_runtime_seconds", (gogoproto.moretags) = "yaml:\"max_runtime_seconds\""];
+  repeated cosmos.base.v1beta1.Coin max_price = 10 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins", (gogoproto.jsontag) = "max_price", (gogoproto.moretags) = "yaml:\"max_price\""];
 }
 
 // MsgSubmitJobResponse is the response for MsgSubmitJob
 message MsgSubmitJobResponse {
-  string job_id = 1;
+  string job_id = 1 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+  string escrow_id = 2 [(gogoproto.jsontag) = "escrow_id", (gogoproto.moretags) = "yaml:\"escrow_id\""];
 }
 
-// MsgCancelJob cancels a job
+// MsgCancelJob cancels an HPC job
 message MsgCancelJob {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "sender";
+  option (cosmos.msg.v1.signer) = "requester_address";
   option (amino.name) = "hpc/MsgCancelJob";
 
-  string sender = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string job_id = 2;
-  string reason = 3;
+  string requester_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "requester_address", (gogoproto.moretags) = "yaml:\"requester_address\""];
+  string job_id = 2 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+  string reason = 3 [(gogoproto.jsontag) = "reason,omitempty", (gogoproto.moretags) = "yaml:\"reason\""];
 }
 
 // MsgCancelJobResponse is the response for MsgCancelJob
 message MsgCancelJobResponse {}
 
-// MsgReportJobStatus reports job status
+// MsgReportJobStatus reports job status from the provider daemon
 message MsgReportJobStatus {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "reporter";
+  option (cosmos.msg.v1.signer) = "provider_address";
   option (amino.name) = "hpc/MsgReportJobStatus";
 
-  string reporter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string job_id = 2;
-  string status = 3;
-  uint64 progress_percent = 4;
-  string output_location = 5;
-  string error_message = 6;
+  string provider_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string job_id = 2 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+  string slurm_job_id = 3 [(gogoproto.jsontag) = "slurm_job_id,omitempty", (gogoproto.moretags) = "yaml:\"slurm_job_id\""];
+  JobState state = 4 [(gogoproto.jsontag) = "state", (gogoproto.moretags) = "yaml:\"state\""];
+  string status_message = 5 [(gogoproto.jsontag) = "status_message,omitempty", (gogoproto.moretags) = "yaml:\"status_message\""];
+  int32 exit_code = 6 [(gogoproto.jsontag) = "exit_code,omitempty", (gogoproto.moretags) = "yaml:\"exit_code\""];
+  HPCUsageMetrics usage_metrics = 7 [(gogoproto.jsontag) = "usage_metrics,omitempty", (gogoproto.moretags) = "yaml:\"usage_metrics\""];
+  string signature = 8 [(gogoproto.jsontag) = "signature", (gogoproto.moretags) = "yaml:\"signature\""];
+  int64 signed_timestamp = 9 [(gogoproto.jsontag) = "signed_timestamp", (gogoproto.moretags) = "yaml:\"signed_timestamp\""];
 }
 
 // MsgReportJobStatusResponse is the response for MsgReportJobStatus
@@ -185,108 +211,66 @@ message MsgReportJobStatusResponse {}
 // MsgUpdateNodeMetadata updates node metadata
 message MsgUpdateNodeMetadata {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "owner";
+  option (cosmos.msg.v1.signer) = "provider_address";
   option (amino.name) = "hpc/MsgUpdateNodeMetadata";
 
-  string owner = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string cluster_id = 2;
-  string node_id = 3;
-  string gpu_model = 4;
-  uint64 gpu_memory_gb = 5;
-  string cpu_model = 6;
-  uint64 memory_gb = 7;
+  string provider_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string node_id = 2 [(gogoproto.jsontag) = "node_id", (gogoproto.moretags) = "yaml:\"node_id\""];
+  string cluster_id = 3 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  string region = 4 [(gogoproto.jsontag) = "region,omitempty", (gogoproto.moretags) = "yaml:\"region\""];
+  string datacenter = 5 [(gogoproto.jsontag) = "datacenter,omitempty", (gogoproto.moretags) = "yaml:\"datacenter\""];
+  repeated LatencyMeasurement latency_measurements = 6 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "latency_measurements,omitempty", (gogoproto.moretags) = "yaml:\"latency_measurements\""];
+  int64 network_bandwidth_mbps = 7 [(gogoproto.jsontag) = "network_bandwidth_mbps,omitempty", (gogoproto.moretags) = "yaml:\"network_bandwidth_mbps\""];
+  NodeResources resources = 8 [(gogoproto.jsontag) = "resources,omitempty", (gogoproto.moretags) = "yaml:\"resources\""];
+  bool active = 9 [(gogoproto.jsontag) = "active,omitempty", (gogoproto.moretags) = "yaml:\"active\""];
 }
 
 // MsgUpdateNodeMetadataResponse is the response for MsgUpdateNodeMetadata
 message MsgUpdateNodeMetadataResponse {}
 
-// MsgFlagDispute flags a dispute for a job
+// MsgFlagDispute flags a dispute for moderation
 message MsgFlagDispute {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "sender";
+  option (cosmos.msg.v1.signer) = "disputer_address";
   option (amino.name) = "hpc/MsgFlagDispute";
 
-  string sender = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string job_id = 2;
-  string reason = 3;
-  string evidence = 4;
+  string disputer_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "disputer_address", (gogoproto.moretags) = "yaml:\"disputer_address\""];
+  string job_id = 2 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+  string reward_id = 3 [(gogoproto.jsontag) = "reward_id,omitempty", (gogoproto.moretags) = "yaml:\"reward_id\""];
+  string dispute_type = 4 [(gogoproto.jsontag) = "dispute_type", (gogoproto.moretags) = "yaml:\"dispute_type\""];
+  string reason = 5 [(gogoproto.jsontag) = "reason", (gogoproto.moretags) = "yaml:\"reason\""];
+  string evidence = 6 [(gogoproto.jsontag) = "evidence,omitempty", (gogoproto.moretags) = "yaml:\"evidence\""];
 }
 
 // MsgFlagDisputeResponse is the response for MsgFlagDispute
 message MsgFlagDisputeResponse {
-  string dispute_id = 1;
+  string dispute_id = 1 [(gogoproto.jsontag) = "dispute_id", (gogoproto.moretags) = "yaml:\"dispute_id\""];
 }
 
-// MsgResolveDispute resolves a flagged dispute
+// MsgResolveDispute resolves a dispute (moderator only)
 message MsgResolveDispute {
   option (gogoproto.equal) = false;
-  option (cosmos.msg.v1.signer) = "authority";
+  option (cosmos.msg.v1.signer) = "resolver_address";
   option (amino.name) = "hpc/MsgResolveDispute";
 
-  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string dispute_id = 2;
-  string resolution = 3;
-  string refund_amount = 4;
+  string resolver_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "resolver_address", (gogoproto.moretags) = "yaml:\"resolver_address\""];
+  string dispute_id = 2 [(gogoproto.jsontag) = "dispute_id", (gogoproto.moretags) = "yaml:\"dispute_id\""];
+  DisputeStatus status = 3 [(gogoproto.jsontag) = "status", (gogoproto.moretags) = "yaml:\"status\""];
+  string resolution = 4 [(gogoproto.jsontag) = "resolution", (gogoproto.moretags) = "yaml:\"resolution\""];
 }
 
 // MsgResolveDisputeResponse is the response for MsgResolveDispute
 message MsgResolveDisputeResponse {}
 
-// GenesisState is the genesis state for the hpc module
-message GenesisState {
-  option (gogoproto.equal) = true;
-  
-  Params params = 1 [(gogoproto.nullable) = false];
-  repeated Cluster clusters = 2 [(gogoproto.nullable) = false];
-  repeated Offering offerings = 3 [(gogoproto.nullable) = false];
-  repeated Job jobs = 4 [(gogoproto.nullable) = false];
-  uint64 cluster_sequence = 5;
-  uint64 offering_sequence = 6;
-  uint64 job_sequence = 7;
+// MsgUpdateParams updates module parameters (governance only)
+message MsgUpdateParams {
+  option (gogoproto.equal) = false;
+  option (cosmos.msg.v1.signer) = "authority";
+  option (amino.name) = "hpc/MsgUpdateParams";
+
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "authority", (gogoproto.moretags) = "yaml:\"authority\""];
+  Params params = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "params", (gogoproto.moretags) = "yaml:\"params\""];
 }
 
-// Params defines the parameters for the hpc module
-message Params {
-  string min_deposit = 1;
-  uint64 max_job_duration = 2;
-  string platform_fee_rate = 3;
-  uint64 dispute_resolution_period = 4;
-}
-
-// Cluster represents an HPC cluster
-message Cluster {
-  string cluster_id = 1;
-  string owner = 2;
-  string name = 3;
-  string cluster_type = 4;
-  string region = 5;
-  string endpoint = 6;
-  uint64 total_nodes = 7;
-  uint64 total_gpus = 8;
-  bool active = 9;
-  int64 registered_at = 10;
-}
-
-// Offering represents an HPC offering
-message Offering {
-  string offering_id = 1;
-  string cluster_id = 2;
-  string provider = 3;
-  string name = 4;
-  string resource_type = 5;
-  string price_per_hour = 6;
-  uint64 min_duration = 7;
-  uint64 max_duration = 8;
-  bool active = 9;
-}
-
-// Job represents an HPC job
-message Job {
-  string job_id = 1;
-  string offering_id = 2;
-  string submitter = 3;
-  string status = 4;
-  int64 submitted_at = 5;
-  int64 started_at = 6;
-  int64 completed_at = 7;
-}
+// MsgUpdateParamsResponse is the response for MsgUpdateParams
+message MsgUpdateParamsResponse {}

--- a/sdk/proto/node/virtengine/hpc/v1/types.proto
+++ b/sdk/proto/node/virtengine/hpc/v1/types.proto
@@ -1,0 +1,477 @@
+syntax = "proto3";
+package virtengine.hpc.v1;
+
+import "gogoproto/gogo.proto";
+import "cosmos_proto/cosmos.proto";
+import "cosmos/base/v1beta1/coin.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/virtengine/virtengine/sdk/go/node/hpc/v1";
+
+// ClusterState represents the state of an HPC cluster
+enum ClusterState {
+  option (gogoproto.goproto_enum_prefix) = false;
+
+  // CLUSTER_STATE_UNSPECIFIED represents an unspecified cluster state
+  CLUSTER_STATE_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "ClusterStateUnspecified"];
+
+  // CLUSTER_STATE_PENDING indicates the cluster is pending registration
+  CLUSTER_STATE_PENDING = 1 [(gogoproto.enumvalue_customname) = "ClusterStatePending"];
+
+  // CLUSTER_STATE_ACTIVE indicates the cluster is active and accepting jobs
+  CLUSTER_STATE_ACTIVE = 2 [(gogoproto.enumvalue_customname) = "ClusterStateActive"];
+
+  // CLUSTER_STATE_DRAINING indicates the cluster is draining (not accepting new jobs)
+  CLUSTER_STATE_DRAINING = 3 [(gogoproto.enumvalue_customname) = "ClusterStateDraining"];
+
+  // CLUSTER_STATE_OFFLINE indicates the cluster is offline
+  CLUSTER_STATE_OFFLINE = 4 [(gogoproto.enumvalue_customname) = "ClusterStateOffline"];
+
+  // CLUSTER_STATE_DEREGISTERED indicates the cluster has been deregistered
+  CLUSTER_STATE_DEREGISTERED = 5 [(gogoproto.enumvalue_customname) = "ClusterStateDeregistered"];
+}
+
+// JobState represents the state of an HPC job
+enum JobState {
+  option (gogoproto.goproto_enum_prefix) = false;
+
+  // JOB_STATE_UNSPECIFIED represents an unspecified job state
+  JOB_STATE_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "JobStateUnspecified"];
+
+  // JOB_STATE_PENDING indicates the job is pending
+  JOB_STATE_PENDING = 1 [(gogoproto.enumvalue_customname) = "JobStatePending"];
+
+  // JOB_STATE_QUEUED indicates the job is queued in SLURM
+  JOB_STATE_QUEUED = 2 [(gogoproto.enumvalue_customname) = "JobStateQueued"];
+
+  // JOB_STATE_RUNNING indicates the job is running
+  JOB_STATE_RUNNING = 3 [(gogoproto.enumvalue_customname) = "JobStateRunning"];
+
+  // JOB_STATE_COMPLETED indicates the job completed successfully
+  JOB_STATE_COMPLETED = 4 [(gogoproto.enumvalue_customname) = "JobStateCompleted"];
+
+  // JOB_STATE_FAILED indicates the job failed
+  JOB_STATE_FAILED = 5 [(gogoproto.enumvalue_customname) = "JobStateFailed"];
+
+  // JOB_STATE_CANCELLED indicates the job was cancelled
+  JOB_STATE_CANCELLED = 6 [(gogoproto.enumvalue_customname) = "JobStateCancelled"];
+
+  // JOB_STATE_TIMEOUT indicates the job timed out
+  JOB_STATE_TIMEOUT = 7 [(gogoproto.enumvalue_customname) = "JobStateTimeout"];
+}
+
+// HPCRewardSource indicates the source of HPC rewards
+enum HPCRewardSource {
+  option (gogoproto.goproto_enum_prefix) = false;
+
+  // HPC_REWARD_SOURCE_UNSPECIFIED represents an unspecified reward source
+  HPC_REWARD_SOURCE_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "HPCRewardSourceUnspecified"];
+
+  // HPC_REWARD_SOURCE_JOB_COMPLETION is for completed job rewards
+  HPC_REWARD_SOURCE_JOB_COMPLETION = 1 [(gogoproto.enumvalue_customname) = "HPCRewardSourceJobCompletion"];
+
+  // HPC_REWARD_SOURCE_USAGE is for usage-based rewards
+  HPC_REWARD_SOURCE_USAGE = 2 [(gogoproto.enumvalue_customname) = "HPCRewardSourceUsage"];
+
+  // HPC_REWARD_SOURCE_BONUS is for bonus rewards
+  HPC_REWARD_SOURCE_BONUS = 3 [(gogoproto.enumvalue_customname) = "HPCRewardSourceBonus"];
+}
+
+// DisputeStatus indicates the status of a dispute
+enum DisputeStatus {
+  option (gogoproto.goproto_enum_prefix) = false;
+
+  // DISPUTE_STATUS_UNSPECIFIED represents an unspecified dispute status
+  DISPUTE_STATUS_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "DisputeStatusUnspecified"];
+
+  // DISPUTE_STATUS_PENDING indicates the dispute is pending
+  DISPUTE_STATUS_PENDING = 1 [(gogoproto.enumvalue_customname) = "DisputeStatusPending"];
+
+  // DISPUTE_STATUS_UNDER_REVIEW indicates the dispute is under review
+  DISPUTE_STATUS_UNDER_REVIEW = 2 [(gogoproto.enumvalue_customname) = "DisputeStatusUnderReview"];
+
+  // DISPUTE_STATUS_RESOLVED indicates the dispute is resolved
+  DISPUTE_STATUS_RESOLVED = 3 [(gogoproto.enumvalue_customname) = "DisputeStatusResolved"];
+
+  // DISPUTE_STATUS_REJECTED indicates the dispute was rejected
+  DISPUTE_STATUS_REJECTED = 4 [(gogoproto.enumvalue_customname) = "DisputeStatusRejected"];
+}
+
+// Partition represents a SLURM partition/queue
+message Partition {
+  option (gogoproto.equal) = false;
+
+  string name = 1 [(gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
+  int32 nodes = 2 [(gogoproto.jsontag) = "nodes", (gogoproto.moretags) = "yaml:\"nodes\""];
+  int64 max_runtime = 3 [(gogoproto.jsontag) = "max_runtime", (gogoproto.moretags) = "yaml:\"max_runtime\""];
+  int64 default_runtime = 4 [(gogoproto.jsontag) = "default_runtime", (gogoproto.moretags) = "yaml:\"default_runtime\""];
+  int32 max_nodes = 5 [(gogoproto.jsontag) = "max_nodes", (gogoproto.moretags) = "yaml:\"max_nodes\""];
+  repeated string features = 6 [(gogoproto.jsontag) = "features,omitempty", (gogoproto.moretags) = "yaml:\"features\""];
+  int32 priority = 7 [(gogoproto.jsontag) = "priority", (gogoproto.moretags) = "yaml:\"priority\""];
+  string state = 8 [(gogoproto.jsontag) = "state", (gogoproto.moretags) = "yaml:\"state\""];
+}
+
+// ClusterMetadata contains additional cluster metadata
+message ClusterMetadata {
+  option (gogoproto.equal) = false;
+
+  int64 total_cpu_cores = 1 [(gogoproto.jsontag) = "total_cpu_cores", (gogoproto.moretags) = "yaml:\"total_cpu_cores\""];
+  int64 total_memory_gb = 2 [(gogoproto.jsontag) = "total_memory_gb", (gogoproto.moretags) = "yaml:\"total_memory_gb\""];
+  int64 total_gpus = 3 [(gogoproto.jsontag) = "total_gpus,omitempty", (gogoproto.moretags) = "yaml:\"total_gpus\""];
+  repeated string gpu_types = 4 [(gogoproto.jsontag) = "gpu_types,omitempty", (gogoproto.moretags) = "yaml:\"gpu_types\""];
+  string interconnect_type = 5 [(gogoproto.jsontag) = "interconnect_type", (gogoproto.moretags) = "yaml:\"interconnect_type\""];
+  string storage_type = 6 [(gogoproto.jsontag) = "storage_type", (gogoproto.moretags) = "yaml:\"storage_type\""];
+  int64 total_storage_gb = 7 [(gogoproto.jsontag) = "total_storage_gb", (gogoproto.moretags) = "yaml:\"total_storage_gb\""];
+}
+
+// HPCCluster represents a SLURM cluster registered on-chain
+message HPCCluster {
+  option (gogoproto.equal) = false;
+
+  string cluster_id = 1 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  string provider_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string name = 3 [(gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
+  string description = 4 [(gogoproto.jsontag) = "description,omitempty", (gogoproto.moretags) = "yaml:\"description\""];
+  ClusterState state = 5 [(gogoproto.jsontag) = "state", (gogoproto.moretags) = "yaml:\"state\""];
+  repeated Partition partitions = 6 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "partitions", (gogoproto.moretags) = "yaml:\"partitions\""];
+  int32 total_nodes = 7 [(gogoproto.jsontag) = "total_nodes", (gogoproto.moretags) = "yaml:\"total_nodes\""];
+  int32 available_nodes = 8 [(gogoproto.jsontag) = "available_nodes", (gogoproto.moretags) = "yaml:\"available_nodes\""];
+  string region = 9 [(gogoproto.jsontag) = "region", (gogoproto.moretags) = "yaml:\"region\""];
+  ClusterMetadata cluster_metadata = 10 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "cluster_metadata", (gogoproto.moretags) = "yaml:\"cluster_metadata\""];
+  string slurm_version = 11 [(gogoproto.jsontag) = "slurm_version", (gogoproto.moretags) = "yaml:\"slurm_version\""];
+  string kubernetes_cluster_id = 12 [(gogoproto.jsontag) = "kubernetes_cluster_id,omitempty", (gogoproto.moretags) = "yaml:\"kubernetes_cluster_id\""];
+  google.protobuf.Timestamp created_at = 13 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "created_at", (gogoproto.moretags) = "yaml:\"created_at\""];
+  google.protobuf.Timestamp updated_at = 14 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "updated_at", (gogoproto.moretags) = "yaml:\"updated_at\""];
+  int64 block_height = 15 [(gogoproto.jsontag) = "block_height", (gogoproto.moretags) = "yaml:\"block_height\""];
+}
+
+// QueueOption represents a queue/partition option in an offering
+message QueueOption {
+  option (gogoproto.equal) = false;
+
+  string partition_name = 1 [(gogoproto.jsontag) = "partition_name", (gogoproto.moretags) = "yaml:\"partition_name\""];
+  string display_name = 2 [(gogoproto.jsontag) = "display_name", (gogoproto.moretags) = "yaml:\"display_name\""];
+  int32 max_nodes = 3 [(gogoproto.jsontag) = "max_nodes", (gogoproto.moretags) = "yaml:\"max_nodes\""];
+  int64 max_runtime = 4 [(gogoproto.jsontag) = "max_runtime", (gogoproto.moretags) = "yaml:\"max_runtime\""];
+  repeated string features = 5 [(gogoproto.jsontag) = "features,omitempty", (gogoproto.moretags) = "yaml:\"features\""];
+  string price_multiplier = 6 [(gogoproto.jsontag) = "price_multiplier", (gogoproto.moretags) = "yaml:\"price_multiplier\""];
+}
+
+// HPCPricing contains HPC pricing information
+message HPCPricing {
+  option (gogoproto.equal) = false;
+
+  string base_node_hour_price = 1 [(gogoproto.jsontag) = "base_node_hour_price", (gogoproto.moretags) = "yaml:\"base_node_hour_price\""];
+  string cpu_core_hour_price = 2 [(gogoproto.jsontag) = "cpu_core_hour_price", (gogoproto.moretags) = "yaml:\"cpu_core_hour_price\""];
+  string gpu_hour_price = 3 [(gogoproto.jsontag) = "gpu_hour_price,omitempty", (gogoproto.moretags) = "yaml:\"gpu_hour_price\""];
+  string memory_gb_hour_price = 4 [(gogoproto.jsontag) = "memory_gb_hour_price", (gogoproto.moretags) = "yaml:\"memory_gb_hour_price\""];
+  string storage_gb_price = 5 [(gogoproto.jsontag) = "storage_gb_price", (gogoproto.moretags) = "yaml:\"storage_gb_price\""];
+  string network_gb_price = 6 [(gogoproto.jsontag) = "network_gb_price", (gogoproto.moretags) = "yaml:\"network_gb_price\""];
+  string currency = 7 [(gogoproto.jsontag) = "currency", (gogoproto.moretags) = "yaml:\"currency\""];
+  string minimum_charge = 8 [(gogoproto.jsontag) = "minimum_charge", (gogoproto.moretags) = "yaml:\"minimum_charge\""];
+}
+
+// JobResources defines resource requirements for an HPC job
+message JobResources {
+  option (gogoproto.equal) = false;
+
+  int32 nodes = 1 [(gogoproto.jsontag) = "nodes", (gogoproto.moretags) = "yaml:\"nodes\""];
+  int32 cpu_cores_per_node = 2 [(gogoproto.jsontag) = "cpu_cores_per_node", (gogoproto.moretags) = "yaml:\"cpu_cores_per_node\""];
+  int32 memory_gb_per_node = 3 [(gogoproto.jsontag) = "memory_gb_per_node", (gogoproto.moretags) = "yaml:\"memory_gb_per_node\""];
+  int32 gpus_per_node = 4 [(gogoproto.jsontag) = "gpus_per_node,omitempty", (gogoproto.moretags) = "yaml:\"gpus_per_node\""];
+  int32 storage_gb = 5 [(gogoproto.jsontag) = "storage_gb", (gogoproto.moretags) = "yaml:\"storage_gb\""];
+  string gpu_type = 6 [(gogoproto.jsontag) = "gpu_type,omitempty", (gogoproto.moretags) = "yaml:\"gpu_type\""];
+}
+
+// PreconfiguredWorkload represents a pre-approved workload
+message PreconfiguredWorkload {
+  option (gogoproto.equal) = false;
+
+  string workload_id = 1 [(gogoproto.jsontag) = "workload_id", (gogoproto.moretags) = "yaml:\"workload_id\""];
+  string name = 2 [(gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
+  string description = 3 [(gogoproto.jsontag) = "description", (gogoproto.moretags) = "yaml:\"description\""];
+  string container_image = 4 [(gogoproto.jsontag) = "container_image", (gogoproto.moretags) = "yaml:\"container_image\""];
+  string default_command = 5 [(gogoproto.jsontag) = "default_command,omitempty", (gogoproto.moretags) = "yaml:\"default_command\""];
+  JobResources required_resources = 6 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "required_resources", (gogoproto.moretags) = "yaml:\"required_resources\""];
+  string category = 7 [(gogoproto.jsontag) = "category", (gogoproto.moretags) = "yaml:\"category\""];
+  string version = 8 [(gogoproto.jsontag) = "version", (gogoproto.moretags) = "yaml:\"version\""];
+}
+
+// HPCOffering represents an HPC service offering
+message HPCOffering {
+  option (gogoproto.equal) = false;
+
+  string offering_id = 1 [(gogoproto.jsontag) = "offering_id", (gogoproto.moretags) = "yaml:\"offering_id\""];
+  string cluster_id = 2 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  string provider_address = 3 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string name = 4 [(gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
+  string description = 5 [(gogoproto.jsontag) = "description,omitempty", (gogoproto.moretags) = "yaml:\"description\""];
+  repeated QueueOption queue_options = 6 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "queue_options", (gogoproto.moretags) = "yaml:\"queue_options\""];
+  HPCPricing pricing = 7 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "pricing", (gogoproto.moretags) = "yaml:\"pricing\""];
+  int32 required_identity_threshold = 8 [(gogoproto.jsontag) = "required_identity_threshold", (gogoproto.moretags) = "yaml:\"required_identity_threshold\""];
+  int64 max_runtime_seconds = 9 [(gogoproto.jsontag) = "max_runtime_seconds", (gogoproto.moretags) = "yaml:\"max_runtime_seconds\""];
+  repeated PreconfiguredWorkload preconfigured_workloads = 10 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "preconfigured_workloads,omitempty", (gogoproto.moretags) = "yaml:\"preconfigured_workloads\""];
+  bool supports_custom_workloads = 11 [(gogoproto.jsontag) = "supports_custom_workloads", (gogoproto.moretags) = "yaml:\"supports_custom_workloads\""];
+  bool active = 12 [(gogoproto.jsontag) = "active", (gogoproto.moretags) = "yaml:\"active\""];
+  google.protobuf.Timestamp created_at = 13 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "created_at", (gogoproto.moretags) = "yaml:\"created_at\""];
+  google.protobuf.Timestamp updated_at = 14 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "updated_at", (gogoproto.moretags) = "yaml:\"updated_at\""];
+  int64 block_height = 15 [(gogoproto.jsontag) = "block_height", (gogoproto.moretags) = "yaml:\"block_height\""];
+}
+
+// JobWorkloadSpec defines the workload for an HPC job
+message JobWorkloadSpec {
+  option (gogoproto.equal) = false;
+
+  string container_image = 1 [(gogoproto.jsontag) = "container_image", (gogoproto.moretags) = "yaml:\"container_image\""];
+  string command = 2 [(gogoproto.jsontag) = "command", (gogoproto.moretags) = "yaml:\"command\""];
+  repeated string arguments = 3 [(gogoproto.jsontag) = "arguments,omitempty", (gogoproto.moretags) = "yaml:\"arguments\""];
+  map<string, string> environment = 4 [(gogoproto.jsontag) = "environment,omitempty", (gogoproto.moretags) = "yaml:\"environment\""];
+  string working_directory = 5 [(gogoproto.jsontag) = "working_directory,omitempty", (gogoproto.moretags) = "yaml:\"working_directory\""];
+  string preconfigured_workload_id = 6 [(gogoproto.jsontag) = "preconfigured_workload_id,omitempty", (gogoproto.moretags) = "yaml:\"preconfigured_workload_id\""];
+  bool is_preconfigured = 7 [(gogoproto.jsontag) = "is_preconfigured", (gogoproto.moretags) = "yaml:\"is_preconfigured\""];
+}
+
+// DataReference references external data
+message DataReference {
+  option (gogoproto.equal) = false;
+
+  string reference_id = 1 [(gogoproto.jsontag) = "reference_id", (gogoproto.moretags) = "yaml:\"reference_id\""];
+  string type = 2 [(gogoproto.jsontag) = "type", (gogoproto.moretags) = "yaml:\"type\""];
+  string uri = 3 [(gogoproto.jsontag) = "uri", (gogoproto.moretags) = "yaml:\"uri\""];
+  bool encrypted = 4 [(gogoproto.jsontag) = "encrypted", (gogoproto.moretags) = "yaml:\"encrypted\""];
+  string checksum = 5 [(gogoproto.jsontag) = "checksum,omitempty", (gogoproto.moretags) = "yaml:\"checksum\""];
+  int64 size_bytes = 6 [(gogoproto.jsontag) = "size_bytes,omitempty", (gogoproto.moretags) = "yaml:\"size_bytes\""];
+}
+
+// HPCUsageMetrics contains usage metrics for an HPC job
+message HPCUsageMetrics {
+  option (gogoproto.equal) = false;
+
+  int64 wall_clock_seconds = 1 [(gogoproto.jsontag) = "wall_clock_seconds", (gogoproto.moretags) = "yaml:\"wall_clock_seconds\""];
+  int64 cpu_core_seconds = 2 [(gogoproto.jsontag) = "cpu_core_seconds", (gogoproto.moretags) = "yaml:\"cpu_core_seconds\""];
+  int64 memory_gb_seconds = 3 [(gogoproto.jsontag) = "memory_gb_seconds", (gogoproto.moretags) = "yaml:\"memory_gb_seconds\""];
+  int64 gpu_seconds = 4 [(gogoproto.jsontag) = "gpu_seconds,omitempty", (gogoproto.moretags) = "yaml:\"gpu_seconds\""];
+  int64 storage_gb_hours = 5 [(gogoproto.jsontag) = "storage_gb_hours", (gogoproto.moretags) = "yaml:\"storage_gb_hours\""];
+  int64 network_bytes_in = 6 [(gogoproto.jsontag) = "network_bytes_in", (gogoproto.moretags) = "yaml:\"network_bytes_in\""];
+  int64 network_bytes_out = 7 [(gogoproto.jsontag) = "network_bytes_out", (gogoproto.moretags) = "yaml:\"network_bytes_out\""];
+  int64 node_hours = 8 [(gogoproto.jsontag) = "node_hours", (gogoproto.moretags) = "yaml:\"node_hours\""];
+  int32 nodes_used = 9 [(gogoproto.jsontag) = "nodes_used", (gogoproto.moretags) = "yaml:\"nodes_used\""];
+}
+
+// HPCJob represents an HPC job request
+message HPCJob {
+  option (gogoproto.equal) = false;
+
+  string job_id = 1 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+  string offering_id = 2 [(gogoproto.jsontag) = "offering_id", (gogoproto.moretags) = "yaml:\"offering_id\""];
+  string cluster_id = 3 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  string provider_address = 4 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string customer_address = 5 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "customer_address", (gogoproto.moretags) = "yaml:\"customer_address\""];
+  string slurm_job_id = 6 [(gogoproto.jsontag) = "slurm_job_id,omitempty", (gogoproto.moretags) = "yaml:\"slurm_job_id\""];
+  JobState state = 7 [(gogoproto.jsontag) = "state", (gogoproto.moretags) = "yaml:\"state\""];
+  string queue_name = 8 [(gogoproto.jsontag) = "queue_name", (gogoproto.moretags) = "yaml:\"queue_name\""];
+  JobWorkloadSpec workload_spec = 9 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "workload_spec", (gogoproto.moretags) = "yaml:\"workload_spec\""];
+  JobResources resources = 10 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "resources", (gogoproto.moretags) = "yaml:\"resources\""];
+  repeated DataReference data_references = 11 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "data_references,omitempty", (gogoproto.moretags) = "yaml:\"data_references\""];
+  string encrypted_inputs_pointer = 12 [(gogoproto.jsontag) = "encrypted_inputs_pointer,omitempty", (gogoproto.moretags) = "yaml:\"encrypted_inputs_pointer\""];
+  string encrypted_outputs_pointer = 13 [(gogoproto.jsontag) = "encrypted_outputs_pointer,omitempty", (gogoproto.moretags) = "yaml:\"encrypted_outputs_pointer\""];
+  int64 max_runtime_seconds = 14 [(gogoproto.jsontag) = "max_runtime_seconds", (gogoproto.moretags) = "yaml:\"max_runtime_seconds\""];
+  repeated cosmos.base.v1beta1.Coin agreed_price = 15 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins", (gogoproto.jsontag) = "agreed_price", (gogoproto.moretags) = "yaml:\"agreed_price\""];
+  string escrow_id = 16 [(gogoproto.jsontag) = "escrow_id,omitempty", (gogoproto.moretags) = "yaml:\"escrow_id\""];
+  string scheduling_decision_id = 17 [(gogoproto.jsontag) = "scheduling_decision_id,omitempty", (gogoproto.moretags) = "yaml:\"scheduling_decision_id\""];
+  string status_message = 18 [(gogoproto.jsontag) = "status_message,omitempty", (gogoproto.moretags) = "yaml:\"status_message\""];
+  int32 exit_code = 19 [(gogoproto.jsontag) = "exit_code,omitempty", (gogoproto.moretags) = "yaml:\"exit_code\""];
+  google.protobuf.Timestamp created_at = 20 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "created_at", (gogoproto.moretags) = "yaml:\"created_at\""];
+  google.protobuf.Timestamp queued_at = 21 [(gogoproto.stdtime) = true, (gogoproto.jsontag) = "queued_at,omitempty", (gogoproto.moretags) = "yaml:\"queued_at\""];
+  google.protobuf.Timestamp started_at = 22 [(gogoproto.stdtime) = true, (gogoproto.jsontag) = "started_at,omitempty", (gogoproto.moretags) = "yaml:\"started_at\""];
+  google.protobuf.Timestamp completed_at = 23 [(gogoproto.stdtime) = true, (gogoproto.jsontag) = "completed_at,omitempty", (gogoproto.moretags) = "yaml:\"completed_at\""];
+  int64 block_height = 24 [(gogoproto.jsontag) = "block_height", (gogoproto.moretags) = "yaml:\"block_height\""];
+}
+
+// NodeReward represents a reward for a specific node
+message NodeReward {
+  option (gogoproto.equal) = false;
+
+  string node_id = 1 [(gogoproto.jsontag) = "node_id", (gogoproto.moretags) = "yaml:\"node_id\""];
+  string provider_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  repeated cosmos.base.v1beta1.Coin amount = 3 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins", (gogoproto.jsontag) = "amount", (gogoproto.moretags) = "yaml:\"amount\""];
+  string contribution_weight = 4 [(gogoproto.jsontag) = "contribution_weight", (gogoproto.moretags) = "yaml:\"contribution_weight\""];
+  int64 usage_seconds = 5 [(gogoproto.jsontag) = "usage_seconds", (gogoproto.moretags) = "yaml:\"usage_seconds\""];
+}
+
+// JobAccounting represents accounting data for an HPC job
+message JobAccounting {
+  option (gogoproto.equal) = false;
+
+  string job_id = 1 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+  string cluster_id = 2 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  string provider_address = 3 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string customer_address = 4 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "customer_address", (gogoproto.moretags) = "yaml:\"customer_address\""];
+  HPCUsageMetrics usage_metrics = 5 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "usage_metrics", (gogoproto.moretags) = "yaml:\"usage_metrics\""];
+  repeated cosmos.base.v1beta1.Coin total_cost = 6 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins", (gogoproto.jsontag) = "total_cost", (gogoproto.moretags) = "yaml:\"total_cost\""];
+  repeated cosmos.base.v1beta1.Coin provider_reward = 7 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins", (gogoproto.jsontag) = "provider_reward", (gogoproto.moretags) = "yaml:\"provider_reward\""];
+  repeated NodeReward node_rewards = 8 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "node_rewards,omitempty", (gogoproto.moretags) = "yaml:\"node_rewards\""];
+  repeated cosmos.base.v1beta1.Coin platform_fee = 9 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins", (gogoproto.jsontag) = "platform_fee", (gogoproto.moretags) = "yaml:\"platform_fee\""];
+  string settlement_status = 10 [(gogoproto.jsontag) = "settlement_status", (gogoproto.moretags) = "yaml:\"settlement_status\""];
+  string settlement_id = 11 [(gogoproto.jsontag) = "settlement_id,omitempty", (gogoproto.moretags) = "yaml:\"settlement_id\""];
+  repeated string signed_usage_record_ids = 12 [(gogoproto.jsontag) = "signed_usage_record_ids", (gogoproto.moretags) = "yaml:\"signed_usage_record_ids\""];
+  JobState job_completion_status = 13 [(gogoproto.jsontag) = "job_completion_status", (gogoproto.moretags) = "yaml:\"job_completion_status\""];
+  google.protobuf.Timestamp created_at = 14 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "created_at", (gogoproto.moretags) = "yaml:\"created_at\""];
+  google.protobuf.Timestamp finalized_at = 15 [(gogoproto.stdtime) = true, (gogoproto.jsontag) = "finalized_at,omitempty", (gogoproto.moretags) = "yaml:\"finalized_at\""];
+  int64 block_height = 16 [(gogoproto.jsontag) = "block_height", (gogoproto.moretags) = "yaml:\"block_height\""];
+}
+
+// LatencyMeasurement contains latency measurement to another node
+message LatencyMeasurement {
+  option (gogoproto.equal) = false;
+
+  string target_node_id = 1 [(gogoproto.jsontag) = "target_node_id", (gogoproto.moretags) = "yaml:\"target_node_id\""];
+  int64 latency_ms = 2 [(gogoproto.jsontag) = "latency_ms", (gogoproto.moretags) = "yaml:\"latency_ms\""];
+  google.protobuf.Timestamp measured_at = 3 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "measured_at", (gogoproto.moretags) = "yaml:\"measured_at\""];
+}
+
+// NodeResources contains node resource capacity
+message NodeResources {
+  option (gogoproto.equal) = false;
+
+  int32 cpu_cores = 1 [(gogoproto.jsontag) = "cpu_cores", (gogoproto.moretags) = "yaml:\"cpu_cores\""];
+  int32 memory_gb = 2 [(gogoproto.jsontag) = "memory_gb", (gogoproto.moretags) = "yaml:\"memory_gb\""];
+  int32 gpus = 3 [(gogoproto.jsontag) = "gpus,omitempty", (gogoproto.moretags) = "yaml:\"gpus\""];
+  string gpu_type = 4 [(gogoproto.jsontag) = "gpu_type,omitempty", (gogoproto.moretags) = "yaml:\"gpu_type\""];
+  int32 storage_gb = 5 [(gogoproto.jsontag) = "storage_gb", (gogoproto.moretags) = "yaml:\"storage_gb\""];
+}
+
+// NodeMetadata contains metadata about a compute node
+message NodeMetadata {
+  option (gogoproto.equal) = false;
+
+  string node_id = 1 [(gogoproto.jsontag) = "node_id", (gogoproto.moretags) = "yaml:\"node_id\""];
+  string cluster_id = 2 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  string provider_address = 3 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "provider_address", (gogoproto.moretags) = "yaml:\"provider_address\""];
+  string region = 4 [(gogoproto.jsontag) = "region", (gogoproto.moretags) = "yaml:\"region\""];
+  string datacenter = 5 [(gogoproto.jsontag) = "datacenter,omitempty", (gogoproto.moretags) = "yaml:\"datacenter\""];
+  repeated LatencyMeasurement latency_measurements = 6 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "latency_measurements,omitempty", (gogoproto.moretags) = "yaml:\"latency_measurements\""];
+  int64 avg_latency_ms = 7 [(gogoproto.jsontag) = "avg_latency_ms", (gogoproto.moretags) = "yaml:\"avg_latency_ms\""];
+  int64 network_bandwidth_mbps = 8 [(gogoproto.jsontag) = "network_bandwidth_mbps", (gogoproto.moretags) = "yaml:\"network_bandwidth_mbps\""];
+  NodeResources resources = 9 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "resources", (gogoproto.moretags) = "yaml:\"resources\""];
+  bool active = 10 [(gogoproto.jsontag) = "active", (gogoproto.moretags) = "yaml:\"active\""];
+  google.protobuf.Timestamp last_heartbeat = 11 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "last_heartbeat", (gogoproto.moretags) = "yaml:\"last_heartbeat\""];
+  google.protobuf.Timestamp joined_at = 12 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "joined_at", (gogoproto.moretags) = "yaml:\"joined_at\""];
+  google.protobuf.Timestamp updated_at = 13 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "updated_at", (gogoproto.moretags) = "yaml:\"updated_at\""];
+  int64 block_height = 14 [(gogoproto.jsontag) = "block_height", (gogoproto.moretags) = "yaml:\"block_height\""];
+}
+
+// ClusterCandidate represents a candidate cluster for scheduling
+message ClusterCandidate {
+  option (gogoproto.equal) = false;
+
+  string cluster_id = 1 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  string region = 2 [(gogoproto.jsontag) = "region", (gogoproto.moretags) = "yaml:\"region\""];
+  int64 avg_latency_ms = 3 [(gogoproto.jsontag) = "avg_latency_ms", (gogoproto.moretags) = "yaml:\"avg_latency_ms\""];
+  int32 available_nodes = 4 [(gogoproto.jsontag) = "available_nodes", (gogoproto.moretags) = "yaml:\"available_nodes\""];
+  string latency_score = 5 [(gogoproto.jsontag) = "latency_score", (gogoproto.moretags) = "yaml:\"latency_score\""];
+  string capacity_score = 6 [(gogoproto.jsontag) = "capacity_score", (gogoproto.moretags) = "yaml:\"capacity_score\""];
+  string combined_score = 7 [(gogoproto.jsontag) = "combined_score", (gogoproto.moretags) = "yaml:\"combined_score\""];
+  bool eligible = 8 [(gogoproto.jsontag) = "eligible", (gogoproto.moretags) = "yaml:\"eligible\""];
+  string ineligibility_reason = 9 [(gogoproto.jsontag) = "ineligibility_reason,omitempty", (gogoproto.moretags) = "yaml:\"ineligibility_reason\""];
+}
+
+// SchedulingDecision records the decision trail for job scheduling
+message SchedulingDecision {
+  option (gogoproto.equal) = false;
+
+  string decision_id = 1 [(gogoproto.jsontag) = "decision_id", (gogoproto.moretags) = "yaml:\"decision_id\""];
+  string job_id = 2 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+  string selected_cluster_id = 3 [(gogoproto.jsontag) = "selected_cluster_id", (gogoproto.moretags) = "yaml:\"selected_cluster_id\""];
+  repeated ClusterCandidate candidate_clusters = 4 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "candidate_clusters", (gogoproto.moretags) = "yaml:\"candidate_clusters\""];
+  string decision_reason = 5 [(gogoproto.jsontag) = "decision_reason", (gogoproto.moretags) = "yaml:\"decision_reason\""];
+  bool is_fallback = 6 [(gogoproto.jsontag) = "is_fallback", (gogoproto.moretags) = "yaml:\"is_fallback\""];
+  string fallback_reason = 7 [(gogoproto.jsontag) = "fallback_reason,omitempty", (gogoproto.moretags) = "yaml:\"fallback_reason\""];
+  string latency_score = 8 [(gogoproto.jsontag) = "latency_score", (gogoproto.moretags) = "yaml:\"latency_score\""];
+  string capacity_score = 9 [(gogoproto.jsontag) = "capacity_score", (gogoproto.moretags) = "yaml:\"capacity_score\""];
+  string combined_score = 10 [(gogoproto.jsontag) = "combined_score", (gogoproto.moretags) = "yaml:\"combined_score\""];
+  google.protobuf.Timestamp created_at = 11 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "created_at", (gogoproto.moretags) = "yaml:\"created_at\""];
+  int64 block_height = 12 [(gogoproto.jsontag) = "block_height", (gogoproto.moretags) = "yaml:\"block_height\""];
+}
+
+// HPCRewardRecipient represents a recipient of HPC rewards
+message HPCRewardRecipient {
+  option (gogoproto.equal) = false;
+
+  string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "address", (gogoproto.moretags) = "yaml:\"address\""];
+  repeated cosmos.base.v1beta1.Coin amount = 2 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins", (gogoproto.jsontag) = "amount", (gogoproto.moretags) = "yaml:\"amount\""];
+  string recipient_type = 3 [(gogoproto.jsontag) = "recipient_type", (gogoproto.moretags) = "yaml:\"recipient_type\""];
+  string node_id = 4 [(gogoproto.jsontag) = "node_id,omitempty", (gogoproto.moretags) = "yaml:\"node_id\""];
+  string contribution_weight = 5 [(gogoproto.jsontag) = "contribution_weight", (gogoproto.moretags) = "yaml:\"contribution_weight\""];
+  string reason = 6 [(gogoproto.jsontag) = "reason", (gogoproto.moretags) = "yaml:\"reason\""];
+}
+
+// RewardCalculationDetails contains transparency data for reward calculation
+message RewardCalculationDetails {
+  option (gogoproto.equal) = false;
+
+  string total_usage_value = 1 [(gogoproto.jsontag) = "total_usage_value", (gogoproto.moretags) = "yaml:\"total_usage_value\""];
+  string reward_pool_contribution = 2 [(gogoproto.jsontag) = "reward_pool_contribution", (gogoproto.moretags) = "yaml:\"reward_pool_contribution\""];
+  string platform_fee_rate = 3 [(gogoproto.jsontag) = "platform_fee_rate", (gogoproto.moretags) = "yaml:\"platform_fee_rate\""];
+  string node_contribution_formula = 4 [(gogoproto.jsontag) = "node_contribution_formula", (gogoproto.moretags) = "yaml:\"node_contribution_formula\""];
+  map<string, string> input_metrics = 5 [(gogoproto.jsontag) = "input_metrics", (gogoproto.moretags) = "yaml:\"input_metrics\""];
+}
+
+// HPCRewardRecord represents a reward distribution for HPC contribution
+message HPCRewardRecord {
+  option (gogoproto.equal) = false;
+
+  string reward_id = 1 [(gogoproto.jsontag) = "reward_id", (gogoproto.moretags) = "yaml:\"reward_id\""];
+  string job_id = 2 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+  string cluster_id = 3 [(gogoproto.jsontag) = "cluster_id", (gogoproto.moretags) = "yaml:\"cluster_id\""];
+  HPCRewardSource source = 4 [(gogoproto.jsontag) = "source", (gogoproto.moretags) = "yaml:\"source\""];
+  repeated cosmos.base.v1beta1.Coin total_reward = 5 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins", (gogoproto.jsontag) = "total_reward", (gogoproto.moretags) = "yaml:\"total_reward\""];
+  repeated HPCRewardRecipient recipients = 6 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "recipients", (gogoproto.moretags) = "yaml:\"recipients\""];
+  repeated string referenced_usage_records = 7 [(gogoproto.jsontag) = "referenced_usage_records", (gogoproto.moretags) = "yaml:\"referenced_usage_records\""];
+  JobState job_completion_status = 8 [(gogoproto.jsontag) = "job_completion_status", (gogoproto.moretags) = "yaml:\"job_completion_status\""];
+  string formula_version = 9 [(gogoproto.jsontag) = "formula_version", (gogoproto.moretags) = "yaml:\"formula_version\""];
+  RewardCalculationDetails calculation_details = 10 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "calculation_details", (gogoproto.moretags) = "yaml:\"calculation_details\""];
+  bool disputed = 11 [(gogoproto.jsontag) = "disputed", (gogoproto.moretags) = "yaml:\"disputed\""];
+  string dispute_id = 12 [(gogoproto.jsontag) = "dispute_id,omitempty", (gogoproto.moretags) = "yaml:\"dispute_id\""];
+  google.protobuf.Timestamp issued_at = 13 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "issued_at", (gogoproto.moretags) = "yaml:\"issued_at\""];
+  int64 block_height = 14 [(gogoproto.jsontag) = "block_height", (gogoproto.moretags) = "yaml:\"block_height\""];
+}
+
+// HPCDispute represents a dispute for HPC rewards/usage
+message HPCDispute {
+  option (gogoproto.equal) = false;
+
+  string dispute_id = 1 [(gogoproto.jsontag) = "dispute_id", (gogoproto.moretags) = "yaml:\"dispute_id\""];
+  string job_id = 2 [(gogoproto.jsontag) = "job_id", (gogoproto.moretags) = "yaml:\"job_id\""];
+  string reward_id = 3 [(gogoproto.jsontag) = "reward_id,omitempty", (gogoproto.moretags) = "yaml:\"reward_id\""];
+  string disputer_address = 4 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "disputer_address", (gogoproto.moretags) = "yaml:\"disputer_address\""];
+  string dispute_type = 5 [(gogoproto.jsontag) = "dispute_type", (gogoproto.moretags) = "yaml:\"dispute_type\""];
+  string reason = 6 [(gogoproto.jsontag) = "reason", (gogoproto.moretags) = "yaml:\"reason\""];
+  string evidence = 7 [(gogoproto.jsontag) = "evidence,omitempty", (gogoproto.moretags) = "yaml:\"evidence\""];
+  DisputeStatus status = 8 [(gogoproto.jsontag) = "status", (gogoproto.moretags) = "yaml:\"status\""];
+  string resolution = 9 [(gogoproto.jsontag) = "resolution,omitempty", (gogoproto.moretags) = "yaml:\"resolution\""];
+  string resolver_address = 10 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.jsontag) = "resolver_address,omitempty", (gogoproto.moretags) = "yaml:\"resolver_address\""];
+  google.protobuf.Timestamp created_at = 11 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true, (gogoproto.jsontag) = "created_at", (gogoproto.moretags) = "yaml:\"created_at\""];
+  google.protobuf.Timestamp resolved_at = 12 [(gogoproto.stdtime) = true, (gogoproto.jsontag) = "resolved_at,omitempty", (gogoproto.moretags) = "yaml:\"resolved_at\""];
+  int64 block_height = 13 [(gogoproto.jsontag) = "block_height", (gogoproto.moretags) = "yaml:\"block_height\""];
+}
+
+// Params defines the parameters for the HPC module
+message Params {
+  option (gogoproto.equal) = false;
+
+  string platform_fee_rate = 1 [(gogoproto.jsontag) = "platform_fee_rate", (gogoproto.moretags) = "yaml:\"platform_fee_rate\""];
+  string provider_reward_rate = 2 [(gogoproto.jsontag) = "provider_reward_rate", (gogoproto.moretags) = "yaml:\"provider_reward_rate\""];
+  string node_reward_rate = 3 [(gogoproto.jsontag) = "node_reward_rate", (gogoproto.moretags) = "yaml:\"node_reward_rate\""];
+  int64 min_job_duration_seconds = 4 [(gogoproto.jsontag) = "min_job_duration_seconds", (gogoproto.moretags) = "yaml:\"min_job_duration_seconds\""];
+  int64 max_job_duration_seconds = 5 [(gogoproto.jsontag) = "max_job_duration_seconds", (gogoproto.moretags) = "yaml:\"max_job_duration_seconds\""];
+  int32 default_identity_threshold = 6 [(gogoproto.jsontag) = "default_identity_threshold", (gogoproto.moretags) = "yaml:\"default_identity_threshold\""];
+  int64 cluster_heartbeat_timeout = 7 [(gogoproto.jsontag) = "cluster_heartbeat_timeout", (gogoproto.moretags) = "yaml:\"cluster_heartbeat_timeout\""];
+  int64 node_heartbeat_timeout = 8 [(gogoproto.jsontag) = "node_heartbeat_timeout", (gogoproto.moretags) = "yaml:\"node_heartbeat_timeout\""];
+  string latency_weight_factor = 9 [(gogoproto.jsontag) = "latency_weight_factor", (gogoproto.moretags) = "yaml:\"latency_weight_factor\""];
+  string capacity_weight_factor = 10 [(gogoproto.jsontag) = "capacity_weight_factor", (gogoproto.moretags) = "yaml:\"capacity_weight_factor\""];
+  int64 max_latency_ms = 11 [(gogoproto.jsontag) = "max_latency_ms", (gogoproto.moretags) = "yaml:\"max_latency_ms\""];
+  int64 dispute_resolution_period = 12 [(gogoproto.jsontag) = "dispute_resolution_period", (gogoproto.moretags) = "yaml:\"dispute_resolution_period\""];
+  string reward_formula_version = 13 [(gogoproto.jsontag) = "reward_formula_version", (gogoproto.moretags) = "yaml:\"reward_formula_version\""];
+  bool enable_proximity_clustering = 14 [(gogoproto.jsontag) = "enable_proximity_clustering", (gogoproto.moretags) = "yaml:\"enable_proximity_clustering\""];
+}

--- a/x/hpc/keeper/keeper_test.go
+++ b/x/hpc/keeper/keeper_test.go
@@ -1,51 +1,21 @@
-//go:build ignore
-// +build ignore
-
-// TODO: This test file is excluded until HPCCluster field definitions are stabilized.
-
 package keeper_test
 
 import (
 	"testing"
+	"time"
 
-	"cosmossdk.io/core/store"
-	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 
-	"github.com/virtengine/virtengine/x/hpc/keeper"
 	"github.com/virtengine/virtengine/x/hpc/types"
 )
 
-// KeeperTestSuite defines the test suite for HPC keeper
-type KeeperTestSuite struct {
-	suite.Suite
-
-	ctx          sdk.Context
-	keeper       *keeper.Keeper
-	cdc          codec.Codec
-	storeService store.KVStoreService
-}
-
-// SetupTest initializes the test suite
-func (s *KeeperTestSuite) SetupTest() {
-	// Create codec
-	interfaceRegistry := codectypes.NewInterfaceRegistry()
-	s.cdc = codec.NewProtoCodec(interfaceRegistry)
-
-	// Initialize keeper with mock dependencies
-	// Note: In production tests, use proper mock store service
-	s.keeper = keeper.NewKeeper(s.cdc, nil, nil, nil)
-}
-
-func TestKeeperTestSuite(t *testing.T) {
-	suite.Run(t, new(KeeperTestSuite))
-}
-
 // TestClusterValidation tests HPC cluster validation
 func TestClusterValidation(t *testing.T) {
+	// Create a valid bech32 address for tests
+	validAddr := sdk.AccAddress(make([]byte, 20)).String()
+
 	testCases := []struct {
 		name        string
 		cluster     types.HPCCluster
@@ -55,61 +25,115 @@ func TestClusterValidation(t *testing.T) {
 		{
 			name: "valid cluster",
 			cluster: types.HPCCluster{
-				ID:              1,
-				Owner:           "cosmos1abc123",
-				ProviderAddress: "provider1",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
 				Name:            "test-cluster",
-				Status:          types.ClusterStatusActive,
-				TotalCPUCores:   100,
-				TotalMemoryMB:   1024000,
-				TotalGPUs:       8,
+				State:           types.ClusterStateActive,
+				TotalNodes:      10,
+				AvailableNodes:  8,
+				Region:          "us-west-2",
 				Partitions: []types.Partition{
 					{
 						Name:           "default",
-						TotalNodes:     10,
-						AvailableNodes: 10,
-						MaxTimeMinutes: 1440,
-						GPUsPerNode:    1,
+						Nodes:          10,
+						MaxRuntime:     86400,
+						DefaultRuntime: 3600,
+						MaxNodes:       10,
+						Priority:       1,
+						State:          "up",
 					},
 				},
+				ClusterMetadata: types.ClusterMetadata{
+					TotalCPUCores:    100,
+					TotalMemoryGB:    1024,
+					TotalGPUs:        8,
+					InterconnectType: "infiniband",
+					StorageType:      "lustre",
+					TotalStorageGB:   10000,
+				},
+				CreatedAt:   time.Now(),
+				UpdatedAt:   time.Now(),
+				BlockHeight: 100,
 			},
 			expectError: false,
 		},
 		{
-			name: "missing owner",
+			name: "missing cluster_id",
 			cluster: types.HPCCluster{
-				ID:              1,
-				Owner:           "",
-				ProviderAddress: "provider1",
+				ClusterID:       "",
+				ProviderAddress: validAddr,
 				Name:            "test-cluster",
-				Status:          types.ClusterStatusActive,
+				State:           types.ClusterStateActive,
+				TotalNodes:      10,
+				Region:          "us-west-2",
 			},
 			expectError: true,
-			errorMsg:    "owner is required",
+			errorMsg:    "cluster_id cannot be empty",
 		},
 		{
 			name: "missing name",
 			cluster: types.HPCCluster{
-				ID:              1,
-				Owner:           "cosmos1abc123",
-				ProviderAddress: "provider1",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
 				Name:            "",
-				Status:          types.ClusterStatusActive,
+				State:           types.ClusterStateActive,
+				TotalNodes:      10,
+				Region:          "us-west-2",
 			},
 			expectError: true,
-			errorMsg:    "name is required",
+			errorMsg:    "name cannot be empty",
 		},
 		{
-			name: "invalid status",
+			name: "invalid provider address",
 			cluster: types.HPCCluster{
-				ID:              1,
-				Owner:           "cosmos1abc123",
-				ProviderAddress: "provider1",
+				ClusterID:       "cluster-001",
+				ProviderAddress: "invalid-address",
 				Name:            "test-cluster",
-				Status:          999,
+				State:           types.ClusterStateActive,
+				TotalNodes:      10,
+				Region:          "us-west-2",
 			},
 			expectError: true,
-			errorMsg:    "invalid status",
+			errorMsg:    "invalid provider address",
+		},
+		{
+			name: "invalid state",
+			cluster: types.HPCCluster{
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				Name:            "test-cluster",
+				State:           types.ClusterState("invalid"),
+				TotalNodes:      10,
+				Region:          "us-west-2",
+			},
+			expectError: true,
+			errorMsg:    "invalid cluster state",
+		},
+		{
+			name: "missing region",
+			cluster: types.HPCCluster{
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				Name:            "test-cluster",
+				State:           types.ClusterStateActive,
+				TotalNodes:      10,
+				Region:          "",
+			},
+			expectError: true,
+			errorMsg:    "region cannot be empty",
+		},
+		{
+			name: "zero total nodes",
+			cluster: types.HPCCluster{
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				Name:            "test-cluster",
+				State:           types.ClusterStateActive,
+				TotalNodes:      0,
+				Region:          "us-west-2",
+			},
+			expectError: true,
+			errorMsg:    "total_nodes must be at least 1",
 		},
 	}
 
@@ -128,6 +152,8 @@ func TestClusterValidation(t *testing.T) {
 
 // TestOfferingValidation tests HPC offering validation
 func TestOfferingValidation(t *testing.T) {
+	validAddr := sdk.AccAddress(make([]byte, 20)).String()
+
 	testCases := []struct {
 		name        string
 		offering    types.HPCOffering
@@ -137,56 +163,116 @@ func TestOfferingValidation(t *testing.T) {
 		{
 			name: "valid offering",
 			offering: types.HPCOffering{
-				ID:          1,
-				ClusterID:   1,
-				Owner:       "cosmos1abc123",
-				Name:        "standard-compute",
-				IsActive:    true,
-				MinCPUCores: 1,
-				MaxCPUCores: 64,
-				MinMemoryMB: 1024,
-				MaxMemoryMB: 256000,
+				OfferingID:                "offering-001",
+				ClusterID:                 "cluster-001",
+				ProviderAddress:           validAddr,
+				Name:                      "standard-compute",
+				Active:                    true,
+				RequiredIdentityThreshold: 50,
+				MaxRuntimeSeconds:         86400,
+				SupportsCustomWorkloads:   true,
 				Pricing: types.HPCPricing{
-					PricePerCPUHour:    sdk.NewInt(100),
-					PricePerGBHour:     sdk.NewInt(10),
-					PricePerGPUHour:    sdk.NewInt(1000),
-					MinimumChargeHours: 1,
+					BaseNodeHourPrice: "100",
+					CPUCoreHourPrice:  "10",
+					GPUHourPrice:      "1000",
+					MemoryGBHourPrice: "5",
+					StorageGBPrice:    "1",
+					NetworkGBPrice:    "2",
+					Currency:          "uvirt",
+					MinimumCharge:     "100",
 				},
 				QueueOptions: []types.QueueOption{
 					{
-						Name:           "standard",
-						Priority:       50,
-						MaxWallTimeMin: 1440,
+						PartitionName:   "default",
+						DisplayName:     "Default Queue",
+						MaxNodes:        10,
+						MaxRuntime:      86400,
+						PriceMultiplier: "1.0",
 					},
 				},
+				CreatedAt:   time.Now(),
+				UpdatedAt:   time.Now(),
+				BlockHeight: 100,
 			},
 			expectError: false,
 		},
 		{
-			name: "missing cluster ID",
+			name: "missing offering_id",
 			offering: types.HPCOffering{
-				ID:          1,
-				ClusterID:   0,
-				Owner:       "cosmos1abc123",
-				Name:        "test",
-				MinCPUCores: 1,
-				MaxCPUCores: 64,
+				OfferingID:                "",
+				ClusterID:                 "cluster-001",
+				ProviderAddress:           validAddr,
+				Name:                      "test",
+				RequiredIdentityThreshold: 50,
+				MaxRuntimeSeconds:         86400,
+				QueueOptions: []types.QueueOption{
+					{PartitionName: "default", DisplayName: "Default", MaxNodes: 10, MaxRuntime: 86400, PriceMultiplier: "1.0"},
+				},
 			},
 			expectError: true,
-			errorMsg:    "cluster ID is required",
+			errorMsg:    "offering_id cannot be empty",
 		},
 		{
-			name: "invalid CPU range",
+			name: "missing cluster_id",
 			offering: types.HPCOffering{
-				ID:          1,
-				ClusterID:   1,
-				Owner:       "cosmos1abc123",
-				Name:        "test",
-				MinCPUCores: 64,
-				MaxCPUCores: 1,
+				OfferingID:                "offering-001",
+				ClusterID:                 "",
+				ProviderAddress:           validAddr,
+				Name:                      "test",
+				RequiredIdentityThreshold: 50,
+				MaxRuntimeSeconds:         86400,
+				QueueOptions: []types.QueueOption{
+					{PartitionName: "default", DisplayName: "Default", MaxNodes: 10, MaxRuntime: 86400, PriceMultiplier: "1.0"},
+				},
 			},
 			expectError: true,
-			errorMsg:    "min CPU cores cannot exceed max",
+			errorMsg:    "cluster_id cannot be empty",
+		},
+		{
+			name: "invalid identity threshold",
+			offering: types.HPCOffering{
+				OfferingID:                "offering-001",
+				ClusterID:                 "cluster-001",
+				ProviderAddress:           validAddr,
+				Name:                      "test",
+				RequiredIdentityThreshold: 150, // Invalid: > 100
+				MaxRuntimeSeconds:         86400,
+				QueueOptions: []types.QueueOption{
+					{PartitionName: "default", DisplayName: "Default", MaxNodes: 10, MaxRuntime: 86400, PriceMultiplier: "1.0"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "required_identity_threshold must be between 0 and 100",
+		},
+		{
+			name: "max runtime too short",
+			offering: types.HPCOffering{
+				OfferingID:                "offering-001",
+				ClusterID:                 "cluster-001",
+				ProviderAddress:           validAddr,
+				Name:                      "test",
+				RequiredIdentityThreshold: 50,
+				MaxRuntimeSeconds:         30, // Invalid: < 60
+				QueueOptions: []types.QueueOption{
+					{PartitionName: "default", DisplayName: "Default", MaxNodes: 10, MaxRuntime: 86400, PriceMultiplier: "1.0"},
+				},
+			},
+			expectError: true,
+			errorMsg:    "max_runtime_seconds must be at least 60",
+		},
+		{
+			name: "no queue options",
+			offering: types.HPCOffering{
+				OfferingID:                "offering-001",
+				ClusterID:                 "cluster-001",
+				ProviderAddress:           validAddr,
+				Name:                      "test",
+				RequiredIdentityThreshold: 50,
+				MaxRuntimeSeconds:         86400,
+				QueueOptions:              []types.QueueOption{}, // Empty
+			},
+			expectError: true,
+			errorMsg:    "at least one queue option is required",
 		},
 	}
 
@@ -203,36 +289,59 @@ func TestOfferingValidation(t *testing.T) {
 	}
 }
 
-// TestJobStateTransitions tests valid state transitions for HPC jobs
-func TestJobStateTransitions(t *testing.T) {
+// TestJobStateValidation tests valid job states
+func TestJobStateValidation(t *testing.T) {
 	testCases := []struct {
-		name      string
-		fromState types.JobState
-		toState   types.JobState
-		valid     bool
+		name  string
+		state types.JobState
+		valid bool
 	}{
-		{"pending to queued", types.JobStatePending, types.JobStateQueued, true},
-		{"queued to running", types.JobStateQueued, types.JobStateRunning, true},
-		{"running to completed", types.JobStateRunning, types.JobStateCompleted, true},
-		{"running to failed", types.JobStateRunning, types.JobStateFailed, true},
-		{"pending to cancelled", types.JobStatePending, types.JobStateCancelled, true},
-		{"queued to cancelled", types.JobStateQueued, types.JobStateCancelled, true},
-		{"running to cancelled", types.JobStateRunning, types.JobStateCancelled, true},
-		{"completed to running", types.JobStateCompleted, types.JobStateRunning, false},
-		{"failed to running", types.JobStateFailed, types.JobStateRunning, false},
-		{"cancelled to running", types.JobStateCancelled, types.JobStateRunning, false},
+		{"pending valid", types.JobStatePending, true},
+		{"queued valid", types.JobStateQueued, true},
+		{"running valid", types.JobStateRunning, true},
+		{"completed valid", types.JobStateCompleted, true},
+		{"failed valid", types.JobStateFailed, true},
+		{"cancelled valid", types.JobStateCancelled, true},
+		{"timeout valid", types.JobStateTimeout, true},
+		{"invalid state", types.JobState("invalid"), false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := types.IsValidStateTransition(tc.fromState, tc.toState)
+			result := types.IsValidJobState(tc.state)
 			require.Equal(t, tc.valid, result)
+		})
+	}
+}
+
+// TestTerminalJobStates tests terminal job state detection
+func TestTerminalJobStates(t *testing.T) {
+	testCases := []struct {
+		name     string
+		state    types.JobState
+		terminal bool
+	}{
+		{"pending not terminal", types.JobStatePending, false},
+		{"queued not terminal", types.JobStateQueued, false},
+		{"running not terminal", types.JobStateRunning, false},
+		{"completed is terminal", types.JobStateCompleted, true},
+		{"failed is terminal", types.JobStateFailed, true},
+		{"cancelled is terminal", types.JobStateCancelled, true},
+		{"timeout is terminal", types.JobStateTimeout, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := types.IsTerminalJobState(tc.state)
+			require.Equal(t, tc.terminal, result)
 		})
 	}
 }
 
 // TestJobValidation tests HPC job validation
 func TestJobValidation(t *testing.T) {
+	validAddr := sdk.AccAddress(make([]byte, 20)).String()
+
 	testCases := []struct {
 		name        string
 		job         types.HPCJob
@@ -242,54 +351,110 @@ func TestJobValidation(t *testing.T) {
 		{
 			name: "valid job",
 			job: types.HPCJob{
-				ID:         1,
-				ClusterID:  1,
-				OfferingID: 1,
-				Owner:      "cosmos1abc123",
-				State:      types.JobStatePending,
-				Workload: types.JobWorkloadSpec{
-					Type:        "batch",
-					Command:     "echo hello",
-					Partition:   "default",
-					NumTasks:    1,
-					CPUsPerTask: 1,
+				JobID:           "job-001",
+				OfferingID:      "offering-001",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				CustomerAddress: validAddr,
+				State:           types.JobStatePending,
+				QueueName:       "default",
+				WorkloadSpec: types.JobWorkloadSpec{
+					ContainerImage: "ubuntu:latest",
+					Command:        "echo hello",
+					IsPreconfigured: false,
 				},
 				Resources: types.JobResources{
-					CPUCores:   4,
-					MemoryMB:   8192,
-					GPUs:       0,
-					MaxTimeMin: 60,
+					Nodes:           1,
+					CPUCoresPerNode: 4,
+					MemoryGBPerNode: 8,
+					StorageGB:       10,
 				},
-				MaxBudget: sdk.NewInt(10000),
+				MaxRuntimeSeconds: 3600,
+				AgreedPrice:       sdk.NewCoins(sdk.NewCoin("uvirt", sdkmath.NewInt(10000))),
+				CreatedAt:         time.Now(),
+				BlockHeight:       100,
 			},
 			expectError: false,
 		},
 		{
-			name: "missing owner",
+			name: "missing job_id",
 			job: types.HPCJob{
-				ID:         1,
-				ClusterID:  1,
-				OfferingID: 1,
-				Owner:      "",
-				State:      types.JobStatePending,
+				JobID:           "",
+				OfferingID:      "offering-001",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				CustomerAddress: validAddr,
+				State:           types.JobStatePending,
+				QueueName:       "default",
+				Resources: types.JobResources{
+					Nodes: 1,
+				},
+				MaxRuntimeSeconds: 3600,
 			},
 			expectError: true,
-			errorMsg:    "owner is required",
+			errorMsg:    "job_id cannot be empty",
 		},
 		{
-			name: "zero resources",
+			name: "invalid customer address",
 			job: types.HPCJob{
-				ID:         1,
-				ClusterID:  1,
-				OfferingID: 1,
-				Owner:      "cosmos1abc123",
-				State:      types.JobStatePending,
+				JobID:           "job-001",
+				OfferingID:      "offering-001",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				CustomerAddress: "invalid-address",
+				State:           types.JobStatePending,
+				QueueName:       "default",
 				Resources: types.JobResources{
-					CPUCores: 0,
+					Nodes: 1,
 				},
+				MaxRuntimeSeconds: 3600,
 			},
 			expectError: true,
-			errorMsg:    "CPU cores must be positive",
+			errorMsg:    "invalid customer address",
+		},
+		{
+			name: "zero nodes",
+			job: types.HPCJob{
+				JobID:           "job-001",
+				OfferingID:      "offering-001",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				CustomerAddress: validAddr,
+				State:           types.JobStatePending,
+				QueueName:       "default",
+				WorkloadSpec: types.JobWorkloadSpec{
+					ContainerImage: "ubuntu:latest",
+					Command:        "echo hello",
+				},
+				Resources: types.JobResources{
+					Nodes: 0, // Invalid
+				},
+				MaxRuntimeSeconds: 3600,
+			},
+			expectError: true,
+			errorMsg:    "nodes must be at least 1",
+		},
+		{
+			name: "max runtime too short",
+			job: types.HPCJob{
+				JobID:           "job-001",
+				OfferingID:      "offering-001",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				CustomerAddress: validAddr,
+				State:           types.JobStatePending,
+				QueueName:       "default",
+				WorkloadSpec: types.JobWorkloadSpec{
+					ContainerImage: "ubuntu:latest",
+					Command:        "echo hello",
+				},
+				Resources: types.JobResources{
+					Nodes: 1,
+				},
+				MaxRuntimeSeconds: 30, // Invalid: < 60
+			},
+			expectError: true,
+			errorMsg:    "max_runtime_seconds must be at least 60",
 		},
 	}
 
@@ -306,67 +471,353 @@ func TestJobValidation(t *testing.T) {
 	}
 }
 
-// TestGenesisParams tests default genesis parameters
-func TestGenesisParams(t *testing.T) {
+// TestDefaultParams tests default genesis parameters
+func TestDefaultParams(t *testing.T) {
 	params := types.DefaultParams()
 
-	require.Equal(t, int64(50000), params.PlatformFeeRate)       // 5% in fixed-point
-	require.Equal(t, int64(700000), params.ProviderRewardRate)   // 70% in fixed-point
-	require.Equal(t, int64(250000), params.NodeRewardRate)       // 25% in fixed-point
-	require.Equal(t, int64(500000), params.LatencyWeightFactor)  // 50% weight
-	require.Equal(t, int64(500000), params.CapacityWeightFactor) // 50% weight
-	require.Equal(t, uint64(100), params.MaxLatencyMs)
-	require.Equal(t, uint64(10), params.MinClusterNodes)
-
-	// Verify rates sum to 100%
-	totalRate := params.PlatformFeeRate + params.ProviderRewardRate + params.NodeRewardRate
-	require.Equal(t, int64(1000000), totalRate, "rates should sum to 100%")
+	require.Equal(t, "50000", params.PlatformFeeRate)       // 5% in fixed-point (50000/1000000)
+	require.Equal(t, "800000", params.ProviderRewardRate)   // 80% in fixed-point (800000/1000000)
+	require.Equal(t, "150000", params.NodeRewardRate)       // 15% in fixed-point (150000/1000000)
+	require.Equal(t, "600000", params.LatencyWeightFactor)  // 0.6 weight
+	require.Equal(t, "400000", params.CapacityWeightFactor) // 0.4 weight
+	require.Equal(t, int64(50), params.MaxLatencyMs)
+	require.Equal(t, int64(60), params.MinJobDurationSeconds)
+	require.Equal(t, int64(604800), params.MaxJobDurationSeconds)
+	require.Equal(t, int32(50), params.DefaultIdentityThreshold)
+	require.Equal(t, "uvirt", params.DefaultDenom)
+	require.True(t, params.EnableProximityClustering)
 }
 
-// TestParamsValidation tests parameter validation
-func TestParamsValidation(t *testing.T) {
+// TestDefaultGenesisState tests default genesis state
+func TestDefaultGenesisState(t *testing.T) {
+	gs := types.DefaultGenesisState()
+
+	require.NotNil(t, gs)
+	require.NotNil(t, gs.Params)
+	require.Empty(t, gs.Clusters)
+	require.Empty(t, gs.Offerings)
+	require.Empty(t, gs.Jobs)
+	require.Empty(t, gs.JobAccountings)
+	require.Empty(t, gs.NodeMetadatas)
+	require.Empty(t, gs.SchedulingDecisions)
+	require.Empty(t, gs.HPCRewards)
+	require.Empty(t, gs.Disputes)
+	require.Equal(t, uint64(1), gs.ClusterSequence)
+	require.Equal(t, uint64(1), gs.OfferingSequence)
+	require.Equal(t, uint64(1), gs.JobSequence)
+	require.Equal(t, uint64(1), gs.DecisionSequence)
+	require.Equal(t, uint64(1), gs.DisputeSequence)
+}
+
+// TestClusterStateValidation tests valid cluster states
+func TestClusterStateValidation(t *testing.T) {
+	testCases := []struct {
+		name  string
+		state types.ClusterState
+		valid bool
+	}{
+		{"pending valid", types.ClusterStatePending, true},
+		{"active valid", types.ClusterStateActive, true},
+		{"draining valid", types.ClusterStateDraining, true},
+		{"offline valid", types.ClusterStateOffline, true},
+		{"deregistered valid", types.ClusterStateDeregistered, true},
+		{"invalid state", types.ClusterState("invalid"), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := types.IsValidClusterState(tc.state)
+			require.Equal(t, tc.valid, result)
+		})
+	}
+}
+
+// TestNodeMetadataValidation tests node metadata validation
+func TestNodeMetadataValidation(t *testing.T) {
+	validAddr := sdk.AccAddress(make([]byte, 20)).String()
+
 	testCases := []struct {
 		name        string
-		params      types.HPCParams
+		node        types.NodeMetadata
 		expectError bool
 		errorMsg    string
 	}{
 		{
-			name:        "default params valid",
-			params:      types.DefaultParams(),
+			name: "valid node metadata",
+			node: types.NodeMetadata{
+				NodeID:          "node-001",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				Region:          "us-west-2",
+				Active:          true,
+				State:           types.NodeStateActive,
+				HealthStatus:    types.HealthStatusHealthy,
+				Resources: types.NodeResources{
+					CPUCores:  32,
+					MemoryGB:  128,
+					GPUs:      4,
+					StorageGB: 1000,
+				},
+			},
 			expectError: false,
 		},
 		{
-			name: "rates exceed 100%",
-			params: types.HPCParams{
-				PlatformFeeRate:    500000,
-				ProviderRewardRate: 500000,
-				NodeRewardRate:     500000, // Total 150%
+			name: "missing node_id",
+			node: types.NodeMetadata{
+				NodeID:          "",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				Region:          "us-west-2",
 			},
 			expectError: true,
-			errorMsg:    "rates must sum to 100%",
+			errorMsg:    "node_id cannot be empty",
 		},
 		{
-			name: "negative platform fee",
-			params: types.HPCParams{
-				PlatformFeeRate:    -1,
-				ProviderRewardRate: 700000,
-				NodeRewardRate:     300001,
+			name: "missing cluster_id",
+			node: types.NodeMetadata{
+				NodeID:          "node-001",
+				ClusterID:       "",
+				ProviderAddress: validAddr,
+				Region:          "us-west-2",
 			},
 			expectError: true,
-			errorMsg:    "platform fee rate must be non-negative",
+			errorMsg:    "cluster_id cannot be empty",
+		},
+		{
+			name: "missing region",
+			node: types.NodeMetadata{
+				NodeID:          "node-001",
+				ClusterID:       "cluster-001",
+				ProviderAddress: validAddr,
+				Region:          "",
+			},
+			expectError: true,
+			errorMsg:    "region cannot be empty",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.params.Validate()
+			err := tc.node.Validate()
 			if tc.expectError {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errorMsg)
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestSchedulingDecisionValidation tests scheduling decision validation
+func TestSchedulingDecisionValidation(t *testing.T) {
+	testCases := []struct {
+		name        string
+		decision    types.SchedulingDecision
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid decision",
+			decision: types.SchedulingDecision{
+				DecisionID:        "decision-001",
+				JobID:             "job-001",
+				SelectedClusterID: "cluster-001",
+				DecisionReason:    "Lowest latency and sufficient capacity",
+				LatencyScore:      "850000",
+				CapacityScore:     "750000",
+				CombinedScore:     "810000",
+				CreatedAt:         time.Now(),
+				BlockHeight:       100,
+			},
+			expectError: false,
+		},
+		{
+			name: "missing decision_id",
+			decision: types.SchedulingDecision{
+				DecisionID:        "",
+				JobID:             "job-001",
+				SelectedClusterID: "cluster-001",
+				DecisionReason:    "Test",
+			},
+			expectError: true,
+			errorMsg:    "decision_id cannot be empty",
+		},
+		{
+			name: "missing job_id",
+			decision: types.SchedulingDecision{
+				DecisionID:        "decision-001",
+				JobID:             "",
+				SelectedClusterID: "cluster-001",
+				DecisionReason:    "Test",
+			},
+			expectError: true,
+			errorMsg:    "job_id cannot be empty",
+		},
+		{
+			name: "missing decision_reason",
+			decision: types.SchedulingDecision{
+				DecisionID:        "decision-001",
+				JobID:             "job-001",
+				SelectedClusterID: "cluster-001",
+				DecisionReason:    "",
+			},
+			expectError: true,
+			errorMsg:    "decision_reason cannot be empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.decision.Validate()
+			if tc.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestHPCRewardSourceValidation tests reward source validation
+func TestHPCRewardSourceValidation(t *testing.T) {
+	testCases := []struct {
+		name   string
+		source types.HPCRewardSource
+		valid  bool
+	}{
+		{"job_completion valid", types.HPCRewardSourceJobCompletion, true},
+		{"usage valid", types.HPCRewardSourceUsage, true},
+		{"bonus valid", types.HPCRewardSourceBonus, true},
+		{"invalid source", types.HPCRewardSource("invalid"), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := types.IsValidHPCRewardSource(tc.source)
+			require.Equal(t, tc.valid, result)
+		})
+	}
+}
+
+// TestDisputeStatusValidation tests dispute status validation
+func TestDisputeStatusValidation(t *testing.T) {
+	testCases := []struct {
+		name   string
+		status types.DisputeStatus
+		valid  bool
+	}{
+		{"pending valid", types.DisputeStatusPending, true},
+		{"under_review valid", types.DisputeStatusUnderReview, true},
+		{"resolved valid", types.DisputeStatusResolved, true},
+		{"rejected valid", types.DisputeStatusRejected, true},
+		{"invalid status", types.DisputeStatus("invalid"), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := types.IsValidDisputeStatus(tc.status)
+			require.Equal(t, tc.valid, result)
+		})
+	}
+}
+
+// TestNodeStateValidation tests node state validation
+func TestNodeStateValidation(t *testing.T) {
+	testCases := []struct {
+		name  string
+		state types.NodeState
+		valid bool
+	}{
+		{"unknown valid", types.NodeStateUnknown, true},
+		{"pending valid", types.NodeStatePending, true},
+		{"active valid", types.NodeStateActive, true},
+		{"stale valid", types.NodeStateStale, true},
+		{"draining valid", types.NodeStateDraining, true},
+		{"drained valid", types.NodeStateDrained, true},
+		{"offline valid", types.NodeStateOffline, true},
+		{"deregistered valid", types.NodeStateDeregistered, true},
+		{"invalid state", types.NodeState("invalid"), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := types.IsValidNodeState(tc.state)
+			require.Equal(t, tc.valid, result)
+		})
+	}
+}
+
+// TestNodeStateTransitions tests valid node state transitions
+func TestNodeStateTransitions(t *testing.T) {
+	testCases := []struct {
+		name      string
+		fromState types.NodeState
+		toState   types.NodeState
+		valid     bool
+	}{
+		{"pending to active", types.NodeStatePending, types.NodeStateActive, true},
+		{"pending to offline", types.NodeStatePending, types.NodeStateOffline, true},
+		{"active to stale", types.NodeStateActive, types.NodeStateStale, true},
+		{"active to draining", types.NodeStateActive, types.NodeStateDraining, true},
+		{"stale to active", types.NodeStateStale, types.NodeStateActive, true},
+		{"draining to drained", types.NodeStateDraining, types.NodeStateDrained, true},
+		{"offline to active", types.NodeStateOffline, types.NodeStateActive, true},
+		{"deregistered to active", types.NodeStateDeregistered, types.NodeStateActive, false}, // Terminal
+		{"active to pending", types.NodeStateActive, types.NodeStatePending, false},           // Invalid
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := types.IsValidNodeStateTransition(tc.fromState, tc.toState)
+			require.Equal(t, tc.valid, result)
+		})
+	}
+}
+
+// TestTerminalNodeState tests terminal node state detection
+func TestTerminalNodeState(t *testing.T) {
+	testCases := []struct {
+		name     string
+		state    types.NodeState
+		terminal bool
+	}{
+		{"pending not terminal", types.NodeStatePending, false},
+		{"active not terminal", types.NodeStateActive, false},
+		{"stale not terminal", types.NodeStateStale, false},
+		{"draining not terminal", types.NodeStateDraining, false},
+		{"offline not terminal", types.NodeStateOffline, false},
+		{"deregistered is terminal", types.NodeStateDeregistered, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := types.IsTerminalNodeState(tc.state)
+			require.Equal(t, tc.terminal, result)
+		})
+	}
+}
+
+// TestHealthStatusValidation tests health status validation
+func TestHealthStatusValidation(t *testing.T) {
+	testCases := []struct {
+		name   string
+		status types.HealthStatus
+		valid  bool
+	}{
+		{"healthy valid", types.HealthStatusHealthy, true},
+		{"degraded valid", types.HealthStatusDegraded, true},
+		{"unhealthy valid", types.HealthStatusUnhealthy, true},
+		{"draining valid", types.HealthStatusDraining, true},
+		{"offline valid", types.HealthStatusOffline, true},
+		{"invalid status", types.HealthStatus("invalid"), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := types.IsValidHealthStatus(tc.status)
+			require.Equal(t, tc.valid, result)
 		})
 	}
 }


### PR DESCRIPTION
**Priority:** HIGH
**Spec Reference:** x/hpc proto generation
**Current State:** HPC has proto definitions but may have gaps; module redesigned

**Implementation Tasks:**
1. Audit x/hpc/types for proto completeness
2. Update hpc.proto with new HPCCluster type fields
3. Run buf generate for HPC module
4. Verify all HPC types match proto definitions
5. Re-enable disabled HPC tests
6. Fix any API mismatches

**Acceptance Criteria:**
- [ ] hpc.proto complete with all current types
- [ ] Go code generated matches keeper expectations
- [ ] Disabled HPC tests re-enabled and passing
- [ ] HPCCluster type fields aligned

**Estimated Effort:** 8-16 hours
**Files to Create/Modify:**
- `sdk/proto/node/virtengine/hpc/v1/*.proto`
- `x/hpc/types/*.go`
- `x/hpc/keeper/keeper_test.go` (re-enable)