### PR TITLE
feat(hpc): create preconfigured SLURM workload library 14C

### DIFF
--- a/pkg/hpc_workload_library/batch_script.go
+++ b/pkg/hpc_workload_library/batch_script.go
@@ -1,0 +1,525 @@
+// Package hpc_workload_library provides batch script generation.
+//
+// VE-5F: SLURM batch script generation from workload templates
+package hpc_workload_library
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	hpctypes "github.com/virtengine/virtengine/x/hpc/types"
+)
+
+// BatchScriptConfig configures batch script generation
+type BatchScriptConfig struct {
+	// Account is the SLURM account
+	Account string
+
+	// Partition is the SLURM partition
+	Partition string
+
+	// QOS is the quality of service
+	QOS string
+
+	// Cluster is the cluster name
+	Cluster string
+
+	// JobName is the job name
+	JobName string
+
+	// OutputPath is the output file path
+	OutputPath string
+
+	// ErrorPath is the error file path
+	ErrorPath string
+
+	// MailUser is the email for notifications
+	MailUser string
+
+	// MailType specifies when to send email (BEGIN, END, FAIL, ALL)
+	MailType string
+
+	// Reservation is a reservation name
+	Reservation string
+
+	// Dependency specifies job dependencies
+	Dependency string
+
+	// CustomDirectives are additional SBATCH directives
+	CustomDirectives map[string]string
+}
+
+// BatchScriptGenerator generates SLURM batch scripts from templates
+type BatchScriptGenerator struct {
+	config BatchScriptConfig
+}
+
+// NewBatchScriptGenerator creates a new batch script generator
+func NewBatchScriptGenerator(config BatchScriptConfig) *BatchScriptGenerator {
+	return &BatchScriptGenerator{config: config}
+}
+
+// GenerateScript generates a SLURM batch script from a template and job parameters
+func (g *BatchScriptGenerator) GenerateScript(tmpl *hpctypes.WorkloadTemplate, params *JobParameters) (string, error) {
+	if tmpl == nil {
+		return "", fmt.Errorf("template is required")
+	}
+	if params == nil {
+		params = &JobParameters{}
+	}
+
+	// Merge defaults
+	params.applyDefaults(tmpl)
+
+	var buf bytes.Buffer
+
+	// Write shebang
+	buf.WriteString("#!/bin/bash\n")
+	buf.WriteString("#\n")
+	buf.WriteString(fmt.Sprintf("# SLURM batch script generated from template: %s v%s\n", tmpl.TemplateID, tmpl.Version))
+	buf.WriteString(fmt.Sprintf("# Template: %s\n", tmpl.Name))
+	buf.WriteString("#\n\n")
+
+	// Write SBATCH directives
+	g.writeSBATCHDirectives(&buf, tmpl, params)
+
+	// Write module loads
+	g.writeModuleLoads(&buf, tmpl)
+
+	// Write environment setup
+	g.writeEnvironment(&buf, tmpl, params)
+
+	// Write pre-run script
+	g.writePreRunScript(&buf, tmpl)
+
+	// Write main command
+	g.writeMainCommand(&buf, tmpl, params)
+
+	// Write post-run script
+	g.writePostRunScript(&buf, tmpl)
+
+	return buf.String(), nil
+}
+
+// writeSBATCHDirectives writes SBATCH directives
+func (g *BatchScriptGenerator) writeSBATCHDirectives(buf *bytes.Buffer, tmpl *hpctypes.WorkloadTemplate, params *JobParameters) {
+	buf.WriteString("# SLURM directives\n")
+
+	// Job name
+	jobName := g.config.JobName
+	if jobName == "" {
+		jobName = tmpl.TemplateID
+	}
+	buf.WriteString(fmt.Sprintf("#SBATCH --job-name=%s\n", jobName))
+
+	// Nodes
+	buf.WriteString(fmt.Sprintf("#SBATCH --nodes=%d\n", params.Nodes))
+
+	// CPUs per node or ntasks
+	if tmpl.Type == hpctypes.WorkloadTypeMPI {
+		totalTasks := params.Nodes * params.TasksPerNode
+		buf.WriteString(fmt.Sprintf("#SBATCH --ntasks=%d\n", totalTasks))
+		buf.WriteString(fmt.Sprintf("#SBATCH --ntasks-per-node=%d\n", params.TasksPerNode))
+	} else {
+		buf.WriteString(fmt.Sprintf("#SBATCH --cpus-per-task=%d\n", params.CPUsPerNode))
+	}
+
+	// Memory
+	buf.WriteString(fmt.Sprintf("#SBATCH --mem=%dM\n", params.MemoryMB))
+
+	// Time limit
+	buf.WriteString(fmt.Sprintf("#SBATCH --time=%s\n", formatTime(params.RuntimeMinutes)))
+
+	// GPUs
+	if params.GPUs > 0 {
+		if params.GPUType != "" {
+			buf.WriteString(fmt.Sprintf("#SBATCH --gres=gpu:%s:%d\n", params.GPUType, params.GPUs))
+		} else {
+			buf.WriteString(fmt.Sprintf("#SBATCH --gres=gpu:%d\n", params.GPUs))
+		}
+	}
+
+	// Partition
+	if g.config.Partition != "" {
+		buf.WriteString(fmt.Sprintf("#SBATCH --partition=%s\n", g.config.Partition))
+	}
+
+	// Account
+	if g.config.Account != "" {
+		buf.WriteString(fmt.Sprintf("#SBATCH --account=%s\n", g.config.Account))
+	}
+
+	// QOS
+	if g.config.QOS != "" {
+		buf.WriteString(fmt.Sprintf("#SBATCH --qos=%s\n", g.config.QOS))
+	}
+
+	// Cluster
+	if g.config.Cluster != "" {
+		buf.WriteString(fmt.Sprintf("#SBATCH --cluster=%s\n", g.config.Cluster))
+	}
+
+	// Output/error paths
+	outputPath := g.config.OutputPath
+	if outputPath == "" {
+		outputPath = "%x-%j.out"
+	}
+	buf.WriteString(fmt.Sprintf("#SBATCH --output=%s\n", outputPath))
+
+	errorPath := g.config.ErrorPath
+	if errorPath == "" {
+		errorPath = "%x-%j.err"
+	}
+	buf.WriteString(fmt.Sprintf("#SBATCH --error=%s\n", errorPath))
+
+	// Exclusive nodes
+	if tmpl.Resources.ExclusiveNodes || params.Exclusive {
+		buf.WriteString("#SBATCH --exclusive\n")
+	}
+
+	// Array job
+	if params.ArrayStart >= 0 && params.ArrayEnd > params.ArrayStart {
+		arraySpec := fmt.Sprintf("%d-%d", params.ArrayStart, params.ArrayEnd)
+		if params.ArrayStep > 1 {
+			arraySpec += fmt.Sprintf(":%d", params.ArrayStep)
+		}
+		if params.ArraySimultaneous > 0 {
+			arraySpec += fmt.Sprintf("%%%d", params.ArraySimultaneous)
+		}
+		buf.WriteString(fmt.Sprintf("#SBATCH --array=%s\n", arraySpec))
+	}
+
+	// Mail notifications
+	if g.config.MailUser != "" {
+		buf.WriteString(fmt.Sprintf("#SBATCH --mail-user=%s\n", g.config.MailUser))
+		mailType := g.config.MailType
+		if mailType == "" {
+			mailType = "END,FAIL"
+		}
+		buf.WriteString(fmt.Sprintf("#SBATCH --mail-type=%s\n", mailType))
+	}
+
+	// Reservation
+	if g.config.Reservation != "" {
+		buf.WriteString(fmt.Sprintf("#SBATCH --reservation=%s\n", g.config.Reservation))
+	}
+
+	// Dependency
+	if g.config.Dependency != "" {
+		buf.WriteString(fmt.Sprintf("#SBATCH --dependency=%s\n", g.config.Dependency))
+	}
+
+	// Constraints
+	if len(params.Constraints) > 0 {
+		buf.WriteString(fmt.Sprintf("#SBATCH --constraint=%s\n", strings.Join(params.Constraints, "&")))
+	}
+
+	// Custom directives
+	for key, value := range g.config.CustomDirectives {
+		buf.WriteString(fmt.Sprintf("#SBATCH --%s=%s\n", key, value))
+	}
+
+	buf.WriteString("\n")
+}
+
+// writeModuleLoads writes module load commands
+func (g *BatchScriptGenerator) writeModuleLoads(buf *bytes.Buffer, tmpl *hpctypes.WorkloadTemplate) {
+	modules := append(tmpl.Runtime.RequiredModules, tmpl.Modules...)
+	if len(modules) == 0 {
+		return
+	}
+
+	buf.WriteString("# Load required modules\n")
+	buf.WriteString("module purge\n")
+	for _, mod := range modules {
+		buf.WriteString(fmt.Sprintf("module load %s\n", mod))
+	}
+	buf.WriteString("\n")
+}
+
+// writeEnvironment writes environment variable setup
+func (g *BatchScriptGenerator) writeEnvironment(buf *bytes.Buffer, tmpl *hpctypes.WorkloadTemplate, params *JobParameters) {
+	if len(tmpl.Environment) == 0 && len(params.Environment) == 0 {
+		return
+	}
+
+	buf.WriteString("# Environment variables\n")
+
+	// Template environment variables
+	for _, env := range tmpl.Environment {
+		value := env.Value
+		if env.ValueTemplate != "" {
+			value = env.ValueTemplate
+		}
+		if value != "" {
+			buf.WriteString(fmt.Sprintf("export %s=\"%s\"\n", env.Name, value))
+		}
+	}
+
+	// User-provided environment variables
+	for key, value := range params.Environment {
+		buf.WriteString(fmt.Sprintf("export %s=\"%s\"\n", key, value))
+	}
+
+	buf.WriteString("\n")
+}
+
+// writePreRunScript writes pre-run setup
+func (g *BatchScriptGenerator) writePreRunScript(buf *bytes.Buffer, tmpl *hpctypes.WorkloadTemplate) {
+	if tmpl.Entrypoint.PreRunScript == "" {
+		return
+	}
+
+	buf.WriteString("# Pre-run setup\n")
+	buf.WriteString(tmpl.Entrypoint.PreRunScript)
+	buf.WriteString("\n\n")
+}
+
+// writeMainCommand writes the main execution command
+func (g *BatchScriptGenerator) writeMainCommand(buf *bytes.Buffer, tmpl *hpctypes.WorkloadTemplate, params *JobParameters) {
+	buf.WriteString("# Main execution\n")
+
+	// Change to working directory
+	workDir := tmpl.Entrypoint.WorkingDirectory
+	if params.WorkingDirectory != "" {
+		workDir = params.WorkingDirectory
+	}
+	if workDir != "" {
+		buf.WriteString(fmt.Sprintf("cd %s || exit 1\n", workDir))
+	}
+
+	// Build command
+	var cmdParts []string
+
+	// MPI wrapper
+	if tmpl.Entrypoint.UseMPIRun {
+		mpiCmd := "srun"
+		if tmpl.Runtime.MPIImplementation == "openmpi" {
+			mpiCmd = "mpirun"
+		}
+		cmdParts = append(cmdParts, mpiCmd)
+		cmdParts = append(cmdParts, tmpl.Entrypoint.MPIRunArgs...)
+	}
+
+	// Singularity wrapper
+	if tmpl.Runtime.RuntimeType == "singularity" || tmpl.Runtime.RuntimeType == "apptainer" {
+		runtime := tmpl.Runtime.RuntimeType
+		cmdParts = append(cmdParts, runtime, "exec")
+
+		// GPU flag
+		if params.GPUs > 0 {
+			cmdParts = append(cmdParts, "--nv")
+		}
+
+		// Bind paths
+		if len(tmpl.DataBindings) > 0 {
+			for _, binding := range tmpl.DataBindings {
+				if binding.HostPath != "" {
+					bindSpec := fmt.Sprintf("%s:%s", binding.HostPath, binding.MountPath)
+					if binding.ReadOnly {
+						bindSpec += ":ro"
+					}
+					cmdParts = append(cmdParts, "-B", bindSpec)
+				}
+			}
+		}
+
+		// Container image
+		cmdParts = append(cmdParts, tmpl.Runtime.ContainerImage)
+	}
+
+	// Main command
+	mainCmd := tmpl.Entrypoint.Command
+	if params.Command != "" {
+		mainCmd = params.Command
+	}
+	cmdParts = append(cmdParts, mainCmd)
+
+	// Arguments
+	args := tmpl.Entrypoint.DefaultArgs
+	if len(params.Arguments) > 0 {
+		args = params.Arguments
+	}
+	cmdParts = append(cmdParts, args...)
+
+	// User script/executable
+	if params.Script != "" {
+		cmdParts = append(cmdParts, params.Script)
+	}
+
+	buf.WriteString(strings.Join(cmdParts, " "))
+	buf.WriteString("\n\n")
+
+	// Capture exit code
+	buf.WriteString("EXIT_CODE=$?\n\n")
+}
+
+// writePostRunScript writes post-run cleanup
+func (g *BatchScriptGenerator) writePostRunScript(buf *bytes.Buffer, tmpl *hpctypes.WorkloadTemplate) {
+	buf.WriteString("# Post-run cleanup\n")
+
+	if tmpl.Entrypoint.PostRunScript != "" {
+		buf.WriteString(tmpl.Entrypoint.PostRunScript)
+		buf.WriteString("\n")
+	}
+
+	buf.WriteString("\nexit $EXIT_CODE\n")
+}
+
+// JobParameters contains job-specific parameters
+type JobParameters struct {
+	// Nodes is the number of nodes
+	Nodes int32
+
+	// CPUsPerNode is CPUs per node
+	CPUsPerNode int32
+
+	// TasksPerNode is MPI tasks per node
+	TasksPerNode int32
+
+	// MemoryMB is memory in MB
+	MemoryMB int64
+
+	// RuntimeMinutes is runtime in minutes
+	RuntimeMinutes int64
+
+	// GPUs is number of GPUs
+	GPUs int32
+
+	// GPUType is the GPU type
+	GPUType string
+
+	// Exclusive requests exclusive nodes
+	Exclusive bool
+
+	// Command is the main command
+	Command string
+
+	// Arguments are command arguments
+	Arguments []string
+
+	// Script is the user script
+	Script string
+
+	// WorkingDirectory is the working directory
+	WorkingDirectory string
+
+	// Environment contains additional environment variables
+	Environment map[string]string
+
+	// ArrayStart is array job start index (-1 for no array)
+	ArrayStart int
+
+	// ArrayEnd is array job end index
+	ArrayEnd int
+
+	// ArrayStep is array job step
+	ArrayStep int
+
+	// ArraySimultaneous is max simultaneous array tasks
+	ArraySimultaneous int
+
+	// Constraints are node constraints
+	Constraints []string
+}
+
+// applyDefaults applies template defaults to parameters
+func (p *JobParameters) applyDefaults(tmpl *hpctypes.WorkloadTemplate) {
+	if p.Nodes == 0 {
+		p.Nodes = tmpl.Resources.DefaultNodes
+	}
+	if p.CPUsPerNode == 0 {
+		p.CPUsPerNode = tmpl.Resources.DefaultCPUsPerNode
+	}
+	if p.TasksPerNode == 0 {
+		p.TasksPerNode = tmpl.Resources.DefaultCPUsPerNode
+	}
+	if p.MemoryMB == 0 {
+		p.MemoryMB = tmpl.Resources.DefaultMemoryMBPerNode
+	}
+	if p.RuntimeMinutes == 0 {
+		p.RuntimeMinutes = tmpl.Resources.DefaultRuntimeMinutes
+	}
+	if p.GPUs == 0 {
+		p.GPUs = tmpl.Resources.DefaultGPUsPerNode
+	}
+	if p.ArrayStart < 0 {
+		p.ArrayStart = -1
+	}
+	if p.ArrayStep == 0 {
+		p.ArrayStep = 1
+	}
+}
+
+// formatTime formats minutes as HH:MM:SS
+func formatTime(minutes int64) string {
+	hours := minutes / 60
+	mins := minutes % 60
+	if hours > 24 {
+		days := hours / 24
+		hours = hours % 24
+		return fmt.Sprintf("%d-%02d:%02d:00", days, hours, mins)
+	}
+	return fmt.Sprintf("%02d:%02d:00", hours, mins)
+}
+
+// BatchScriptTemplateData contains data for script templating
+type BatchScriptTemplateData struct {
+	Template   *hpctypes.WorkloadTemplate
+	Parameters *JobParameters
+	Config     *BatchScriptConfig
+}
+
+// templateFuncs contains functions for template rendering
+var templateFuncs = template.FuncMap{
+	"formatTime": formatTime,
+}
+
+// scriptTemplate is the Go template for batch scripts (alternative approach)
+var scriptTemplate = template.Must(template.New("batchscript").Funcs(templateFuncs).Parse(`#!/bin/bash
+#
+# SLURM batch script generated from template: {{.Template.TemplateID}} v{{.Template.Version}}
+# Template: {{.Template.Name}}
+#
+
+# SLURM directives
+#SBATCH --job-name={{.Config.JobName}}
+#SBATCH --nodes={{.Parameters.Nodes}}
+#SBATCH --cpus-per-task={{.Parameters.CPUsPerNode}}
+#SBATCH --mem={{.Parameters.MemoryMB}}M
+#SBATCH --time={{.Parameters.RuntimeMinutes | formatTime}}
+{{if .Config.Partition}}#SBATCH --partition={{.Config.Partition}}{{end}}
+{{if .Config.Account}}#SBATCH --account={{.Config.Account}}{{end}}
+#SBATCH --output=%x-%j.out
+#SBATCH --error=%x-%j.err
+
+{{if .Template.Modules}}
+# Load modules
+module purge
+{{range .Template.Modules}}module load {{.}}
+{{end}}{{end}}
+
+# Environment
+{{range .Template.Environment}}export {{.Name}}="{{if .Value}}{{.Value}}{{else}}{{.ValueTemplate}}{{end}}"
+{{end}}
+
+{{if .Template.Entrypoint.PreRunScript}}
+# Pre-run
+{{.Template.Entrypoint.PreRunScript}}
+{{end}}
+
+# Main execution
+{{if .Template.Entrypoint.WorkingDirectory}}cd {{.Template.Entrypoint.WorkingDirectory}} || exit 1{{end}}
+{{.Template.Entrypoint.Command}} {{range .Template.Entrypoint.DefaultArgs}}{{.}} {{end}}{{.Parameters.Script}}
+
+EXIT_CODE=$?
+
+{{if .Template.Entrypoint.PostRunScript}}
+# Post-run
+{{.Template.Entrypoint.PostRunScript}}
+{{end}}
+
+exit $EXIT_CODE
+`))

--- a/pkg/hpc_workload_library/batch_script_test.go
+++ b/pkg/hpc_workload_library/batch_script_test.go
@@ -1,0 +1,443 @@
+// Package hpc_workload_library provides tests for batch script generation.
+//
+// VE-5F: Tests for SLURM batch script generation
+package hpc_workload_library
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	_ "github.com/virtengine/virtengine/sdk/go/sdkutil" // Initialize SDK config
+)
+
+func TestNewBatchScriptGenerator(t *testing.T) {
+	config := BatchScriptConfig{
+		Account:   "testaccount",
+		Partition: "compute",
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	if gen == nil {
+		t.Fatal("expected generator to be created")
+	}
+}
+
+func TestGenerateScript_MPI(t *testing.T) {
+	config := BatchScriptConfig{
+		Account:   "hpc-project",
+		Partition: "compute",
+		JobName:   "mpi-test",
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetMPITemplate()
+	params := &JobParameters{
+		Nodes:        4,
+		TasksPerNode: 16,
+		MemoryMB:     32000,
+		RuntimeMinutes: 120,
+		Script:       "./my_mpi_app",
+	}
+
+	script, err := gen.GenerateScript(template, params)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	// Verify shebang
+	if !strings.HasPrefix(script, "#!/bin/bash") {
+		t.Error("script should start with shebang")
+	}
+
+	// Verify SBATCH directives
+	checks := []string{
+		"#SBATCH --job-name=mpi-test",
+		"#SBATCH --nodes=4",
+		"#SBATCH --ntasks=64",
+		"#SBATCH --ntasks-per-node=16",
+		"#SBATCH --mem=32000M",
+		"#SBATCH --time=02:00:00",
+		"#SBATCH --partition=compute",
+		"#SBATCH --account=hpc-project",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(script, check) {
+			t.Errorf("script missing: %s", check)
+		}
+	}
+
+	// Verify module load
+	if !strings.Contains(script, "module load openmpi") {
+		t.Error("script should load openmpi module")
+	}
+
+	// Verify MPI execution
+	if !strings.Contains(script, "mpirun") || !strings.Contains(script, "srun") {
+		// At least one MPI launcher should be present
+		t.Log("script may be using srun or mpirun")
+	}
+}
+
+func TestGenerateScript_GPU(t *testing.T) {
+	config := BatchScriptConfig{
+		Partition: "gpu",
+		JobName:   "gpu-test",
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetGPUComputeTemplate()
+	params := &JobParameters{
+		Nodes:          1,
+		CPUsPerNode:    16,
+		MemoryMB:       64000,
+		RuntimeMinutes: 60,
+		GPUs:           2,
+		GPUType:        "nvidia-a100",
+		Script:         "train.py",
+	}
+
+	script, err := gen.GenerateScript(template, params)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	// Verify GPU directive
+	if !strings.Contains(script, "#SBATCH --gres=gpu:nvidia-a100:2") {
+		t.Error("script should have GPU gres directive")
+	}
+
+	// Verify CUDA module
+	if !strings.Contains(script, "cuda") {
+		t.Error("script should load CUDA module")
+	}
+}
+
+func TestGenerateScript_Batch(t *testing.T) {
+	config := BatchScriptConfig{
+		Partition: "batch",
+		JobName:   "batch-test",
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetBatchTemplate()
+	params := &JobParameters{
+		Nodes:          1,
+		CPUsPerNode:    4,
+		MemoryMB:       8000,
+		RuntimeMinutes: 30,
+		Command:        "python",
+		Arguments:      []string{"-c", "print('hello')"},
+	}
+
+	script, err := gen.GenerateScript(template, params)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	// Verify single node
+	if !strings.Contains(script, "#SBATCH --nodes=1") {
+		t.Error("script should have nodes=1")
+	}
+
+	// Verify time format
+	if !strings.Contains(script, "#SBATCH --time=00:30:00") {
+		t.Error("script should have 30 minute time limit")
+	}
+}
+
+func TestGenerateScript_ArrayJob(t *testing.T) {
+	config := BatchScriptConfig{
+		Partition: "batch",
+		JobName:   "array-test",
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetArrayJobTemplate()
+	params := &JobParameters{
+		Nodes:             1,
+		CPUsPerNode:       4,
+		MemoryMB:          8000,
+		RuntimeMinutes:    60,
+		ArrayStart:        0,
+		ArrayEnd:          99,
+		ArrayStep:         1,
+		ArraySimultaneous: 10,
+		Script:            "process.sh",
+	}
+
+	script, err := gen.GenerateScript(template, params)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	// Verify array directive - step is only added when > 1
+	if !strings.Contains(script, "#SBATCH --array=0-99%10") {
+		t.Error("script should have array directive with limit")
+	}
+
+	// Verify array environment variables
+	if !strings.Contains(script, "SLURM_ARRAY_TASK_ID") {
+		t.Error("script should reference array task ID")
+	}
+}
+
+func TestGenerateScript_SingularityContainer(t *testing.T) {
+	config := BatchScriptConfig{
+		Partition: "compute",
+		JobName:   "singularity-test",
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetSingularityContainerTemplate()
+	params := &JobParameters{
+		Nodes:          1,
+		CPUsPerNode:    8,
+		MemoryMB:       16000,
+		RuntimeMinutes: 120,
+		GPUs:           1,
+		Script:         "./run_analysis.sh",
+	}
+
+	script, err := gen.GenerateScript(template, params)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	// Verify singularity execution
+	if !strings.Contains(script, "singularity exec") {
+		t.Error("script should use singularity exec")
+	}
+
+	// Verify GPU flag
+	if !strings.Contains(script, "--nv") {
+		t.Error("script should have --nv flag for GPU")
+	}
+}
+
+func TestGenerateScript_DefaultParameters(t *testing.T) {
+	config := BatchScriptConfig{}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetBatchTemplate()
+	// nil params should use defaults
+	script, err := gen.GenerateScript(template, nil)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	// Should have default values from template
+	if !strings.Contains(script, fmt.Sprintf("#SBATCH --nodes=%d", template.Resources.DefaultNodes)) {
+		t.Error("script should use default nodes from template")
+	}
+}
+
+func TestGenerateScript_CustomEnvironment(t *testing.T) {
+	config := BatchScriptConfig{}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetBatchTemplate()
+	params := &JobParameters{
+		Environment: map[string]string{
+			"MY_VAR":      "custom_value",
+			"ANOTHER_VAR": "another_value",
+		},
+	}
+
+	script, err := gen.GenerateScript(template, params)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	if !strings.Contains(script, "export MY_VAR=\"custom_value\"") {
+		t.Error("script should have custom environment variable")
+	}
+	if !strings.Contains(script, "export ANOTHER_VAR=\"another_value\"") {
+		t.Error("script should have another custom environment variable")
+	}
+}
+
+func TestGenerateScript_MailNotifications(t *testing.T) {
+	config := BatchScriptConfig{
+		MailUser: "user@example.com",
+		MailType: "ALL",
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetBatchTemplate()
+	script, err := gen.GenerateScript(template, nil)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	if !strings.Contains(script, "#SBATCH --mail-user=user@example.com") {
+		t.Error("script should have mail-user directive")
+	}
+	if !strings.Contains(script, "#SBATCH --mail-type=ALL") {
+		t.Error("script should have mail-type directive")
+	}
+}
+
+func TestGenerateScript_ExclusiveNodes(t *testing.T) {
+	config := BatchScriptConfig{}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetGPUComputeTemplate() // GPU template has exclusive=true
+	script, err := gen.GenerateScript(template, nil)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	if !strings.Contains(script, "#SBATCH --exclusive") {
+		t.Error("script should have exclusive directive")
+	}
+}
+
+func TestGenerateScript_Constraints(t *testing.T) {
+	config := BatchScriptConfig{}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetBatchTemplate()
+	params := &JobParameters{
+		Constraints: []string{"avx512", "infiniband"},
+	}
+
+	script, err := gen.GenerateScript(template, params)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	if !strings.Contains(script, "#SBATCH --constraint=avx512&infiniband") {
+		t.Error("script should have constraint directive with AND")
+	}
+}
+
+func TestGenerateScript_CustomDirectives(t *testing.T) {
+	config := BatchScriptConfig{
+		CustomDirectives: map[string]string{
+			"nice":    "100",
+			"comment": "test-job",
+		},
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetBatchTemplate()
+	script, err := gen.GenerateScript(template, nil)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	if !strings.Contains(script, "#SBATCH --nice=100") {
+		t.Error("script should have custom nice directive")
+	}
+	if !strings.Contains(script, "#SBATCH --comment=test-job") {
+		t.Error("script should have custom comment directive")
+	}
+}
+
+func TestGenerateScript_NilTemplate(t *testing.T) {
+	config := BatchScriptConfig{}
+	gen := NewBatchScriptGenerator(config)
+
+	_, err := gen.GenerateScript(nil, nil)
+	if err == nil {
+		t.Error("expected error for nil template")
+	}
+}
+
+func TestFormatTime(t *testing.T) {
+	tests := []struct {
+		minutes  int64
+		expected string
+	}{
+		{30, "00:30:00"},
+		{60, "01:00:00"},
+		{90, "01:30:00"},
+		{120, "02:00:00"},
+		{1440, "24:00:00"},
+		{1500, "1-01:00:00"},
+		{2880, "2-00:00:00"},
+		{4320, "3-00:00:00"},
+	}
+
+	for _, tt := range tests {
+		result := formatTime(tt.minutes)
+		if result != tt.expected {
+			t.Errorf("formatTime(%d) = %s, want %s", tt.minutes, result, tt.expected)
+		}
+	}
+}
+
+func TestJobParametersApplyDefaults(t *testing.T) {
+	template := GetBatchTemplate()
+	params := &JobParameters{}
+
+	params.applyDefaults(template)
+
+	if params.Nodes != template.Resources.DefaultNodes {
+		t.Errorf("expected default nodes %d, got %d", template.Resources.DefaultNodes, params.Nodes)
+	}
+	if params.CPUsPerNode != template.Resources.DefaultCPUsPerNode {
+		t.Errorf("expected default CPUs %d, got %d", template.Resources.DefaultCPUsPerNode, params.CPUsPerNode)
+	}
+	if params.MemoryMB != template.Resources.DefaultMemoryMBPerNode {
+		t.Errorf("expected default memory %d, got %d", template.Resources.DefaultMemoryMBPerNode, params.MemoryMB)
+	}
+	if params.RuntimeMinutes != template.Resources.DefaultRuntimeMinutes {
+		t.Errorf("expected default runtime %d, got %d", template.Resources.DefaultRuntimeMinutes, params.RuntimeMinutes)
+	}
+}
+
+func TestGenerateScript_WorkingDirectory(t *testing.T) {
+	config := BatchScriptConfig{}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetBatchTemplate()
+	params := &JobParameters{
+		WorkingDirectory: "/custom/workdir",
+	}
+
+	script, err := gen.GenerateScript(template, params)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	if !strings.Contains(script, "cd /custom/workdir") {
+		t.Error("script should change to custom working directory")
+	}
+}
+
+func TestGenerateScript_Dependency(t *testing.T) {
+	config := BatchScriptConfig{
+		Dependency: "afterok:12345",
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetBatchTemplate()
+	script, err := gen.GenerateScript(template, nil)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	if !strings.Contains(script, "#SBATCH --dependency=afterok:12345") {
+		t.Error("script should have dependency directive")
+	}
+}
+
+func TestGenerateScript_Reservation(t *testing.T) {
+	config := BatchScriptConfig{
+		Reservation: "maintenance",
+	}
+	gen := NewBatchScriptGenerator(config)
+
+	template := GetBatchTemplate()
+	script, err := gen.GenerateScript(template, nil)
+	if err != nil {
+		t.Fatalf("failed to generate script: %v", err)
+	}
+
+	if !strings.Contains(script, "#SBATCH --reservation=maintenance") {
+		t.Error("script should have reservation directive")
+	}
+}

--- a/pkg/hpc_workload_library/manifest.go
+++ b/pkg/hpc_workload_library/manifest.go
@@ -1,0 +1,528 @@
+// Package hpc_workload_library provides YAML manifest loading.
+//
+// VE-5F: YAML manifest format for workload templates
+package hpc_workload_library
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	hpctypes "github.com/virtengine/virtengine/x/hpc/types"
+)
+
+//go:embed templates/*.yaml
+var embeddedTemplates embed.FS
+
+// ManifestSchemaVersion is the current manifest schema version
+const ManifestSchemaVersion = "1.0.0"
+
+// YAMLManifest represents a YAML manifest file
+type YAMLManifest struct {
+	SchemaVersion string         `yaml:"schema_version"`
+	Template      YAMLTemplate   `yaml:"template"`
+	Signature     *YAMLSignature `yaml:"signature,omitempty"`
+}
+
+// YAMLTemplate represents a template in YAML format
+type YAMLTemplate struct {
+	TemplateID     string                `yaml:"template_id"`
+	Name           string                `yaml:"name"`
+	Version        string                `yaml:"version"`
+	Description    string                `yaml:"description"`
+	Type           string                `yaml:"type"`
+	Runtime        YAMLRuntime           `yaml:"runtime"`
+	Resources      YAMLResources         `yaml:"resources"`
+	Security       YAMLSecurity          `yaml:"security"`
+	Entrypoint     YAMLEntrypoint        `yaml:"entrypoint"`
+	Environment    []YAMLEnvironment     `yaml:"environment,omitempty"`
+	Modules        []string              `yaml:"modules,omitempty"`
+	DataBindings   []YAMLDataBinding     `yaml:"data_bindings,omitempty"`
+	ParameterSchema []YAMLParameter      `yaml:"parameter_schema,omitempty"`
+	ApprovalStatus string                `yaml:"approval_status"`
+	Publisher      string                `yaml:"publisher,omitempty"`
+	Tags           []string              `yaml:"tags,omitempty"`
+}
+
+// YAMLRuntime represents runtime configuration
+type YAMLRuntime struct {
+	RuntimeType       string   `yaml:"runtime_type"`
+	ContainerImage    string   `yaml:"container_image,omitempty"`
+	ContainerRegistry string   `yaml:"container_registry,omitempty"`
+	ImageDigest       string   `yaml:"image_digest,omitempty"`
+	RequiredModules   []string `yaml:"required_modules,omitempty"`
+	MPIImplementation string   `yaml:"mpi_implementation,omitempty"`
+	CUDAVersion       string   `yaml:"cuda_version,omitempty"`
+	PythonVersion     string   `yaml:"python_version,omitempty"`
+}
+
+// YAMLResources represents resource configuration
+type YAMLResources struct {
+	MinNodes               int32    `yaml:"min_nodes"`
+	MaxNodes               int32    `yaml:"max_nodes"`
+	DefaultNodes           int32    `yaml:"default_nodes"`
+	MinCPUsPerNode         int32    `yaml:"min_cpus_per_node"`
+	MaxCPUsPerNode         int32    `yaml:"max_cpus_per_node"`
+	DefaultCPUsPerNode     int32    `yaml:"default_cpus_per_node"`
+	MinMemoryMBPerNode     int64    `yaml:"min_memory_mb_per_node"`
+	MaxMemoryMBPerNode     int64    `yaml:"max_memory_mb_per_node"`
+	DefaultMemoryMBPerNode int64    `yaml:"default_memory_mb_per_node"`
+	MinGPUsPerNode         int32    `yaml:"min_gpus_per_node,omitempty"`
+	MaxGPUsPerNode         int32    `yaml:"max_gpus_per_node,omitempty"`
+	DefaultGPUsPerNode     int32    `yaml:"default_gpus_per_node,omitempty"`
+	GPUTypes               []string `yaml:"gpu_types,omitempty"`
+	MinRuntimeMinutes      int64    `yaml:"min_runtime_minutes"`
+	MaxRuntimeMinutes      int64    `yaml:"max_runtime_minutes"`
+	DefaultRuntimeMinutes  int64    `yaml:"default_runtime_minutes"`
+	StorageGBRequired      int32    `yaml:"storage_gb_required,omitempty"`
+	NetworkRequired        bool     `yaml:"network_required,omitempty"`
+	ExclusiveNodes         bool     `yaml:"exclusive_nodes,omitempty"`
+}
+
+// YAMLSecurity represents security configuration
+type YAMLSecurity struct {
+	AllowedRegistries  []string `yaml:"allowed_registries,omitempty"`
+	BlockedRegistries  []string `yaml:"blocked_registries,omitempty"`
+	AllowedImages      []string `yaml:"allowed_images,omitempty"`
+	BlockedImages      []string `yaml:"blocked_images,omitempty"`
+	RequireImageDigest bool     `yaml:"require_image_digest"`
+	AllowNetworkAccess bool     `yaml:"allow_network_access"`
+	AllowHostMounts    bool     `yaml:"allow_host_mounts"`
+	AllowedHostPaths   []string `yaml:"allowed_host_paths,omitempty"`
+	SandboxLevel       string   `yaml:"sandbox_level"`
+	MaxOpenFiles       int64    `yaml:"max_open_files,omitempty"`
+	MaxProcesses       int64    `yaml:"max_processes,omitempty"`
+	MaxFileSize        int64    `yaml:"max_file_size,omitempty"`
+}
+
+// YAMLEntrypoint represents entrypoint configuration
+type YAMLEntrypoint struct {
+	Command          string   `yaml:"command"`
+	DefaultArgs      []string `yaml:"default_args,omitempty"`
+	ArgTemplate      string   `yaml:"arg_template,omitempty"`
+	WorkingDirectory string   `yaml:"working_directory,omitempty"`
+	PreRunScript     string   `yaml:"pre_run_script,omitempty"`
+	PostRunScript    string   `yaml:"post_run_script,omitempty"`
+	UseMPIRun        bool     `yaml:"use_mpirun,omitempty"`
+	MPIRunArgs       []string `yaml:"mpirun_args,omitempty"`
+}
+
+// YAMLEnvironment represents environment variable configuration
+type YAMLEnvironment struct {
+	Name          string `yaml:"name"`
+	Value         string `yaml:"value,omitempty"`
+	ValueTemplate string `yaml:"value_template,omitempty"`
+	Required      bool   `yaml:"required,omitempty"`
+	Secret        bool   `yaml:"secret,omitempty"`
+	Description   string `yaml:"description,omitempty"`
+}
+
+// YAMLDataBinding represents data binding configuration
+type YAMLDataBinding struct {
+	Name      string `yaml:"name"`
+	MountPath string `yaml:"mount_path"`
+	HostPath  string `yaml:"host_path,omitempty"`
+	DataType  string `yaml:"data_type"`
+	Required  bool   `yaml:"required"`
+	ReadOnly  bool   `yaml:"read_only"`
+}
+
+// YAMLParameter represents parameter definition
+type YAMLParameter struct {
+	Name        string   `yaml:"name"`
+	Type        string   `yaml:"type"`
+	Description string   `yaml:"description,omitempty"`
+	Default     string   `yaml:"default,omitempty"`
+	Required    bool     `yaml:"required,omitempty"`
+	EnumValues  []string `yaml:"enum_values,omitempty"`
+	MinValue    string   `yaml:"min_value,omitempty"`
+	MaxValue    string   `yaml:"max_value,omitempty"`
+	Pattern     string   `yaml:"pattern,omitempty"`
+}
+
+// YAMLSignature represents template signature
+type YAMLSignature struct {
+	Algorithm       string `yaml:"algorithm"`
+	PublisherPubKey string `yaml:"publisher_pub_key"`
+	Signature       string `yaml:"signature"`
+	SignedAt        string `yaml:"signed_at"`
+	ContentHash     string `yaml:"content_hash"`
+}
+
+// ManifestLoader loads templates from YAML manifests
+type ManifestLoader struct {
+	defaultPublisher string
+}
+
+// NewManifestLoader creates a new manifest loader
+func NewManifestLoader(defaultPublisher string) *ManifestLoader {
+	if defaultPublisher == "" {
+		defaultPublisher = BuiltinTemplatePublisher
+	}
+	return &ManifestLoader{
+		defaultPublisher: defaultPublisher,
+	}
+}
+
+// LoadFromBytes loads a template from YAML bytes
+func (l *ManifestLoader) LoadFromBytes(data []byte) (*hpctypes.WorkloadTemplate, error) {
+	var manifest YAMLManifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	return l.convertToTemplate(&manifest)
+}
+
+// LoadFromFile loads a template from a YAML file
+func (l *ManifestLoader) LoadFromFile(path string) (*hpctypes.WorkloadTemplate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return l.LoadFromBytes(data)
+}
+
+// LoadFromDirectory loads all templates from a directory
+func (l *ManifestLoader) LoadFromDirectory(dir string) ([]*hpctypes.WorkloadTemplate, error) {
+	var templates []*hpctypes.WorkloadTemplate
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
+		template, err := l.LoadFromFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to load %s: %w", path, err)
+		}
+
+		templates = append(templates, template)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return templates, nil
+}
+
+// LoadEmbedded loads templates from embedded files
+func (l *ManifestLoader) LoadEmbedded() ([]*hpctypes.WorkloadTemplate, error) {
+	var templates []*hpctypes.WorkloadTemplate
+
+	err := fs.WalkDir(embeddedTemplates, "templates", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+
+		data, err := embeddedTemplates.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded file %s: %w", path, err)
+		}
+
+		template, err := l.LoadFromBytes(data)
+		if err != nil {
+			return fmt.Errorf("failed to parse embedded file %s: %w", path, err)
+		}
+
+		templates = append(templates, template)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return templates, nil
+}
+
+// convertToTemplate converts YAML manifest to WorkloadTemplate
+func (l *ManifestLoader) convertToTemplate(manifest *YAMLManifest) (*hpctypes.WorkloadTemplate, error) {
+	t := manifest.Template
+
+	publisher := t.Publisher
+	if publisher == "" {
+		publisher = l.defaultPublisher
+	}
+
+	workloadType := hpctypes.WorkloadType(t.Type)
+	if !workloadType.IsValid() {
+		return nil, fmt.Errorf("invalid workload type: %s", t.Type)
+	}
+
+	approvalStatus := hpctypes.WorkloadApprovalStatus(t.ApprovalStatus)
+	if !approvalStatus.IsValid() {
+		approvalStatus = hpctypes.WorkloadApprovalPending
+	}
+
+	template := &hpctypes.WorkloadTemplate{
+		TemplateID:  t.TemplateID,
+		Name:        t.Name,
+		Version:     t.Version,
+		Description: t.Description,
+		Type:        workloadType,
+		Runtime: hpctypes.WorkloadRuntime{
+			RuntimeType:       t.Runtime.RuntimeType,
+			ContainerImage:    t.Runtime.ContainerImage,
+			ContainerRegistry: t.Runtime.ContainerRegistry,
+			ImageDigest:       t.Runtime.ImageDigest,
+			RequiredModules:   t.Runtime.RequiredModules,
+			MPIImplementation: t.Runtime.MPIImplementation,
+			CUDAVersion:       t.Runtime.CUDAVersion,
+			PythonVersion:     t.Runtime.PythonVersion,
+		},
+		Resources: hpctypes.WorkloadResourceSpec{
+			MinNodes:               t.Resources.MinNodes,
+			MaxNodes:               t.Resources.MaxNodes,
+			DefaultNodes:           t.Resources.DefaultNodes,
+			MinCPUsPerNode:         t.Resources.MinCPUsPerNode,
+			MaxCPUsPerNode:         t.Resources.MaxCPUsPerNode,
+			DefaultCPUsPerNode:     t.Resources.DefaultCPUsPerNode,
+			MinMemoryMBPerNode:     t.Resources.MinMemoryMBPerNode,
+			MaxMemoryMBPerNode:     t.Resources.MaxMemoryMBPerNode,
+			DefaultMemoryMBPerNode: t.Resources.DefaultMemoryMBPerNode,
+			MinGPUsPerNode:         t.Resources.MinGPUsPerNode,
+			MaxGPUsPerNode:         t.Resources.MaxGPUsPerNode,
+			DefaultGPUsPerNode:     t.Resources.DefaultGPUsPerNode,
+			GPUTypes:               t.Resources.GPUTypes,
+			MinRuntimeMinutes:      t.Resources.MinRuntimeMinutes,
+			MaxRuntimeMinutes:      t.Resources.MaxRuntimeMinutes,
+			DefaultRuntimeMinutes:  t.Resources.DefaultRuntimeMinutes,
+			StorageGBRequired:      t.Resources.StorageGBRequired,
+			NetworkRequired:        t.Resources.NetworkRequired,
+			ExclusiveNodes:         t.Resources.ExclusiveNodes,
+		},
+		Security: hpctypes.WorkloadSecuritySpec{
+			AllowedRegistries:  t.Security.AllowedRegistries,
+			BlockedImages:      t.Security.BlockedImages,
+			AllowedImages:      t.Security.AllowedImages,
+			RequireImageDigest: t.Security.RequireImageDigest,
+			AllowNetworkAccess: t.Security.AllowNetworkAccess,
+			AllowHostMounts:    t.Security.AllowHostMounts,
+			AllowedHostPaths:   t.Security.AllowedHostPaths,
+			SandboxLevel:       t.Security.SandboxLevel,
+			MaxOpenFiles:       t.Security.MaxOpenFiles,
+			MaxProcesses:       t.Security.MaxProcesses,
+			MaxFileSize:        t.Security.MaxFileSize,
+		},
+		Entrypoint: hpctypes.WorkloadEntrypoint{
+			Command:          t.Entrypoint.Command,
+			DefaultArgs:      t.Entrypoint.DefaultArgs,
+			ArgTemplate:      t.Entrypoint.ArgTemplate,
+			WorkingDirectory: t.Entrypoint.WorkingDirectory,
+			PreRunScript:     t.Entrypoint.PreRunScript,
+			PostRunScript:    t.Entrypoint.PostRunScript,
+			UseMPIRun:        t.Entrypoint.UseMPIRun,
+			MPIRunArgs:       t.Entrypoint.MPIRunArgs,
+		},
+		Modules:        t.Modules,
+		ApprovalStatus: approvalStatus,
+		Publisher:      publisher,
+		Tags:           t.Tags,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	// Convert environment variables
+	for _, env := range t.Environment {
+		template.Environment = append(template.Environment, hpctypes.EnvironmentVariable{
+			Name:          env.Name,
+			Value:         env.Value,
+			ValueTemplate: env.ValueTemplate,
+			Required:      env.Required,
+			Secret:        env.Secret,
+			Description:   env.Description,
+		})
+	}
+
+	// Convert data bindings
+	for _, binding := range t.DataBindings {
+		template.DataBindings = append(template.DataBindings, hpctypes.DataBinding{
+			Name:      binding.Name,
+			MountPath: binding.MountPath,
+			HostPath:  binding.HostPath,
+			DataType:  binding.DataType,
+			Required:  binding.Required,
+			ReadOnly:  binding.ReadOnly,
+		})
+	}
+
+	// Convert parameter schema
+	for _, param := range t.ParameterSchema {
+		template.ParameterSchema = append(template.ParameterSchema, hpctypes.ParameterDefinition{
+			Name:        param.Name,
+			Type:        param.Type,
+			Description: param.Description,
+			Default:     param.Default,
+			Required:    param.Required,
+			EnumValues:  param.EnumValues,
+			MinValue:    param.MinValue,
+			MaxValue:    param.MaxValue,
+			Pattern:     param.Pattern,
+		})
+	}
+
+	// Convert signature if present
+	if manifest.Signature != nil {
+		signedAt, _ := time.Parse(time.RFC3339, manifest.Signature.SignedAt)
+		template.Signature = hpctypes.WorkloadSignature{
+			Algorithm:       manifest.Signature.Algorithm,
+			PublisherPubKey: manifest.Signature.PublisherPubKey,
+			Signature:       manifest.Signature.Signature,
+			SignedAt:        signedAt,
+			ContentHash:     manifest.Signature.ContentHash,
+		}
+	}
+
+	return template, nil
+}
+
+// ExportToYAML exports a template to YAML format
+func ExportToYAML(template *hpctypes.WorkloadTemplate) ([]byte, error) {
+	manifest := YAMLManifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Template: YAMLTemplate{
+			TemplateID:     template.TemplateID,
+			Name:           template.Name,
+			Version:        template.Version,
+			Description:    template.Description,
+			Type:           string(template.Type),
+			ApprovalStatus: string(template.ApprovalStatus),
+			Publisher:      template.Publisher,
+			Tags:           template.Tags,
+			Modules:        template.Modules,
+			Runtime: YAMLRuntime{
+				RuntimeType:       template.Runtime.RuntimeType,
+				ContainerImage:    template.Runtime.ContainerImage,
+				ContainerRegistry: template.Runtime.ContainerRegistry,
+				ImageDigest:       template.Runtime.ImageDigest,
+				RequiredModules:   template.Runtime.RequiredModules,
+				MPIImplementation: template.Runtime.MPIImplementation,
+				CUDAVersion:       template.Runtime.CUDAVersion,
+				PythonVersion:     template.Runtime.PythonVersion,
+			},
+			Resources: YAMLResources{
+				MinNodes:               template.Resources.MinNodes,
+				MaxNodes:               template.Resources.MaxNodes,
+				DefaultNodes:           template.Resources.DefaultNodes,
+				MinCPUsPerNode:         template.Resources.MinCPUsPerNode,
+				MaxCPUsPerNode:         template.Resources.MaxCPUsPerNode,
+				DefaultCPUsPerNode:     template.Resources.DefaultCPUsPerNode,
+				MinMemoryMBPerNode:     template.Resources.MinMemoryMBPerNode,
+				MaxMemoryMBPerNode:     template.Resources.MaxMemoryMBPerNode,
+				DefaultMemoryMBPerNode: template.Resources.DefaultMemoryMBPerNode,
+				MinGPUsPerNode:         template.Resources.MinGPUsPerNode,
+				MaxGPUsPerNode:         template.Resources.MaxGPUsPerNode,
+				DefaultGPUsPerNode:     template.Resources.DefaultGPUsPerNode,
+				GPUTypes:               template.Resources.GPUTypes,
+				MinRuntimeMinutes:      template.Resources.MinRuntimeMinutes,
+				MaxRuntimeMinutes:      template.Resources.MaxRuntimeMinutes,
+				DefaultRuntimeMinutes:  template.Resources.DefaultRuntimeMinutes,
+				StorageGBRequired:      template.Resources.StorageGBRequired,
+				NetworkRequired:        template.Resources.NetworkRequired,
+				ExclusiveNodes:         template.Resources.ExclusiveNodes,
+			},
+			Security: YAMLSecurity{
+				AllowedRegistries:  template.Security.AllowedRegistries,
+				AllowedImages:      template.Security.AllowedImages,
+				BlockedImages:      template.Security.BlockedImages,
+				RequireImageDigest: template.Security.RequireImageDigest,
+				AllowNetworkAccess: template.Security.AllowNetworkAccess,
+				AllowHostMounts:    template.Security.AllowHostMounts,
+				AllowedHostPaths:   template.Security.AllowedHostPaths,
+				SandboxLevel:       template.Security.SandboxLevel,
+				MaxOpenFiles:       template.Security.MaxOpenFiles,
+				MaxProcesses:       template.Security.MaxProcesses,
+				MaxFileSize:        template.Security.MaxFileSize,
+			},
+			Entrypoint: YAMLEntrypoint{
+				Command:          template.Entrypoint.Command,
+				DefaultArgs:      template.Entrypoint.DefaultArgs,
+				ArgTemplate:      template.Entrypoint.ArgTemplate,
+				WorkingDirectory: template.Entrypoint.WorkingDirectory,
+				PreRunScript:     template.Entrypoint.PreRunScript,
+				PostRunScript:    template.Entrypoint.PostRunScript,
+				UseMPIRun:        template.Entrypoint.UseMPIRun,
+				MPIRunArgs:       template.Entrypoint.MPIRunArgs,
+			},
+		},
+	}
+
+	// Convert environment
+	for _, env := range template.Environment {
+		manifest.Template.Environment = append(manifest.Template.Environment, YAMLEnvironment{
+			Name:          env.Name,
+			Value:         env.Value,
+			ValueTemplate: env.ValueTemplate,
+			Required:      env.Required,
+			Secret:        env.Secret,
+			Description:   env.Description,
+		})
+	}
+
+	// Convert data bindings
+	for _, binding := range template.DataBindings {
+		manifest.Template.DataBindings = append(manifest.Template.DataBindings, YAMLDataBinding{
+			Name:      binding.Name,
+			MountPath: binding.MountPath,
+			HostPath:  binding.HostPath,
+			DataType:  binding.DataType,
+			Required:  binding.Required,
+			ReadOnly:  binding.ReadOnly,
+		})
+	}
+
+	// Convert parameters
+	for _, param := range template.ParameterSchema {
+		manifest.Template.ParameterSchema = append(manifest.Template.ParameterSchema, YAMLParameter{
+			Name:        param.Name,
+			Type:        param.Type,
+			Description: param.Description,
+			Default:     param.Default,
+			Required:    param.Required,
+			EnumValues:  param.EnumValues,
+			MinValue:    param.MinValue,
+			MaxValue:    param.MaxValue,
+			Pattern:     param.Pattern,
+		})
+	}
+
+	// Convert signature
+	if template.Signature.Signature != "" {
+		manifest.Signature = &YAMLSignature{
+			Algorithm:       template.Signature.Algorithm,
+			PublisherPubKey: template.Signature.PublisherPubKey,
+			Signature:       template.Signature.Signature,
+			SignedAt:        template.Signature.SignedAt.Format(time.RFC3339),
+			ContentHash:     template.Signature.ContentHash,
+		}
+	}
+
+	return yaml.Marshal(manifest)
+}

--- a/pkg/hpc_workload_library/manifest_test.go
+++ b/pkg/hpc_workload_library/manifest_test.go
@@ -1,0 +1,483 @@
+// Package hpc_workload_library provides tests for manifest loading.
+//
+// VE-5F: Tests for YAML manifest parsing
+package hpc_workload_library
+
+import (
+	"testing"
+
+	_ "github.com/virtengine/virtengine/sdk/go/sdkutil" // Initialize SDK config
+
+	hpctypes "github.com/virtengine/virtengine/x/hpc/types"
+)
+
+func TestNewManifestLoader(t *testing.T) {
+	loader := NewManifestLoader("")
+	if loader == nil {
+		t.Fatal("expected loader to be created")
+	}
+	if loader.defaultPublisher != BuiltinTemplatePublisher {
+		t.Errorf("expected default publisher %s, got %s", BuiltinTemplatePublisher, loader.defaultPublisher)
+	}
+}
+
+func TestLoadFromBytes(t *testing.T) {
+	loader := NewManifestLoader("")
+
+	yaml := `
+schema_version: "1.0.0"
+template:
+  template_id: test-template
+  name: Test Template
+  version: 1.0.0
+  description: A test template
+  type: batch
+  runtime:
+    runtime_type: singularity
+    container_image: library/ubuntu:22.04
+  resources:
+    min_nodes: 1
+    max_nodes: 4
+    default_nodes: 1
+    min_cpus_per_node: 1
+    max_cpus_per_node: 16
+    default_cpus_per_node: 4
+    min_memory_mb_per_node: 1024
+    max_memory_mb_per_node: 32000
+    default_memory_mb_per_node: 8000
+    min_runtime_minutes: 1
+    max_runtime_minutes: 60
+    default_runtime_minutes: 30
+  security:
+    sandbox_level: basic
+    allow_network_access: false
+    allow_host_mounts: true
+    allowed_host_paths:
+      - /scratch
+  entrypoint:
+    command: /bin/bash
+    working_directory: /work
+  approval_status: approved
+  tags:
+    - test
+    - batch
+`
+
+	template, err := loader.LoadFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("failed to load template: %v", err)
+	}
+
+	if template.TemplateID != "test-template" {
+		t.Errorf("expected template ID 'test-template', got %s", template.TemplateID)
+	}
+
+	if template.Type != hpctypes.WorkloadTypeBatch {
+		t.Errorf("expected type batch, got %s", template.Type)
+	}
+
+	if template.Resources.MaxNodes != 4 {
+		t.Errorf("expected max nodes 4, got %d", template.Resources.MaxNodes)
+	}
+
+	if len(template.Tags) != 2 {
+		t.Errorf("expected 2 tags, got %d", len(template.Tags))
+	}
+}
+
+func TestLoadFromBytesWithEnvironment(t *testing.T) {
+	loader := NewManifestLoader("")
+
+	yaml := `
+schema_version: "1.0.0"
+template:
+  template_id: env-test
+  name: Environment Test
+  version: 1.0.0
+  type: batch
+  runtime:
+    runtime_type: singularity
+    container_image: library/ubuntu:22.04
+  resources:
+    min_nodes: 1
+    max_nodes: 1
+    default_nodes: 1
+    min_cpus_per_node: 1
+    max_cpus_per_node: 4
+    default_cpus_per_node: 1
+    min_memory_mb_per_node: 1024
+    max_memory_mb_per_node: 8000
+    default_memory_mb_per_node: 2000
+    min_runtime_minutes: 1
+    max_runtime_minutes: 60
+    default_runtime_minutes: 10
+  security:
+    sandbox_level: basic
+  entrypoint:
+    command: /bin/bash
+  environment:
+    - name: MY_VAR
+      value: my_value
+      description: A test variable
+    - name: TEMPLATE_VAR
+      value_template: "${SLURM_JOB_ID}"
+      description: A template variable
+    - name: SECRET_VAR
+      value: secret
+      secret: true
+  approval_status: approved
+`
+
+	template, err := loader.LoadFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("failed to load template: %v", err)
+	}
+
+	if len(template.Environment) != 3 {
+		t.Errorf("expected 3 environment variables, got %d", len(template.Environment))
+	}
+
+	// Check first variable
+	if template.Environment[0].Name != "MY_VAR" {
+		t.Errorf("expected first env name 'MY_VAR', got %s", template.Environment[0].Name)
+	}
+	if template.Environment[0].Value != "my_value" {
+		t.Errorf("expected first env value 'my_value', got %s", template.Environment[0].Value)
+	}
+
+	// Check template variable
+	if template.Environment[1].ValueTemplate != "${SLURM_JOB_ID}" {
+		t.Errorf("expected value template, got %s", template.Environment[1].ValueTemplate)
+	}
+
+	// Check secret
+	if !template.Environment[2].Secret {
+		t.Error("expected secret to be true")
+	}
+}
+
+func TestLoadFromBytesWithDataBindings(t *testing.T) {
+	loader := NewManifestLoader("")
+
+	yaml := `
+schema_version: "1.0.0"
+template:
+  template_id: binding-test
+  name: Binding Test
+  version: 1.0.0
+  type: batch
+  runtime:
+    runtime_type: singularity
+    container_image: library/ubuntu:22.04
+  resources:
+    min_nodes: 1
+    max_nodes: 1
+    default_nodes: 1
+    min_cpus_per_node: 1
+    max_cpus_per_node: 4
+    default_cpus_per_node: 1
+    min_memory_mb_per_node: 1024
+    max_memory_mb_per_node: 8000
+    default_memory_mb_per_node: 2000
+    min_runtime_minutes: 1
+    max_runtime_minutes: 60
+    default_runtime_minutes: 10
+  security:
+    sandbox_level: basic
+  entrypoint:
+    command: /bin/bash
+  data_bindings:
+    - name: input
+      mount_path: /input
+      data_type: input
+      required: true
+      read_only: true
+    - name: output
+      mount_path: /output
+      host_path: /work/$USER/output
+      data_type: output
+      required: true
+      read_only: false
+  approval_status: approved
+`
+
+	template, err := loader.LoadFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("failed to load template: %v", err)
+	}
+
+	if len(template.DataBindings) != 2 {
+		t.Errorf("expected 2 data bindings, got %d", len(template.DataBindings))
+	}
+
+	// Check input binding
+	if template.DataBindings[0].Name != "input" {
+		t.Errorf("expected first binding name 'input', got %s", template.DataBindings[0].Name)
+	}
+	if !template.DataBindings[0].ReadOnly {
+		t.Error("expected input binding to be read-only")
+	}
+
+	// Check output binding with host path
+	if template.DataBindings[1].HostPath != "/work/$USER/output" {
+		t.Errorf("expected host path, got %s", template.DataBindings[1].HostPath)
+	}
+}
+
+func TestLoadFromBytesWithParameters(t *testing.T) {
+	loader := NewManifestLoader("")
+
+	yaml := `
+schema_version: "1.0.0"
+template:
+  template_id: param-test
+  name: Parameter Test
+  version: 1.0.0
+  type: batch
+  runtime:
+    runtime_type: singularity
+    container_image: library/ubuntu:22.04
+  resources:
+    min_nodes: 1
+    max_nodes: 1
+    default_nodes: 1
+    min_cpus_per_node: 1
+    max_cpus_per_node: 4
+    default_cpus_per_node: 1
+    min_memory_mb_per_node: 1024
+    max_memory_mb_per_node: 8000
+    default_memory_mb_per_node: 2000
+    min_runtime_minutes: 1
+    max_runtime_minutes: 60
+    default_runtime_minutes: 10
+  security:
+    sandbox_level: basic
+  entrypoint:
+    command: /bin/bash
+  parameter_schema:
+    - name: input_file
+      type: string
+      description: Input file path
+      required: true
+    - name: iterations
+      type: int
+      description: Number of iterations
+      default: "100"
+      min_value: "1"
+      max_value: "10000"
+    - name: mode
+      type: enum
+      description: Processing mode
+      enum_values:
+        - fast
+        - accurate
+        - balanced
+      default: balanced
+  approval_status: approved
+`
+
+	template, err := loader.LoadFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("failed to load template: %v", err)
+	}
+
+	if len(template.ParameterSchema) != 3 {
+		t.Errorf("expected 3 parameters, got %d", len(template.ParameterSchema))
+	}
+
+	// Check string parameter
+	if template.ParameterSchema[0].Type != "string" {
+		t.Errorf("expected type string, got %s", template.ParameterSchema[0].Type)
+	}
+	if !template.ParameterSchema[0].Required {
+		t.Error("expected input_file to be required")
+	}
+
+	// Check int parameter with min/max
+	if template.ParameterSchema[1].MinValue != "1" {
+		t.Errorf("expected min value '1', got %s", template.ParameterSchema[1].MinValue)
+	}
+
+	// Check enum parameter
+	if len(template.ParameterSchema[2].EnumValues) != 3 {
+		t.Errorf("expected 3 enum values, got %d", len(template.ParameterSchema[2].EnumValues))
+	}
+}
+
+func TestLoadFromBytesInvalidYAML(t *testing.T) {
+	loader := NewManifestLoader("")
+
+	invalidYAML := `
+schema_version: "1.0.0"
+template:
+  template_id: [invalid yaml
+`
+
+	_, err := loader.LoadFromBytes([]byte(invalidYAML))
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestLoadFromBytesInvalidType(t *testing.T) {
+	loader := NewManifestLoader("")
+
+	yaml := `
+schema_version: "1.0.0"
+template:
+  template_id: invalid-type
+  name: Invalid Type Test
+  version: 1.0.0
+  type: invalid_type
+  runtime:
+    runtime_type: singularity
+    container_image: library/ubuntu:22.04
+  resources:
+    min_nodes: 1
+    max_nodes: 1
+    default_nodes: 1
+    min_cpus_per_node: 1
+    max_cpus_per_node: 1
+    default_cpus_per_node: 1
+    min_memory_mb_per_node: 1024
+    max_memory_mb_per_node: 1024
+    default_memory_mb_per_node: 1024
+    min_runtime_minutes: 1
+    max_runtime_minutes: 1
+    default_runtime_minutes: 1
+  security:
+    sandbox_level: basic
+  entrypoint:
+    command: /bin/bash
+  approval_status: approved
+`
+
+	_, err := loader.LoadFromBytes([]byte(yaml))
+	if err == nil {
+		t.Error("expected error for invalid type")
+	}
+}
+
+func TestLoadEmbedded(t *testing.T) {
+	loader := NewManifestLoader("")
+
+	templates, err := loader.LoadEmbedded()
+	if err != nil {
+		t.Fatalf("failed to load embedded templates: %v", err)
+	}
+
+	if len(templates) == 0 {
+		t.Error("expected at least one embedded template")
+	}
+
+	// Verify all templates are valid
+	for _, template := range templates {
+		if template.TemplateID == "" {
+			t.Error("template has no ID")
+		}
+		if template.Name == "" {
+			t.Error("template has no name")
+		}
+	}
+}
+
+func TestExportToYAML(t *testing.T) {
+	template := GetMPITemplate()
+
+	yaml, err := ExportToYAML(template)
+	if err != nil {
+		t.Fatalf("failed to export template: %v", err)
+	}
+
+	if len(yaml) == 0 {
+		t.Error("expected non-empty YAML output")
+	}
+
+	// Verify we can reload it
+	loader := NewManifestLoader(template.Publisher)
+	reloaded, err := loader.LoadFromBytes(yaml)
+	if err != nil {
+		t.Fatalf("failed to reload exported YAML: %v", err)
+	}
+
+	if reloaded.TemplateID != template.TemplateID {
+		t.Errorf("template ID mismatch: %s vs %s", reloaded.TemplateID, template.TemplateID)
+	}
+
+	if reloaded.Name != template.Name {
+		t.Errorf("template name mismatch: %s vs %s", reloaded.Name, template.Name)
+	}
+}
+
+func TestExportToYAMLRoundTrip(t *testing.T) {
+	// Test round-trip for all built-in templates
+	for _, template := range GetBuiltinTemplates() {
+		yaml, err := ExportToYAML(template)
+		if err != nil {
+			t.Errorf("failed to export %s: %v", template.TemplateID, err)
+			continue
+		}
+
+		loader := NewManifestLoader(template.Publisher)
+		reloaded, err := loader.LoadFromBytes(yaml)
+		if err != nil {
+			t.Errorf("failed to reload %s: %v", template.TemplateID, err)
+			continue
+		}
+
+		// Verify key fields match
+		if reloaded.TemplateID != template.TemplateID {
+			t.Errorf("%s: ID mismatch", template.TemplateID)
+		}
+		if reloaded.Type != template.Type {
+			t.Errorf("%s: type mismatch", template.TemplateID)
+		}
+		if reloaded.Resources.MaxNodes != template.Resources.MaxNodes {
+			t.Errorf("%s: max nodes mismatch", template.TemplateID)
+		}
+	}
+}
+
+func TestManifestLoaderCustomPublisher(t *testing.T) {
+	customPublisher := "akash1customaddress123456789"
+	loader := NewManifestLoader(customPublisher)
+
+	yaml := `
+schema_version: "1.0.0"
+template:
+  template_id: custom-pub-test
+  name: Custom Publisher Test
+  version: 1.0.0
+  type: batch
+  runtime:
+    runtime_type: singularity
+    container_image: library/ubuntu:22.04
+  resources:
+    min_nodes: 1
+    max_nodes: 1
+    default_nodes: 1
+    min_cpus_per_node: 1
+    max_cpus_per_node: 1
+    default_cpus_per_node: 1
+    min_memory_mb_per_node: 1024
+    max_memory_mb_per_node: 1024
+    default_memory_mb_per_node: 1024
+    min_runtime_minutes: 1
+    max_runtime_minutes: 1
+    default_runtime_minutes: 1
+  security:
+    sandbox_level: basic
+  entrypoint:
+    command: /bin/bash
+  approval_status: approved
+`
+
+	template, err := loader.LoadFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("failed to load template: %v", err)
+	}
+
+	if template.Publisher != customPublisher {
+		t.Errorf("expected publisher %s, got %s", customPublisher, template.Publisher)
+	}
+}

--- a/pkg/hpc_workload_library/registry.go
+++ b/pkg/hpc_workload_library/registry.go
@@ -1,0 +1,581 @@
+// Package hpc_workload_library provides workload registry functionality.
+//
+// VE-5F: Registry for workload template discovery and search
+package hpc_workload_library
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/virtengine/virtengine/pkg/artifact_store"
+	hpctypes "github.com/virtengine/virtengine/x/hpc/types"
+)
+
+// WorkloadRegistry provides discovery and search for workload templates
+type WorkloadRegistry struct {
+	mu sync.RWMutex
+
+	// In-memory cache of templates
+	templates map[string]*hpctypes.WorkloadTemplate
+
+	// Index by type
+	byType map[hpctypes.WorkloadType][]string
+
+	// Index by tag
+	byTag map[string][]string
+
+	// Artifact store for persistence
+	store artifact_store.ArtifactStore
+
+	// Validator for templates
+	validator *WorkloadValidator
+
+	// Verifier for signatures
+	verifier *TemplateVerifier
+
+	// Config
+	config RegistryConfig
+}
+
+// RegistryConfig configures the workload registry
+type RegistryConfig struct {
+	// RequireSignature requires templates to be signed
+	RequireSignature bool
+
+	// RequireApproval requires templates to be approved
+	RequireApproval bool
+
+	// CacheTTL is the cache TTL
+	CacheTTL time.Duration
+
+	// MaxTemplates is the maximum templates in cache
+	MaxTemplates int
+
+	// ValidationConfig is the validation configuration
+	ValidationConfig ValidationConfig
+}
+
+// DefaultRegistryConfig returns the default registry configuration
+func DefaultRegistryConfig() RegistryConfig {
+	return RegistryConfig{
+		RequireSignature: false,
+		RequireApproval:  true,
+		CacheTTL:         time.Hour,
+		MaxTemplates:     1000,
+		ValidationConfig: DefaultValidationConfig(),
+	}
+}
+
+// NewWorkloadRegistry creates a new workload registry
+func NewWorkloadRegistry(store artifact_store.ArtifactStore, config RegistryConfig) *WorkloadRegistry {
+	r := &WorkloadRegistry{
+		templates: make(map[string]*hpctypes.WorkloadTemplate),
+		byType:    make(map[hpctypes.WorkloadType][]string),
+		byTag:     make(map[string][]string),
+		store:     store,
+		validator: NewWorkloadValidator(config.ValidationConfig),
+		verifier:  NewTemplateVerifier(),
+		config:    config,
+	}
+
+	// Load built-in templates
+	for _, t := range GetBuiltinTemplates() {
+		r.addToCache(t)
+	}
+
+	return r
+}
+
+// Register registers a new workload template
+func (r *WorkloadRegistry) Register(ctx context.Context, template *hpctypes.WorkloadTemplate) error {
+	// Validate template
+	result := r.validator.ValidateTemplate(ctx, template)
+	if !result.IsValid() {
+		return result.Error()
+	}
+
+	// Verify signature if required
+	if r.config.RequireSignature {
+		if err := r.verifier.Verify(template); err != nil {
+			return fmt.Errorf("signature verification failed: %w", err)
+		}
+	}
+
+	// Check approval status if required
+	if r.config.RequireApproval && !template.ApprovalStatus.CanBeUsed() {
+		return fmt.Errorf("template must be approved before registration")
+	}
+
+	// Store in artifact store if available
+	if r.store != nil {
+		data, err := json.Marshal(template)
+		if err != nil {
+			return fmt.Errorf("failed to serialize template: %w", err)
+		}
+
+		_, err = r.store.Put(ctx, &artifact_store.PutRequest{
+			Data: data,
+			EncryptionMetadata: &artifact_store.EncryptionMetadata{
+				AlgorithmID: "none",
+			},
+			Owner:        template.Publisher,
+			ArtifactType: "workload_template",
+			Metadata: map[string]string{
+				"template_id": template.TemplateID,
+				"version":     template.Version,
+				"type":        string(template.Type),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to store template: %w", err)
+		}
+	}
+
+	// Add to cache
+	r.addToCache(template)
+
+	return nil
+}
+
+// Get retrieves a template by ID
+func (r *WorkloadRegistry) Get(ctx context.Context, templateID string) (*hpctypes.WorkloadTemplate, error) {
+	r.mu.RLock()
+	template, ok := r.templates[templateID]
+	r.mu.RUnlock()
+
+	if ok {
+		return template, nil
+	}
+
+	return nil, fmt.Errorf("template not found: %s", templateID)
+}
+
+// GetVersion retrieves a specific version of a template
+func (r *WorkloadRegistry) GetVersion(ctx context.Context, templateID, version string) (*hpctypes.WorkloadTemplate, error) {
+	versionedID := templateID + "@" + version
+
+	r.mu.RLock()
+	template, ok := r.templates[versionedID]
+	r.mu.RUnlock()
+
+	if ok {
+		return template, nil
+	}
+
+	// Fall back to latest if version matches
+	r.mu.RLock()
+	template, ok = r.templates[templateID]
+	r.mu.RUnlock()
+
+	if ok && template.Version == version {
+		return template, nil
+	}
+
+	return nil, fmt.Errorf("template version not found: %s@%s", templateID, version)
+}
+
+// List lists all templates with optional filters
+func (r *WorkloadRegistry) List(ctx context.Context, filter *TemplateFilter) ([]*hpctypes.WorkloadTemplate, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var results []*hpctypes.WorkloadTemplate
+
+	// Get candidate IDs based on filter
+	var candidateIDs []string
+	if filter != nil && filter.Type != "" {
+		candidateIDs = r.byType[filter.Type]
+	} else if filter != nil && len(filter.Tags) > 0 {
+		// Get intersection of all tag indices
+		candidateIDs = r.getIDsByTags(filter.Tags)
+	} else {
+		// All templates
+		for id := range r.templates {
+			// Skip versioned IDs to avoid duplicates
+			if !strings.Contains(id, "@") {
+				candidateIDs = append(candidateIDs, id)
+			}
+		}
+	}
+
+	// Filter and collect results
+	for _, id := range candidateIDs {
+		template := r.templates[id]
+		if template == nil {
+			continue
+		}
+
+		if filter != nil && !filter.Matches(template) {
+			continue
+		}
+
+		results = append(results, template)
+	}
+
+	// Sort by name
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+
+	// Apply pagination
+	if filter != nil && filter.Limit > 0 {
+		start := filter.Offset
+		if start >= len(results) {
+			return []*hpctypes.WorkloadTemplate{}, nil
+		}
+		end := start + filter.Limit
+		if end > len(results) {
+			end = len(results)
+		}
+		results = results[start:end]
+	}
+
+	return results, nil
+}
+
+// Search searches templates by query string
+func (r *WorkloadRegistry) Search(ctx context.Context, query string, limit int) ([]*hpctypes.WorkloadTemplate, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	query = strings.ToLower(query)
+	var results []*hpctypes.WorkloadTemplate
+
+	for id, template := range r.templates {
+		// Skip versioned IDs
+		if strings.Contains(id, "@") {
+			continue
+		}
+
+		// Search in name, description, tags
+		if strings.Contains(strings.ToLower(template.Name), query) ||
+			strings.Contains(strings.ToLower(template.Description), query) ||
+			containsTag(template.Tags, query) {
+			results = append(results, template)
+		}
+	}
+
+	// Sort by relevance (exact matches first)
+	sort.Slice(results, func(i, j int) bool {
+		iExact := strings.EqualFold(results[i].Name, query)
+		jExact := strings.EqualFold(results[j].Name, query)
+		if iExact && !jExact {
+			return true
+		}
+		if !iExact && jExact {
+			return false
+		}
+		return results[i].Name < results[j].Name
+	})
+
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results, nil
+}
+
+// ListByType lists templates by workload type
+func (r *WorkloadRegistry) ListByType(ctx context.Context, workloadType hpctypes.WorkloadType) ([]*hpctypes.WorkloadTemplate, error) {
+	return r.List(ctx, &TemplateFilter{Type: workloadType})
+}
+
+// ListByTag lists templates by tag
+func (r *WorkloadRegistry) ListByTag(ctx context.Context, tag string) ([]*hpctypes.WorkloadTemplate, error) {
+	return r.List(ctx, &TemplateFilter{Tags: []string{tag}})
+}
+
+// ListTags returns all unique tags
+func (r *WorkloadRegistry) ListTags(ctx context.Context) ([]string, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	tags := make([]string, 0, len(r.byTag))
+	for tag := range r.byTag {
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+	return tags, nil
+}
+
+// ListTypes returns all template types with counts
+func (r *WorkloadRegistry) ListTypes(ctx context.Context) (map[hpctypes.WorkloadType]int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	counts := make(map[hpctypes.WorkloadType]int)
+	for t, ids := range r.byType {
+		counts[t] = len(ids)
+	}
+	return counts, nil
+}
+
+// Count returns the total number of templates
+func (r *WorkloadRegistry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	count := 0
+	for id := range r.templates {
+		if !strings.Contains(id, "@") {
+			count++
+		}
+	}
+	return count
+}
+
+// Unregister removes a template from the registry
+func (r *WorkloadRegistry) Unregister(ctx context.Context, templateID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	template, ok := r.templates[templateID]
+	if !ok {
+		return fmt.Errorf("template not found: %s", templateID)
+	}
+
+	// Remove from indices
+	r.removeFromIndices(template)
+
+	// Remove from cache
+	delete(r.templates, templateID)
+	delete(r.templates, template.GetVersionedID())
+
+	return nil
+}
+
+// Refresh refreshes the template cache from the artifact store
+func (r *WorkloadRegistry) Refresh(ctx context.Context) error {
+	if r.store == nil {
+		return nil
+	}
+
+	// List all workload templates from store
+	resp, err := r.store.ListByOwner(ctx, "", &artifact_store.Pagination{
+		Limit: uint64(r.config.MaxTemplates),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list templates: %w", err)
+	}
+
+	for _, ref := range resp.References {
+		if ref.ArtifactType != "workload_template" {
+			continue
+		}
+
+		// Get template data
+		getResp, err := r.store.Get(ctx, &artifact_store.GetRequest{
+			ContentAddress: ref.ContentAddress,
+		})
+		if err != nil {
+			continue
+		}
+
+		var template hpctypes.WorkloadTemplate
+		if err := json.Unmarshal(getResp.Data, &template); err != nil {
+			continue
+		}
+
+		// Add to cache
+		r.addToCache(&template)
+	}
+
+	return nil
+}
+
+// addToCache adds a template to the cache and indices
+func (r *WorkloadRegistry) addToCache(template *hpctypes.WorkloadTemplate) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Store by ID
+	r.templates[template.TemplateID] = template
+
+	// Store by versioned ID
+	r.templates[template.GetVersionedID()] = template
+
+	// Update type index
+	if _, ok := r.byType[template.Type]; !ok {
+		r.byType[template.Type] = []string{}
+	}
+	if !contains(r.byType[template.Type], template.TemplateID) {
+		r.byType[template.Type] = append(r.byType[template.Type], template.TemplateID)
+	}
+
+	// Update tag index
+	for _, tag := range template.Tags {
+		if _, ok := r.byTag[tag]; !ok {
+			r.byTag[tag] = []string{}
+		}
+		if !contains(r.byTag[tag], template.TemplateID) {
+			r.byTag[tag] = append(r.byTag[tag], template.TemplateID)
+		}
+	}
+}
+
+// removeFromIndices removes a template from indices
+func (r *WorkloadRegistry) removeFromIndices(template *hpctypes.WorkloadTemplate) {
+	// Remove from type index
+	if ids, ok := r.byType[template.Type]; ok {
+		r.byType[template.Type] = removeString(ids, template.TemplateID)
+	}
+
+	// Remove from tag index
+	for _, tag := range template.Tags {
+		if ids, ok := r.byTag[tag]; ok {
+			r.byTag[tag] = removeString(ids, template.TemplateID)
+		}
+	}
+}
+
+// getIDsByTags returns template IDs that have all specified tags
+func (r *WorkloadRegistry) getIDsByTags(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	// Start with first tag's IDs
+	result := make(map[string]bool)
+	for _, id := range r.byTag[tags[0]] {
+		result[id] = true
+	}
+
+	// Intersect with remaining tags
+	for _, tag := range tags[1:] {
+		ids := r.byTag[tag]
+		for id := range result {
+			if !contains(ids, id) {
+				delete(result, id)
+			}
+		}
+	}
+
+	out := make([]string, 0, len(result))
+	for id := range result {
+		out = append(out, id)
+	}
+	return out
+}
+
+// TemplateFilter defines filters for template listing
+type TemplateFilter struct {
+	// Type filters by workload type
+	Type hpctypes.WorkloadType
+
+	// Tags filters by tags (AND logic)
+	Tags []string
+
+	// Publisher filters by publisher address
+	Publisher string
+
+	// ApprovalStatus filters by approval status
+	ApprovalStatus hpctypes.WorkloadApprovalStatus
+
+	// Offset for pagination
+	Offset int
+
+	// Limit for pagination
+	Limit int
+}
+
+// Matches checks if a template matches the filter
+func (f *TemplateFilter) Matches(t *hpctypes.WorkloadTemplate) bool {
+	if f.Type != "" && t.Type != f.Type {
+		return false
+	}
+
+	if len(f.Tags) > 0 {
+		for _, tag := range f.Tags {
+			if !containsTag(t.Tags, tag) {
+				return false
+			}
+		}
+	}
+
+	if f.Publisher != "" && t.Publisher != f.Publisher {
+		return false
+	}
+
+	if f.ApprovalStatus != "" && t.ApprovalStatus != f.ApprovalStatus {
+		return false
+	}
+
+	return true
+}
+
+// DiscoveryInfo contains template discovery information
+type DiscoveryInfo struct {
+	// TotalTemplates is the total template count
+	TotalTemplates int `json:"total_templates"`
+
+	// TypeCounts is the count per type
+	TypeCounts map[hpctypes.WorkloadType]int `json:"type_counts"`
+
+	// Tags is the list of all tags
+	Tags []string `json:"tags"`
+
+	// FeaturedTemplates is a list of featured template IDs
+	FeaturedTemplates []string `json:"featured_templates"`
+}
+
+// GetDiscoveryInfo returns discovery information about the registry
+func (r *WorkloadRegistry) GetDiscoveryInfo(ctx context.Context) (*DiscoveryInfo, error) {
+	types, err := r.ListTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	tags, err := r.ListTags(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Featured templates are built-in ones
+	featured := make([]string, 0)
+	for _, t := range GetBuiltinTemplates() {
+		featured = append(featured, t.TemplateID)
+	}
+
+	return &DiscoveryInfo{
+		TotalTemplates:    r.Count(),
+		TypeCounts:        types,
+		Tags:              tags,
+		FeaturedTemplates: featured,
+	}, nil
+}
+
+// Helper functions
+
+func contains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func containsTag(tags []string, tag string) bool {
+	tag = strings.ToLower(tag)
+	for _, t := range tags {
+		if strings.ToLower(t) == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(slice []string, s string) []string {
+	result := make([]string, 0, len(slice))
+	for _, item := range slice {
+		if item != s {
+			result = append(result, item)
+		}
+	}
+	return result
+}

--- a/pkg/hpc_workload_library/registry_test.go
+++ b/pkg/hpc_workload_library/registry_test.go
@@ -1,0 +1,540 @@
+// Package hpc_workload_library provides tests for registry functionality.
+//
+// VE-5F: Tests for workload registry
+package hpc_workload_library
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "github.com/virtengine/virtengine/sdk/go/sdkutil" // Initialize SDK config
+
+	hpctypes "github.com/virtengine/virtengine/x/hpc/types"
+)
+
+func TestNewWorkloadRegistry(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+
+	if registry == nil {
+		t.Fatal("expected registry to be created")
+	}
+
+	// Should have built-in templates
+	count := registry.Count()
+	if count < 5 {
+		t.Errorf("expected at least 5 built-in templates, got %d", count)
+	}
+}
+
+func TestRegistryGet(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	// Should find built-in templates
+	template, err := registry.Get(ctx, "mpi-standard")
+	if err != nil {
+		t.Errorf("failed to get mpi-standard template: %v", err)
+	}
+	if template == nil {
+		t.Fatal("expected template to be found")
+	}
+	if template.TemplateID != "mpi-standard" {
+		t.Errorf("expected template ID 'mpi-standard', got %s", template.TemplateID)
+	}
+
+	// Should not find non-existent template
+	_, err = registry.Get(ctx, "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent template")
+	}
+}
+
+func TestRegistryGetVersion(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	// Should find template by version
+	template, err := registry.GetVersion(ctx, "mpi-standard", "1.0.0")
+	if err != nil {
+		t.Errorf("failed to get template version: %v", err)
+	}
+	if template == nil {
+		t.Fatal("expected template to be found")
+	}
+
+	// Should not find non-existent version
+	_, err = registry.GetVersion(ctx, "mpi-standard", "999.0.0")
+	if err == nil {
+		t.Error("expected error for nonexistent version")
+	}
+}
+
+func TestRegistryList(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	// List all templates
+	templates, err := registry.List(ctx, nil)
+	if err != nil {
+		t.Errorf("failed to list templates: %v", err)
+	}
+	if len(templates) < 5 {
+		t.Errorf("expected at least 5 templates, got %d", len(templates))
+	}
+
+	// List with type filter
+	templates, err = registry.List(ctx, &TemplateFilter{
+		Type: hpctypes.WorkloadTypeMPI,
+	})
+	if err != nil {
+		t.Errorf("failed to list MPI templates: %v", err)
+	}
+	if len(templates) == 0 {
+		t.Error("expected at least one MPI template")
+	}
+	for _, tmpl := range templates {
+		if tmpl.Type != hpctypes.WorkloadTypeMPI {
+			t.Errorf("expected MPI type, got %s", tmpl.Type)
+		}
+	}
+}
+
+func TestRegistryListByType(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	tests := []struct {
+		workloadType hpctypes.WorkloadType
+		expectCount  int
+	}{
+		{hpctypes.WorkloadTypeMPI, 1},
+		{hpctypes.WorkloadTypeGPU, 1},
+		{hpctypes.WorkloadTypeBatch, 1},
+		{hpctypes.WorkloadTypeDataProcessing, 1},
+		{hpctypes.WorkloadTypeInteractive, 1},
+	}
+
+	for _, tt := range tests {
+		templates, err := registry.ListByType(ctx, tt.workloadType)
+		if err != nil {
+			t.Errorf("failed to list %s templates: %v", tt.workloadType, err)
+			continue
+		}
+		if len(templates) < tt.expectCount {
+			t.Errorf("expected at least %d %s templates, got %d",
+				tt.expectCount, tt.workloadType, len(templates))
+		}
+	}
+}
+
+func TestRegistryListByTag(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	// List by tag
+	templates, err := registry.ListByTag(ctx, "gpu")
+	if err != nil {
+		t.Errorf("failed to list templates by tag: %v", err)
+	}
+	if len(templates) == 0 {
+		t.Error("expected at least one template with 'gpu' tag")
+	}
+}
+
+func TestRegistryListTags(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	tags, err := registry.ListTags(ctx)
+	if err != nil {
+		t.Errorf("failed to list tags: %v", err)
+	}
+	if len(tags) == 0 {
+		t.Error("expected at least one tag")
+	}
+
+	// Check for expected tags
+	expectedTags := []string{"mpi", "gpu", "batch", "interactive"}
+	for _, expected := range expectedTags {
+		if !contains(tags, expected) {
+			t.Errorf("expected tag '%s' not found", expected)
+		}
+	}
+}
+
+func TestRegistryListTypes(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	types, err := registry.ListTypes(ctx)
+	if err != nil {
+		t.Errorf("failed to list types: %v", err)
+	}
+	if len(types) == 0 {
+		t.Error("expected at least one type")
+	}
+
+	// Check for expected types
+	expectedTypes := []hpctypes.WorkloadType{
+		hpctypes.WorkloadTypeMPI,
+		hpctypes.WorkloadTypeGPU,
+		hpctypes.WorkloadTypeBatch,
+	}
+	for _, expected := range expectedTypes {
+		if _, ok := types[expected]; !ok {
+			t.Errorf("expected type '%s' not found", expected)
+		}
+	}
+}
+
+func TestRegistrySearch(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	tests := []struct {
+		query       string
+		expectMatch bool
+	}{
+		{"mpi", true},
+		{"gpu", true},
+		{"batch", true},
+		{"parallel", true},
+		{"nonexistent-query-xyz", false},
+	}
+
+	for _, tt := range tests {
+		templates, err := registry.Search(ctx, tt.query, 10)
+		if err != nil {
+			t.Errorf("search failed for '%s': %v", tt.query, err)
+			continue
+		}
+		if tt.expectMatch && len(templates) == 0 {
+			t.Errorf("expected search results for '%s'", tt.query)
+		}
+		if !tt.expectMatch && len(templates) > 0 {
+			t.Errorf("expected no results for '%s', got %d", tt.query, len(templates))
+		}
+	}
+}
+
+func TestRegistryRegister(t *testing.T) {
+	config := DefaultRegistryConfig()
+	config.RequireApproval = false // Allow unapproved for testing
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	template := createValidTemplate()
+	template.TemplateID = "custom-template-1"
+	template.ApprovalStatus = hpctypes.WorkloadApprovalPending
+
+	err := registry.Register(ctx, template)
+	if err != nil {
+		t.Errorf("failed to register template: %v", err)
+	}
+
+	// Should be findable
+	found, err := registry.Get(ctx, "custom-template-1")
+	if err != nil {
+		t.Errorf("failed to get registered template: %v", err)
+	}
+	if found == nil {
+		t.Error("expected template to be found")
+	}
+
+	// Count should increase
+	if registry.Count() < 6 {
+		t.Error("expected count to increase after registration")
+	}
+}
+
+func TestRegistryRegisterApprovalRequired(t *testing.T) {
+	config := DefaultRegistryConfig()
+	config.RequireApproval = true
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	template := createValidTemplate()
+	template.TemplateID = "custom-template-2"
+	template.ApprovalStatus = hpctypes.WorkloadApprovalPending
+
+	err := registry.Register(ctx, template)
+	if err == nil {
+		t.Error("expected error for unapproved template")
+	}
+
+	// Approved template should work
+	template.ApprovalStatus = hpctypes.WorkloadApprovalApproved
+	err = registry.Register(ctx, template)
+	if err != nil {
+		t.Errorf("failed to register approved template: %v", err)
+	}
+}
+
+func TestRegistryUnregister(t *testing.T) {
+	config := DefaultRegistryConfig()
+	config.RequireApproval = false
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	template := createValidTemplate()
+	template.TemplateID = "custom-template-3"
+
+	err := registry.Register(ctx, template)
+	if err != nil {
+		t.Fatalf("failed to register template: %v", err)
+	}
+
+	initialCount := registry.Count()
+
+	err = registry.Unregister(ctx, "custom-template-3")
+	if err != nil {
+		t.Errorf("failed to unregister template: %v", err)
+	}
+
+	if registry.Count() >= initialCount {
+		t.Error("expected count to decrease after unregister")
+	}
+
+	// Should not be findable
+	_, err = registry.Get(ctx, "custom-template-3")
+	if err == nil {
+		t.Error("expected error for unregistered template")
+	}
+}
+
+func TestRegistryPagination(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	// Get all templates
+	all, err := registry.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("failed to list all templates: %v", err)
+	}
+
+	// Get first page
+	page1, err := registry.List(ctx, &TemplateFilter{
+		Offset: 0,
+		Limit:  2,
+	})
+	if err != nil {
+		t.Errorf("failed to get first page: %v", err)
+	}
+	if len(page1) > 2 {
+		t.Errorf("expected max 2 templates, got %d", len(page1))
+	}
+
+	// Get second page
+	page2, err := registry.List(ctx, &TemplateFilter{
+		Offset: 2,
+		Limit:  2,
+	})
+	if err != nil {
+		t.Errorf("failed to get second page: %v", err)
+	}
+
+	// Pages should not overlap
+	for _, p1 := range page1 {
+		for _, p2 := range page2 {
+			if p1.TemplateID == p2.TemplateID {
+				t.Errorf("duplicate template in pages: %s", p1.TemplateID)
+			}
+		}
+	}
+
+	// All pages combined should equal total
+	if len(page1)+len(page2) > len(all) {
+		t.Error("pagination returned more items than total")
+	}
+}
+
+func TestRegistryGetDiscoveryInfo(t *testing.T) {
+	config := DefaultRegistryConfig()
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	info, err := registry.GetDiscoveryInfo(ctx)
+	if err != nil {
+		t.Errorf("failed to get discovery info: %v", err)
+	}
+
+	if info.TotalTemplates < 5 {
+		t.Errorf("expected at least 5 templates, got %d", info.TotalTemplates)
+	}
+
+	if len(info.TypeCounts) == 0 {
+		t.Error("expected type counts")
+	}
+
+	if len(info.Tags) == 0 {
+		t.Error("expected tags")
+	}
+
+	if len(info.FeaturedTemplates) == 0 {
+		t.Error("expected featured templates")
+	}
+}
+
+func TestTemplateFilterMatches(t *testing.T) {
+	template := &hpctypes.WorkloadTemplate{
+		TemplateID:     "test-template",
+		Type:           hpctypes.WorkloadTypeMPI,
+		Tags:           []string{"mpi", "parallel"},
+		Publisher:      "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63",
+		ApprovalStatus: hpctypes.WorkloadApprovalApproved,
+	}
+
+	tests := []struct {
+		name    string
+		filter  *TemplateFilter
+		matches bool
+	}{
+		{
+			name:    "nil filter matches all",
+			filter:  nil,
+			matches: true,
+		},
+		{
+			name:    "empty filter matches all",
+			filter:  &TemplateFilter{},
+			matches: true,
+		},
+		{
+			name:    "matching type",
+			filter:  &TemplateFilter{Type: hpctypes.WorkloadTypeMPI},
+			matches: true,
+		},
+		{
+			name:    "non-matching type",
+			filter:  &TemplateFilter{Type: hpctypes.WorkloadTypeGPU},
+			matches: false,
+		},
+		{
+			name:    "matching tag",
+			filter:  &TemplateFilter{Tags: []string{"mpi"}},
+			matches: true,
+		},
+		{
+			name:    "matching multiple tags",
+			filter:  &TemplateFilter{Tags: []string{"mpi", "parallel"}},
+			matches: true,
+		},
+		{
+			name:    "non-matching tag",
+			filter:  &TemplateFilter{Tags: []string{"gpu"}},
+			matches: false,
+		},
+		{
+			name:    "matching publisher",
+			filter:  &TemplateFilter{Publisher: "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63"},
+			matches: true,
+		},
+		{
+			name:    "non-matching publisher",
+			filter:  &TemplateFilter{Publisher: "akash1other"},
+			matches: false,
+		},
+		{
+			name:    "matching approval status",
+			filter:  &TemplateFilter{ApprovalStatus: hpctypes.WorkloadApprovalApproved},
+			matches: true,
+		},
+		{
+			name:    "non-matching approval status",
+			filter:  &TemplateFilter{ApprovalStatus: hpctypes.WorkloadApprovalPending},
+			matches: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.filter == nil {
+				// nil filter always matches
+				return
+			}
+			result := tt.filter.Matches(template)
+			if result != tt.matches {
+				t.Errorf("Matches() = %v, want %v", result, tt.matches)
+			}
+		})
+	}
+}
+
+func TestContainsTag(t *testing.T) {
+	tags := []string{"mpi", "GPU", "Parallel"}
+
+	tests := []struct {
+		tag      string
+		expected bool
+	}{
+		{"mpi", true},
+		{"MPI", true}, // Case insensitive
+		{"gpu", true},
+		{"parallel", true},
+		{"nonexistent", false},
+	}
+
+	for _, tt := range tests {
+		result := containsTag(tags, tt.tag)
+		if result != tt.expected {
+			t.Errorf("containsTag(%v, %s) = %v, want %v", tags, tt.tag, result, tt.expected)
+		}
+	}
+}
+
+func TestRemoveString(t *testing.T) {
+	slice := []string{"a", "b", "c", "d"}
+
+	result := removeString(slice, "b")
+
+	if len(result) != 3 {
+		t.Errorf("expected 3 elements, got %d", len(result))
+	}
+
+	if contains(result, "b") {
+		t.Error("expected 'b' to be removed")
+	}
+
+	// Original should be unchanged
+	if len(slice) != 4 {
+		t.Error("original slice should be unchanged")
+	}
+}
+
+func TestRegistryConcurrentAccess(t *testing.T) {
+	config := DefaultRegistryConfig()
+	config.RequireApproval = false
+	registry := NewWorkloadRegistry(nil, config)
+	ctx := context.Background()
+
+	// Concurrent reads
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			_, _ = registry.List(ctx, nil)
+			_, _ = registry.Search(ctx, "mpi", 10)
+			_, _ = registry.Get(ctx, "mpi-standard")
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for concurrent reads")
+		}
+	}
+}

--- a/pkg/hpc_workload_library/templates/batch-array.yaml
+++ b/pkg/hpc_workload_library/templates/batch-array.yaml
@@ -1,0 +1,147 @@
+# Batch Array Job Template
+# VE-5F: Pre-configured workload templates
+#
+# This template configures SLURM array jobs for parameter sweeps,
+# ensemble simulations, and embarrassingly parallel tasks.
+
+schema_version: "1.0.0"
+
+template:
+  template_id: batch-array
+  name: Batch Array Job
+  version: 1.0.0
+  description: >
+    Run parameter sweeps, ensemble simulations, or embarrassingly
+    parallel tasks using SLURM array jobs. Each array task runs
+    independently with a unique task ID for input partitioning.
+  type: batch
+
+  runtime:
+    runtime_type: singularity
+    container_image: library/ubuntu:22.04
+    required_modules: []
+
+  resources:
+    min_nodes: 1
+    max_nodes: 1
+    default_nodes: 1
+    min_cpus_per_node: 1
+    max_cpus_per_node: 64
+    default_cpus_per_node: 4
+    min_memory_mb_per_node: 512
+    max_memory_mb_per_node: 256000
+    default_memory_mb_per_node: 8000
+    min_runtime_minutes: 1
+    max_runtime_minutes: 2880  # 48 hours per task
+    default_runtime_minutes: 60
+    exclusive_nodes: false
+
+  security:
+    allowed_registries:
+      - library
+      - docker.io
+      - ghcr.io
+      - quay.io
+    require_image_digest: false
+    allow_network_access: false
+    allow_host_mounts: true
+    allowed_host_paths:
+      - /scratch
+      - /home
+      - /work
+    sandbox_level: strict
+    max_open_files: 16384
+    max_processes: 4096
+    max_file_size: 10737418240  # 10GB
+
+  entrypoint:
+    command: /bin/bash
+    default_args:
+      - "-c"
+    working_directory: /work
+    pre_run_script: "echo 'Starting array task $SLURM_ARRAY_TASK_ID of $SLURM_ARRAY_TASK_COUNT'"
+    post_run_script: "echo 'Array task $SLURM_ARRAY_TASK_ID completed with exit code $?'"
+
+  environment:
+    - name: TASK_ID
+      value_template: "${SLURM_ARRAY_TASK_ID}"
+      description: Current array task ID (0-indexed)
+    - name: TASK_COUNT
+      value_template: "${SLURM_ARRAY_TASK_COUNT}"
+      description: Total number of array tasks
+    - name: TASK_MIN
+      value_template: "${SLURM_ARRAY_TASK_MIN}"
+      description: Minimum array task ID
+    - name: TASK_MAX
+      value_template: "${SLURM_ARRAY_TASK_MAX}"
+      description: Maximum array task ID
+    - name: INPUT_FILE
+      value_template: "/data/input/input_${SLURM_ARRAY_TASK_ID}.dat"
+      description: Task-specific input file
+    - name: OUTPUT_FILE
+      value_template: "/data/output/output_${SLURM_ARRAY_TASK_ID}.dat"
+      description: Task-specific output file
+    - name: TMPDIR
+      value: /scratch/$USER/$SLURM_JOB_ID/$SLURM_ARRAY_TASK_ID
+      description: Task-specific temp directory
+
+  data_bindings:
+    - name: input
+      mount_path: /data/input
+      data_type: input
+      required: true
+      read_only: true
+    - name: output
+      mount_path: /data/output
+      data_type: output
+      required: true
+      read_only: false
+    - name: scratch
+      mount_path: /scratch
+      data_type: scratch
+      required: true
+      read_only: false
+
+  parameter_schema:
+    - name: script
+      type: string
+      description: Script or command to execute for each task
+      required: true
+    - name: array_start
+      type: int
+      description: Array start index
+      default: "0"
+      min_value: "0"
+      max_value: "100000"
+    - name: array_end
+      type: int
+      description: Array end index
+      default: "9"
+      min_value: "0"
+      max_value: "100000"
+    - name: array_step
+      type: int
+      description: Array step size
+      default: "1"
+      min_value: "1"
+      max_value: "1000"
+    - name: simultaneous
+      type: int
+      description: Maximum simultaneous tasks (%N syntax)
+      default: "0"
+      min_value: "0"
+      max_value: "10000"
+    - name: throttle_rate
+      type: int
+      description: Submit rate limit (tasks per minute)
+      default: "0"
+      min_value: "0"
+      max_value: "1000"
+
+  approval_status: approved
+  tags:
+    - array
+    - batch
+    - parameter-sweep
+    - ensemble
+    - embarrassingly-parallel

--- a/pkg/hpc_workload_library/templates/gpu-compute.yaml
+++ b/pkg/hpc_workload_library/templates/gpu-compute.yaml
@@ -1,0 +1,131 @@
+# GPU Compute Workload Template
+# VE-5F: Pre-configured workload templates
+#
+# This template configures GPU-accelerated compute workloads
+# using CUDA with NVIDIA containers on SLURM clusters.
+
+schema_version: "1.0.0"
+
+template:
+  template_id: gpu-compute
+  name: GPU Compute Workload
+  version: 1.0.0
+  description: >
+    GPU-accelerated compute workload using CUDA. Suitable for
+    deep learning training, scientific simulations, and
+    GPU-accelerated applications.
+  type: gpu
+
+  runtime:
+    runtime_type: singularity
+    container_image: nvcr.io/nvidia/cuda:12.2-runtime-ubuntu22.04
+    cuda_version: "12.2"
+    required_modules:
+      - cuda/12.2
+      - cudnn/8.9
+
+  resources:
+    min_nodes: 1
+    max_nodes: 32
+    default_nodes: 1
+    min_cpus_per_node: 4
+    max_cpus_per_node: 128
+    default_cpus_per_node: 16
+    min_memory_mb_per_node: 8192
+    max_memory_mb_per_node: 512000
+    default_memory_mb_per_node: 64000
+    min_gpus_per_node: 1
+    max_gpus_per_node: 8
+    default_gpus_per_node: 1
+    gpu_types:
+      - nvidia-a100
+      - nvidia-v100
+      - nvidia-h100
+    min_runtime_minutes: 1
+    max_runtime_minutes: 4320  # 72 hours
+    default_runtime_minutes: 120
+    network_required: true
+    exclusive_nodes: true
+
+  security:
+    allowed_registries:
+      - nvcr.io
+      - docker.io
+      - ghcr.io
+    require_image_digest: true
+    allow_network_access: true
+    allow_host_mounts: true
+    allowed_host_paths:
+      - /scratch
+      - /home
+      - /work
+      - /datasets
+    sandbox_level: basic
+    max_open_files: 262144
+    max_processes: 65536
+
+  entrypoint:
+    command: /bin/bash
+    default_args:
+      - "-c"
+    working_directory: /workspace
+    pre_run_script: "nvidia-smi && echo 'CUDA devices: '$CUDA_VISIBLE_DEVICES"
+    post_run_script: "nvidia-smi --query-gpu=utilization.gpu --format=csv"
+
+  environment:
+    - name: CUDA_VISIBLE_DEVICES
+      value_template: "${SLURM_GPUS_ON_NODE}"
+      description: GPU devices visible to CUDA
+    - name: NCCL_DEBUG
+      value: INFO
+      description: NCCL debug level
+    - name: CUDA_CACHE_PATH
+      value: /tmp/cuda_cache
+      description: CUDA compilation cache
+
+  modules:
+    - cuda/12.2
+    - cudnn/8.9
+
+  data_bindings:
+    - name: datasets
+      mount_path: /datasets
+      data_type: input
+      required: false
+      read_only: true
+    - name: models
+      mount_path: /models
+      data_type: output
+      required: false
+      read_only: false
+    - name: checkpoints
+      mount_path: /checkpoints
+      data_type: output
+      required: false
+      read_only: false
+
+  parameter_schema:
+    - name: script
+      type: string
+      description: Python script to run
+      required: true
+    - name: gpu_type
+      type: enum
+      description: GPU type to use
+      enum_values:
+        - nvidia-a100
+        - nvidia-v100
+        - nvidia-h100
+      default: nvidia-a100
+    - name: mixed_precision
+      type: bool
+      description: Enable mixed precision training
+      default: "true"
+
+  approval_status: approved
+  tags:
+    - gpu
+    - cuda
+    - deep-learning
+    - ai
+    - ml

--- a/pkg/hpc_workload_library/templates/interactive-session.yaml
+++ b/pkg/hpc_workload_library/templates/interactive-session.yaml
@@ -1,0 +1,118 @@
+# Interactive Session Template
+# VE-5F: Pre-configured workload templates
+#
+# This template configures interactive computing sessions
+# with JupyterLab or terminal access.
+
+schema_version: "1.0.0"
+
+template:
+  template_id: interactive-session
+  name: Interactive Session
+  version: 1.0.0
+  description: >
+    Interactive computing session with JupyterLab or terminal access.
+    Suitable for development, debugging, and exploratory analysis.
+  type: interactive
+
+  runtime:
+    runtime_type: singularity
+    container_image: jupyter/scipy-notebook:latest
+    python_version: "3.11"
+    required_modules:
+      - python/3.11
+
+  resources:
+    min_nodes: 1
+    max_nodes: 1
+    default_nodes: 1
+    min_cpus_per_node: 2
+    max_cpus_per_node: 32
+    default_cpus_per_node: 8
+    min_memory_mb_per_node: 4096
+    max_memory_mb_per_node: 128000
+    default_memory_mb_per_node: 16000
+    min_gpus_per_node: 0
+    max_gpus_per_node: 2
+    default_gpus_per_node: 0
+    gpu_types:
+      - nvidia-a100
+      - nvidia-v100
+    min_runtime_minutes: 15
+    max_runtime_minutes: 480  # 8 hours
+    default_runtime_minutes: 120
+    exclusive_nodes: false
+
+  security:
+    allowed_registries:
+      - jupyter
+      - docker.io
+      - ghcr.io
+    require_image_digest: false
+    allow_network_access: true
+    allow_host_mounts: true
+    allowed_host_paths:
+      - /home
+      - /work
+      - /scratch
+    sandbox_level: basic
+    max_open_files: 32768
+    max_processes: 8192
+
+  entrypoint:
+    command: jupyter
+    default_args:
+      - lab
+      - "--no-browser"
+      - "--ip=0.0.0.0"
+    working_directory: /home/jovyan/work
+    pre_run_script: "echo 'Starting JupyterLab session'"
+
+  environment:
+    - name: JUPYTER_ENABLE_LAB
+      value: "yes"
+      description: Enable JupyterLab interface
+    - name: JUPYTER_TOKEN
+      value_template: "${SLURM_JOB_ID}"
+      description: Jupyter authentication token
+      secret: true
+
+  data_bindings:
+    - name: work
+      mount_path: /home/jovyan/work
+      host_path: /work/$USER
+      data_type: output
+      required: true
+      read_only: false
+    - name: data
+      mount_path: /home/jovyan/data
+      data_type: input
+      required: false
+      read_only: true
+
+  parameter_schema:
+    - name: port
+      type: int
+      description: JupyterLab port
+      default: "8888"
+      min_value: "8000"
+      max_value: "9999"
+    - name: gpu_enabled
+      type: bool
+      description: Enable GPU support
+      default: "false"
+    - name: interface
+      type: enum
+      description: Interface type
+      enum_values:
+        - jupyterlab
+        - notebook
+        - terminal
+      default: jupyterlab
+
+  approval_status: approved
+  tags:
+    - interactive
+    - jupyter
+    - development
+    - notebook

--- a/pkg/hpc_workload_library/templates/mpi-standard.yaml
+++ b/pkg/hpc_workload_library/templates/mpi-standard.yaml
@@ -1,0 +1,119 @@
+# MPI Standard Workload Template
+# VE-5F: Pre-configured workload templates
+#
+# This template configures MPI-based parallel computing workloads
+# using OpenMPI with Singularity containers on SLURM clusters.
+
+schema_version: "1.0.0"
+
+template:
+  template_id: mpi-standard
+  name: MPI Standard Workload
+  version: 1.0.0
+  description: >
+    Standard MPI-based parallel computing workload using OpenMPI.
+    Suitable for distributed memory parallel applications with
+    multi-node communication.
+  type: mpi
+  
+  runtime:
+    runtime_type: singularity
+    container_image: library/ubuntu-mpi:22.04
+    mpi_implementation: openmpi
+    required_modules:
+      - openmpi/4.1
+      - gcc/11
+
+  resources:
+    min_nodes: 1
+    max_nodes: 128
+    default_nodes: 4
+    min_cpus_per_node: 1
+    max_cpus_per_node: 128
+    default_cpus_per_node: 16
+    min_memory_mb_per_node: 1024
+    max_memory_mb_per_node: 512000
+    default_memory_mb_per_node: 32000
+    min_runtime_minutes: 1
+    max_runtime_minutes: 2880  # 48 hours
+    default_runtime_minutes: 60
+    network_required: true
+    exclusive_nodes: false
+
+  security:
+    allowed_registries:
+      - library
+      - docker.io
+      - ghcr.io
+    require_image_digest: false
+    allow_network_access: true
+    allow_host_mounts: true
+    allowed_host_paths:
+      - /scratch
+      - /home
+      - /work
+    sandbox_level: basic
+    max_open_files: 65536
+    max_processes: 32768
+
+  entrypoint:
+    command: mpirun
+    default_args:
+      - "-np"
+      - "${SLURM_NTASKS}"
+    working_directory: /scratch/$USER/$SLURM_JOB_ID
+    use_mpirun: true
+    pre_run_script: "mkdir -p /scratch/$USER/$SLURM_JOB_ID"
+    post_run_script: "echo 'Job completed at $(date)'"
+
+  environment:
+    - name: OMP_NUM_THREADS
+      value: "1"
+      description: OpenMP threads per MPI rank
+    - name: MPI_BUFFER_SIZE
+      value: "20971520"
+      description: MPI buffer size in bytes
+
+  modules:
+    - openmpi/4.1
+    - gcc/11
+
+  data_bindings:
+    - name: input
+      mount_path: /data/input
+      data_type: input
+      required: false
+      read_only: true
+    - name: output
+      mount_path: /data/output
+      data_type: output
+      required: false
+      read_only: false
+    - name: scratch
+      mount_path: /scratch
+      data_type: scratch
+      required: true
+      read_only: false
+
+  parameter_schema:
+    - name: executable
+      type: string
+      description: Path to MPI executable
+      required: true
+    - name: args
+      type: string
+      description: Arguments to pass to executable
+      required: false
+    - name: tasks_per_node
+      type: int
+      description: MPI tasks per node
+      default: "16"
+      min_value: "1"
+      max_value: "128"
+
+  approval_status: approved
+  tags:
+    - mpi
+    - parallel
+    - distributed
+    - hpc

--- a/pkg/hpc_workload_library/templates/singularity-container.yaml
+++ b/pkg/hpc_workload_library/templates/singularity-container.yaml
@@ -1,0 +1,137 @@
+# Singularity Container Workload Template
+# VE-5F: Pre-configured workload templates
+#
+# This template configures custom Singularity/Apptainer container
+# workloads on HPC clusters.
+
+schema_version: "1.0.0"
+
+template:
+  template_id: singularity-container
+  name: Singularity Container Workload
+  version: 1.0.0
+  description: >
+    Run custom Singularity/Apptainer containers on HPC clusters.
+    Supports Docker Hub, Singularity Library, and custom SIF files
+    with configurable bindings and overlay filesystems.
+  type: batch
+
+  runtime:
+    runtime_type: singularity
+    container_image: library/default:latest
+    required_modules:
+      - singularity/3.11
+
+  resources:
+    min_nodes: 1
+    max_nodes: 64
+    default_nodes: 1
+    min_cpus_per_node: 1
+    max_cpus_per_node: 128
+    default_cpus_per_node: 8
+    min_memory_mb_per_node: 1024
+    max_memory_mb_per_node: 512000
+    default_memory_mb_per_node: 16000
+    min_gpus_per_node: 0
+    max_gpus_per_node: 8
+    default_gpus_per_node: 0
+    gpu_types:
+      - nvidia-a100
+      - nvidia-v100
+      - nvidia-h100
+      - amd-mi250
+    min_runtime_minutes: 1
+    max_runtime_minutes: 4320  # 72 hours
+    default_runtime_minutes: 60
+    network_required: false
+    exclusive_nodes: false
+
+  security:
+    allowed_registries:
+      - library
+      - docker.io
+      - ghcr.io
+      - quay.io
+      - nvcr.io
+    require_image_digest: false
+    allow_network_access: true
+    allow_host_mounts: true
+    allowed_host_paths:
+      - /scratch
+      - /home
+      - /work
+      - /data
+      - /opt
+    sandbox_level: basic
+    max_open_files: 65536
+    max_processes: 16384
+
+  entrypoint:
+    command: singularity
+    default_args:
+      - exec
+    working_directory: /work
+    pre_run_script: "export SINGULARITY_CACHEDIR=/scratch/$USER/.singularity && mkdir -p $SINGULARITY_CACHEDIR"
+    post_run_script: "echo 'Container execution completed at $(date)'"
+
+  environment:
+    - name: SINGULARITY_BINDPATH
+      value: /scratch,/home,/work
+      description: Paths to bind into container
+    - name: SINGULARITYENV_OMP_NUM_THREADS
+      value_template: "${SLURM_CPUS_PER_TASK}"
+      description: OpenMP threads
+
+  modules:
+    - singularity/3.11
+
+  data_bindings:
+    - name: input
+      mount_path: /input
+      data_type: input
+      required: false
+      read_only: true
+    - name: output
+      mount_path: /output
+      data_type: output
+      required: false
+      read_only: false
+    - name: overlay
+      mount_path: /overlay
+      data_type: scratch
+      required: false
+      read_only: false
+
+  parameter_schema:
+    - name: image
+      type: string
+      description: Container image (Docker Hub, library://, or .sif path)
+      required: true
+    - name: command
+      type: string
+      description: Command to run inside container
+      required: true
+    - name: bind_paths
+      type: string
+      description: Additional bind paths (comma separated)
+      default: ""
+    - name: use_gpu
+      type: bool
+      description: Enable GPU passthrough (--nv flag)
+      default: "false"
+    - name: writable_tmpfs
+      type: bool
+      description: Use writable tmpfs overlay
+      default: "false"
+    - name: fakeroot
+      type: bool
+      description: Run with fakeroot for user namespace
+      default: "false"
+
+  approval_status: approved
+  tags:
+    - singularity
+    - container
+    - apptainer
+    - docker
+    - portable

--- a/pkg/hpc_workload_library/templates_test.go
+++ b/pkg/hpc_workload_library/templates_test.go
@@ -14,8 +14,8 @@ import (
 func TestGetBuiltinTemplates(t *testing.T) {
 	templates := GetBuiltinTemplates()
 
-	if len(templates) != 5 {
-		t.Errorf("expected 5 built-in templates, got %d", len(templates))
+	if len(templates) != 7 {
+		t.Errorf("expected 7 built-in templates, got %d", len(templates))
 	}
 
 	// Verify all templates are valid
@@ -175,30 +175,30 @@ func TestGetTemplateByID(t *testing.T) {
 
 func TestGetTemplatesByType(t *testing.T) {
 	tests := []struct {
-		workloadType hpctypes.WorkloadType
-		expectedIDs  []string
+		workloadType   hpctypes.WorkloadType
+		expectedMinIDs int // Minimum number of templates
 	}{
-		{hpctypes.WorkloadTypeMPI, []string{"mpi-standard"}},
-		{hpctypes.WorkloadTypeGPU, []string{"gpu-compute"}},
-		{hpctypes.WorkloadTypeBatch, []string{"batch-standard"}},
-		{hpctypes.WorkloadTypeDataProcessing, []string{"data-processing"}},
-		{hpctypes.WorkloadTypeInteractive, []string{"interactive-session"}},
-		{hpctypes.WorkloadTypeCustom, []string{}},
+		{hpctypes.WorkloadTypeMPI, 1},
+		{hpctypes.WorkloadTypeGPU, 1},
+		{hpctypes.WorkloadTypeBatch, 3}, // batch-standard, singularity-container, batch-array
+		{hpctypes.WorkloadTypeDataProcessing, 1},
+		{hpctypes.WorkloadTypeInteractive, 1},
+		{hpctypes.WorkloadTypeCustom, 0},
 	}
 
 	for _, tt := range tests {
 		templates := GetTemplatesByType(tt.workloadType)
 
-		if len(templates) != len(tt.expectedIDs) {
-			t.Errorf("GetTemplatesByType(%s) returned %d templates, want %d",
-				tt.workloadType, len(templates), len(tt.expectedIDs))
+		if len(templates) < tt.expectedMinIDs {
+			t.Errorf("GetTemplatesByType(%s) returned %d templates, want at least %d",
+				tt.workloadType, len(templates), tt.expectedMinIDs)
 			continue
 		}
 
-		for i, tmpl := range templates {
-			if tmpl.TemplateID != tt.expectedIDs[i] {
-				t.Errorf("GetTemplatesByType(%s)[%d] = %s, want %s",
-					tt.workloadType, i, tmpl.TemplateID, tt.expectedIDs[i])
+		for _, tmpl := range templates {
+			if tmpl.Type != tt.workloadType {
+				t.Errorf("GetTemplatesByType(%s) returned template %s with type %s",
+					tt.workloadType, tmpl.TemplateID, tmpl.Type)
 			}
 		}
 	}


### PR DESCRIPTION
**Priority:** HIGH
**Spec Reference:** AU2024203136A1-LIVE - preconfigured SLURM workloads
**Current State:** No workload library exists

**Implementation Tasks:**
1. Create library of validated SLURM job templates
2. Implement workload packaging format
3. Add workload manifest validation
4. Create signed workload artifacts
5. Store in artifact store with versioning
6. Add workload discovery and search

**Accepted Templates:**
- MPI parallel compute workload
- GPU CUDA/ROCm workload
- Batch array job workload
- Interactive/Jupyter workload
- Container (Singularity) workload

**Acceptance Criteria:**
- [ ] 5+ validated SLURM job templates
- [ ] Workload packaging format documented
- [ ] Manifest validation implemented
- [ ] Templates signed and versioned
- [ ] Discovery API for workload browsing

**Estimated Effort:** 16-24 hours
**Files to Create:**
- `pkg/workload_library/templates/*.yaml`
- `pkg/workload_library/manifest.go`
- `pkg/workload_library/validator.go`
- `pkg/workload_library/registry.go`