### PR TITLE
feat(waldur): Auto-create marketplace categories on localnet startup - 25A

### DIFF
--- a/cmd/virtengine/cmd/root.go
+++ b/cmd/virtengine/cmd/root.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/virtengine/virtengine/app"
 	"github.com/virtengine/virtengine/cmd/virtengine/cmd/testnetify"
+	"github.com/virtengine/virtengine/cmd/virtengine/cmd/waldur"
 )
 
 // NewRootCmd creates a new root command for virtengine. It is called once in the
@@ -103,6 +104,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig sdkutil.EncodingConfig) 
 		testnetCmd(app.ModuleBasics(), banktypes.GenesisBalancesIterator{}),
 		PrepareGenesisCmd(app.DefaultHome, app.ModuleBasics()),
 		testnetify.GetCmd(ac.newTestnetApp),
+		waldur.GetCmd(),
 	)
 
 	cli.ServerCmds(rootCmd, home, ac.newApp, ac.appExport, addModuleInitFlags)

--- a/cmd/virtengine/cmd/waldur/init_categories.go
+++ b/cmd/virtengine/cmd/waldur/init_categories.go
@@ -1,0 +1,253 @@
+// Package waldur provides CLI commands for Waldur integration.
+//
+// VE-25A: CLI command to initialize marketplace categories in Waldur.
+package waldur
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/virtengine/virtengine/pkg/provider_daemon"
+	"github.com/virtengine/virtengine/pkg/waldur"
+)
+
+const (
+	flagWaldurURL   = "waldur-url"
+	flagWaldurToken = "waldur-token"
+	flagOutput      = "output"
+	flagTimeout     = "timeout"
+)
+
+func getInitCategoriesCmd() *cobra.Command {
+	var (
+		waldurURL   string
+		waldurToken string
+		output      string
+		timeout     int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "init-categories",
+		Short: "Initialize marketplace categories in Waldur",
+		Long: `Initialize the default VirtEngine marketplace categories in Waldur.
+
+This command creates the following categories if they don't already exist:
+  - Compute: VMs, containers, general-purpose computing
+  - HPC: High-performance computing, MPI clusters
+  - GPU: GPU-accelerated instances for ML/DL
+  - Storage: Object, block, and file storage
+  - Network: VPNs, load balancers, firewalls
+  - TEE: Trusted Execution Environments
+  - AI/ML: Machine learning platforms
+
+Categories are required before offerings can be created in Waldur.
+Run this command after starting Waldur for the first time.`,
+		Example: `  # Initialize categories using environment variables
+  export WALDUR_URL=https://localhost/api/
+  export WALDUR_TOKEN=your-api-token
+  virtengine waldur init-categories
+
+  # Initialize categories with explicit flags
+  virtengine waldur init-categories --waldur-url https://localhost/api/ --waldur-token your-token
+
+  # Output as JSON
+  virtengine waldur init-categories --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Get Waldur URL from flag or environment
+			if waldurURL == "" {
+				waldurURL = os.Getenv("WALDUR_URL")
+			}
+			if waldurURL == "" {
+				return fmt.Errorf("waldur URL is required (set --waldur-url or WALDUR_URL)")
+			}
+
+			// Get Waldur token from flag or environment
+			if waldurToken == "" {
+				waldurToken = os.Getenv("WALDUR_TOKEN")
+			}
+			if waldurToken == "" {
+				return fmt.Errorf("waldur token is required (set --waldur-token or WALDUR_TOKEN)")
+			}
+
+			// Create context with timeout
+			ctx, cancel := context.WithTimeout(cmd.Context(), time.Duration(timeout)*time.Second)
+			defer cancel()
+
+			// Initialize categories
+			result, err := provider_daemon.InitCategories(ctx, waldurURL, waldurToken)
+			if err != nil {
+				return fmt.Errorf("failed to initialize categories: %w", err)
+			}
+
+			// Output result
+			switch output {
+			case "json":
+				return outputJSON(result)
+			default:
+				return outputInitResult(result)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&waldurURL, flagWaldurURL, "", "Waldur API URL (or set WALDUR_URL)")
+	cmd.Flags().StringVar(&waldurToken, flagWaldurToken, "", "Waldur API token (or set WALDUR_TOKEN)")
+	cmd.Flags().StringVarP(&output, flagOutput, "o", "text", "Output format (text|json)")
+	cmd.Flags().IntVar(&timeout, flagTimeout, 120, "Timeout in seconds")
+
+	return cmd
+}
+
+func getListCategoriesCmd() *cobra.Command {
+	var (
+		waldurURL   string
+		waldurToken string
+		output      string
+		timeout     int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list-categories",
+		Short: "List marketplace categories from Waldur",
+		Long: `List all marketplace categories configured in Waldur.
+
+This shows the categories that are available for creating offerings.
+Use init-categories to create the default VirtEngine categories.`,
+		Example: `  # List categories
+  virtengine waldur list-categories
+
+  # Output as JSON
+  virtengine waldur list-categories --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Get Waldur URL from flag or environment
+			if waldurURL == "" {
+				waldurURL = os.Getenv("WALDUR_URL")
+			}
+			if waldurURL == "" {
+				return fmt.Errorf("waldur URL is required (set --waldur-url or WALDUR_URL)")
+			}
+
+			// Get Waldur token from flag or environment
+			if waldurToken == "" {
+				waldurToken = os.Getenv("WALDUR_TOKEN")
+			}
+			if waldurToken == "" {
+				return fmt.Errorf("waldur token is required (set --waldur-token or WALDUR_TOKEN)")
+			}
+
+			// Create context with timeout
+			ctx, cancel := context.WithTimeout(cmd.Context(), time.Duration(timeout)*time.Second)
+			defer cancel()
+
+			// Create Waldur client
+			cfg := waldur.DefaultConfig()
+			cfg.BaseURL = waldurURL
+			cfg.Token = waldurToken
+
+			client, err := waldur.NewClient(cfg)
+			if err != nil {
+				return fmt.Errorf("failed to create Waldur client: %w", err)
+			}
+
+			marketplace := waldur.NewMarketplaceClient(client)
+
+			// List categories
+			categories, err := marketplace.ListCategories(ctx, waldur.ListCategoriesParams{PageSize: 100})
+			if err != nil {
+				return fmt.Errorf("failed to list categories: %w", err)
+			}
+
+			// Output result
+			switch output {
+			case "json":
+				return outputJSON(categories)
+			default:
+				return outputCategoriesTable(categories)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&waldurURL, flagWaldurURL, "", "Waldur API URL (or set WALDUR_URL)")
+	cmd.Flags().StringVar(&waldurToken, flagWaldurToken, "", "Waldur API token (or set WALDUR_TOKEN)")
+	cmd.Flags().StringVarP(&output, flagOutput, "o", "text", "Output format (text|json)")
+	cmd.Flags().IntVar(&timeout, flagTimeout, 60, "Timeout in seconds")
+
+	return cmd
+}
+
+func outputInitResult(result *provider_daemon.InitCategoriesResult) error {
+	fmt.Println("Category Initialization Result")
+	fmt.Println("==============================")
+	fmt.Println()
+
+	if len(result.Created) > 0 {
+		fmt.Printf("✅ Created (%d):\n", len(result.Created))
+		for _, cat := range result.Created {
+			uuid := result.Mappings[cat]
+			fmt.Printf("   - %s [%s]\n", cat, uuid)
+		}
+		fmt.Println()
+	}
+
+	if len(result.Existing) > 0 {
+		fmt.Printf("ℹ️  Already Existed (%d):\n", len(result.Existing))
+		for _, cat := range result.Existing {
+			uuid := result.Mappings[cat]
+			fmt.Printf("   - %s [%s]\n", cat, uuid)
+		}
+		fmt.Println()
+	}
+
+	if len(result.Failed) > 0 {
+		fmt.Printf("❌ Failed (%d):\n", len(result.Failed))
+		for _, cat := range result.Failed {
+			fmt.Printf("   - %s\n", cat)
+		}
+		fmt.Println()
+	}
+
+	total := len(result.Created) + len(result.Existing)
+	fmt.Printf("Total: %d categories available\n", total)
+
+	if len(result.Failed) > 0 {
+		return fmt.Errorf("%d categories failed to initialize", len(result.Failed))
+	}
+
+	return nil
+}
+
+func outputCategoriesTable(categories []waldur.Category) error {
+	if len(categories) == 0 {
+		fmt.Println("No categories found.")
+		fmt.Println("Run 'virtengine waldur init-categories' to create default categories.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "TITLE\tUUID\tDESCRIPTION")
+	fmt.Fprintln(w, "-----\t----\t-----------")
+
+	for _, cat := range categories {
+		desc := cat.Description
+		if len(desc) > 50 {
+			desc = desc[:47] + "..."
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", cat.Title, cat.UUID, desc)
+	}
+
+	return w.Flush()
+}
+
+func outputJSON(v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}

--- a/cmd/virtengine/cmd/waldur/waldur.go
+++ b/cmd/virtengine/cmd/waldur/waldur.go
@@ -1,0 +1,27 @@
+// Package waldur provides CLI commands for Waldur integration.
+//
+// VE-25A: CLI commands for Waldur marketplace category management.
+package waldur
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// GetCmd returns the waldur command group.
+func GetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "waldur",
+		Short: "Waldur integration commands",
+		Long: `Commands for managing VirtEngine integration with Waldur.
+
+Waldur is used as the provider backend for marketplace operations.
+These commands help initialize and manage the integration.`,
+	}
+
+	cmd.AddCommand(
+		getInitCategoriesCmd(),
+		getListCategoriesCmd(),
+	)
+
+	return cmd
+}

--- a/pkg/provider_daemon/category_sync.go
+++ b/pkg/provider_daemon/category_sync.go
@@ -1,0 +1,486 @@
+// Package provider_daemon provides category synchronization for Waldur integration.
+//
+// VE-25A: Auto-create and sync marketplace categories between VirtEngine and Waldur.
+package provider_daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/virtengine/virtengine/pkg/waldur"
+)
+
+// VirtEngine default categories that are synced to Waldur.
+// These are the only categories that will be synced from provider offerings to Waldur.
+var DefaultCategories = []CategoryDefinition{
+	{
+		Title:       "Compute",
+		Description: "Virtual machines, containers, and general-purpose computing resources for running workloads.",
+		Icon:        "server",
+		Priority:    1,
+	},
+	{
+		Title:       "HPC",
+		Description: "High-performance computing resources including MPI clusters, batch processing, and scientific computing environments.",
+		Icon:        "cpu",
+		Priority:    2,
+	},
+	{
+		Title:       "GPU",
+		Description: "GPU-accelerated computing instances for machine learning, deep learning, and graphics processing workloads.",
+		Icon:        "gpu",
+		Priority:    3,
+	},
+	{
+		Title:       "Storage",
+		Description: "Object storage, block storage, and file storage solutions for data persistence and sharing.",
+		Icon:        "database",
+		Priority:    4,
+	},
+	{
+		Title:       "Network",
+		Description: "Networking services including VPNs, load balancers, firewalls, and private networks.",
+		Icon:        "network",
+		Priority:    5,
+	},
+	{
+		Title:       "TEE",
+		Description: "Trusted Execution Environment resources for confidential computing and secure enclaves.",
+		Icon:        "shield",
+		Priority:    6,
+	},
+	{
+		Title:       "AI/ML",
+		Description: "Machine learning platforms, model training infrastructure, and inference services.",
+		Icon:        "brain",
+		Priority:    7,
+	},
+}
+
+// CategoryDefinition defines a VirtEngine marketplace category.
+type CategoryDefinition struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Icon        string `json:"icon,omitempty"`
+	Priority    int    `json:"priority,omitempty"`
+}
+
+// CategoryMapping maps a VirtEngine category title to its Waldur UUID.
+type CategoryMapping struct {
+	Title       string    `json:"title"`
+	WaldurUUID  string    `json:"waldur_uuid"`
+	Description string    `json:"description,omitempty"`
+	SyncedAt    time.Time `json:"synced_at"`
+}
+
+// CategorySyncState holds the state of category synchronization.
+type CategorySyncState struct {
+	Mappings    map[string]*CategoryMapping `json:"mappings"`
+	LastSync    time.Time                   `json:"last_sync"`
+	SyncVersion string                      `json:"sync_version"`
+}
+
+// CategorySyncConfig configures the category sync worker.
+type CategorySyncConfig struct {
+	// Enabled enables category sync.
+	Enabled bool
+
+	// WaldurBaseURL is the Waldur API base URL.
+	WaldurBaseURL string
+
+	// WaldurToken is the API authentication token.
+	WaldurToken string
+
+	// StateFilePath is the path to persist category sync state.
+	StateFilePath string
+
+	// SyncIntervalSeconds is the reconciliation interval.
+	SyncIntervalSeconds int64
+
+	// MaxRetries is the maximum retry attempts.
+	MaxRetries int
+
+	// OperationTimeout is the timeout for Waldur operations.
+	OperationTimeout time.Duration
+
+	// CategoriesFilePath is an optional path to custom categories JSON file.
+	CategoriesFilePath string
+}
+
+// DefaultCategorySyncConfig returns sensible defaults.
+func DefaultCategorySyncConfig() CategorySyncConfig {
+	return CategorySyncConfig{
+		StateFilePath:       "data/category_sync_state.json",
+		SyncIntervalSeconds: 300,
+		MaxRetries:          3,
+		OperationTimeout:    30 * time.Second,
+	}
+}
+
+// CategorySyncWorker handles category synchronization with Waldur.
+type CategorySyncWorker struct {
+	mu     sync.RWMutex
+	cfg    CategorySyncConfig
+	state  *CategorySyncState
+	client *waldur.MarketplaceClient
+
+	stopCh chan struct{}
+	doneCh chan struct{}
+}
+
+// NewCategorySyncWorker creates a new category sync worker.
+func NewCategorySyncWorker(cfg CategorySyncConfig, client *waldur.MarketplaceClient) (*CategorySyncWorker, error) {
+	if client == nil {
+		return nil, fmt.Errorf("marketplace client is required")
+	}
+
+	// Load existing state if available
+	state := &CategorySyncState{
+		Mappings:    make(map[string]*CategoryMapping),
+		SyncVersion: "1.0.0",
+	}
+
+	if cfg.StateFilePath != "" {
+		if data, err := os.ReadFile(cfg.StateFilePath); err == nil {
+			if err := json.Unmarshal(data, state); err != nil {
+				log.Printf("[category-sync] warning: failed to parse state file: %v", err)
+			}
+		}
+	}
+
+	return &CategorySyncWorker{
+		cfg:    cfg,
+		state:  state,
+		client: client,
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}, nil
+}
+
+// Start begins the category sync worker.
+func (w *CategorySyncWorker) Start(ctx context.Context) error {
+	if !w.cfg.Enabled {
+		return nil
+	}
+
+	// Perform initial sync
+	if err := w.SyncCategories(ctx); err != nil {
+		log.Printf("[category-sync] initial sync failed (will retry): %v", err)
+	}
+
+	// Start background reconciliation loop
+	go w.reconcileLoop(ctx)
+
+	log.Printf("[category-sync] worker started")
+	return nil
+}
+
+// Stop stops the category sync worker.
+func (w *CategorySyncWorker) Stop() error {
+	close(w.stopCh)
+	<-w.doneCh
+	return nil
+}
+
+// State returns the current sync state.
+func (w *CategorySyncWorker) State() *CategorySyncState {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	// Return a copy to prevent race conditions
+	stateCopy := &CategorySyncState{
+		Mappings:    make(map[string]*CategoryMapping),
+		LastSync:    w.state.LastSync,
+		SyncVersion: w.state.SyncVersion,
+	}
+	for k, v := range w.state.Mappings {
+		stateCopy.Mappings[k] = &CategoryMapping{
+			Title:       v.Title,
+			WaldurUUID:  v.WaldurUUID,
+			Description: v.Description,
+			SyncedAt:    v.SyncedAt,
+		}
+	}
+	return stateCopy
+}
+
+// GetCategoryUUID returns the Waldur UUID for a category title.
+func (w *CategorySyncWorker) GetCategoryUUID(title string) (string, bool) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	mapping, ok := w.state.Mappings[title]
+	if !ok || mapping == nil {
+		return "", false
+	}
+	return mapping.WaldurUUID, true
+}
+
+// GetAllMappings returns all category mappings.
+func (w *CategorySyncWorker) GetAllMappings() map[string]string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	result := make(map[string]string)
+	for title, mapping := range w.state.Mappings {
+		if mapping != nil {
+			result[title] = mapping.WaldurUUID
+		}
+	}
+	return result
+}
+
+// SyncCategories synchronizes all default categories to Waldur.
+func (w *CategorySyncWorker) SyncCategories(ctx context.Context) error {
+	categories := w.getCategoriesToSync()
+
+	log.Printf("[category-sync] syncing %d categories to Waldur", len(categories))
+
+	var syncErrors []error
+	for _, cat := range categories {
+		if err := w.syncCategory(ctx, cat); err != nil {
+			syncErrors = append(syncErrors, fmt.Errorf("sync category %s: %w", cat.Title, err))
+			log.Printf("[category-sync] failed to sync category %s: %v", cat.Title, err)
+		} else {
+			log.Printf("[category-sync] synced category: %s", cat.Title)
+		}
+	}
+
+	w.mu.Lock()
+	w.state.LastSync = time.Now().UTC()
+	w.mu.Unlock()
+
+	if err := w.saveState(); err != nil {
+		log.Printf("[category-sync] warning: failed to save state: %v", err)
+	}
+
+	if len(syncErrors) > 0 {
+		return fmt.Errorf("failed to sync %d categories", len(syncErrors))
+	}
+
+	return nil
+}
+
+// DiscoverCategories discovers existing categories from Waldur and updates mappings.
+func (w *CategorySyncWorker) DiscoverCategories(ctx context.Context) error {
+	opCtx, cancel := context.WithTimeout(ctx, w.cfg.OperationTimeout)
+	defer cancel()
+
+	categories, err := w.client.ListCategories(opCtx, waldur.ListCategoriesParams{PageSize: 100})
+	if err != nil {
+		return fmt.Errorf("list categories: %w", err)
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Update mappings with discovered categories
+	for _, cat := range categories {
+		if existing, ok := w.state.Mappings[cat.Title]; ok {
+			// Update existing mapping if UUID changed
+			if existing.WaldurUUID != cat.UUID {
+				existing.WaldurUUID = cat.UUID
+				existing.SyncedAt = time.Now().UTC()
+			}
+		} else {
+			// Add new mapping for discovered category
+			w.state.Mappings[cat.Title] = &CategoryMapping{
+				Title:       cat.Title,
+				WaldurUUID:  cat.UUID,
+				Description: cat.Description,
+				SyncedAt:    time.Now().UTC(),
+			}
+		}
+	}
+
+	return nil
+}
+
+func (w *CategorySyncWorker) getCategoriesToSync() []CategoryDefinition {
+	// If custom categories file is specified, load from there
+	if w.cfg.CategoriesFilePath != "" {
+		categories, err := LoadCategoriesFromFile(w.cfg.CategoriesFilePath)
+		if err != nil {
+			log.Printf("[category-sync] warning: failed to load custom categories, using defaults: %v", err)
+			return DefaultCategories
+		}
+		return categories
+	}
+
+	return DefaultCategories
+}
+
+func (w *CategorySyncWorker) syncCategory(ctx context.Context, cat CategoryDefinition) error {
+	opCtx, cancel := context.WithTimeout(ctx, w.cfg.OperationTimeout)
+	defer cancel()
+
+	result, err := w.client.EnsureCategory(opCtx, waldur.CreateCategoryRequest{
+		Title:       cat.Title,
+		Description: cat.Description,
+		Icon:        cat.Icon,
+	})
+	if err != nil {
+		return err
+	}
+
+	w.mu.Lock()
+	w.state.Mappings[cat.Title] = &CategoryMapping{
+		Title:       cat.Title,
+		WaldurUUID:  result.UUID,
+		Description: cat.Description,
+		SyncedAt:    time.Now().UTC(),
+	}
+	w.mu.Unlock()
+
+	return nil
+}
+
+func (w *CategorySyncWorker) reconcileLoop(ctx context.Context) {
+	defer close(w.doneCh)
+
+	interval := time.Duration(w.cfg.SyncIntervalSeconds) * time.Second
+	if interval < time.Minute {
+		interval = 5 * time.Minute
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			if err := w.SyncCategories(ctx); err != nil {
+				log.Printf("[category-sync] reconciliation failed: %v", err)
+			}
+		}
+	}
+}
+
+func (w *CategorySyncWorker) saveState() error {
+	if w.cfg.StateFilePath == "" {
+		return nil
+	}
+
+	w.mu.RLock()
+	data, err := json.MarshalIndent(w.state, "", "  ")
+	w.mu.RUnlock()
+
+	if err != nil {
+		return fmt.Errorf("marshal state: %w", err)
+	}
+
+	return os.WriteFile(w.cfg.StateFilePath, data, 0o600)
+}
+
+// LoadCategoriesFromFile loads category definitions from a JSON file.
+func LoadCategoriesFromFile(path string) ([]CategoryDefinition, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+
+	var fixture struct {
+		Categories []CategoryDefinition `json:"categories"`
+	}
+
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	return fixture.Categories, nil
+}
+
+// SyncDefaultCategories is a convenience function to sync default categories.
+// This can be called from the localnet script or CLI.
+func SyncDefaultCategories(ctx context.Context, waldurBaseURL, waldurToken string) error {
+	cfg := waldur.DefaultConfig()
+	cfg.BaseURL = waldurBaseURL
+	cfg.Token = waldurToken
+
+	client, err := waldur.NewClient(cfg)
+	if err != nil {
+		return fmt.Errorf("create waldur client: %w", err)
+	}
+
+	marketplace := waldur.NewMarketplaceClient(client)
+
+	workerCfg := DefaultCategorySyncConfig()
+	workerCfg.Enabled = true
+
+	worker, err := NewCategorySyncWorker(workerCfg, marketplace)
+	if err != nil {
+		return fmt.Errorf("create sync worker: %w", err)
+	}
+
+	return worker.SyncCategories(ctx)
+}
+
+// InitCategoriesResult contains the result of category initialization.
+type InitCategoriesResult struct {
+	Created  []string          `json:"created"`
+	Existing []string          `json:"existing"`
+	Failed   []string          `json:"failed"`
+	Mappings map[string]string `json:"mappings"`
+}
+
+// InitCategories initializes all default categories and returns the result.
+func InitCategories(ctx context.Context, waldurBaseURL, waldurToken string) (*InitCategoriesResult, error) {
+	cfg := waldur.DefaultConfig()
+	cfg.BaseURL = waldurBaseURL
+	cfg.Token = waldurToken
+
+	client, err := waldur.NewClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create waldur client: %w", err)
+	}
+
+	marketplace := waldur.NewMarketplaceClient(client)
+
+	result := &InitCategoriesResult{
+		Created:  []string{},
+		Existing: []string{},
+		Failed:   []string{},
+		Mappings: make(map[string]string),
+	}
+
+	for _, cat := range DefaultCategories {
+		opCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+
+		// Try to get existing category first
+		existing, err := marketplace.GetCategoryByTitle(opCtx, cat.Title)
+		if err == nil && existing != nil {
+			result.Existing = append(result.Existing, cat.Title)
+			result.Mappings[cat.Title] = existing.UUID
+			cancel()
+			continue
+		}
+
+		// Create new category
+		created, err := marketplace.CreateCategory(opCtx, waldur.CreateCategoryRequest{
+			Title:       cat.Title,
+			Description: cat.Description,
+			Icon:        cat.Icon,
+		})
+		cancel()
+
+		if err != nil {
+			result.Failed = append(result.Failed, cat.Title)
+			log.Printf("[init-categories] failed to create category %s: %v", cat.Title, err)
+			continue
+		}
+
+		result.Created = append(result.Created, cat.Title)
+		result.Mappings[cat.Title] = created.UUID
+	}
+
+	return result, nil
+}

--- a/pkg/provider_daemon/category_sync_test.go
+++ b/pkg/provider_daemon/category_sync_test.go
@@ -1,0 +1,307 @@
+package provider_daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestDefaultCategories(t *testing.T) {
+	// Verify all 7 default categories are defined
+	expectedCategories := []string{"Compute", "HPC", "GPU", "Storage", "Network", "TEE", "AI/ML"}
+
+	if len(DefaultCategories) != len(expectedCategories) {
+		t.Errorf("expected %d categories, got %d", len(expectedCategories), len(DefaultCategories))
+	}
+
+	categoryTitles := make(map[string]bool)
+	for _, cat := range DefaultCategories {
+		categoryTitles[cat.Title] = true
+	}
+
+	for _, expected := range expectedCategories {
+		if !categoryTitles[expected] {
+			t.Errorf("missing expected category: %s", expected)
+		}
+	}
+}
+
+func TestCategoryDefinitionValidation(t *testing.T) {
+	for _, cat := range DefaultCategories {
+		if cat.Title == "" {
+			t.Error("category has empty title")
+		}
+		if cat.Description == "" {
+			t.Errorf("category %s has empty description", cat.Title)
+		}
+		if cat.Priority <= 0 {
+			t.Errorf("category %s has invalid priority: %d", cat.Title, cat.Priority)
+		}
+	}
+}
+
+func TestCategorySyncStateInitialization(t *testing.T) {
+	state := &CategorySyncState{
+		Mappings:    make(map[string]*CategoryMapping),
+		SyncVersion: "1.0.0",
+	}
+
+	if state.Mappings == nil {
+		t.Error("mappings should not be nil")
+	}
+
+	if state.SyncVersion != "1.0.0" {
+		t.Errorf("expected version 1.0.0, got %s", state.SyncVersion)
+	}
+}
+
+func TestDefaultCategorySyncConfig(t *testing.T) {
+	cfg := DefaultCategorySyncConfig()
+
+	if cfg.StateFilePath == "" {
+		t.Error("state file path should have default value")
+	}
+
+	if cfg.SyncIntervalSeconds <= 0 {
+		t.Error("sync interval should be positive")
+	}
+
+	if cfg.MaxRetries <= 0 {
+		t.Error("max retries should be positive")
+	}
+
+	if cfg.OperationTimeout <= 0 {
+		t.Error("operation timeout should be positive")
+	}
+}
+
+func TestCategorySyncStateCopy(t *testing.T) {
+	state := &CategorySyncState{
+		Mappings:    make(map[string]*CategoryMapping),
+		LastSync:    time.Now().UTC(),
+		SyncVersion: "1.0.0",
+	}
+
+	state.Mappings["Compute"] = &CategoryMapping{
+		Title:      "Compute",
+		WaldurUUID: "test-uuid-123",
+		SyncedAt:   time.Now().UTC(),
+	}
+
+	// Create a copy
+	stateCopy := &CategorySyncState{
+		Mappings:    make(map[string]*CategoryMapping),
+		LastSync:    state.LastSync,
+		SyncVersion: state.SyncVersion,
+	}
+	for k, v := range state.Mappings {
+		stateCopy.Mappings[k] = &CategoryMapping{
+			Title:       v.Title,
+			WaldurUUID:  v.WaldurUUID,
+			Description: v.Description,
+			SyncedAt:    v.SyncedAt,
+		}
+	}
+
+	// Modify original
+	state.Mappings["Compute"].WaldurUUID = "modified-uuid"
+
+	// Verify copy is not affected
+	if stateCopy.Mappings["Compute"].WaldurUUID == "modified-uuid" {
+		t.Error("copy should not be affected by modifications to original")
+	}
+}
+
+func TestCategoryMappingLookup(t *testing.T) {
+	state := &CategorySyncState{
+		Mappings: map[string]*CategoryMapping{
+			"Compute": {
+				Title:      "Compute",
+				WaldurUUID: "compute-uuid",
+			},
+			"GPU": {
+				Title:      "GPU",
+				WaldurUUID: "gpu-uuid",
+			},
+		},
+	}
+
+	// Test existing category
+	mapping, ok := state.Mappings["Compute"]
+	if !ok {
+		t.Error("Compute mapping should exist")
+	}
+	if mapping.WaldurUUID != "compute-uuid" {
+		t.Errorf("expected compute-uuid, got %s", mapping.WaldurUUID)
+	}
+
+	// Test non-existent category
+	_, ok = state.Mappings["NonExistent"]
+	if ok {
+		t.Error("NonExistent mapping should not exist")
+	}
+}
+
+func TestLoadCategoriesFromFile(t *testing.T) {
+	// Test loading from the actual fixture file
+	categories, err := LoadCategoriesFromFile("../../scripts/waldur/categories.json")
+	if err != nil {
+		t.Skipf("skipping test: categories file not found: %v", err)
+	}
+
+	if len(categories) < 7 {
+		t.Errorf("expected at least 7 categories, got %d", len(categories))
+	}
+
+	// Verify all expected categories are present
+	expectedTitles := map[string]bool{
+		"Compute": true,
+		"HPC":     true,
+		"GPU":     true,
+		"Storage": true,
+		"Network": true,
+		"TEE":     true,
+		"AI/ML":   true,
+	}
+
+	for _, cat := range categories {
+		delete(expectedTitles, cat.Title)
+	}
+
+	if len(expectedTitles) > 0 {
+		t.Errorf("missing categories: %v", expectedTitles)
+	}
+}
+
+func TestInitCategoriesResultStructure(t *testing.T) {
+	result := &InitCategoriesResult{
+		Created:  []string{"Compute", "GPU"},
+		Existing: []string{"Storage"},
+		Failed:   []string{},
+		Mappings: map[string]string{
+			"Compute": "uuid-1",
+			"GPU":     "uuid-2",
+			"Storage": "uuid-3",
+		},
+	}
+
+	if len(result.Created) != 2 {
+		t.Errorf("expected 2 created, got %d", len(result.Created))
+	}
+
+	if len(result.Existing) != 1 {
+		t.Errorf("expected 1 existing, got %d", len(result.Existing))
+	}
+
+	if len(result.Failed) != 0 {
+		t.Errorf("expected 0 failed, got %d", len(result.Failed))
+	}
+
+	if len(result.Mappings) != 3 {
+		t.Errorf("expected 3 mappings, got %d", len(result.Mappings))
+	}
+}
+
+func TestCategorySyncWorkerCreation(t *testing.T) {
+	// Test that worker creation fails without client
+	cfg := DefaultCategorySyncConfig()
+	_, err := NewCategorySyncWorker(cfg, nil)
+	if err == nil {
+		t.Error("expected error when creating worker without client")
+	}
+}
+
+func TestCategorySyncWorkerGetCategoryUUID(t *testing.T) {
+	// Create a worker with mock state
+	worker := &CategorySyncWorker{
+		cfg: DefaultCategorySyncConfig(),
+		state: &CategorySyncState{
+			Mappings: map[string]*CategoryMapping{
+				"Compute": {
+					Title:      "Compute",
+					WaldurUUID: "test-compute-uuid",
+				},
+			},
+		},
+	}
+
+	// Test existing category
+	uuid, ok := worker.GetCategoryUUID("Compute")
+	if !ok {
+		t.Error("Compute should exist")
+	}
+	if uuid != "test-compute-uuid" {
+		t.Errorf("expected test-compute-uuid, got %s", uuid)
+	}
+
+	// Test non-existent category
+	_, ok = worker.GetCategoryUUID("NonExistent")
+	if ok {
+		t.Error("NonExistent should not exist")
+	}
+}
+
+func TestCategorySyncWorkerGetAllMappings(t *testing.T) {
+	worker := &CategorySyncWorker{
+		cfg: DefaultCategorySyncConfig(),
+		state: &CategorySyncState{
+			Mappings: map[string]*CategoryMapping{
+				"Compute": {Title: "Compute", WaldurUUID: "uuid-1"},
+				"GPU":     {Title: "GPU", WaldurUUID: "uuid-2"},
+			},
+		},
+	}
+
+	mappings := worker.GetAllMappings()
+
+	if len(mappings) != 2 {
+		t.Errorf("expected 2 mappings, got %d", len(mappings))
+	}
+
+	if mappings["Compute"] != "uuid-1" {
+		t.Errorf("expected uuid-1 for Compute, got %s", mappings["Compute"])
+	}
+
+	if mappings["GPU"] != "uuid-2" {
+		t.Errorf("expected uuid-2 for GPU, got %s", mappings["GPU"])
+	}
+}
+
+func TestCategorySyncWorkerStateCopy(t *testing.T) {
+	worker := &CategorySyncWorker{
+		cfg: DefaultCategorySyncConfig(),
+		state: &CategorySyncState{
+			Mappings: map[string]*CategoryMapping{
+				"Compute": {Title: "Compute", WaldurUUID: "uuid-1"},
+			},
+			LastSync:    time.Now().UTC(),
+			SyncVersion: "1.0.0",
+		},
+	}
+
+	// Get state copy
+	stateCopy := worker.State()
+
+	// Modify original
+	worker.state.Mappings["Compute"].WaldurUUID = "modified"
+
+	// Verify copy is unchanged
+	if stateCopy.Mappings["Compute"].WaldurUUID == "modified" {
+		t.Error("state copy should not be affected by modifications")
+	}
+}
+
+func TestCategorySyncWorkerDisabledStart(t *testing.T) {
+	worker := &CategorySyncWorker{
+		cfg: CategorySyncConfig{Enabled: false},
+		state: &CategorySyncState{
+			Mappings: make(map[string]*CategoryMapping),
+		},
+	}
+
+	// Start should return nil when disabled
+	err := worker.Start(context.Background())
+	if err != nil {
+		t.Errorf("expected nil error when disabled, got %v", err)
+	}
+}

--- a/scripts/waldur/categories.json
+++ b/scripts/waldur/categories.json
@@ -1,0 +1,121 @@
+{
+  "version": "1.0.0",
+  "description": "VirtEngine marketplace categories for Waldur integration",
+  "categories": [
+    {
+      "title": "Compute",
+      "description": "Virtual machines, containers, and general-purpose computing resources for running workloads.",
+      "icon": "server",
+      "offering_types": [
+        "VirtEngine.VM",
+        "VirtEngine.Container",
+        "VirtEngine.Instance"
+      ],
+      "metadata": {
+        "color": "#3498db",
+        "priority": 1,
+        "default_for_sync": true
+      }
+    },
+    {
+      "title": "HPC",
+      "description": "High-performance computing resources including MPI clusters, batch processing, and scientific computing environments.",
+      "icon": "cpu",
+      "offering_types": [
+        "VirtEngine.HPC",
+        "VirtEngine.HPCCluster",
+        "VirtEngine.BatchJob"
+      ],
+      "metadata": {
+        "color": "#9b59b6",
+        "priority": 2,
+        "default_for_sync": true
+      }
+    },
+    {
+      "title": "GPU",
+      "description": "GPU-accelerated computing instances for machine learning, deep learning, and graphics processing workloads.",
+      "icon": "gpu",
+      "offering_types": [
+        "VirtEngine.GPU",
+        "VirtEngine.GPUInstance",
+        "VirtEngine.GPUCluster"
+      ],
+      "metadata": {
+        "color": "#27ae60",
+        "priority": 3,
+        "default_for_sync": true
+      }
+    },
+    {
+      "title": "Storage",
+      "description": "Object storage, block storage, and file storage solutions for data persistence and sharing.",
+      "icon": "database",
+      "offering_types": [
+        "VirtEngine.ObjectStorage",
+        "VirtEngine.BlockStorage",
+        "VirtEngine.FileStorage",
+        "VirtEngine.S3"
+      ],
+      "metadata": {
+        "color": "#e67e22",
+        "priority": 4,
+        "default_for_sync": true
+      }
+    },
+    {
+      "title": "Network",
+      "description": "Networking services including VPNs, load balancers, firewalls, and private networks.",
+      "icon": "network",
+      "offering_types": [
+        "VirtEngine.VPN",
+        "VirtEngine.LoadBalancer",
+        "VirtEngine.Firewall",
+        "VirtEngine.PrivateNetwork"
+      ],
+      "metadata": {
+        "color": "#1abc9c",
+        "priority": 5,
+        "default_for_sync": true
+      }
+    },
+    {
+      "title": "TEE",
+      "description": "Trusted Execution Environment resources for confidential computing and secure enclaves.",
+      "icon": "shield",
+      "offering_types": [
+        "VirtEngine.TEE",
+        "VirtEngine.SecureEnclave",
+        "VirtEngine.ConfidentialVM"
+      ],
+      "metadata": {
+        "color": "#e74c3c",
+        "priority": 6,
+        "default_for_sync": true
+      }
+    },
+    {
+      "title": "AI/ML",
+      "description": "Machine learning platforms, model training infrastructure, and inference services.",
+      "icon": "brain",
+      "offering_types": [
+        "VirtEngine.AIML",
+        "VirtEngine.MLTraining",
+        "VirtEngine.Inference",
+        "VirtEngine.NotebookServer"
+      ],
+      "metadata": {
+        "color": "#f39c12",
+        "priority": 7,
+        "default_for_sync": true
+      }
+    }
+  ],
+  "default_category": "Compute",
+  "sync_settings": {
+    "auto_sync_enabled": true,
+    "sync_interval_seconds": 300,
+    "retry_on_failure": true,
+    "max_retries": 3
+  }
+}


### PR DESCRIPTION
# Task: Auto-create Marketplace Categories on Localnet Startup

## Objective

Automatically create marketplace categories in Waldur when starting localnet.

## Priority: CRITICAL (P0)

Categories are prerequisite for offering creation - blocks all Waldur development.

## Estimated Lines: 800-1,200

## Problem Statement

Waldur requires marketplace categories before offerings can be created. Currently localnet starts Waldur but doesn't initialize categories, blocking development.

## Solution

### Localnet Script Updates

1. Wait for Waldur to be ready
2. Call `waldur load_categories` or equivalent
3. Create VirtEngine-specific categories
4. Verify categories exist

### Categories to Create

- **Compute**: VMs, containers
- **HPC**: High-performance computing
- **GPU**: GPU instances
- **Storage**: Object, block, file storage
- **Network**: VPN, load balancers
- **TEE**: Trusted execution environments
- **AI/ML**: Machine learning resources

### Provider Daemon Enhancement

- Auto-discover categories on startup
- Cache category mapping
- Handle category changes

## Implementation

### Phase 1: Category Fixture (300 lines)

- Location: `scripts/waldur/categories.json`
- VirtEngine category definitions
- Icon/description metadata

### Phase 2: Localnet Script (400 lines)

- Location: `scripts/localnet.sh`
- Wait for Waldur health
- Load categories via API
- Verify creation

### Phase 3: Provider Daemon (300 lines)

- Location: `pkg/provider_daemon/category_sync.go`
- Category discovery
- Caching

### Phase 4: CLI Command (200 lines)

- `virtengine waldur init-categories`
- For manual setup

## Files to Create/Modify

- `scripts/waldur/categories.json`
- `scripts/localnet.sh`
- `pkg/provider_daemon/category_sync.go`
- `cmd/virtengine/cmd/waldur/init_categories.go`

## Acceptance Criteria

- [ ] Localnet creates categories on start
- [ ] All 7 categories created
- [ ] Provider daemon discovers categories
- [ ] CLI command for manual init
- [ ] Documented in localnet guide

## Agent Instructions

1. Check Waldur category API
2. Create comprehensive category fixture
3. Update localnet script
4. Test complete startup flow
5. Add error handling for Waldur unavailable
6. Document manual recovery steps

This list of categories will be what is used when syncing products, if a provider creates an additional category and adds listings to that category, it wont be synced into the blockchain as its not a default category. 