### PR TITLE
feat(market): automated Waldur offering sync (bidirectional) 14D 

### DIFF
--- a/pkg/provider_daemon/offering_sync_worker_test.go
+++ b/pkg/provider_daemon/offering_sync_worker_test.go
@@ -1,0 +1,845 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-14D: Tests for offering sync worker and chain-to-Waldur synchronization.
+package provider_daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/virtengine/virtengine/x/market/types/marketplace"
+)
+
+// sampleCompute returns a sample compute offering for testing.
+func sampleCompute() *marketplace.Offering {
+	now := time.Now().UTC()
+	return &marketplace.Offering{
+		ID: marketplace.OfferingID{
+			ProviderAddress: "virtengine1provider123",
+			Sequence:        1,
+		},
+		Name:        "Basic Compute Instance",
+		Description: "A basic compute instance with 2 vCPUs and 4GB RAM",
+		Category:    marketplace.OfferingCategoryCompute,
+		State:       marketplace.OfferingStateActive,
+		Version:     "1.0.0",
+		Pricing: marketplace.PricingInfo{
+			Model:      marketplace.PricingModelHourly,
+			BasePrice:  50000,
+			Currency:   "uvirt",
+			UsageRates: map[string]uint64{},
+		},
+		IdentityRequirement: marketplace.IdentityRequirement{
+			MinScore:   10,
+			RequireMFA: false,
+		},
+		Tags:                []string{"compute", "basic"},
+		Regions:             []string{"us-east-1", "eu-west-1"},
+		MaxConcurrentOrders: 10,
+		RequireMFAForOrders: false,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+}
+
+// sampleHPC returns a sample HPC offering for testing.
+func sampleHPC() *marketplace.Offering {
+	now := time.Now().UTC()
+	return &marketplace.Offering{
+		ID: marketplace.OfferingID{
+			ProviderAddress: "virtengine1provider123",
+			Sequence:        2,
+		},
+		Name:        "HPC Cluster Access",
+		Description: "High-performance computing cluster with SLURM scheduling",
+		Category:    marketplace.OfferingCategoryHPC,
+		State:       marketplace.OfferingStateActive,
+		Version:     "1.0.0",
+		Pricing: marketplace.PricingInfo{
+			Model:     marketplace.PricingModelUsageBased,
+			BasePrice: 0,
+			Currency:  "uvirt",
+			UsageRates: map[string]uint64{
+				"cpu_hours": 10000,
+				"gpu_hours": 1500000,
+			},
+		},
+		IdentityRequirement: marketplace.IdentityRequirement{
+			MinScore:   50,
+			RequireMFA: true,
+		},
+		Tags:                []string{"hpc", "slurm", "research"},
+		Regions:             []string{"us-west-2"},
+		MaxConcurrentOrders: 5,
+		RequireMFAForOrders: true,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+}
+
+func TestOffering_ToWaldurCreate(t *testing.T) {
+	cfg := marketplace.DefaultOfferingSyncConfig()
+	cfg.WaldurCustomerUUID = "waldur-customer-uuid-123"
+	cfg.WaldurCategoryMap = map[string]string{
+		"compute": "waldur-cat-compute",
+		"hpc":     "waldur-cat-hpc",
+	}
+
+	tests := []struct {
+		name         string
+		offering     *marketplace.Offering
+		wantName     string
+		wantType     string
+		wantState    string
+		wantShared   bool
+		wantBillable bool
+	}{
+		{
+			name:         "compute offering",
+			offering:     sampleCompute(),
+			wantName:     "Basic Compute Instance",
+			wantType:     "VirtEngine.Compute",
+			wantState:    "Active",
+			wantShared:   true,
+			wantBillable: true,
+		},
+		{
+			name:         "hpc offering",
+			offering:     sampleHPC(),
+			wantName:     "HPC Cluster Access",
+			wantType:     "VirtEngine.HPC",
+			wantState:    "Active",
+			wantShared:   true,
+			wantBillable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			waldurCreate := tt.offering.ToWaldurCreate(cfg)
+
+			if waldurCreate.Name != tt.wantName {
+				t.Errorf("Name = %s, want %s", waldurCreate.Name, tt.wantName)
+			}
+			if waldurCreate.Type != tt.wantType {
+				t.Errorf("Type = %s, want %s", waldurCreate.Type, tt.wantType)
+			}
+			if waldurCreate.State != tt.wantState {
+				t.Errorf("State = %s, want %s", waldurCreate.State, tt.wantState)
+			}
+			if waldurCreate.Shared != tt.wantShared {
+				t.Errorf("Shared = %t, want %t", waldurCreate.Shared, tt.wantShared)
+			}
+			if waldurCreate.Billable != tt.wantBillable {
+				t.Errorf("Billable = %t, want %t", waldurCreate.Billable, tt.wantBillable)
+			}
+			if waldurCreate.CustomerUUID != cfg.WaldurCustomerUUID {
+				t.Errorf("CustomerUUID = %s, want %s", waldurCreate.CustomerUUID, cfg.WaldurCustomerUUID)
+			}
+			if waldurCreate.BackendID != tt.offering.ID.String() {
+				t.Errorf("BackendID = %s, want %s", waldurCreate.BackendID, tt.offering.ID.String())
+			}
+		})
+	}
+}
+
+func TestOffering_ToWaldurUpdate(t *testing.T) {
+	cfg := marketplace.DefaultOfferingSyncConfig()
+	offering := sampleCompute()
+	offering.Name = "Updated Compute Instance"
+	offering.Description = "Updated description"
+
+	waldurUpdate := offering.ToWaldurUpdate(cfg)
+
+	if waldurUpdate.Name != "Updated Compute Instance" {
+		t.Errorf("Name = %s, want 'Updated Compute Instance'", waldurUpdate.Name)
+	}
+	if waldurUpdate.Description != "Updated description" {
+		t.Errorf("Description = %s, want 'Updated description'", waldurUpdate.Description)
+	}
+	if waldurUpdate.State != "Active" {
+		t.Errorf("State = %s, want 'Active'", waldurUpdate.State)
+	}
+}
+
+func TestOffering_SyncChecksum(t *testing.T) {
+	offering := sampleCompute()
+
+	checksum1 := offering.SyncChecksum()
+	checksum2 := offering.SyncChecksum()
+
+	if checksum1 != checksum2 {
+		t.Error("checksums should be deterministic")
+	}
+
+	// Modify offering and check checksum changes
+	offering.Name = "Modified Name"
+	checksum3 := offering.SyncChecksum()
+
+	if checksum1 == checksum3 {
+		t.Error("checksum should differ for modified offering")
+	}
+}
+
+func TestOfferingSyncState(t *testing.T) {
+	state := NewOfferingSyncState("virtengine1provider123")
+
+	if state.ProviderAddress != "virtengine1provider123" {
+		t.Errorf("ProviderAddress = %s, want virtengine1provider123", state.ProviderAddress)
+	}
+	if len(state.Records) != 0 {
+		t.Errorf("Records should be empty, got %d", len(state.Records))
+	}
+
+	t.Run("mark synced", func(t *testing.T) {
+		state.MarkSynced("offering/1", "waldur-uuid-1", "checksum123", 1)
+		record := state.GetRecord("offering/1")
+		if record == nil {
+			t.Fatal("record should exist")
+		}
+		if record.State != SyncStateSynced {
+			t.Errorf("state = %v, want synced", record.State)
+		}
+		if record.WaldurUUID != "waldur-uuid-1" {
+			t.Errorf("WaldurUUID = %s, want waldur-uuid-1", record.WaldurUUID)
+		}
+		if record.Checksum != "checksum123" {
+			t.Errorf("Checksum = %s, want checksum123", record.Checksum)
+		}
+		if record.SyncedVersion != 1 {
+			t.Errorf("SyncedVersion = %d, want 1", record.SyncedVersion)
+		}
+	})
+
+	t.Run("mark failed with retry", func(t *testing.T) {
+		state.GetOrCreateRecord("offering/2")
+		deadLettered := state.MarkFailed("offering/2", "test error", 3, time.Second, time.Minute)
+		if deadLettered {
+			t.Error("should not be dead-lettered on first failure")
+		}
+		record := state.GetRecord("offering/2")
+		if record.State != SyncStateRetrying {
+			t.Errorf("state = %v, want retrying", record.State)
+		}
+		if record.RetryCount != 1 {
+			t.Errorf("RetryCount = %d, want 1", record.RetryCount)
+		}
+		if record.NextRetryAt == nil {
+			t.Error("NextRetryAt should be set")
+		}
+	})
+
+	t.Run("dead letter after max retries", func(t *testing.T) {
+		state.GetOrCreateRecord("offering/3")
+		for i := 0; i <= 3; i++ {
+			state.MarkFailed("offering/3", "persistent error", 3, time.Second, time.Minute)
+		}
+		record := state.GetRecord("offering/3")
+		if record.State != SyncStateDeadLettered {
+			t.Errorf("state = %v, want dead_lettered", record.State)
+		}
+		if len(state.DeadLetterQueue) != 1 {
+			t.Errorf("dead letter queue size = %d, want 1", len(state.DeadLetterQueue))
+		}
+	})
+
+	t.Run("mark out of sync", func(t *testing.T) {
+		state.MarkSynced("offering/4", "waldur-uuid-4", "old-checksum", 1)
+		state.MarkOutOfSync("offering/4", 2, "new-checksum")
+		record := state.GetRecord("offering/4")
+		if record.State != SyncStateOutOfSync {
+			t.Errorf("state = %v, want out_of_sync", record.State)
+		}
+		if record.ChainVersion != 2 {
+			t.Errorf("ChainVersion = %d, want 2", record.ChainVersion)
+		}
+		if record.Checksum != "new-checksum" {
+			t.Errorf("Checksum = %s, want new-checksum", record.Checksum)
+		}
+	})
+
+	t.Run("needs sync offerings", func(t *testing.T) {
+		state.GetOrCreateRecord("offering/5") // Pending state
+		needs := state.NeedsSyncOfferings()
+		found := false
+		for _, id := range needs {
+			if id == "offering/5" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("offering/5 should need sync")
+		}
+	})
+
+	t.Run("reprocess dead letter", func(t *testing.T) {
+		ok := state.ReprocessDeadLetter("offering/3")
+		if !ok {
+			t.Error("reprocess should succeed")
+		}
+		record := state.GetRecord("offering/3")
+		if record.State != SyncStatePending {
+			t.Errorf("state = %v, want pending after reprocess", record.State)
+		}
+		if record.RetryCount != 0 {
+			t.Errorf("RetryCount = %d, want 0 after reprocess", record.RetryCount)
+		}
+		if len(state.DeadLetterQueue) != 0 {
+			t.Errorf("dead letter queue size = %d, want 0", len(state.DeadLetterQueue))
+		}
+	})
+}
+
+func TestOfferingSyncStateStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	statePath := filepath.Join(tmpDir, "offering_sync_state.json")
+	store := NewOfferingSyncStateStore(statePath)
+
+	// Load non-existent creates new
+	state, err := store.Load("virtengine1provider123")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if state.ProviderAddress != "virtengine1provider123" {
+		t.Errorf("ProviderAddress = %s, want virtengine1provider123", state.ProviderAddress)
+	}
+
+	// Add data and save
+	state.MarkSynced("offering/1", "waldur-uuid-1", "checksum", 1)
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(statePath); os.IsNotExist(err) {
+		t.Fatal("state file should exist")
+	}
+
+	// Load and verify
+	loaded, err := store.Load("virtengine1provider123")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.GetRecord("offering/1") == nil {
+		t.Error("loaded state should contain offering/1")
+	}
+
+	// Delete
+	if err := store.Delete(); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Error("state file should be deleted")
+	}
+}
+
+func TestOfferingSyncWorkerConfig(t *testing.T) {
+	cfg := DefaultOfferingSyncWorkerConfig()
+
+	if cfg.EventBuffer != 100 {
+		t.Errorf("EventBuffer = %d, want 100", cfg.EventBuffer)
+	}
+	if cfg.SyncIntervalSeconds != 300 {
+		t.Errorf("SyncIntervalSeconds = %d, want 300", cfg.SyncIntervalSeconds)
+	}
+	if !cfg.ReconcileOnStartup {
+		t.Error("ReconcileOnStartup should be true")
+	}
+	if cfg.MaxRetries != 5 {
+		t.Errorf("MaxRetries = %d, want 5", cfg.MaxRetries)
+	}
+	if cfg.CurrencyDenominator != 1000000 {
+		t.Errorf("CurrencyDenominator = %d, want 1000000", cfg.CurrencyDenominator)
+	}
+}
+
+func TestOfferingSyncTask(t *testing.T) {
+	offering := sampleCompute()
+	task := &OfferingSyncTask{
+		OfferingID: offering.ID.String(),
+		Action:     SyncActionCreate,
+		Offering:   offering,
+		Timestamp:  time.Now().UTC(),
+	}
+
+	if task.OfferingID == "" {
+		t.Error("OfferingID should not be empty")
+	}
+	if task.Action != SyncActionCreate {
+		t.Errorf("Action = %s, want create", task.Action)
+	}
+	if task.Offering == nil {
+		t.Error("Offering should not be nil")
+	}
+}
+
+func TestSyncActions(t *testing.T) {
+	tests := []struct {
+		action SyncAction
+		want   string
+	}{
+		{SyncActionCreate, "create"},
+		{SyncActionUpdate, "update"},
+		{SyncActionDisable, "disable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if string(tt.action) != tt.want {
+				t.Errorf("action = %s, want %s", tt.action, tt.want)
+			}
+		})
+	}
+}
+
+func TestSyncStates(t *testing.T) {
+	tests := []struct {
+		state SyncState
+		want  string
+	}{
+		{SyncStatePending, "pending"},
+		{SyncStateSynced, "synced"},
+		{SyncStateFailed, "failed"},
+		{SyncStateRetrying, "retrying"},
+		{SyncStateDeadLettered, "dead_lettered"},
+		{SyncStateOutOfSync, "out_of_sync"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if string(tt.state) != tt.want {
+				t.Errorf("state = %s, want %s", tt.state, tt.want)
+			}
+		})
+	}
+}
+
+func TestOfferingSyncAuditEntry(t *testing.T) {
+	entry := OfferingSyncAuditEntry{
+		Timestamp:       time.Now().UTC(),
+		OfferingID:      "offering/1",
+		WaldurUUID:      "waldur-uuid-1",
+		Action:          SyncActionCreate,
+		Success:         true,
+		Duration:        time.Millisecond * 100,
+		RetryCount:      0,
+		ProviderAddress: "virtengine1provider123",
+		Checksum:        "checksum123",
+	}
+
+	if entry.OfferingID != "offering/1" {
+		t.Errorf("OfferingID = %s, want offering/1", entry.OfferingID)
+	}
+	if !entry.Success {
+		t.Error("Success should be true")
+	}
+}
+
+func TestReconciliationAuditEntry(t *testing.T) {
+	entry := ReconciliationAuditEntry{
+		Timestamp:        time.Now().UTC(),
+		ProviderAddress:  "virtengine1provider123",
+		OfferingsChecked: 100,
+		DriftDetected:    5,
+		OfferingsQueued:  5,
+		Duration:         time.Second * 2,
+	}
+
+	if entry.OfferingsChecked != 100 {
+		t.Errorf("OfferingsChecked = %d, want 100", entry.OfferingsChecked)
+	}
+	if entry.DriftDetected != 5 {
+		t.Errorf("DriftDetected = %d, want 5", entry.DriftDetected)
+	}
+}
+
+func TestDeadLetterAuditEntry(t *testing.T) {
+	entry := DeadLetterAuditEntry{
+		Timestamp:       time.Now().UTC(),
+		OfferingID:      "offering/1",
+		ProviderAddress: "virtengine1provider123",
+		TotalAttempts:   5,
+		LastError:       "connection timeout",
+		Action:          "dead_lettered",
+	}
+
+	if entry.TotalAttempts != 5 {
+		t.Errorf("TotalAttempts = %d, want 5", entry.TotalAttempts)
+	}
+	if entry.Action != "dead_lettered" {
+		t.Errorf("Action = %s, want dead_lettered", entry.Action)
+	}
+}
+
+func TestDefaultAuditLogger(t *testing.T) {
+	logger := NewDefaultAuditLogger("[test-audit]")
+
+	// Should not panic
+	logger.LogSyncAttempt(OfferingSyncAuditEntry{
+		OfferingID: "test-offering",
+		Action:     SyncActionCreate,
+		Success:    true,
+	})
+
+	logger.LogReconciliation(ReconciliationAuditEntry{
+		ProviderAddress:  "test-provider",
+		OfferingsChecked: 10,
+	})
+
+	logger.LogDeadLetter(DeadLetterAuditEntry{
+		OfferingID: "test-offering",
+		Action:     "dead_lettered",
+	})
+}
+
+func TestOfferingSyncWorkerMetrics(t *testing.T) {
+	metrics := &OfferingSyncWorkerMetrics{
+		WorkerUptime: time.Now().UTC(),
+	}
+
+	if metrics.SyncsTotal != 0 {
+		t.Errorf("SyncsTotal = %d, want 0", metrics.SyncsTotal)
+	}
+	if metrics.WorkerUptime.IsZero() {
+		t.Error("WorkerUptime should be set")
+	}
+}
+
+func TestOfferingSyncPrometheusMetrics(t *testing.T) {
+	metrics := &OfferingSyncPrometheusMetrics{}
+
+	metrics.SyncsTotal.Add(1)
+	metrics.SyncsSuccessful.Add(1)
+	metrics.ReconciliationsRun.Add(1)
+
+	if metrics.SyncsTotal.Load() != 1 {
+		t.Errorf("SyncsTotal = %d, want 1", metrics.SyncsTotal.Load())
+	}
+	if metrics.SyncsSuccessful.Load() != 1 {
+		t.Errorf("SyncsSuccessful = %d, want 1", metrics.SyncsSuccessful.Load())
+	}
+	if metrics.ReconciliationsRun.Load() != 1 {
+		t.Errorf("ReconciliationsRun = %d, want 1", metrics.ReconciliationsRun.Load())
+	}
+}
+
+func TestEventTypeToAction(t *testing.T) {
+	w := &OfferingSyncWorker{}
+
+	tests := []struct {
+		eventType marketplace.MarketplaceEventType
+		want      SyncAction
+	}{
+		{marketplace.EventOfferingCreated, SyncActionCreate},
+		{marketplace.EventOfferingUpdated, SyncActionUpdate},
+		{marketplace.EventOfferingTerminated, SyncActionDisable},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.eventType), func(t *testing.T) {
+			got := w.eventTypeToAction(tt.eventType)
+			if got != tt.want {
+				t.Errorf("eventTypeToAction(%s) = %s, want %s", tt.eventType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStateToAction(t *testing.T) {
+	w := &OfferingSyncWorker{}
+
+	tests := []struct {
+		state string
+		want  string
+	}{
+		{"Active", "activate"},
+		{"Paused", "pause"},
+		{"Archived", "archive"},
+		{"Unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			got := w.stateToAction(tt.state)
+			if got != tt.want {
+				t.Errorf("stateToAction(%s) = %s, want %s", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaldurOfferingTypeMapping(t *testing.T) {
+	tests := []struct {
+		category marketplace.OfferingCategory
+		want     string
+	}{
+		{marketplace.OfferingCategoryCompute, "VirtEngine.Compute"},
+		{marketplace.OfferingCategoryStorage, "VirtEngine.Storage"},
+		{marketplace.OfferingCategoryNetwork, "VirtEngine.Network"},
+		{marketplace.OfferingCategoryHPC, "VirtEngine.HPC"},
+		{marketplace.OfferingCategoryGPU, "VirtEngine.GPU"},
+		{marketplace.OfferingCategoryML, "VirtEngine.ML"},
+		{marketplace.OfferingCategoryOther, "VirtEngine.Generic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.category), func(t *testing.T) {
+			got := marketplace.WaldurOfferingType[tt.category]
+			if got != tt.want {
+				t.Errorf("WaldurOfferingType[%s] = %s, want %s", tt.category, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaldurOfferingStateMapping(t *testing.T) {
+	tests := []struct {
+		state marketplace.OfferingState
+		want  string
+	}{
+		{marketplace.OfferingStateActive, "Active"},
+		{marketplace.OfferingStatePaused, "Paused"},
+		{marketplace.OfferingStateSuspended, "Archived"},
+		{marketplace.OfferingStateDeprecated, "Paused"},
+		{marketplace.OfferingStateTerminated, "Archived"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			got := marketplace.WaldurOfferingState[tt.state]
+			if got != tt.want {
+				t.Errorf("WaldurOfferingState[%s] = %s, want %s", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOfferingSyncWorkerCreation tests worker creation with nil marketplace client.
+func TestOfferingSyncWorkerCreation(t *testing.T) {
+	cfg := DefaultOfferingSyncWorkerConfig()
+	cfg.ProviderAddress = "virtengine1provider123"
+
+	// Should fail with nil marketplace client
+	_, err := NewOfferingSyncWorker(cfg, nil)
+	if err == nil {
+		t.Error("should fail with nil marketplace client")
+	}
+}
+
+// TestOfferingSyncWorkerWithLogger tests worker creation with custom logger.
+func TestOfferingSyncWorkerWithLogger(t *testing.T) {
+	cfg := DefaultOfferingSyncWorkerConfig()
+	cfg.ProviderAddress = "virtengine1provider123"
+
+	// Should fail with nil marketplace client
+	customLogger := NewDefaultAuditLogger("[custom]")
+	_, err := NewOfferingSyncWorkerWithLogger(cfg, nil, customLogger)
+	if err == nil {
+		t.Error("should fail with nil marketplace client")
+	}
+}
+
+// TestSyncMetrics tests the sync metrics structure.
+func TestSyncMetrics(t *testing.T) {
+	metrics := &SyncMetrics{
+		TotalSyncs:       100,
+		SuccessfulSyncs:  95,
+		FailedSyncs:      5,
+		DeadLettered:     2,
+		DriftDetections:  10,
+		ReconciliationsRun: 20,
+	}
+
+	if metrics.TotalSyncs != 100 {
+		t.Errorf("TotalSyncs = %d, want 100", metrics.TotalSyncs)
+	}
+	if metrics.SuccessfulSyncs != 95 {
+		t.Errorf("SuccessfulSyncs = %d, want 95", metrics.SuccessfulSyncs)
+	}
+	successRate := float64(metrics.SuccessfulSyncs) / float64(metrics.TotalSyncs)
+	if successRate < 0.95 {
+		t.Errorf("success rate = %.2f, want >= 0.95", successRate)
+	}
+}
+
+// TestDeadLetterItem tests the dead letter item structure.
+func TestDeadLetterItem(t *testing.T) {
+	now := time.Now().UTC()
+	item := &DeadLetterItem{
+		OfferingID:     "offering/1",
+		Action:         "update",
+		LastError:      "connection timeout",
+		RetryCount:     5,
+		FirstAttemptAt: now.Add(-time.Hour),
+		DeadLetteredAt: now,
+		Checksum:       "checksum123",
+		ChainVersion:   3,
+	}
+
+	if item.OfferingID != "offering/1" {
+		t.Errorf("OfferingID = %s, want offering/1", item.OfferingID)
+	}
+	if item.RetryCount != 5 {
+		t.Errorf("RetryCount = %d, want 5", item.RetryCount)
+	}
+	if item.ChainVersion != 3 {
+		t.Errorf("ChainVersion = %d, want 3", item.ChainVersion)
+	}
+}
+
+// TestOfferingSyncRecord tests the sync record structure.
+func TestOfferingSyncRecord(t *testing.T) {
+	now := time.Now().UTC()
+	record := &OfferingSyncRecord{
+		OfferingID:   "offering/1",
+		WaldurUUID:   "waldur-uuid-1",
+		State:        SyncStateSynced,
+		ChainVersion: 1,
+		SyncedVersion: 1,
+		Checksum:     "checksum123",
+		LastSyncedAt: &now,
+		CreatedAt:    now,
+	}
+
+	if record.OfferingID != "offering/1" {
+		t.Errorf("OfferingID = %s, want offering/1", record.OfferingID)
+	}
+	if record.State != SyncStateSynced {
+		t.Errorf("State = %s, want synced", record.State)
+	}
+	if record.LastSyncedAt == nil {
+		t.Error("LastSyncedAt should be set")
+	}
+}
+
+// TestQueueSync tests the queue sync functionality.
+func TestQueueSync(t *testing.T) {
+	// Create a minimal worker for testing queue operations
+	cfg := DefaultOfferingSyncWorkerConfig()
+	cfg.EventBuffer = 10
+
+	worker := &OfferingSyncWorker{
+		cfg:       cfg,
+		syncQueue: make(chan *OfferingSyncTask, cfg.EventBuffer),
+		metrics:   &OfferingSyncWorkerMetrics{},
+	}
+
+	offering := sampleCompute()
+	err := worker.QueueSync(offering.ID.String(), SyncActionUpdate, offering)
+	if err != nil {
+		t.Errorf("QueueSync failed: %v", err)
+	}
+
+	// Verify task was queued
+	select {
+	case task := <-worker.syncQueue:
+		if task.OfferingID != offering.ID.String() {
+			t.Errorf("queued task OfferingID = %s, want %s", task.OfferingID, offering.ID.String())
+		}
+		if task.Action != SyncActionUpdate {
+			t.Errorf("queued task Action = %s, want update", task.Action)
+		}
+	default:
+		t.Error("no task was queued")
+	}
+}
+
+// TestQueueSyncFull tests queue full behavior.
+func TestQueueSyncFull(t *testing.T) {
+	cfg := DefaultOfferingSyncWorkerConfig()
+	cfg.EventBuffer = 1 // Small buffer for testing
+
+	worker := &OfferingSyncWorker{
+		cfg:       cfg,
+		syncQueue: make(chan *OfferingSyncTask, cfg.EventBuffer),
+		metrics:   &OfferingSyncWorkerMetrics{},
+	}
+
+	offering := sampleCompute()
+
+	// Fill the queue
+	_ = worker.QueueSync("offering/1", SyncActionCreate, offering)
+
+	// Next queue should fail
+	err := worker.QueueSync("offering/2", SyncActionCreate, offering)
+	if err == nil {
+		t.Error("QueueSync should fail when queue is full")
+	}
+	if !errors.Is(err, errors.New("sync queue full")) && err.Error() != "sync queue full" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestReconcile tests the reconcile method.
+func TestReconcile(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := DefaultOfferingSyncWorkerConfig()
+	cfg.EventBuffer = 100
+
+	state := NewOfferingSyncState("virtengine1provider123")
+	// Add some offerings that need sync
+	state.GetOrCreateRecord("offering/1")
+	state.MarkOutOfSync("offering/1", 2, "new-checksum")
+
+	worker := &OfferingSyncWorker{
+		cfg:       cfg,
+		state:     state,
+		syncQueue: make(chan *OfferingSyncTask, cfg.EventBuffer),
+		metrics:   &OfferingSyncWorkerMetrics{},
+		promMetrics: &OfferingSyncPrometheusMetrics{},
+		auditLogger: NewDefaultAuditLogger("[test]"),
+	}
+
+	err := worker.Reconcile(ctx)
+	if err != nil {
+		t.Errorf("Reconcile failed: %v", err)
+	}
+
+	// Verify task was queued
+	select {
+	case task := <-worker.syncQueue:
+		if task.OfferingID != "offering/1" {
+			t.Errorf("queued task OfferingID = %s, want offering/1", task.OfferingID)
+		}
+	default:
+		t.Error("reconcile should have queued a task")
+	}
+}
+
+// TestWorkerMetricsSnapshot tests the Metrics method.
+func TestWorkerMetricsSnapshot(t *testing.T) {
+	cfg := DefaultOfferingSyncWorkerConfig()
+	cfg.EventBuffer = 10
+
+	worker := &OfferingSyncWorker{
+		cfg:       cfg,
+		syncQueue: make(chan *OfferingSyncTask, cfg.EventBuffer),
+		metrics: &OfferingSyncWorkerMetrics{
+			SyncsTotal:      100,
+			SyncsSuccessful: 95,
+			SyncsFailed:     5,
+			WorkerUptime:    time.Now().UTC().Add(-time.Hour),
+		},
+	}
+
+	snapshot := worker.Metrics()
+
+	if snapshot.SyncsTotal != 100 {
+		t.Errorf("SyncsTotal = %d, want 100", snapshot.SyncsTotal)
+	}
+	if snapshot.SyncsSuccessful != 95 {
+		t.Errorf("SyncsSuccessful = %d, want 95", snapshot.SyncsSuccessful)
+	}
+	if snapshot.SyncsFailed != 5 {
+		t.Errorf("SyncsFailed = %d, want 5", snapshot.SyncsFailed)
+	}
+	if snapshot.QueueDepth != 0 {
+		t.Errorf("QueueDepth = %d, want 0", snapshot.QueueDepth)
+	}
+}

--- a/x/market/types/marketplace/sync_status.go
+++ b/x/market/types/marketplace/sync_status.go
@@ -1,0 +1,630 @@
+// Package marketplace provides types for the marketplace on-chain module.
+//
+// VE-14D: On-chain sync status tracking for bidirectional Waldur offering sync.
+// This file defines types for tracking sync status on-chain, enabling drift
+// detection and reconciliation between VirtEngine and Waldur.
+package marketplace
+
+import (
+	"time"
+)
+
+// SyncDirection represents the direction of synchronization.
+type SyncDirection string
+
+const (
+	// SyncDirectionToWaldur indicates chain-to-Waldur sync (offerings pushed to Waldur).
+	SyncDirectionToWaldur SyncDirection = "to_waldur"
+
+	// SyncDirectionFromWaldur indicates Waldur-to-chain sync (offerings ingested from Waldur).
+	SyncDirectionFromWaldur SyncDirection = "from_waldur"
+
+	// SyncDirectionBidirectional indicates both directions are active.
+	SyncDirectionBidirectional SyncDirection = "bidirectional"
+)
+
+// SyncStatusState represents the overall sync status state.
+type SyncStatusState string
+
+const (
+	// SyncStatusStateHealthy indicates sync is working normally.
+	SyncStatusStateHealthy SyncStatusState = "healthy"
+
+	// SyncStatusStateDegraded indicates some sync operations are failing.
+	SyncStatusStateDegraded SyncStatusState = "degraded"
+
+	// SyncStatusStateFailed indicates sync is completely failed.
+	SyncStatusStateFailed SyncStatusState = "failed"
+
+	// SyncStatusStateDisabled indicates sync is disabled.
+	SyncStatusStateDisabled SyncStatusState = "disabled"
+
+	// SyncStatusStateReconciling indicates active reconciliation in progress.
+	SyncStatusStateReconciling SyncStatusState = "reconciling"
+)
+
+// OfferingSyncStatus tracks the on-chain sync status for a provider's offerings.
+// This is stored on-chain to enable cross-node visibility of sync state.
+type OfferingSyncStatus struct {
+	// ProviderAddress is the provider this status belongs to.
+	ProviderAddress string `json:"provider_address"`
+
+	// Direction is the sync direction for this provider.
+	Direction SyncDirection `json:"direction"`
+
+	// State is the overall sync status state.
+	State SyncStatusState `json:"state"`
+
+	// WaldurCustomerUUID is the linked Waldur customer UUID.
+	WaldurCustomerUUID string `json:"waldur_customer_uuid,omitempty"`
+
+	// ToWaldurStats contains chain-to-Waldur sync statistics.
+	ToWaldurStats *SyncDirectionStats `json:"to_waldur_stats,omitempty"`
+
+	// FromWaldurStats contains Waldur-to-chain ingestion statistics.
+	FromWaldurStats *SyncDirectionStats `json:"from_waldur_stats,omitempty"`
+
+	// LastReconciliationAt is when the last reconciliation completed.
+	LastReconciliationAt *time.Time `json:"last_reconciliation_at,omitempty"`
+
+	// LastDriftCheckAt is when the last drift detection check ran.
+	LastDriftCheckAt *time.Time `json:"last_drift_check_at,omitempty"`
+
+	// DriftCount is the number of offerings currently out of sync.
+	DriftCount uint32 `json:"drift_count"`
+
+	// DeadLetterCount is the number of offerings in dead letter queue.
+	DeadLetterCount uint32 `json:"dead_letter_count"`
+
+	// EnabledAt is when sync was enabled for this provider.
+	EnabledAt *time.Time `json:"enabled_at,omitempty"`
+
+	// UpdatedAt is when this status was last modified.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// SyncDirectionStats contains statistics for a sync direction.
+type SyncDirectionStats struct {
+	// TotalOfferings is the total number of offerings tracked.
+	TotalOfferings uint32 `json:"total_offerings"`
+
+	// SyncedOfferings is the number of offerings in sync.
+	SyncedOfferings uint32 `json:"synced_offerings"`
+
+	// PendingOfferings is the number of offerings pending sync.
+	PendingOfferings uint32 `json:"pending_offerings"`
+
+	// FailedOfferings is the number of offerings with failed sync.
+	FailedOfferings uint32 `json:"failed_offerings"`
+
+	// DeadLetteredOfferings is the number of dead-lettered offerings.
+	DeadLetteredOfferings uint32 `json:"dead_lettered_offerings"`
+
+	// TotalSyncAttempts is the total number of sync attempts.
+	TotalSyncAttempts uint64 `json:"total_sync_attempts"`
+
+	// SuccessfulSyncs is the count of successful sync operations.
+	SuccessfulSyncs uint64 `json:"successful_syncs"`
+
+	// FailedSyncs is the count of failed sync attempts.
+	FailedSyncs uint64 `json:"failed_syncs"`
+
+	// LastSyncAt is when the last sync operation completed.
+	LastSyncAt *time.Time `json:"last_sync_at,omitempty"`
+
+	// LastSuccessAt is when the last successful sync completed.
+	LastSuccessAt *time.Time `json:"last_success_at,omitempty"`
+
+	// LastFailureAt is when the last sync failure occurred.
+	LastFailureAt *time.Time `json:"last_failure_at,omitempty"`
+
+	// LastError is the most recent error message.
+	LastError string `json:"last_error,omitempty"`
+
+	// AverageSyncDurationMs is the average sync duration in milliseconds.
+	AverageSyncDurationMs float64 `json:"average_sync_duration_ms"`
+}
+
+// OfferingSyncRecord tracks the sync state of a single offering on-chain.
+type OfferingSyncRecord struct {
+	// OfferingID is the on-chain offering ID.
+	OfferingID string `json:"offering_id"`
+
+	// ProviderAddress is the provider's address.
+	ProviderAddress string `json:"provider_address"`
+
+	// WaldurUUID is the corresponding Waldur offering UUID (if synced).
+	WaldurUUID string `json:"waldur_uuid,omitempty"`
+
+	// SyncState is the current sync state.
+	SyncState OfferingSyncState `json:"sync_state"`
+
+	// Direction is the sync direction for this offering.
+	Direction SyncDirection `json:"direction"`
+
+	// ChainVersion is the on-chain offering version.
+	ChainVersion uint64 `json:"chain_version"`
+
+	// WaldurVersion is a hash representing the Waldur offering state.
+	WaldurVersion string `json:"waldur_version,omitempty"`
+
+	// ChainChecksum is the checksum of on-chain data.
+	ChainChecksum string `json:"chain_checksum"`
+
+	// WaldurChecksum is the checksum of Waldur data.
+	WaldurChecksum string `json:"waldur_checksum,omitempty"`
+
+	// InSync indicates if chain and Waldur are in sync.
+	InSync bool `json:"in_sync"`
+
+	// LastSyncedAt is when the offering was last successfully synced.
+	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
+
+	// LastAttemptAt is when sync was last attempted.
+	LastAttemptAt *time.Time `json:"last_attempt_at,omitempty"`
+
+	// RetryCount is the number of consecutive retry attempts.
+	RetryCount uint32 `json:"retry_count"`
+
+	// NextRetryAt is when the next retry should be attempted.
+	NextRetryAt *time.Time `json:"next_retry_at,omitempty"`
+
+	// LastError is the most recent sync error.
+	LastError string `json:"last_error,omitempty"`
+
+	// CreatedAt is when this record was created.
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is when this record was last modified.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// OfferingSyncState represents the sync state of an individual offering.
+type OfferingSyncState string
+
+const (
+	// OfferingSyncStatePending indicates sync is pending.
+	OfferingSyncStatePending OfferingSyncState = "pending"
+
+	// OfferingSyncStateSynced indicates offering is in sync.
+	OfferingSyncStateSynced OfferingSyncState = "synced"
+
+	// OfferingSyncStateFailed indicates last sync attempt failed.
+	OfferingSyncStateFailed OfferingSyncState = "failed"
+
+	// OfferingSyncStateRetrying indicates sync is being retried.
+	OfferingSyncStateRetrying OfferingSyncState = "retrying"
+
+	// OfferingSyncStateDeadLettered indicates sync failed permanently.
+	OfferingSyncStateDeadLettered OfferingSyncState = "dead_lettered"
+
+	// OfferingSyncStateDrifted indicates offering is out of sync.
+	OfferingSyncStateDrifted OfferingSyncState = "drifted"
+
+	// OfferingSyncStateSkipped indicates offering was intentionally skipped.
+	OfferingSyncStateSkipped OfferingSyncState = "skipped"
+)
+
+// SyncEvent represents a sync event for audit trail.
+type SyncEvent struct {
+	// EventID is the unique event identifier.
+	EventID string `json:"event_id"`
+
+	// OfferingID is the offering involved.
+	OfferingID string `json:"offering_id"`
+
+	// ProviderAddress is the provider's address.
+	ProviderAddress string `json:"provider_address"`
+
+	// Direction is the sync direction.
+	Direction SyncDirection `json:"direction"`
+
+	// EventType is the type of sync event.
+	EventType SyncEventType `json:"event_type"`
+
+	// OldState is the previous sync state.
+	OldState OfferingSyncState `json:"old_state,omitempty"`
+
+	// NewState is the new sync state.
+	NewState OfferingSyncState `json:"new_state"`
+
+	// WaldurUUID is the Waldur offering UUID (if applicable).
+	WaldurUUID string `json:"waldur_uuid,omitempty"`
+
+	// ErrorMessage is the error message (if failed).
+	ErrorMessage string `json:"error_message,omitempty"`
+
+	// RetryCount is the current retry count.
+	RetryCount uint32 `json:"retry_count"`
+
+	// Timestamp is when the event occurred.
+	Timestamp time.Time `json:"timestamp"`
+
+	// Metadata contains additional event metadata.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// SyncEventType represents the type of sync event.
+type SyncEventType string
+
+const (
+	// SyncEventCreated is emitted when sync record is created.
+	SyncEventCreated SyncEventType = "created"
+
+	// SyncEventSynced is emitted when sync succeeds.
+	SyncEventSynced SyncEventType = "synced"
+
+	// SyncEventFailed is emitted when sync fails.
+	SyncEventFailed SyncEventType = "failed"
+
+	// SyncEventRetrying is emitted when sync is being retried.
+	SyncEventRetrying SyncEventType = "retrying"
+
+	// SyncEventDeadLettered is emitted when sync is dead-lettered.
+	SyncEventDeadLettered SyncEventType = "dead_lettered"
+
+	// SyncEventDriftDetected is emitted when drift is detected.
+	SyncEventDriftDetected SyncEventType = "drift_detected"
+
+	// SyncEventReconciled is emitted when reconciliation completes.
+	SyncEventReconciled SyncEventType = "reconciled"
+
+	// SyncEventReprocessed is emitted when a dead-letter is reprocessed.
+	SyncEventReprocessed SyncEventType = "reprocessed"
+)
+
+// ReconciliationReport contains the results of a reconciliation run.
+type ReconciliationReport struct {
+	// ReportID is the unique report identifier.
+	ReportID string `json:"report_id"`
+
+	// ProviderAddress is the provider this report is for.
+	ProviderAddress string `json:"provider_address"`
+
+	// Direction is the sync direction reconciled.
+	Direction SyncDirection `json:"direction"`
+
+	// StartedAt is when reconciliation started.
+	StartedAt time.Time `json:"started_at"`
+
+	// CompletedAt is when reconciliation completed.
+	CompletedAt time.Time `json:"completed_at"`
+
+	// Duration is how long reconciliation took.
+	DurationMs int64 `json:"duration_ms"`
+
+	// TotalOfferings is the total offerings checked.
+	TotalOfferings uint32 `json:"total_offerings"`
+
+	// InSyncCount is offerings already in sync.
+	InSyncCount uint32 `json:"in_sync_count"`
+
+	// DriftedCount is offerings with detected drift.
+	DriftedCount uint32 `json:"drifted_count"`
+
+	// RepairedCount is offerings successfully repaired.
+	RepairedCount uint32 `json:"repaired_count"`
+
+	// FailedCount is offerings that failed to repair.
+	FailedCount uint32 `json:"failed_count"`
+
+	// NewOfferingsCount is newly discovered offerings.
+	NewOfferingsCount uint32 `json:"new_offerings_count"`
+
+	// DeadLetteredCount is offerings moved to dead letter.
+	DeadLetteredCount uint32 `json:"dead_lettered_count"`
+
+	// Success indicates if reconciliation completed successfully.
+	Success bool `json:"success"`
+
+	// Error is the error message if reconciliation failed.
+	Error string `json:"error,omitempty"`
+
+	// DriftDetails contains details about detected drift.
+	DriftDetails []DriftDetail `json:"drift_details,omitempty"`
+}
+
+// DriftDetail describes a detected drift for an offering.
+type DriftDetail struct {
+	// OfferingID is the on-chain offering ID.
+	OfferingID string `json:"offering_id"`
+
+	// WaldurUUID is the Waldur offering UUID.
+	WaldurUUID string `json:"waldur_uuid,omitempty"`
+
+	// DriftType is the type of drift detected.
+	DriftType DriftType `json:"drift_type"`
+
+	// ChainValue is the on-chain value.
+	ChainValue string `json:"chain_value,omitempty"`
+
+	// WaldurValue is the Waldur value.
+	WaldurValue string `json:"waldur_value,omitempty"`
+
+	// Field is the field that drifted.
+	Field string `json:"field,omitempty"`
+
+	// Repaired indicates if the drift was repaired.
+	Repaired bool `json:"repaired"`
+
+	// Error is the repair error (if failed).
+	Error string `json:"error,omitempty"`
+}
+
+// DriftType represents the type of drift detected.
+type DriftType string
+
+const (
+	// DriftTypeNameMismatch indicates offering name differs.
+	DriftTypeNameMismatch DriftType = "name_mismatch"
+
+	// DriftTypeDescriptionMismatch indicates description differs.
+	DriftTypeDescriptionMismatch DriftType = "description_mismatch"
+
+	// DriftTypePricingMismatch indicates pricing differs.
+	DriftTypePricingMismatch DriftType = "pricing_mismatch"
+
+	// DriftTypeStateMismatch indicates state differs.
+	DriftTypeStateMismatch DriftType = "state_mismatch"
+
+	// DriftTypeAttributesMismatch indicates attributes differ.
+	DriftTypeAttributesMismatch DriftType = "attributes_mismatch"
+
+	// DriftTypeMissingInWaldur indicates offering missing in Waldur.
+	DriftTypeMissingInWaldur DriftType = "missing_in_waldur"
+
+	// DriftTypeMissingOnChain indicates offering missing on-chain.
+	DriftTypeMissingOnChain DriftType = "missing_on_chain"
+
+	// DriftTypeChecksumMismatch indicates overall checksum differs.
+	DriftTypeChecksumMismatch DriftType = "checksum_mismatch"
+)
+
+// SyncConfiguration contains on-chain sync configuration for a provider.
+type SyncConfiguration struct {
+	// ProviderAddress is the provider this configuration is for.
+	ProviderAddress string `json:"provider_address"`
+
+	// Enabled indicates if sync is enabled.
+	Enabled bool `json:"enabled"`
+
+	// Direction is the sync direction(s) enabled.
+	Direction SyncDirection `json:"direction"`
+
+	// WaldurCustomerUUID is the linked Waldur customer UUID.
+	WaldurCustomerUUID string `json:"waldur_customer_uuid"`
+
+	// SyncIntervalSeconds is how often to run reconciliation.
+	SyncIntervalSeconds uint32 `json:"sync_interval_seconds"`
+
+	// MaxRetries is the max retries before dead-lettering.
+	MaxRetries uint32 `json:"max_retries"`
+
+	// AutoRepairDrift enables automatic drift repair.
+	AutoRepairDrift bool `json:"auto_repair_drift"`
+
+	// CategoryMapping maps on-chain categories to Waldur category UUIDs.
+	CategoryMapping map[string]string `json:"category_mapping,omitempty"`
+
+	// EnabledAt is when sync was enabled.
+	EnabledAt *time.Time `json:"enabled_at,omitempty"`
+
+	// LastModifiedAt is when configuration was last modified.
+	LastModifiedAt time.Time `json:"last_modified_at"`
+
+	// ModifiedBy is who last modified the configuration.
+	ModifiedBy string `json:"modified_by,omitempty"`
+}
+
+// NewOfferingSyncStatus creates a new sync status for a provider.
+func NewOfferingSyncStatus(providerAddress string) *OfferingSyncStatus {
+	now := time.Now().UTC()
+	return &OfferingSyncStatus{
+		ProviderAddress: providerAddress,
+		Direction:       SyncDirectionBidirectional,
+		State:           SyncStatusStateDisabled,
+		ToWaldurStats:   &SyncDirectionStats{},
+		FromWaldurStats: &SyncDirectionStats{},
+		UpdatedAt:       now,
+	}
+}
+
+// Enable enables sync for the provider.
+func (s *OfferingSyncStatus) Enable(direction SyncDirection, waldurCustomerUUID string) {
+	now := time.Now().UTC()
+	s.State = SyncStatusStateHealthy
+	s.Direction = direction
+	s.WaldurCustomerUUID = waldurCustomerUUID
+	s.EnabledAt = &now
+	s.UpdatedAt = now
+}
+
+// Disable disables sync for the provider.
+func (s *OfferingSyncStatus) Disable() {
+	s.State = SyncStatusStateDisabled
+	s.UpdatedAt = time.Now().UTC()
+}
+
+// RecordSync records a sync operation.
+func (s *OfferingSyncStatus) RecordSync(direction SyncDirection, success bool, err error) {
+	now := time.Now().UTC()
+	var stats *SyncDirectionStats
+
+	switch direction {
+	case SyncDirectionToWaldur:
+		stats = s.ToWaldurStats
+	case SyncDirectionFromWaldur:
+		stats = s.FromWaldurStats
+	default:
+		return
+	}
+
+	if stats == nil {
+		return
+	}
+
+	stats.TotalSyncAttempts++
+	stats.LastSyncAt = &now
+
+	if success {
+		stats.SuccessfulSyncs++
+		stats.LastSuccessAt = &now
+		stats.LastError = ""
+	} else {
+		stats.FailedSyncs++
+		stats.LastFailureAt = &now
+		if err != nil {
+			stats.LastError = err.Error()
+		}
+	}
+
+	s.UpdatedAt = now
+	s.updateState()
+}
+
+// RecordReconciliation records a reconciliation run.
+func (s *OfferingSyncStatus) RecordReconciliation(report *ReconciliationReport) {
+	now := time.Now().UTC()
+	s.LastReconciliationAt = &now
+	s.DriftCount = report.DriftedCount - report.RepairedCount
+	s.DeadLetterCount += report.DeadLetteredCount
+	s.UpdatedAt = now
+	s.updateState()
+}
+
+// updateState updates the overall state based on statistics.
+func (s *OfferingSyncStatus) updateState() {
+	if s.State == SyncStatusStateDisabled {
+		return
+	}
+
+	// Check failure rates
+	totalStats := &SyncDirectionStats{}
+	if s.ToWaldurStats != nil {
+		totalStats.TotalSyncAttempts += s.ToWaldurStats.TotalSyncAttempts
+		totalStats.FailedSyncs += s.ToWaldurStats.FailedSyncs
+	}
+	if s.FromWaldurStats != nil {
+		totalStats.TotalSyncAttempts += s.FromWaldurStats.TotalSyncAttempts
+		totalStats.FailedSyncs += s.FromWaldurStats.FailedSyncs
+	}
+
+	if totalStats.TotalSyncAttempts == 0 {
+		s.State = SyncStatusStateHealthy
+		return
+	}
+
+	failureRate := float64(totalStats.FailedSyncs) / float64(totalStats.TotalSyncAttempts)
+	if failureRate > 0.5 {
+		s.State = SyncStatusStateFailed
+	} else if failureRate > 0.1 || s.DriftCount > 10 || s.DeadLetterCount > 5 {
+		s.State = SyncStatusStateDegraded
+	} else {
+		s.State = SyncStatusStateHealthy
+	}
+}
+
+// IsHealthy returns true if sync is in a healthy state.
+func (s *OfferingSyncStatus) IsHealthy() bool {
+	return s.State == SyncStatusStateHealthy
+}
+
+// GetSuccessRate returns the overall sync success rate.
+func (s *OfferingSyncStatus) GetSuccessRate() float64 {
+	var total, success uint64
+
+	if s.ToWaldurStats != nil {
+		total += s.ToWaldurStats.TotalSyncAttempts
+		success += s.ToWaldurStats.SuccessfulSyncs
+	}
+	if s.FromWaldurStats != nil {
+		total += s.FromWaldurStats.TotalSyncAttempts
+		success += s.FromWaldurStats.SuccessfulSyncs
+	}
+
+	if total == 0 {
+		return 1.0
+	}
+	return float64(success) / float64(total)
+}
+
+// NewOfferingSyncRecord creates a new sync record for an offering.
+func NewOfferingSyncRecord(offeringID, providerAddress string, direction SyncDirection) *OfferingSyncRecord {
+	now := time.Now().UTC()
+	return &OfferingSyncRecord{
+		OfferingID:      offeringID,
+		ProviderAddress: providerAddress,
+		SyncState:       OfferingSyncStatePending,
+		Direction:       direction,
+		ChainVersion:    1,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
+// MarkSynced marks the offering as successfully synced.
+func (r *OfferingSyncRecord) MarkSynced(waldurUUID, chainChecksum, waldurChecksum string) {
+	now := time.Now().UTC()
+	r.WaldurUUID = waldurUUID
+	r.SyncState = OfferingSyncStateSynced
+	r.ChainChecksum = chainChecksum
+	r.WaldurChecksum = waldurChecksum
+	r.InSync = true
+	r.LastSyncedAt = &now
+	r.LastAttemptAt = &now
+	r.RetryCount = 0
+	r.NextRetryAt = nil
+	r.LastError = ""
+	r.UpdatedAt = now
+}
+
+// MarkFailed marks the offering sync as failed.
+func (r *OfferingSyncRecord) MarkFailed(err error, maxRetries uint32) bool {
+	now := time.Now().UTC()
+	r.LastAttemptAt = &now
+	r.RetryCount++
+	r.InSync = false
+	r.UpdatedAt = now
+
+	if err != nil {
+		r.LastError = err.Error()
+	}
+
+	if r.RetryCount >= maxRetries {
+		r.SyncState = OfferingSyncStateDeadLettered
+		return true
+	}
+
+	r.SyncState = OfferingSyncStateRetrying
+	// Exponential backoff: 30s * 2^(retryCount-1), max 1 hour
+	backoffSeconds := 30 * (1 << (r.RetryCount - 1))
+	if backoffSeconds > 3600 {
+		backoffSeconds = 3600
+	}
+	nextRetry := now.Add(time.Duration(backoffSeconds) * time.Second)
+	r.NextRetryAt = &nextRetry
+	return false
+}
+
+// MarkDrifted marks the offering as drifted.
+func (r *OfferingSyncRecord) MarkDrifted(newChecksum string) {
+	now := time.Now().UTC()
+	r.SyncState = OfferingSyncStateDrifted
+	r.InSync = false
+	if r.Direction == SyncDirectionToWaldur {
+		r.ChainChecksum = newChecksum
+	} else {
+		r.WaldurChecksum = newChecksum
+	}
+	r.UpdatedAt = now
+}
+
+// ResetForRetry resets the record to allow retry.
+func (r *OfferingSyncRecord) ResetForRetry() {
+	now := time.Now().UTC()
+	r.SyncState = OfferingSyncStatePending
+	r.RetryCount = 0
+	r.NextRetryAt = nil
+	r.LastError = ""
+	r.UpdatedAt = now
+}


### PR DESCRIPTION
**Priority:** HIGH
**Spec Reference:** AU2024203136A1-LIVE - marketplace listing sync
**Current State:** Manual WaldurOfferingMap required; no automated sync

**Implementation Tasks:**
1. Implement on-chain → Waldur offering sync on create/update
2. Implement Waldur → on-chain catalog ingestion
3. Add sync status tracking on-chain
4. Implement retry logic for failed syncs
5. Add reconciliation for drift detection
6. Remove manual WaldurOfferingMap dependency

**Acceptance Criteria:**
- [ ] Offerings auto-sync on create/update
- [ ] Waldur catalog imported to chain
- [ ] Sync status tracked with retries
- [ ] Drift detection and reconciliation working
- [ ] Manual mapping removed

**Estimated Effort:** 24-40 hours
**Files to Create/Modify:**
- `pkg/provider_daemon/offering_sync.go`
- `pkg/provider_daemon/catalog_importer.go`
- `pkg/provider_daemon/reconciliation.go`
- `x/market/types/marketplace/sync_status.go`