### PR TITLE
feat(bme,oracle): Integrate bank keeper for token operations - 26G

### DIFF
--- a/_execute_commands.ps1
+++ b/_execute_commands.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = "Continue"
+$resultsFile = "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine\_command_results.txt"
+Set-Location "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine"
+
+"=== GO BUILD ./x/bme/... ./x/oracle/... ===" | Out-File $resultsFile -Encoding utf8
+"Started at: $(Get-Date)" | Out-File $resultsFile -Append
+
+$buildOutput = & go build ./x/bme/... ./x/oracle/... 2>&1 | Out-String
+$buildExit = $LASTEXITCODE
+
+"$buildOutput" | Out-File $resultsFile -Append
+"BUILD_EXIT_CODE: $buildExit" | Out-File $resultsFile -Append
+"" | Out-File $resultsFile -Append
+
+"=== GO TEST ./x/bme/keeper/... ./x/oracle/keeper/... ===" | Out-File $resultsFile -Append
+"Started at: $(Get-Date)" | Out-File $resultsFile -Append
+
+$testOutput = & go test ./x/bme/keeper/... ./x/oracle/keeper/... 2>&1 | Out-String
+$testExit = $LASTEXITCODE
+
+"$testOutput" | Out-File $resultsFile -Append
+"TEST_EXIT_CODE: $testExit" | Out-File $resultsFile -Append
+"" | Out-File $resultsFile -Append
+"=== COMPLETED at: $(Get-Date) ===" | Out-File $resultsFile -Append

--- a/_run_and_save.ps1
+++ b/_run_and_save.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = "Continue"
+$outputFile = "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine\_command_results.txt"
+
+Set-Location "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine"
+
+"=== COMMAND 1: go build ./x/bme/... ./x/oracle/... ===" | Out-File -FilePath $outputFile
+"Started at: $(Get-Date)" | Out-File -FilePath $outputFile -Append
+
+$buildOutput = go build ./x/bme/... ./x/oracle/... 2>&1 | Out-String
+$buildExitCode = $LASTEXITCODE
+
+$buildOutput | Out-File -FilePath $outputFile -Append
+"BUILD_EXIT_CODE: $buildExitCode" | Out-File -FilePath $outputFile -Append
+"Completed at: $(Get-Date)" | Out-File -FilePath $outputFile -Append
+
+"" | Out-File -FilePath $outputFile -Append
+"=== COMMAND 2: go test ./x/bme/keeper/... ./x/oracle/keeper/... ===" | Out-File -FilePath $outputFile -Append
+"Started at: $(Get-Date)" | Out-File -FilePath $outputFile -Append
+
+$testOutput = go test ./x/bme/keeper/... ./x/oracle/keeper/... 2>&1 | Out-String
+$testExitCode = $LASTEXITCODE
+
+$testOutput | Out-File -FilePath $outputFile -Append
+"TEST_EXIT_CODE: $testExitCode" | Out-File -FilePath $outputFile -Append
+"Completed at: $(Get-Date)" | Out-File -FilePath $outputFile -Append
+
+"=== DONE ===" | Out-File -FilePath $outputFile -Append

--- a/_run_build_test.ps1
+++ b/_run_build_test.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = "Continue"
+Set-Location "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine"
+
+$outFile = "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine\_output.log"
+
+"=== STARTING BUILD ===" | Out-File $outFile
+"Command: go build ./x/bme/... ./x/oracle/..." | Add-Content $outFile
+"Started: $(Get-Date)" | Add-Content $outFile
+"" | Add-Content $outFile
+
+$buildOutput = go build -v ./x/bme/... ./x/oracle/... 2>&1 | Out-String
+$buildCode = $LASTEXITCODE
+$buildOutput | Add-Content $outFile
+
+"" | Add-Content $outFile
+"BUILD_EXIT_CODE: $buildCode" | Add-Content $outFile
+"Completed: $(Get-Date)" | Add-Content $outFile
+"" | Add-Content $outFile
+
+"=== STARTING TESTS ===" | Add-Content $outFile
+"Command: go test ./x/bme/keeper/... ./x/oracle/keeper/..." | Add-Content $outFile
+"Started: $(Get-Date)" | Add-Content $outFile
+"" | Add-Content $outFile
+
+$testOutput = go test -v ./x/bme/keeper/... ./x/oracle/keeper/... 2>&1 | Out-String
+$testCode = $LASTEXITCODE
+$testOutput | Add-Content $outFile
+
+"" | Add-Content $outFile
+"TEST_EXIT_CODE: $testCode" | Add-Content $outFile
+"Completed: $(Get-Date)" | Add-Content $outFile
+"" | Add-Content $outFile
+"=== ALL DONE ===" | Add-Content $outFile

--- a/_run_go_commands.bat
+++ b/_run_go_commands.bat
@@ -1,0 +1,11 @@
+@echo off
+cd /d "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine"
+
+echo === COMMAND 1: go build ./x/bme/... ./x/oracle/... ===
+go build ./x/bme/... ./x/oracle/... 2>&1
+echo BUILD_EXIT_CODE: %ERRORLEVEL%
+
+echo.
+echo === COMMAND 2: go test ./x/bme/keeper/... ./x/oracle/keeper/... ===
+go test ./x/bme/keeper/... ./x/oracle/keeper/... 2>&1
+echo TEST_EXIT_CODE: %ERRORLEVEL%

--- a/_simple_build.ps1
+++ b/_simple_build.ps1
@@ -1,0 +1,38 @@
+$outFile = "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine\_build_test_results.txt"
+$workDir = "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine"
+
+"Script started at $(Get-Date)" | Out-File $outFile -Force
+"Working dir: $workDir" | Out-File $outFile -Append
+"" | Out-File $outFile -Append
+
+try {
+    Set-Location $workDir
+    
+    "=== COMMAND 1: go build ./x/bme/... ./x/oracle/... ===" | Out-File $outFile -Append
+    "Start: $(Get-Date)" | Out-File $outFile -Append
+    
+    $buildOutput = & go build ./x/bme/... ./x/oracle/... 2>&1 | Out-String
+    $buildExit = $LASTEXITCODE
+    
+    "STDOUT/STDERR:" | Out-File $outFile -Append
+    $buildOutput | Out-File $outFile -Append
+    "Exit Code: $buildExit" | Out-File $outFile -Append
+    "End: $(Get-Date)" | Out-File $outFile -Append
+    "" | Out-File $outFile -Append
+    
+    "=== COMMAND 2: go test ./x/bme/keeper/... ./x/oracle/keeper/... ===" | Out-File $outFile -Append
+    "Start: $(Get-Date)" | Out-File $outFile -Append
+    
+    $testOutput = & go test ./x/bme/keeper/... ./x/oracle/keeper/... 2>&1 | Out-String
+    $testExit = $LASTEXITCODE
+    
+    "STDOUT/STDERR:" | Out-File $outFile -Append
+    $testOutput | Out-File $outFile -Append
+    "Exit Code: $testExit" | Out-File $outFile -Append
+    "End: $(Get-Date)" | Out-File $outFile -Append
+    
+} catch {
+    "ERROR: $_" | Out-File $outFile -Append
+}
+
+"Script completed at $(Get-Date)" | Out-File $outFile -Append

--- a/_test_script.ps1
+++ b/_test_script.ps1
@@ -1,0 +1,22 @@
+# Build and Test Script
+$ErrorActionPreference = 'Continue'
+Set-Location 'C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine'
+
+Write-Host "=== BUILD START ==="
+$buildOutput = go build ./x/bme/... ./x/oracle/... 2>&1
+$buildCode = $LASTEXITCODE
+if ($buildOutput) { Write-Host $buildOutput }
+Write-Host "BUILD EXIT CODE: $buildCode"
+if ($buildCode -eq 0) { Write-Host "BUILD: PASS" } else { Write-Host "BUILD: FAIL" }
+
+Write-Host ""
+Write-Host "=== TEST START ==="
+go test ./x/bme/keeper/... ./x/oracle/keeper/... 2>&1
+$testCode = $LASTEXITCODE
+Write-Host "TEST EXIT CODE: $testCode"
+if ($testCode -eq 0) { Write-Host "TEST: PASS" } else { Write-Host "TEST: FAIL" }
+
+Write-Host ""
+Write-Host "=== SUMMARY ==="
+Write-Host "Build: $(if($buildCode -eq 0){'PASS'}else{'FAIL'})"
+Write-Host "Test: $(if($testCode -eq 0){'PASS'}else{'FAIL'})"

--- a/app/types/app.go
+++ b/app/types/app.go
@@ -625,12 +625,15 @@ func (app *App) InitNormalKeepers(
 		cdc,
 		app.keys[bmetypes.StoreKey],
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		app.Keepers.Cosmos.Bank,
+		nil, // OracleKeeper - will be set after Oracle keeper is created
 	)
 
 	app.Keepers.VirtEngine.Oracle = oraclekeeper.NewKeeper(
 		cdc,
 		app.keys[oracletypes.StoreKey],
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		app.Keepers.Cosmos.Bank,
 	)
 }
 

--- a/results.txt
+++ b/results.txt
@@ -1,0 +1,36 @@
+=== BUILD RESULTS ===
+COMMAND: go build ./x/bme/... ./x/oracle/...
+STATUS: UNABLE TO EXECUTE
+REASON: PowerShell sessions terminate prematurely - environment issue prevents command execution.
+All attempts (sync, async, Start-Process, Python subprocess) resulted in invalid shell sessions.
+BUILD EXIT CODE: N/A (could not run)
+
+=== TEST RESULTS ===
+COMMAND: go test ./x/bme/keeper/... ./x/oracle/keeper/...
+STATUS: UNABLE TO EXECUTE
+REASON: Same environment issue - PowerShell sessions become invalid immediately after timeout.
+TEST EXIT CODE: N/A (could not run)
+
+=== MODULE VERIFICATION ===
+The following modules and test files exist and appear properly structured:
+
+x/bme/
+  - module.go
+  - keeper/keeper.go, keeper_test.go, msg_server.go, msg_server_test.go, genesis.go, genesis_test.go
+  - types/
+
+x/oracle/
+  - module.go
+  - keeper/keeper.go, keeper_test.go, msg_server.go, genesis.go, genesis_test.go
+  - types/
+
+=== ENVIRONMENT ISSUE ===
+The PowerShell execution environment is not functioning correctly.
+All shell sessions (tested with go version, pwd, simple echo commands) become invalid
+immediately after the wait period expires. This is a systemic issue with the execution
+environment, not a problem with the Go code or modules.
+
+To manually verify:
+  cd C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine
+  go build ./x/bme/... ./x/oracle/...
+  go test ./x/bme/keeper/... ./x/oracle/keeper/...

--- a/run_build_tests.ps1
+++ b/run_build_tests.ps1
@@ -1,0 +1,39 @@
+$workDir = "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine"
+Set-Location $workDir
+
+# Build command
+$buildProc = Start-Process -FilePath "go" -ArgumentList "build","./x/bme/...","./x/oracle/..." -WorkingDirectory $workDir -Wait -PassThru -NoNewWindow -RedirectStandardOutput "$workDir\build_stdout.tmp" -RedirectStandardError "$workDir\build_stderr.tmp"
+$buildExit = $buildProc.ExitCode
+$buildStdout = Get-Content "$workDir\build_stdout.tmp" -Raw -ErrorAction SilentlyContinue
+$buildStderr = Get-Content "$workDir\build_stderr.tmp" -Raw -ErrorAction SilentlyContinue
+$buildOut = "$buildStdout`n$buildStderr".Trim()
+if ([string]::IsNullOrWhiteSpace($buildOut)) { $buildOut = "Build passed with no output" }
+$buildStatus = if ($buildExit -eq 0) { "PASSED" } else { "FAILED" }
+
+# Test command
+$testProc = Start-Process -FilePath "go" -ArgumentList "test","./x/bme/keeper/...","./x/oracle/keeper/..." -WorkingDirectory $workDir -Wait -PassThru -NoNewWindow -RedirectStandardOutput "$workDir\test_stdout.tmp" -RedirectStandardError "$workDir\test_stderr.tmp"
+$testExit = $testProc.ExitCode
+$testStdout = Get-Content "$workDir\test_stdout.tmp" -Raw -ErrorAction SilentlyContinue
+$testStderr = Get-Content "$workDir\test_stderr.tmp" -Raw -ErrorAction SilentlyContinue
+$testOut = "$testStdout`n$testStderr".Trim()
+$testStatus = if ($testExit -eq 0) { "PASSED" } else { "FAILED" }
+
+# Create results file
+$content = @"
+=== BUILD RESULTS ===
+$buildOut
+BUILD EXIT CODE: $buildExit
+BUILD STATUS: $buildStatus
+
+=== TEST RESULTS ===
+$testOut
+TEST EXIT CODE: $testExit
+TEST STATUS: $testStatus
+"@
+
+$content | Out-File -FilePath "$workDir\results.txt" -Encoding utf8
+
+# Cleanup temp files
+Remove-Item "$workDir\build_stdout.tmp","$workDir\build_stderr.tmp","$workDir\test_stdout.tmp","$workDir\test_stderr.tmp" -ErrorAction SilentlyContinue
+
+Write-Host "Done: Build=$buildStatus Tests=$testStatus"

--- a/run_commands.bat
+++ b/run_commands.bat
@@ -1,0 +1,48 @@
+@echo off
+cd /d C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine
+
+set OUTFILE=results.txt
+set BUILD_TEMP=build_temp.txt
+set TEST_TEMP=test_temp.txt
+
+REM Run build and capture output
+go build ./x/bme/... ./x/oracle/... > %BUILD_TEMP% 2>&1
+set BUILD_EXIT=%ERRORLEVEL%
+
+REM Run tests and capture output  
+go test ./x/bme/keeper/... ./x/oracle/keeper/... > %TEST_TEMP% 2>&1
+set TEST_EXIT=%ERRORLEVEL%
+
+REM Determine statuses
+if %BUILD_EXIT%==0 (
+    set BUILD_STATUS=PASSED
+) else (
+    set BUILD_STATUS=FAILED
+)
+
+if %TEST_EXIT%==0 (
+    set TEST_STATUS=PASSED
+) else (
+    set TEST_STATUS=FAILED
+)
+
+REM Write final results file
+echo === BUILD RESULTS === > %OUTFILE%
+for %%I in (%BUILD_TEMP%) do if %%~zI==0 (
+    echo Build passed with no output >> %OUTFILE%
+) else (
+    type %BUILD_TEMP% >> %OUTFILE%
+)
+echo BUILD EXIT CODE: %BUILD_EXIT% >> %OUTFILE%
+echo BUILD STATUS: %BUILD_STATUS% >> %OUTFILE%
+echo. >> %OUTFILE%
+echo === TEST RESULTS === >> %OUTFILE%
+type %TEST_TEMP% >> %OUTFILE%
+echo TEST EXIT CODE: %TEST_EXIT% >> %OUTFILE%
+echo TEST STATUS: %TEST_STATUS% >> %OUTFILE%
+
+REM Cleanup
+del %BUILD_TEMP% 2>nul
+del %TEST_TEMP% 2>nul
+
+echo Done - results written to %OUTFILE%

--- a/run_commands.py
+++ b/run_commands.py
@@ -1,0 +1,41 @@
+import subprocess
+import os
+
+os.chdir(r"C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine")
+
+# Run build
+build_result = subprocess.run(
+    ["go", "build", "./x/bme/...", "./x/oracle/..."],
+    capture_output=True, text=True, timeout=600
+)
+build_output = build_result.stdout + build_result.stderr
+if not build_output.strip():
+    build_output = "Build passed with no output"
+build_exit = build_result.returncode
+build_status = "PASSED" if build_exit == 0 else "FAILED"
+
+# Run tests
+test_result = subprocess.run(
+    ["go", "test", "./x/bme/keeper/...", "./x/oracle/keeper/..."],
+    capture_output=True, text=True, timeout=600
+)
+test_output = test_result.stdout + test_result.stderr
+test_exit = test_result.returncode
+test_status = "PASSED" if test_exit == 0 else "FAILED"
+
+# Write results
+with open("results.txt", "w", encoding="utf-8") as f:
+    f.write(f"""=== BUILD RESULTS ===
+{build_output}
+BUILD EXIT CODE: {build_exit}
+BUILD STATUS: {build_status}
+
+=== TEST RESULTS ===
+{test_output}
+TEST EXIT CODE: {test_exit}
+TEST STATUS: {test_status}
+""")
+
+print(f"Build: {build_status} (exit {build_exit})")
+print(f"Tests: {test_status} (exit {test_exit})")
+print("Results written to results.txt")

--- a/run_go_commands.ps1
+++ b/run_go_commands.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = "Continue"
+Set-Location "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine"
+
+$resultsFile = "results.txt"
+
+# Run build command
+Write-Host "Starting build..."
+$buildOutput = go build ./x/bme/... ./x/oracle/... 2>&1 | Out-String
+$buildExitCode = $LASTEXITCODE
+Write-Host "Build completed with exit code: $buildExitCode"
+
+# Run test command  
+Write-Host "Starting tests..."
+$testOutput = go test ./x/bme/keeper/... ./x/oracle/keeper/... 2>&1 | Out-String
+$testExitCode = $LASTEXITCODE
+Write-Host "Tests completed with exit code: $testExitCode"
+
+# Determine status
+$buildStatus = if ($buildExitCode -eq 0) { "PASSED" } else { "FAILED" }
+$testStatus = if ($testExitCode -eq 0) { "PASSED" } else { "FAILED" }
+
+# Write results
+$results = @"
+=== BUILD RESULTS ===
+$(if ([string]::IsNullOrWhiteSpace($buildOutput)) { "Build passed with no output" } else { $buildOutput.Trim() })
+BUILD EXIT CODE: $buildExitCode
+BUILD STATUS: $buildStatus
+
+=== TEST RESULTS ===
+$($testOutput.Trim())
+TEST EXIT CODE: $testExitCode
+TEST STATUS: $testStatus
+"@
+
+$results | Out-File -FilePath $resultsFile -Encoding UTF8
+Write-Host "Results written to $resultsFile"
+Get-Content $resultsFile

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,0 +1,24 @@
+@echo off
+cd /d "C:\Users\jonathan\AppData\Local\Temp\vibe-kanban\worktrees\ed79-feat-bme-oracle\virtengine"
+
+echo === BUILD RESULTS === > results.txt
+go build ./x/bme/... ./x/oracle/... >> results.txt 2>&1
+if %errorlevel%==0 (
+    echo Build passed with no output >> results.txt
+    echo BUILD EXIT CODE: 0 >> results.txt
+    echo BUILD STATUS: PASSED >> results.txt
+) else (
+    echo BUILD EXIT CODE: %errorlevel% >> results.txt
+    echo BUILD STATUS: FAILED >> results.txt
+)
+
+echo. >> results.txt
+echo === TEST RESULTS === >> results.txt
+go test ./x/bme/keeper/... ./x/oracle/keeper/... >> results.txt 2>&1
+set TESTEXIT=%errorlevel%
+echo TEST EXIT CODE: %TESTEXIT% >> results.txt
+if %TESTEXIT%==0 (
+    echo TEST STATUS: PASSED >> results.txt
+) else (
+    echo TEST STATUS: FAILED >> results.txt
+)

--- a/x/bme/keeper/bank_integration_test.go
+++ b/x/bme/keeper/bank_integration_test.go
@@ -1,0 +1,323 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper_test
+
+import (
+	"context"
+	"testing"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/math"
+	"cosmossdk.io/store"
+	"cosmossdk.io/store/metrics"
+	storetypes "cosmossdk.io/store/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/stretchr/testify/require"
+
+	types "github.com/virtengine/virtengine/sdk/go/node/bme/v1"
+	"github.com/virtengine/virtengine/x/bme/keeper"
+)
+
+const testOrderID = "order-1"
+
+// MockBankKeeper implements the BankKeeper interface for testing.
+type MockBankKeeper struct {
+	balances map[string]sdk.Coins
+	modules  map[string]sdk.Coins
+}
+
+func NewMockBankKeeper() *MockBankKeeper {
+	return &MockBankKeeper{
+		balances: make(map[string]sdk.Coins),
+		modules:  make(map[string]sdk.Coins),
+	}
+}
+
+func (m *MockBankKeeper) SpendableCoins(_ context.Context, addr sdk.AccAddress) sdk.Coins {
+	coins := m.balances[addr.String()]
+	if coins == nil {
+		return sdk.Coins{}
+	}
+	return coins
+}
+
+func (m *MockBankKeeper) SendCoins(_ context.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error {
+	from := fromAddr.String()
+	to := toAddr.String()
+
+	if !m.balances[from].IsAllGTE(amt) {
+		return keeper.ErrInsufficientFunds
+	}
+
+	m.balances[from] = m.balances[from].Sub(amt...)
+	m.balances[to] = m.balances[to].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) SendCoinsFromModuleToAccount(_ context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error {
+	if !m.modules[senderModule].IsAllGTE(amt) {
+		return keeper.ErrInsufficientFunds
+	}
+
+	m.modules[senderModule] = m.modules[senderModule].Sub(amt...)
+	to := recipientAddr.String()
+	m.balances[to] = m.balances[to].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) SendCoinsFromAccountToModule(_ context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error {
+	from := senderAddr.String()
+	if !m.balances[from].IsAllGTE(amt) {
+		return keeper.ErrInsufficientFunds
+	}
+
+	m.balances[from] = m.balances[from].Sub(amt...)
+	m.modules[recipientModule] = m.modules[recipientModule].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) SendCoinsFromModuleToModule(_ context.Context, senderModule, recipientModule string, amt sdk.Coins) error {
+	if !m.modules[senderModule].IsAllGTE(amt) {
+		return keeper.ErrInsufficientFunds
+	}
+
+	m.modules[senderModule] = m.modules[senderModule].Sub(amt...)
+	m.modules[recipientModule] = m.modules[recipientModule].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) MintCoins(_ context.Context, moduleName string, amt sdk.Coins) error {
+	m.modules[moduleName] = m.modules[moduleName].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) BurnCoins(_ context.Context, moduleName string, amt sdk.Coins) error {
+	if !m.modules[moduleName].IsAllGTE(amt) {
+		return keeper.ErrInsufficientFunds
+	}
+	m.modules[moduleName] = m.modules[moduleName].Sub(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) GetBalance(_ context.Context, addr sdk.AccAddress, denom string) sdk.Coin {
+	coins := m.balances[addr.String()]
+	return sdk.NewCoin(denom, coins.AmountOf(denom))
+}
+
+// SetBalance sets the balance for an address (test helper).
+func (m *MockBankKeeper) SetBalance(addr sdk.AccAddress, coins sdk.Coins) {
+	m.balances[addr.String()] = coins
+}
+
+// SetModuleBalance sets the balance for a module (test helper).
+func (m *MockBankKeeper) SetModuleBalance(module string, coins sdk.Coins) {
+	m.modules[module] = coins
+}
+
+// GetModuleBalance returns the module balance (test helper).
+func (m *MockBankKeeper) GetModuleBalance(module string) sdk.Coins {
+	return m.modules[module]
+}
+
+// Ensure MockBankKeeper implements the interface
+var _ keeper.BankKeeper = (*MockBankKeeper)(nil)
+
+func setupKeeperWithBankMock(t testing.TB) (keeper.IKeeper, sdk.Context, *MockBankKeeper) {
+	t.Helper()
+
+	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+
+	db := dbm.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db, log.NewNopLogger(), metrics.NewNoOpMetrics())
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	types.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+
+	authority := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+
+	bankKeeper := NewMockBankKeeper()
+	k := keeper.NewKeeper(cdc, storeKey, authority, bankKeeper, nil)
+	ctx := sdk.NewContext(stateStore, cmtproto.Header{Height: 1}, false, log.NewNopLogger())
+
+	// Initialize with default params
+	err := k.SetParams(ctx, types.DefaultParams())
+	require.NoError(t, err)
+
+	return k, ctx, bankKeeper
+}
+
+func TestHoldEscrow(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	depositor := sdk.AccAddress([]byte("depositor1234567890"))
+	orderID := testOrderID
+	amount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+
+	// Set depositor balance
+	bankKeeper.SetBalance(depositor, amount)
+
+	// Hold escrow
+	err := k.HoldEscrow(ctx, orderID, depositor, amount)
+	require.NoError(t, err)
+
+	// Verify escrow balance
+	escrowBalance := k.GetEscrowBalance(ctx, orderID)
+	require.True(t, escrowBalance.Equal(amount))
+
+	// Verify depositor balance is zero
+	depositorBalance := bankKeeper.SpendableCoins(ctx, depositor)
+	require.True(t, depositorBalance.IsZero())
+
+	// Verify module received the coins
+	moduleBalance := bankKeeper.GetModuleBalance(types.ModuleName)
+	require.True(t, moduleBalance.Equal(amount))
+}
+
+func TestReleaseEscrow(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	depositor := sdk.AccAddress([]byte("depositor1234567890"))
+	recipient := sdk.AccAddress([]byte("recipient123456789"))
+	orderID := testOrderID
+	amount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+
+	// Set depositor balance and hold escrow
+	bankKeeper.SetBalance(depositor, amount)
+	err := k.HoldEscrow(ctx, orderID, depositor, amount)
+	require.NoError(t, err)
+
+	// Release escrow to recipient
+	err = k.ReleaseEscrow(ctx, orderID, recipient)
+	require.NoError(t, err)
+
+	// Verify recipient received the coins
+	recipientBalance := bankKeeper.SpendableCoins(ctx, recipient)
+	require.True(t, recipientBalance.Equal(amount))
+
+	// Verify escrow is empty
+	escrowBalance := k.GetEscrowBalance(ctx, orderID)
+	require.True(t, escrowBalance.IsZero())
+}
+
+func TestHoldEscrowInsufficientFunds(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	depositor := sdk.AccAddress([]byte("depositor1234567890"))
+	orderID := testOrderID
+	amount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+
+	// Set depositor balance to less than required
+	bankKeeper.SetBalance(depositor, sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(500))))
+
+	// Hold escrow should fail
+	err := k.HoldEscrow(ctx, orderID, depositor, amount)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient funds")
+}
+
+func TestMintTokens(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	recipient := sdk.AccAddress([]byte("recipient123456789"))
+	amount := sdk.NewCoins(sdk.NewCoin("uvact", math.NewInt(500)))
+
+	// Mint tokens
+	err := k.MintTokens(ctx, recipient, amount)
+	require.NoError(t, err)
+
+	// Verify recipient received the minted coins
+	recipientBalance := bankKeeper.SpendableCoins(ctx, recipient)
+	require.True(t, recipientBalance.Equal(amount))
+
+	// Verify vault state updated
+	state := k.GetState(ctx)
+	require.True(t, state.TotalMinted.Equal(amount))
+}
+
+func TestBurnTokens(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	from := sdk.AccAddress([]byte("burner1234567890xx"))
+	amount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(300)))
+
+	// Set balance
+	bankKeeper.SetBalance(from, amount)
+
+	// Burn tokens
+	err := k.BurnTokens(ctx, from, amount)
+	require.NoError(t, err)
+
+	// Verify balance is zero
+	balance := bankKeeper.SpendableCoins(ctx, from)
+	require.True(t, balance.IsZero())
+
+	// Verify vault state updated
+	state := k.GetState(ctx)
+	require.True(t, state.TotalBurned.Equal(amount))
+}
+
+func TestCollectFees(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	payer := sdk.AccAddress([]byte("payer12345678901234"))
+	amount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(100)))
+
+	// Set payer balance
+	bankKeeper.SetBalance(payer, amount)
+
+	// Collect fees
+	err := k.CollectFees(ctx, payer, amount)
+	require.NoError(t, err)
+
+	// Verify payer balance is zero
+	payerBalance := bankKeeper.SpendableCoins(ctx, payer)
+	require.True(t, payerBalance.IsZero())
+
+	// Verify fees went to distribution module
+	feeBalance := bankKeeper.GetModuleBalance("distribution")
+	require.True(t, feeBalance.Equal(amount))
+}
+
+func TestSettleBilling(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	depositor := sdk.AccAddress([]byte("depositor1234567890"))
+	provider := sdk.AccAddress([]byte("provider1234567890x"))
+	orderID := testOrderID
+	leaseID := "lease-1"
+	depositAmount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(10000)))
+	usageAmount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+
+	// Set depositor balance and hold escrow
+	bankKeeper.SetBalance(depositor, depositAmount)
+	err := k.HoldEscrow(ctx, orderID, depositor, depositAmount)
+	require.NoError(t, err)
+
+	// Register lease escrow
+	keeperPtr := k.(*keeper.Keeper)
+	err = keeperPtr.RegisterLeaseEscrow(ctx, leaseID, orderID, provider, depositor)
+	require.NoError(t, err)
+
+	// Settle billing
+	err = k.SettleBilling(ctx, leaseID, provider, usageAmount)
+	require.NoError(t, err)
+
+	// Verify provider received payment (minus fees)
+	providerBalance := bankKeeper.SpendableCoins(ctx, provider)
+	require.False(t, providerBalance.IsZero())
+
+	// Verify escrow still has remaining funds
+	escrowBalance := k.GetEscrowBalance(ctx, orderID)
+	require.False(t, escrowBalance.IsZero())
+	require.True(t, escrowBalance.IsAllLT(depositAmount))
+}

--- a/x/bme/keeper/escrow.go
+++ b/x/bme/keeper/escrow.go
@@ -1,0 +1,195 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper
+
+import (
+	"encoding/json"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	types "github.com/virtengine/virtengine/sdk/go/node/bme/v1"
+)
+
+// Escrow store key prefixes
+var (
+	EscrowPrefix = []byte{0x10}
+)
+
+// EscrowKey returns the store key for an escrow record.
+func EscrowKey(orderID string) []byte {
+	return append(EscrowPrefix, []byte(orderID)...)
+}
+
+// EscrowRecord represents a held escrow for an order.
+type EscrowRecord struct {
+	OrderID   string    `json:"order_id"`
+	Depositor string    `json:"depositor"`
+	Amount    sdk.Coins `json:"amount"`
+	Height    int64     `json:"height"`
+}
+
+// HoldEscrow locks tokens from a depositor for an order.
+// The tokens are transferred from the depositor's account to the BME module account.
+func (k *Keeper) HoldEscrow(ctx sdk.Context, orderID string, depositor sdk.AccAddress, amount sdk.Coins) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !amount.IsValid() || amount.IsZero() {
+		return fmt.Errorf("%w: amount must be positive", ErrInvalidAmount)
+	}
+
+	// Check if depositor has sufficient funds
+	spendable := k.bankKeeper.SpendableCoins(ctx, depositor)
+	if !spendable.IsAllGTE(amount) {
+		return fmt.Errorf("%w: depositor has %s, needs %s", ErrInsufficientFunds, spendable, amount)
+	}
+
+	// Transfer tokens from depositor to module account
+	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, depositor, types.ModuleName, amount); err != nil {
+		return fmt.Errorf("failed to transfer tokens to escrow: %w", err)
+	}
+
+	// Store escrow record
+	record := EscrowRecord{
+		OrderID:   orderID,
+		Depositor: depositor.String(),
+		Amount:    amount,
+		Height:    ctx.BlockHeight(),
+	}
+
+	if err := k.setEscrowRecord(ctx, record); err != nil {
+		return fmt.Errorf("failed to store escrow record: %w", err)
+	}
+
+	// Update vault state
+	state := k.GetState(ctx)
+	state.Balances = state.Balances.Add(amount...)
+	if err := k.SetState(ctx, state); err != nil {
+		return fmt.Errorf("failed to update vault state: %w", err)
+	}
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "hold_escrow"),
+			sdk.NewAttribute("order_id", orderID),
+			sdk.NewAttribute("depositor", depositor.String()),
+			sdk.NewAttribute("amount", amount.String()),
+		),
+	)
+
+	return nil
+}
+
+// ReleaseEscrow releases escrowed tokens to a recipient.
+// This is typically called when an order is fulfilled or cancelled.
+func (k *Keeper) ReleaseEscrow(ctx sdk.Context, orderID string, recipient sdk.AccAddress) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	// Get escrow record
+	record, found := k.getEscrowRecord(ctx, orderID)
+	if !found {
+		return fmt.Errorf("%w: order %s", ErrEscrowNotFound, orderID)
+	}
+
+	if record.Amount.IsZero() {
+		return fmt.Errorf("%w: escrow has no funds", ErrInvalidAmount)
+	}
+
+	// Transfer tokens from module account to recipient
+	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, recipient, record.Amount); err != nil {
+		return fmt.Errorf("failed to release escrow: %w", err)
+	}
+
+	// Update vault state
+	state := k.GetState(ctx)
+	state.Balances = state.Balances.Sub(record.Amount...)
+	if err := k.SetState(ctx, state); err != nil {
+		return fmt.Errorf("failed to update vault state: %w", err)
+	}
+
+	// Delete escrow record
+	k.deleteEscrowRecord(ctx, orderID)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "release_escrow"),
+			sdk.NewAttribute("order_id", orderID),
+			sdk.NewAttribute("recipient", recipient.String()),
+			sdk.NewAttribute("amount", record.Amount.String()),
+		),
+	)
+
+	return nil
+}
+
+// GetEscrowBalance returns the escrowed amount for an order.
+func (k *Keeper) GetEscrowBalance(ctx sdk.Context, orderID string) sdk.Coins {
+	record, found := k.getEscrowRecord(ctx, orderID)
+	if !found {
+		return sdk.Coins{}
+	}
+	return record.Amount
+}
+
+// setEscrowRecord stores an escrow record.
+func (k *Keeper) setEscrowRecord(ctx sdk.Context, record EscrowRecord) error {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&record)
+	if err != nil {
+		return err
+	}
+	store.Set(EscrowKey(record.OrderID), bz)
+	return nil
+}
+
+// getEscrowRecord retrieves an escrow record.
+func (k *Keeper) getEscrowRecord(ctx sdk.Context, orderID string) (EscrowRecord, bool) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(EscrowKey(orderID))
+	if bz == nil {
+		return EscrowRecord{}, false
+	}
+
+	var record EscrowRecord
+	if err := json.Unmarshal(bz, &record); err != nil {
+		return EscrowRecord{}, false
+	}
+	return record, true
+}
+
+// deleteEscrowRecord removes an escrow record.
+func (k *Keeper) deleteEscrowRecord(ctx sdk.Context, orderID string) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(EscrowKey(orderID))
+}
+
+// RefundEscrow refunds escrowed tokens back to the original depositor.
+// This is called when an order is cancelled before fulfillment.
+func (k *Keeper) RefundEscrow(ctx sdk.Context, orderID string) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	// Get escrow record
+	record, found := k.getEscrowRecord(ctx, orderID)
+	if !found {
+		return fmt.Errorf("%w: order %s", ErrEscrowNotFound, orderID)
+	}
+
+	depositor, err := sdk.AccAddressFromBech32(record.Depositor)
+	if err != nil {
+		return fmt.Errorf("invalid depositor address: %w", err)
+	}
+
+	// Release back to original depositor
+	return k.ReleaseEscrow(ctx, orderID, depositor)
+}

--- a/x/bme/keeper/expected_keepers.go
+++ b/x/bme/keeper/expected_keepers.go
@@ -1,0 +1,53 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper
+
+import (
+	"context"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// BankKeeper defines the expected interface for the bank module.
+type BankKeeper interface {
+	// SpendableCoins returns the spendable coins for an account.
+	SpendableCoins(ctx context.Context, addr sdk.AccAddress) sdk.Coins
+
+	// SendCoins transfers coins from one account to another.
+	SendCoins(ctx context.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error
+
+	// SendCoinsFromModuleToAccount transfers coins from a module to an account.
+	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+
+	// SendCoinsFromAccountToModule transfers coins from an account to a module.
+	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+
+	// SendCoinsFromModuleToModule transfers coins between modules.
+	SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
+
+	// MintCoins mints new coins in a module account.
+	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+
+	// BurnCoins burns coins from a module account.
+	BurnCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+
+	// GetBalance returns the balance of a specific denomination for an address.
+	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
+}
+
+// OracleKeeper defines the expected interface for the oracle module.
+type OracleKeeper interface {
+	// GetAggregatedPrice returns the aggregated price for a denomination.
+	GetAggregatedPrice(ctx sdk.Context, denom, baseDenom string) (price sdkmath.LegacyDec, healthy bool, err error)
+}
+
+// AccountKeeper defines the expected interface for the auth module.
+type AccountKeeper interface {
+	// GetModuleAddress returns the module account address for a given module name.
+	GetModuleAddress(moduleName string) sdk.AccAddress
+
+	// GetModuleAccount returns the module account for a given module name.
+	GetModuleAccount(ctx context.Context, moduleName string) sdk.ModuleAccountI
+}

--- a/x/bme/keeper/fee_collection.go
+++ b/x/bme/keeper/fee_collection.go
@@ -1,0 +1,190 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper
+
+import (
+	"fmt"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+
+	types "github.com/virtengine/virtengine/sdk/go/node/bme/v1"
+)
+
+// Fee collection constants
+const (
+	// FeeCollectorName is the module name for the fee collector (distribution module)
+	FeeCollectorName = distrtypes.ModuleName
+)
+
+// CollectFees collects fees from a payer and sends them to the fee pool.
+// This is used for transaction fees, protocol fees, etc.
+func (k *Keeper) CollectFees(ctx sdk.Context, payer sdk.AccAddress, amount sdk.Coins) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !amount.IsValid() || amount.IsZero() {
+		return fmt.Errorf("%w: fee amount must be positive", ErrInvalidAmount)
+	}
+
+	// Check if payer has sufficient funds
+	spendable := k.bankKeeper.SpendableCoins(ctx, payer)
+	if !spendable.IsAllGTE(amount) {
+		return fmt.Errorf("%w: payer has %s, needs %s for fees", ErrInsufficientFunds, spendable, amount)
+	}
+
+	// Transfer fees to the BME module first
+	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, payer, types.ModuleName, amount); err != nil {
+		return fmt.Errorf("failed to collect fees: %w", err)
+	}
+
+	// Then transfer from BME module to the distribution module (fee collector)
+	if err := k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, FeeCollectorName, amount); err != nil {
+		return fmt.Errorf("failed to transfer fees to fee collector: %w", err)
+	}
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "collect_fees"),
+			sdk.NewAttribute("payer", payer.String()),
+			sdk.NewAttribute("amount", amount.String()),
+		),
+	)
+
+	return nil
+}
+
+// MintTokens mints new tokens and sends them to a recipient.
+// This is used for reward distribution, collateral release, etc.
+func (k *Keeper) MintTokens(ctx sdk.Context, recipient sdk.AccAddress, amount sdk.Coins) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !amount.IsValid() || amount.IsZero() {
+		return fmt.Errorf("%w: mint amount must be positive", ErrInvalidAmount)
+	}
+
+	// Mint tokens to the BME module account
+	if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, amount); err != nil {
+		return fmt.Errorf("failed to mint tokens: %w", err)
+	}
+
+	// Transfer minted tokens to recipient
+	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, recipient, amount); err != nil {
+		return fmt.Errorf("failed to send minted tokens to recipient: %w", err)
+	}
+
+	// Update vault state
+	state := k.GetState(ctx)
+	state.TotalMinted = state.TotalMinted.Add(amount...)
+	if err := k.SetState(ctx, state); err != nil {
+		return fmt.Errorf("failed to update vault state: %w", err)
+	}
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "mint_tokens"),
+			sdk.NewAttribute("recipient", recipient.String()),
+			sdk.NewAttribute("amount", amount.String()),
+		),
+	)
+
+	return nil
+}
+
+// BurnTokens burns tokens from an account.
+// This is used for token destruction, collateral burning, etc.
+func (k *Keeper) BurnTokens(ctx sdk.Context, from sdk.AccAddress, amount sdk.Coins) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !amount.IsValid() || amount.IsZero() {
+		return fmt.Errorf("%w: burn amount must be positive", ErrInvalidAmount)
+	}
+
+	// Check if account has sufficient funds
+	spendable := k.bankKeeper.SpendableCoins(ctx, from)
+	if !spendable.IsAllGTE(amount) {
+		return fmt.Errorf("%w: account has %s, needs %s to burn", ErrInsufficientFunds, spendable, amount)
+	}
+
+	// Transfer tokens from account to BME module
+	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, from, types.ModuleName, amount); err != nil {
+		return fmt.Errorf("failed to transfer tokens for burning: %w", err)
+	}
+
+	// Burn tokens from BME module
+	if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, amount); err != nil {
+		return fmt.Errorf("failed to burn tokens: %w", err)
+	}
+
+	// Update vault state
+	state := k.GetState(ctx)
+	state.TotalBurned = state.TotalBurned.Add(amount...)
+	if err := k.SetState(ctx, state); err != nil {
+		return fmt.Errorf("failed to update vault state: %w", err)
+	}
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "burn_tokens"),
+			sdk.NewAttribute("from", from.String()),
+			sdk.NewAttribute("amount", amount.String()),
+		),
+	)
+
+	return nil
+}
+
+// TransferTokens transfers tokens between two accounts through the BME module.
+// This provides an auditable transfer mechanism for billing operations.
+func (k *Keeper) TransferTokens(ctx sdk.Context, from, to sdk.AccAddress, amount sdk.Coins) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !amount.IsValid() || amount.IsZero() {
+		return fmt.Errorf("%w: transfer amount must be positive", ErrInvalidAmount)
+	}
+
+	// Direct transfer using bank keeper
+	if err := k.bankKeeper.SendCoins(ctx, from, to, amount); err != nil {
+		return fmt.Errorf("failed to transfer tokens: %w", err)
+	}
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "transfer_tokens"),
+			sdk.NewAttribute("from", from.String()),
+			sdk.NewAttribute("to", to.String()),
+			sdk.NewAttribute("amount", amount.String()),
+		),
+	)
+
+	return nil
+}
+
+// GetModuleBalance returns the current balance held by the BME module.
+func (k *Keeper) GetModuleBalance(ctx sdk.Context, denom string) sdk.Coin {
+	if k.bankKeeper == nil {
+		return sdk.NewCoin(denom, math.ZeroInt())
+	}
+
+	// Get BME module address - we need to compute it from the module name
+	// The module address is derived from the module name
+	moduleAddr := sdk.AccAddress([]byte(types.ModuleName))
+	return k.bankKeeper.GetBalance(ctx, moduleAddr, denom)
+}

--- a/x/bme/keeper/keeper_test.go
+++ b/x/bme/keeper/keeper_test.go
@@ -37,7 +37,7 @@ func setupKeeper(t testing.TB) (keeper.IKeeper, sdk.Context) {
 
 	authority := authtypes.NewModuleAddress(govtypes.ModuleName).String()
 
-	k := keeper.NewKeeper(cdc, storeKey, authority)
+	k := keeper.NewKeeper(cdc, storeKey, authority, nil, nil)
 	ctx := sdk.NewContext(stateStore, cmtproto.Header{}, false, log.NewNopLogger())
 
 	// Initialize with default params

--- a/x/bme/keeper/settlement.go
+++ b/x/bme/keeper/settlement.go
@@ -1,0 +1,230 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper
+
+import (
+	"encoding/json"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	types "github.com/virtengine/virtengine/sdk/go/node/bme/v1"
+)
+
+// Settlement store key prefixes
+var (
+	SettlementPrefix = []byte{0x11}
+	LeasePrefix      = []byte{0x12}
+)
+
+// SettlementKey returns the store key for a settlement record.
+func SettlementKey(leaseID string) []byte {
+	return append(SettlementPrefix, []byte(leaseID)...)
+}
+
+// LeaseKey returns the store key for a lease's escrow association.
+func LeaseKey(leaseID string) []byte {
+	return append(LeasePrefix, []byte(leaseID)...)
+}
+
+// LeaseEscrowInfo stores the association between a lease and its escrow.
+type LeaseEscrowInfo struct {
+	LeaseID   string `json:"lease_id"`
+	OrderID   string `json:"order_id"`
+	Provider  string `json:"provider"`
+	Depositor string `json:"depositor"`
+}
+
+// SettlementRecord stores settlement history for a lease.
+type SettlementRecord struct {
+	LeaseID     string    `json:"lease_id"`
+	Provider    string    `json:"provider"`
+	TotalPaid   sdk.Coins `json:"total_paid"`
+	LastSettled int64     `json:"last_settled"`
+}
+
+// SettleBilling calculates and transfers payment from escrow to a provider based on usage.
+// This is called periodically to settle billing for active leases.
+func (k *Keeper) SettleBilling(ctx sdk.Context, leaseID string, provider sdk.AccAddress, usageAmount sdk.Coins) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !usageAmount.IsValid() {
+		return fmt.Errorf("%w: invalid usage amount", ErrInvalidAmount)
+	}
+
+	// If usage amount is zero, nothing to settle
+	if usageAmount.IsZero() {
+		return nil
+	}
+
+	// Get lease escrow info
+	leaseInfo, found := k.getLeaseEscrowInfo(ctx, leaseID)
+	if !found {
+		return fmt.Errorf("lease escrow info not found for lease %s", leaseID)
+	}
+
+	// Get current escrow balance
+	escrowBalance := k.GetEscrowBalance(ctx, leaseInfo.OrderID)
+	if escrowBalance.IsZero() {
+		return fmt.Errorf("%w: no funds in escrow for order %s", ErrInsufficientFunds, leaseInfo.OrderID)
+	}
+
+	// Calculate amount to pay (min of usage and available escrow)
+	paymentAmount := sdk.Coins{}
+	for _, usageCoin := range usageAmount {
+		escrowCoin := escrowBalance.AmountOf(usageCoin.Denom)
+		if escrowCoin.IsZero() {
+			continue
+		}
+		if usageCoin.Amount.LTE(escrowCoin) {
+			paymentAmount = paymentAmount.Add(usageCoin)
+		} else {
+			paymentAmount = paymentAmount.Add(sdk.NewCoin(usageCoin.Denom, escrowCoin))
+		}
+	}
+
+	if paymentAmount.IsZero() {
+		return nil
+	}
+
+	// Get params for fee calculation
+	params := k.GetParams(ctx)
+
+	// Calculate settlement fee (in basis points)
+	feeAmount := sdk.Coins{}
+	providerAmount := sdk.Coins{}
+	for _, coin := range paymentAmount {
+		// Fee = amount * settleSpreadBps / 10000
+		fee := coin.Amount.MulRaw(int64(params.SettleSpreadBps)).QuoRaw(10000)
+		if fee.IsPositive() {
+			feeAmount = feeAmount.Add(sdk.NewCoin(coin.Denom, fee))
+		}
+		providerAmt := coin.Amount.Sub(fee)
+		if providerAmt.IsPositive() {
+			providerAmount = providerAmount.Add(sdk.NewCoin(coin.Denom, providerAmt))
+		}
+	}
+
+	// Transfer provider payment from module to provider
+	if !providerAmount.IsZero() {
+		if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, provider, providerAmount); err != nil {
+			return fmt.Errorf("failed to pay provider: %w", err)
+		}
+	}
+
+	// Burn the fee (or could send to fee collector)
+	if !feeAmount.IsZero() {
+		if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, feeAmount); err != nil {
+			return fmt.Errorf("failed to burn settlement fees: %w", err)
+		}
+	}
+
+	// Update escrow record with remaining balance
+	escrowRecord, _ := k.getEscrowRecord(ctx, leaseInfo.OrderID)
+	escrowRecord.Amount = escrowRecord.Amount.Sub(paymentAmount...)
+	if err := k.setEscrowRecord(ctx, escrowRecord); err != nil {
+		return fmt.Errorf("failed to update escrow record: %w", err)
+	}
+
+	// Update vault state
+	state := k.GetState(ctx)
+	state.Balances = state.Balances.Sub(paymentAmount...)
+	if err := k.SetState(ctx, state); err != nil {
+		return fmt.Errorf("failed to update vault state: %w", err)
+	}
+
+	// Update settlement record
+	settlementRecord, _ := k.getSettlementRecord(ctx, leaseID)
+	settlementRecord.LeaseID = leaseID
+	settlementRecord.Provider = provider.String()
+	settlementRecord.TotalPaid = settlementRecord.TotalPaid.Add(providerAmount...)
+	settlementRecord.LastSettled = ctx.BlockHeight()
+	if err := k.setSettlementRecord(ctx, settlementRecord); err != nil {
+		return fmt.Errorf("failed to update settlement record: %w", err)
+	}
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "settle_billing"),
+			sdk.NewAttribute("lease_id", leaseID),
+			sdk.NewAttribute("provider", provider.String()),
+			sdk.NewAttribute("payment", providerAmount.String()),
+			sdk.NewAttribute("fee", feeAmount.String()),
+		),
+	)
+
+	return nil
+}
+
+// RegisterLeaseEscrow associates a lease with an escrow order.
+func (k *Keeper) RegisterLeaseEscrow(ctx sdk.Context, leaseID, orderID string, provider, depositor sdk.AccAddress) error {
+	info := LeaseEscrowInfo{
+		LeaseID:   leaseID,
+		OrderID:   orderID,
+		Provider:  provider.String(),
+		Depositor: depositor.String(),
+	}
+
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&info)
+	if err != nil {
+		return err
+	}
+	store.Set(LeaseKey(leaseID), bz)
+	return nil
+}
+
+// getLeaseEscrowInfo retrieves the escrow info for a lease.
+func (k *Keeper) getLeaseEscrowInfo(ctx sdk.Context, leaseID string) (LeaseEscrowInfo, bool) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(LeaseKey(leaseID))
+	if bz == nil {
+		return LeaseEscrowInfo{}, false
+	}
+
+	var info LeaseEscrowInfo
+	if err := json.Unmarshal(bz, &info); err != nil {
+		return LeaseEscrowInfo{}, false
+	}
+	return info, true
+}
+
+// setSettlementRecord stores a settlement record.
+func (k *Keeper) setSettlementRecord(ctx sdk.Context, record SettlementRecord) error {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&record)
+	if err != nil {
+		return err
+	}
+	store.Set(SettlementKey(record.LeaseID), bz)
+	return nil
+}
+
+// getSettlementRecord retrieves a settlement record.
+func (k *Keeper) getSettlementRecord(ctx sdk.Context, leaseID string) (SettlementRecord, bool) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(SettlementKey(leaseID))
+	if bz == nil {
+		return SettlementRecord{
+			TotalPaid: sdk.Coins{},
+		}, false
+	}
+
+	var record SettlementRecord
+	if err := json.Unmarshal(bz, &record); err != nil {
+		return SettlementRecord{
+			TotalPaid: sdk.Coins{},
+		}, false
+	}
+	return record, true
+}
+
+// GetSettlementRecord returns the settlement record for a lease (public accessor).
+func (k *Keeper) GetSettlementRecord(ctx sdk.Context, leaseID string) (SettlementRecord, bool) {
+	return k.getSettlementRecord(ctx, leaseID)
+}

--- a/x/oracle/keeper/bank_integration_test.go
+++ b/x/oracle/keeper/bank_integration_test.go
@@ -1,0 +1,350 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/math"
+	"cosmossdk.io/store"
+	"cosmossdk.io/store/metrics"
+	storetypes "cosmossdk.io/store/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	types "github.com/virtengine/virtengine/sdk/go/node/oracle/v1"
+	otypes "github.com/virtengine/virtengine/x/oracle/types"
+)
+
+// MockBankKeeper implements the BankKeeper interface for testing.
+type MockBankKeeper struct {
+	balances map[string]sdk.Coins
+	modules  map[string]sdk.Coins
+}
+
+func NewMockBankKeeper() *MockBankKeeper {
+	return &MockBankKeeper{
+		balances: make(map[string]sdk.Coins),
+		modules:  make(map[string]sdk.Coins),
+	}
+}
+
+func (m *MockBankKeeper) SpendableCoins(_ context.Context, addr sdk.AccAddress) sdk.Coins {
+	coins := m.balances[addr.String()]
+	if coins == nil {
+		return sdk.Coins{}
+	}
+	return coins
+}
+
+func (m *MockBankKeeper) SendCoins(_ context.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error {
+	from := fromAddr.String()
+	to := toAddr.String()
+
+	if !m.balances[from].IsAllGTE(amt) {
+		return ErrInsufficientFunds
+	}
+
+	m.balances[from] = m.balances[from].Sub(amt...)
+	m.balances[to] = m.balances[to].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) SendCoinsFromModuleToAccount(_ context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error {
+	if !m.modules[senderModule].IsAllGTE(amt) {
+		return ErrInsufficientFunds
+	}
+
+	m.modules[senderModule] = m.modules[senderModule].Sub(amt...)
+	to := recipientAddr.String()
+	m.balances[to] = m.balances[to].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) SendCoinsFromAccountToModule(_ context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error {
+	from := senderAddr.String()
+	if !m.balances[from].IsAllGTE(amt) {
+		return ErrInsufficientFunds
+	}
+
+	m.balances[from] = m.balances[from].Sub(amt...)
+	m.modules[recipientModule] = m.modules[recipientModule].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) SendCoinsFromModuleToModule(_ context.Context, senderModule, recipientModule string, amt sdk.Coins) error {
+	if !m.modules[senderModule].IsAllGTE(amt) {
+		return ErrInsufficientFunds
+	}
+
+	m.modules[senderModule] = m.modules[senderModule].Sub(amt...)
+	m.modules[recipientModule] = m.modules[recipientModule].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) MintCoins(_ context.Context, moduleName string, amt sdk.Coins) error {
+	m.modules[moduleName] = m.modules[moduleName].Add(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) BurnCoins(_ context.Context, moduleName string, amt sdk.Coins) error {
+	if !m.modules[moduleName].IsAllGTE(amt) {
+		return ErrInsufficientFunds
+	}
+	m.modules[moduleName] = m.modules[moduleName].Sub(amt...)
+	return nil
+}
+
+func (m *MockBankKeeper) GetBalance(_ context.Context, addr sdk.AccAddress, denom string) sdk.Coin {
+	coins := m.balances[addr.String()]
+	return sdk.NewCoin(denom, coins.AmountOf(denom))
+}
+
+// SetBalance sets the balance for an address (test helper).
+func (m *MockBankKeeper) SetBalance(addr sdk.AccAddress, coins sdk.Coins) {
+	m.balances[addr.String()] = coins
+}
+
+// SetModuleBalance sets the balance for a module (test helper).
+func (m *MockBankKeeper) SetModuleBalance(module string, coins sdk.Coins) {
+	m.modules[module] = coins
+}
+
+// GetModuleBalance returns the module balance (test helper).
+func (m *MockBankKeeper) GetModuleBalance(module string) sdk.Coins {
+	return m.modules[module]
+}
+
+// Ensure MockBankKeeper implements the interface
+var _ BankKeeper = (*MockBankKeeper)(nil)
+
+func setupKeeperWithBankMock(t testing.TB) (IKeeper, sdk.Context, *MockBankKeeper) {
+	t.Helper()
+
+	storeKey := storetypes.NewKVStoreKey(otypes.StoreKey)
+
+	db := dbm.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db, log.NewNopLogger(), metrics.NewNoOpMetrics())
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	types.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+
+	bankKeeper := NewMockBankKeeper()
+	k := NewKeeper(cdc, storeKey, "test-authority", bankKeeper)
+	ctx := sdk.NewContext(stateStore, cmtproto.Header{Height: 1, Time: time.Now()}, false, log.NewNopLogger())
+
+	// Initialize with default params
+	err := k.SetParams(ctx, types.DefaultParams())
+	require.NoError(t, err)
+
+	return k, ctx, bankKeeper
+}
+
+func TestDelegateStake(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	delegator := sdk.AccAddress([]byte("delegator123456789"))
+	oracleAddr := sdk.AccAddress([]byte("oracle123456789012"))
+	amount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+
+	// Set delegator balance
+	bankKeeper.SetBalance(delegator, amount)
+
+	// Delegate stake
+	err := k.DelegateStake(ctx, delegator, oracleAddr, amount)
+	require.NoError(t, err)
+
+	// Verify delegator balance is zero
+	delegatorBalance := bankKeeper.SpendableCoins(ctx, delegator)
+	require.True(t, delegatorBalance.IsZero())
+
+	// Verify oracle stake
+	stake := k.GetOracleStake(ctx, oracleAddr)
+	require.True(t, stake.Equal(amount))
+
+	// Verify module received the coins
+	moduleBalance := bankKeeper.GetModuleBalance(types.ModuleName)
+	require.True(t, moduleBalance.Equal(amount))
+}
+
+func TestUndelegateStake(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	delegator := sdk.AccAddress([]byte("delegator123456789"))
+	oracleAddr := sdk.AccAddress([]byte("oracle123456789012"))
+	amount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+	undelegateAmount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(500)))
+
+	// Set delegator balance and delegate
+	bankKeeper.SetBalance(delegator, amount)
+	err := k.DelegateStake(ctx, delegator, oracleAddr, amount)
+	require.NoError(t, err)
+
+	// Undelegate partial amount
+	err = k.UndelegateStake(ctx, delegator, oracleAddr, undelegateAmount)
+	require.NoError(t, err)
+
+	// Verify delegator received coins back
+	delegatorBalance := bankKeeper.SpendableCoins(ctx, delegator)
+	require.True(t, delegatorBalance.Equal(undelegateAmount))
+
+	// Verify oracle stake is reduced
+	stake := k.GetOracleStake(ctx, oracleAddr)
+	require.True(t, stake.Equal(undelegateAmount))
+}
+
+func TestSlashDeposit(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	delegator := sdk.AccAddress([]byte("delegator123456789"))
+	oracleAddr := sdk.AccAddress([]byte("oracle123456789012"))
+	stakeAmount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+	slashAmount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(100)))
+
+	// Set up oracle stake
+	bankKeeper.SetBalance(delegator, stakeAmount)
+	err := k.DelegateStake(ctx, delegator, oracleAddr, stakeAmount)
+	require.NoError(t, err)
+
+	// Slash deposit
+	err = k.SlashDeposit(ctx, oracleAddr, slashAmount, "test misbehavior")
+	require.NoError(t, err)
+
+	// Verify stake is reduced
+	stake := k.GetOracleStake(ctx, oracleAddr)
+	expectedStake := stakeAmount.Sub(slashAmount...)
+	require.True(t, stake.Equal(expectedStake))
+}
+
+func TestDistributeRewards(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	// Get keeper to access internal methods
+	kp := k.(*Keeper)
+
+	// Create oracle addresses using raw bytes (like BME tests)
+	oracle1 := sdk.AccAddress([]byte("oracle1234567890123"))
+	oracle2 := sdk.AccAddress([]byte("oracle2234567890123"))
+
+	// Get the bech32 strings for params
+	oracle1Str := oracle1.String()
+	oracle2Str := oracle2.String()
+
+	// Set params with oracles
+	params := types.DefaultParams()
+	params.Sources = []string{oracle1Str, oracle2Str}
+	err := k.SetParams(ctx, params)
+	require.NoError(t, err)
+
+	// Add to reward pool
+	rewardAmount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+	bankKeeper.SetModuleBalance(types.ModuleName, rewardAmount)
+	kp.setRewardPool(ctx, rewardAmount)
+
+	// Distribute rewards
+	err = k.DistributeRewards(ctx, 1)
+	require.NoError(t, err)
+
+	// Verify oracles received rewards
+	oracle1Balance := bankKeeper.SpendableCoins(ctx, oracle1)
+	oracle2Balance := bankKeeper.SpendableCoins(ctx, oracle2)
+
+	// Each oracle should get 500 (1000 / 2 oracles)
+	expectedPerOracle := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(500)))
+	require.True(t, oracle1Balance.Equal(expectedPerOracle))
+	require.True(t, oracle2Balance.Equal(expectedPerOracle))
+
+	// Verify reward pool is now empty
+	pool := kp.GetRewardPool(ctx)
+	require.True(t, pool.IsZero())
+}
+
+func TestAddToRewardPool(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	sender := sdk.AccAddress([]byte("sender123456789012"))
+	amount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(500)))
+
+	// Set sender balance
+	bankKeeper.SetBalance(sender, amount)
+
+	// Get keeper to access internal methods
+	kp := k.(*Keeper)
+
+	// Add to reward pool
+	err := kp.AddToRewardPool(ctx, sender, amount)
+	require.NoError(t, err)
+
+	// Verify pool has the coins
+	pool := kp.GetRewardPool(ctx)
+	require.True(t, pool.Equal(amount))
+
+	// Verify sender balance is zero
+	senderBalance := bankKeeper.SpendableCoins(ctx, sender)
+	require.True(t, senderBalance.IsZero())
+}
+
+func TestDelegateStakeInsufficientFunds(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	delegator := sdk.AccAddress([]byte("delegator123456789"))
+	oracleAddr := sdk.AccAddress([]byte("oracle123456789012"))
+	amount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+
+	// Set delegator balance to less than required
+	bankKeeper.SetBalance(delegator, sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(500))))
+
+	// Delegate stake should fail
+	err := k.DelegateStake(ctx, delegator, oracleAddr, amount)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "insufficient funds")
+}
+
+func TestSlashDepositNoStake(t *testing.T) {
+	k, ctx, _ := setupKeeperWithBankMock(t)
+
+	oracleAddr := sdk.AccAddress([]byte("oracle123456789012"))
+	slashAmount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(100)))
+
+	// Slash deposit without stake should fail
+	err := k.SlashDeposit(ctx, oracleAddr, slashAmount, "test")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "has no stake")
+}
+
+func TestGetDelegatorDelegations(t *testing.T) {
+	k, ctx, bankKeeper := setupKeeperWithBankMock(t)
+
+	delegator := sdk.AccAddress([]byte("delegator123456789"))
+	oracle1 := sdk.AccAddress([]byte("oracle111111111111"))
+	oracle2 := sdk.AccAddress([]byte("oracle222222222222"))
+	totalAmount := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(2000)))
+	amountPerOracle := sdk.NewCoins(sdk.NewCoin("uve", math.NewInt(1000)))
+
+	// Set delegator balance
+	bankKeeper.SetBalance(delegator, totalAmount)
+
+	// Delegate to multiple oracles
+	err := k.DelegateStake(ctx, delegator, oracle1, amountPerOracle)
+	require.NoError(t, err)
+	err = k.DelegateStake(ctx, delegator, oracle2, amountPerOracle)
+	require.NoError(t, err)
+
+	// Get keeper to access internal methods
+	kp := k.(*Keeper)
+
+	// Get delegator delegations
+	delegations := kp.GetDelegatorDelegations(ctx, delegator)
+	require.Len(t, delegations, 2)
+}

--- a/x/oracle/keeper/delegation.go
+++ b/x/oracle/keeper/delegation.go
@@ -1,0 +1,280 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper
+
+import (
+	"encoding/json"
+	"fmt"
+
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	types "github.com/virtengine/virtengine/sdk/go/node/oracle/v1"
+)
+
+// Delegation store key prefixes
+var (
+	OracleStakePrefix     = []byte{0x30}
+	DelegationPrefix      = []byte{0x31}
+	DelegatorIndexPrefix  = []byte{0x32}
+	TotalStakedKey        = []byte{0x33}
+)
+
+// OracleStakeKey returns the key for an oracle's total stake.
+func OracleStakeKey(oracleAddr sdk.AccAddress) []byte {
+	return append(OracleStakePrefix, oracleAddr.Bytes()...)
+}
+
+// DelegationKey returns the key for a delegation record.
+func DelegationKey(delegator, oracleAddr sdk.AccAddress) []byte {
+	key := make([]byte, 0, len(DelegationPrefix)+len(delegator.Bytes())+len(oracleAddr.Bytes()))
+	key = append(key, DelegationPrefix...)
+	key = append(key, delegator.Bytes()...)
+	key = append(key, oracleAddr.Bytes()...)
+	return key
+}
+
+// DelegatorIndexKey returns the key for indexing delegations by delegator.
+func DelegatorIndexKey(delegator sdk.AccAddress) []byte {
+	return append(DelegatorIndexPrefix, delegator.Bytes()...)
+}
+
+// DelegationRecord stores information about a delegation.
+type DelegationRecord struct {
+	Delegator   string    `json:"delegator"`
+	Oracle      string    `json:"oracle"`
+	Amount      sdk.Coins `json:"amount"`
+	StartHeight int64     `json:"start_height"`
+}
+
+// DelegateStake allows a delegator to stake tokens on an oracle.
+// The staked tokens are transferred from the delegator to the oracle module.
+func (k *Keeper) DelegateStake(ctx sdk.Context, delegator, oracleAddr sdk.AccAddress, amount sdk.Coins) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !amount.IsValid() || amount.IsZero() {
+		return fmt.Errorf("%w: delegation amount must be positive", ErrInvalidAmount)
+	}
+
+	// Check if delegator has sufficient funds
+	spendable := k.bankKeeper.SpendableCoins(ctx, delegator)
+	if !spendable.IsAllGTE(amount) {
+		return fmt.Errorf("%w: delegator has %s, needs %s", ErrInsufficientFunds, spendable, amount)
+	}
+
+	// Transfer tokens from delegator to oracle module
+	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, delegator, types.ModuleName, amount); err != nil {
+		return fmt.Errorf("failed to transfer stake: %w", err)
+	}
+
+	// Update delegation record
+	delegation := k.getDelegation(ctx, delegator, oracleAddr)
+	delegation.Delegator = delegator.String()
+	delegation.Oracle = oracleAddr.String()
+	delegation.Amount = delegation.Amount.Add(amount...)
+	if delegation.StartHeight == 0 {
+		delegation.StartHeight = ctx.BlockHeight()
+	}
+	k.setDelegation(ctx, delegator, oracleAddr, delegation)
+
+	// Update oracle's total stake
+	oracleStake := k.GetOracleStake(ctx, oracleAddr)
+	oracleStake = oracleStake.Add(amount...)
+	k.setOracleStake(ctx, oracleAddr, oracleStake)
+
+	// Update total staked
+	totalStaked := k.getTotalStaked(ctx)
+	totalStaked = totalStaked.Add(amount...)
+	k.setTotalStaked(ctx, totalStaked)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "delegate_stake"),
+			sdk.NewAttribute("delegator", delegator.String()),
+			sdk.NewAttribute("oracle", oracleAddr.String()),
+			sdk.NewAttribute("amount", amount.String()),
+		),
+	)
+
+	return nil
+}
+
+// UndelegateStake allows a delegator to remove staked tokens from an oracle.
+// The tokens are transferred from the oracle module back to the delegator.
+func (k *Keeper) UndelegateStake(ctx sdk.Context, delegator, oracleAddr sdk.AccAddress, amount sdk.Coins) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !amount.IsValid() || amount.IsZero() {
+		return fmt.Errorf("%w: undelegation amount must be positive", ErrInvalidAmount)
+	}
+
+	// Get current delegation
+	delegation := k.getDelegation(ctx, delegator, oracleAddr)
+	if delegation.Amount.IsZero() {
+		return fmt.Errorf("no delegation found from %s to %s", delegator.String(), oracleAddr.String())
+	}
+
+	// Check if undelegation amount is valid
+	if !delegation.Amount.IsAllGTE(amount) {
+		return fmt.Errorf("%w: delegated %s, requested %s", ErrInsufficientFunds, delegation.Amount, amount)
+	}
+
+	// Transfer tokens from oracle module to delegator
+	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, delegator, amount); err != nil {
+		return fmt.Errorf("failed to return stake: %w", err)
+	}
+
+	// Update delegation record
+	delegation.Amount = delegation.Amount.Sub(amount...)
+	if delegation.Amount.IsZero() {
+		k.deleteDelegation(ctx, delegator, oracleAddr)
+	} else {
+		k.setDelegation(ctx, delegator, oracleAddr, delegation)
+	}
+
+	// Update oracle's total stake
+	oracleStake := k.GetOracleStake(ctx, oracleAddr)
+	oracleStake = oracleStake.Sub(amount...)
+	k.setOracleStake(ctx, oracleAddr, oracleStake)
+
+	// Update total staked
+	totalStaked := k.getTotalStaked(ctx)
+	totalStaked = totalStaked.Sub(amount...)
+	k.setTotalStaked(ctx, totalStaked)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "undelegate_stake"),
+			sdk.NewAttribute("delegator", delegator.String()),
+			sdk.NewAttribute("oracle", oracleAddr.String()),
+			sdk.NewAttribute("amount", amount.String()),
+		),
+	)
+
+	return nil
+}
+
+// GetOracleStake returns the total stake for an oracle.
+func (k *Keeper) GetOracleStake(ctx sdk.Context, oracleAddr sdk.AccAddress) sdk.Coins {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(OracleStakeKey(oracleAddr))
+	if bz == nil {
+		return sdk.Coins{}
+	}
+
+	var stake sdk.Coins
+	if err := json.Unmarshal(bz, &stake); err != nil {
+		return sdk.Coins{}
+	}
+	return stake
+}
+
+// setOracleStake stores an oracle's total stake.
+func (k *Keeper) setOracleStake(ctx sdk.Context, oracleAddr sdk.AccAddress, stake sdk.Coins) {
+	store := ctx.KVStore(k.storeKey)
+	if stake.IsZero() {
+		store.Delete(OracleStakeKey(oracleAddr))
+		return
+	}
+	bz, err := json.Marshal(&stake)
+	if err != nil {
+		return // Silently fail if marshal fails (should not happen for valid coins)
+	}
+	store.Set(OracleStakeKey(oracleAddr), bz)
+}
+
+// getDelegation retrieves a delegation record.
+func (k *Keeper) getDelegation(ctx sdk.Context, delegator, oracleAddr sdk.AccAddress) DelegationRecord {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(DelegationKey(delegator, oracleAddr))
+	if bz == nil {
+		return DelegationRecord{Amount: sdk.Coins{}}
+	}
+
+	var record DelegationRecord
+	if err := json.Unmarshal(bz, &record); err != nil {
+		return DelegationRecord{Amount: sdk.Coins{}}
+	}
+	return record
+}
+
+// setDelegation stores a delegation record.
+func (k *Keeper) setDelegation(ctx sdk.Context, delegator, oracleAddr sdk.AccAddress, record DelegationRecord) {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&record)
+	if err != nil {
+		return // Silently fail if marshal fails
+	}
+	store.Set(DelegationKey(delegator, oracleAddr), bz)
+}
+
+// deleteDelegation removes a delegation record.
+func (k *Keeper) deleteDelegation(ctx sdk.Context, delegator, oracleAddr sdk.AccAddress) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(DelegationKey(delegator, oracleAddr))
+}
+
+// getTotalStaked retrieves the total staked amount.
+func (k *Keeper) getTotalStaked(ctx sdk.Context) sdk.Coins {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(TotalStakedKey)
+	if bz == nil {
+		return sdk.Coins{}
+	}
+
+	var total sdk.Coins
+	if err := json.Unmarshal(bz, &total); err != nil {
+		return sdk.Coins{}
+	}
+	return total
+}
+
+// setTotalStaked stores the total staked amount.
+func (k *Keeper) setTotalStaked(ctx sdk.Context, total sdk.Coins) {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&total)
+	if err != nil {
+		return // Silently fail if marshal fails
+	}
+	store.Set(TotalStakedKey, bz)
+}
+
+// GetTotalStaked returns the total amount staked across all oracles.
+func (k *Keeper) GetTotalStaked(ctx sdk.Context) sdk.Coins {
+	return k.getTotalStaked(ctx)
+}
+
+// GetDelegation returns a delegation record (public accessor).
+func (k *Keeper) GetDelegation(ctx sdk.Context, delegator, oracleAddr sdk.AccAddress) DelegationRecord {
+	return k.getDelegation(ctx, delegator, oracleAddr)
+}
+
+// GetDelegatorDelegations returns all delegations for a delegator.
+func (k *Keeper) GetDelegatorDelegations(ctx sdk.Context, delegator sdk.AccAddress) []DelegationRecord {
+	store := ctx.KVStore(k.storeKey)
+	prefix := make([]byte, 0, len(DelegationPrefix)+len(delegator.Bytes()))
+	prefix = append(prefix, DelegationPrefix...)
+	prefix = append(prefix, delegator.Bytes()...)
+
+	var delegations []DelegationRecord
+	iter := storetypes.KVStorePrefixIterator(store, prefix)
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		var record DelegationRecord
+		if err := json.Unmarshal(iter.Value(), &record); err == nil {
+			delegations = append(delegations, record)
+		}
+	}
+
+	return delegations
+}

--- a/x/oracle/keeper/expected_keepers.go
+++ b/x/oracle/keeper/expected_keepers.go
@@ -1,0 +1,52 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// BankKeeper defines the expected interface for the bank module.
+type BankKeeper interface {
+	// SpendableCoins returns the spendable coins for an account.
+	SpendableCoins(ctx context.Context, addr sdk.AccAddress) sdk.Coins
+
+	// SendCoins transfers coins from one account to another.
+	SendCoins(ctx context.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error
+
+	// SendCoinsFromModuleToAccount transfers coins from a module to an account.
+	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+
+	// SendCoinsFromAccountToModule transfers coins from an account to a module.
+	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+
+	// SendCoinsFromModuleToModule transfers coins between modules.
+	SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
+
+	// MintCoins mints new coins in a module account.
+	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+
+	// BurnCoins burns coins from a module account.
+	BurnCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+
+	// GetBalance returns the balance of a specific denomination for an address.
+	GetBalance(ctx context.Context, addr sdk.AccAddress, denom string) sdk.Coin
+}
+
+// AccountKeeper defines the expected interface for the auth module.
+type AccountKeeper interface {
+	// GetModuleAddress returns the module account address for a given module name.
+	GetModuleAddress(moduleName string) sdk.AccAddress
+
+	// GetModuleAccount returns the module account for a given module name.
+	GetModuleAccount(ctx context.Context, moduleName string) sdk.ModuleAccountI
+}
+
+// StakingKeeper defines the expected interface for the staking module.
+type StakingKeeper interface {
+	// GetValidator returns a validator by operator address.
+	GetValidator(ctx context.Context, addr sdk.ValAddress) (validator interface{}, err error)
+}

--- a/x/oracle/keeper/keeper_test.go
+++ b/x/oracle/keeper/keeper_test.go
@@ -38,6 +38,7 @@ func setupTestKeeper(t *testing.T) (IKeeper, sdk.Context) {
 		cdc,
 		storeKey,
 		"test-authority",
+		nil, // BankKeeper - nil for basic tests
 	)
 
 	return keeper, testCtx

--- a/x/oracle/keeper/rewards.go
+++ b/x/oracle/keeper/rewards.go
@@ -1,0 +1,301 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper
+
+import (
+	"encoding/json"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	types "github.com/virtengine/virtengine/sdk/go/node/oracle/v1"
+	otypes "github.com/virtengine/virtengine/x/oracle/types"
+)
+
+// Reward store key prefixes
+var (
+	RewardPoolPrefix       = []byte{0x10}
+	OracleRewardPrefix     = []byte{0x11}
+	EpochRewardPrefix      = []byte{0x12}
+	LastRewardEpochKey     = []byte{0x13}
+	OraclePerformanceKey   = []byte{0x14}
+)
+
+// RewardPoolKey returns the key for the reward pool.
+func RewardPoolKey() []byte {
+	return RewardPoolPrefix
+}
+
+// OracleRewardKey returns the key for an oracle's accumulated rewards.
+func OracleRewardKey(oracleAddr sdk.AccAddress) []byte {
+	return append(OracleRewardPrefix, oracleAddr.Bytes()...)
+}
+
+// EpochRewardKey returns the key for epoch reward data.
+func EpochRewardKey(epoch uint64) []byte {
+	key := make([]byte, 0, len(EpochRewardPrefix)+8)
+	key = append(key, EpochRewardPrefix...)
+	key = append(key, byte(epoch>>56), byte(epoch>>48), byte(epoch>>40), byte(epoch>>32))
+	key = append(key, byte(epoch>>24), byte(epoch>>16), byte(epoch>>8), byte(epoch))
+	return key
+}
+
+// OraclePerformance tracks an oracle's performance metrics.
+type OraclePerformance struct {
+	Address           string `json:"address"`
+	TotalSubmissions  uint64 `json:"total_submissions"`
+	ValidSubmissions  uint64 `json:"valid_submissions"`
+	LastActiveHeight  int64  `json:"last_active_height"`
+	ConsecutiveMisses uint32 `json:"consecutive_misses"`
+}
+
+// OracleRewardRecord tracks accumulated rewards for an oracle.
+type OracleRewardRecord struct {
+	Address          string    `json:"address"`
+	AccumulatedRewards sdk.Coins `json:"accumulated_rewards"`
+	LastClaimHeight  int64     `json:"last_claim_height"`
+}
+
+// EpochRewardInfo stores information about rewards for an epoch.
+type EpochRewardInfo struct {
+	Epoch           uint64    `json:"epoch"`
+	TotalRewards    sdk.Coins `json:"total_rewards"`
+	DistributedAt   int64     `json:"distributed_at"`
+	NumOracles      uint32    `json:"num_oracles"`
+}
+
+// DistributeRewards distributes rewards to oracle operators for a given epoch.
+// Rewards are distributed proportionally based on oracle performance.
+func (k *Keeper) DistributeRewards(ctx sdk.Context, epoch uint64) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	params := k.GetParams(ctx)
+
+	// Get all active oracles (sources) from params
+	if len(params.Sources) == 0 {
+		return nil // No oracles to reward
+	}
+
+	// Calculate reward per oracle (equal distribution for now)
+	// In a more sophisticated system, this would be based on performance metrics
+	rewardPool := k.getRewardPool(ctx)
+	if rewardPool.IsZero() {
+		return nil // No rewards to distribute
+	}
+
+	numOracles := len(params.Sources)
+	if numOracles == 0 {
+		return nil
+	}
+
+	// Calculate per-oracle reward
+	perOracleReward := sdk.Coins{}
+	for _, coin := range rewardPool {
+		amountPerOracle := coin.Amount.QuoRaw(int64(numOracles))
+		if amountPerOracle.IsPositive() {
+			perOracleReward = perOracleReward.Add(sdk.NewCoin(coin.Denom, amountPerOracle))
+		}
+	}
+
+	if perOracleReward.IsZero() {
+		return nil
+	}
+
+	totalDistributed := sdk.Coins{}
+
+	// Distribute to each oracle
+	for _, sourceAddr := range params.Sources {
+		oracleAddr, err := sdk.AccAddressFromBech32(sourceAddr)
+		if err != nil {
+			continue // Skip invalid addresses
+		}
+
+		// Check oracle performance (only reward active oracles)
+		perf := k.getOraclePerformance(ctx, oracleAddr)
+		if perf.ConsecutiveMisses > 10 {
+			continue // Skip inactive oracles
+		}
+
+		// Transfer rewards from module to oracle
+		if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, oracleAddr, perOracleReward); err != nil {
+			return fmt.Errorf("failed to distribute rewards to oracle %s: %w", sourceAddr, err)
+		}
+
+		totalDistributed = totalDistributed.Add(perOracleReward...)
+
+		// Update oracle reward record
+		rewardRecord := k.getOracleRewardRecord(ctx, oracleAddr)
+		rewardRecord.Address = sourceAddr
+		rewardRecord.AccumulatedRewards = rewardRecord.AccumulatedRewards.Add(perOracleReward...)
+		rewardRecord.LastClaimHeight = ctx.BlockHeight()
+		k.setOracleRewardRecord(ctx, oracleAddr, rewardRecord)
+	}
+
+	// Update reward pool (subtract distributed)
+	remainingPool := rewardPool.Sub(totalDistributed...)
+	k.setRewardPool(ctx, remainingPool)
+
+	// Store epoch reward info
+	epochInfo := EpochRewardInfo{
+		Epoch:         epoch,
+		TotalRewards:  totalDistributed,
+		DistributedAt: ctx.BlockHeight(),
+		NumOracles:    uint32(min(numOracles, int(^uint32(0)))), //nolint:gosec // numOracles is bounded by len(sources)
+	}
+	k.setEpochRewardInfo(ctx, epoch, epochInfo)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "distribute_rewards"),
+			sdk.NewAttribute("epoch", fmt.Sprintf("%d", epoch)),
+			sdk.NewAttribute("total_distributed", totalDistributed.String()),
+			sdk.NewAttribute("num_oracles", fmt.Sprintf("%d", numOracles)),
+		),
+	)
+
+	return nil
+}
+
+// AddToRewardPool adds tokens to the oracle reward pool.
+func (k *Keeper) AddToRewardPool(ctx sdk.Context, from sdk.AccAddress, amount sdk.Coins) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !amount.IsValid() || amount.IsZero() {
+		return fmt.Errorf("%w: amount must be positive", ErrInvalidAmount)
+	}
+
+	// Transfer from sender to oracle module
+	if err := k.bankKeeper.SendCoinsFromAccountToModule(ctx, from, types.ModuleName, amount); err != nil {
+		return fmt.Errorf("failed to add to reward pool: %w", err)
+	}
+
+	// Update reward pool
+	pool := k.getRewardPool(ctx)
+	pool = pool.Add(amount...)
+	k.setRewardPool(ctx, pool)
+
+	return nil
+}
+
+// GetRewardPool returns the current reward pool balance.
+func (k *Keeper) GetRewardPool(ctx sdk.Context) sdk.Coins {
+	return k.getRewardPool(ctx)
+}
+
+// getRewardPool retrieves the reward pool from store.
+func (k *Keeper) getRewardPool(ctx sdk.Context) sdk.Coins {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(RewardPoolKey())
+	if bz == nil {
+		return sdk.Coins{}
+	}
+
+	var pool sdk.Coins
+	if err := json.Unmarshal(bz, &pool); err != nil {
+		return sdk.Coins{}
+	}
+	return pool
+}
+
+// setRewardPool stores the reward pool.
+func (k *Keeper) setRewardPool(ctx sdk.Context, pool sdk.Coins) {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&pool)
+	if err != nil {
+		return
+	}
+	store.Set(RewardPoolKey(), bz)
+}
+
+// getOracleRewardRecord retrieves an oracle's reward record.
+func (k *Keeper) getOracleRewardRecord(ctx sdk.Context, oracleAddr sdk.AccAddress) OracleRewardRecord {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(OracleRewardKey(oracleAddr))
+	if bz == nil {
+		return OracleRewardRecord{AccumulatedRewards: sdk.Coins{}}
+	}
+
+	var record OracleRewardRecord
+	if err := json.Unmarshal(bz, &record); err != nil {
+		return OracleRewardRecord{AccumulatedRewards: sdk.Coins{}}
+	}
+	return record
+}
+
+// setOracleRewardRecord stores an oracle's reward record.
+func (k *Keeper) setOracleRewardRecord(ctx sdk.Context, oracleAddr sdk.AccAddress, record OracleRewardRecord) {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&record)
+	if err != nil {
+		return
+	}
+	store.Set(OracleRewardKey(oracleAddr), bz)
+}
+
+// getOraclePerformance retrieves an oracle's performance metrics.
+func (k *Keeper) getOraclePerformance(ctx sdk.Context, oracleAddr sdk.AccAddress) OraclePerformance {
+	store := ctx.KVStore(k.storeKey)
+	key := make([]byte, 0, len(OraclePerformanceKey)+len(oracleAddr.Bytes()))
+	key = append(key, OraclePerformanceKey...)
+	key = append(key, oracleAddr.Bytes()...)
+	bz := store.Get(key)
+	if bz == nil {
+		return OraclePerformance{}
+	}
+
+	var perf OraclePerformance
+	if err := json.Unmarshal(bz, &perf); err != nil {
+		return OraclePerformance{}
+	}
+	return perf
+}
+
+// setOraclePerformance stores an oracle's performance metrics.
+func (k *Keeper) setOraclePerformance(ctx sdk.Context, oracleAddr sdk.AccAddress, perf OraclePerformance) {
+	store := ctx.KVStore(k.storeKey)
+	key := make([]byte, 0, len(OraclePerformanceKey)+len(oracleAddr.Bytes()))
+	key = append(key, OraclePerformanceKey...)
+	key = append(key, oracleAddr.Bytes()...)
+	bz, err := json.Marshal(&perf)
+	if err != nil {
+		return
+	}
+	store.Set(key, bz)
+}
+
+// setEpochRewardInfo stores epoch reward information.
+func (k *Keeper) setEpochRewardInfo(ctx sdk.Context, epoch uint64, info EpochRewardInfo) {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&info)
+	if err != nil {
+		return
+	}
+	store.Set(EpochRewardKey(epoch), bz)
+}
+
+// UpdateOraclePerformance updates an oracle's performance after a price submission.
+func (k *Keeper) UpdateOraclePerformance(ctx sdk.Context, oracleAddr sdk.AccAddress, valid bool) {
+	perf := k.getOraclePerformance(ctx, oracleAddr)
+	perf.Address = oracleAddr.String()
+	perf.TotalSubmissions++
+	perf.LastActiveHeight = ctx.BlockHeight()
+
+	if valid {
+		perf.ValidSubmissions++
+		perf.ConsecutiveMisses = 0
+	} else {
+		perf.ConsecutiveMisses++
+	}
+
+	k.setOraclePerformance(ctx, oracleAddr, perf)
+}
+
+// Ensure unused import is used
+var _ = otypes.ParamsPrefix

--- a/x/oracle/keeper/slashing.go
+++ b/x/oracle/keeper/slashing.go
@@ -1,0 +1,247 @@
+// Copyright (c) VirtEngine Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package keeper
+
+import (
+	"encoding/json"
+	"fmt"
+
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	types "github.com/virtengine/virtengine/sdk/go/node/oracle/v1"
+)
+
+// Slashing store key prefixes
+var (
+	SlashRecordPrefix = []byte{0x20}
+	TotalSlashedKey   = []byte{0x21}
+)
+
+// SlashRecordKey returns the key for a slash record.
+func SlashRecordKey(oracleAddr sdk.AccAddress, height int64) []byte {
+	key := make([]byte, 0, len(SlashRecordPrefix)+len(oracleAddr.Bytes())+8)
+	key = append(key, SlashRecordPrefix...)
+	key = append(key, oracleAddr.Bytes()...)
+	key = append(key, byte(height>>56), byte(height>>48), byte(height>>40), byte(height>>32))
+	key = append(key, byte(height>>24), byte(height>>16), byte(height>>8), byte(height))
+	return key
+}
+
+// SlashRecord stores information about a slashing event.
+type SlashRecord struct {
+	OracleAddress string    `json:"oracle_address"`
+	Amount        sdk.Coins `json:"amount"`
+	Reason        string    `json:"reason"`
+	Height        int64     `json:"height"`
+}
+
+// SlashDeposit slashes an oracle's staked deposit for misbehavior.
+// The slashed tokens are burned from the oracle module.
+func (k *Keeper) SlashDeposit(ctx sdk.Context, oracleAddr sdk.AccAddress, amount sdk.Coins, reason string) error {
+	if k.bankKeeper == nil {
+		return ErrBankKeeperNotSet
+	}
+
+	if !amount.IsValid() || amount.IsZero() {
+		return fmt.Errorf("%w: slash amount must be positive", ErrInvalidAmount)
+	}
+
+	// Get oracle's current stake
+	stake := k.GetOracleStake(ctx, oracleAddr)
+	if stake.IsZero() {
+		return fmt.Errorf("%w: oracle %s has no stake", ErrOracleNotFound, oracleAddr.String())
+	}
+
+	// Calculate actual slash amount (can't slash more than staked)
+	actualSlash := sdk.Coins{}
+	for _, slashCoin := range amount {
+		stakeAmount := stake.AmountOf(slashCoin.Denom)
+		if stakeAmount.IsZero() {
+			continue
+		}
+		if slashCoin.Amount.LTE(stakeAmount) {
+			actualSlash = actualSlash.Add(slashCoin)
+		} else {
+			actualSlash = actualSlash.Add(sdk.NewCoin(slashCoin.Denom, stakeAmount))
+		}
+	}
+
+	if actualSlash.IsZero() {
+		return nil // Nothing to slash
+	}
+
+	// Burn the slashed tokens from the oracle module
+	if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, actualSlash); err != nil {
+		return fmt.Errorf("failed to burn slashed tokens: %w", err)
+	}
+
+	// Update oracle's stake record
+	remainingStake := stake.Sub(actualSlash...)
+	k.setOracleStake(ctx, oracleAddr, remainingStake)
+
+	// Update total slashed
+	totalSlashed := k.getTotalSlashed(ctx)
+	totalSlashed = totalSlashed.Add(actualSlash...)
+	k.setTotalSlashed(ctx, totalSlashed)
+
+	// Store slash record
+	record := SlashRecord{
+		OracleAddress: oracleAddr.String(),
+		Amount:        actualSlash,
+		Reason:        reason,
+		Height:        ctx.BlockHeight(),
+	}
+	k.setSlashRecord(ctx, oracleAddr, ctx.BlockHeight(), record)
+
+	// Update oracle performance
+	perf := k.getOraclePerformance(ctx, oracleAddr)
+	perf.ConsecutiveMisses++ // Slashing counts as a miss
+	k.setOraclePerformance(ctx, oracleAddr, perf)
+
+	// Emit event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.ModuleName,
+			sdk.NewAttribute("action", "slash_deposit"),
+			sdk.NewAttribute("oracle", oracleAddr.String()),
+			sdk.NewAttribute("amount", actualSlash.String()),
+			sdk.NewAttribute("reason", reason),
+		),
+	)
+
+	return nil
+}
+
+// SlashForInactivity slashes an oracle for being inactive.
+func (k *Keeper) SlashForInactivity(ctx sdk.Context, oracleAddr sdk.AccAddress, missedBlocks uint32) error {
+	// Calculate slash amount based on missed blocks
+	// Using a simple formula: slash 0.1% per 10 missed blocks
+	slashBps := int64(missedBlocks / 10)
+	if slashBps == 0 {
+		return nil // Not enough missed blocks to slash
+	}
+	if slashBps > 1000 {
+		slashBps = 1000 // Cap at 10%
+	}
+
+	stake := k.GetOracleStake(ctx, oracleAddr)
+	if stake.IsZero() {
+		return nil
+	}
+
+	slashAmount := sdk.Coins{}
+	for _, coin := range stake {
+		slashAmt := coin.Amount.MulRaw(slashBps).QuoRaw(10000)
+		if slashAmt.IsPositive() {
+			slashAmount = slashAmount.Add(sdk.NewCoin(coin.Denom, slashAmt))
+		}
+	}
+
+	if slashAmount.IsZero() {
+		return nil
+	}
+
+	reason := fmt.Sprintf("inactivity: missed %d blocks", missedBlocks)
+	return k.SlashDeposit(ctx, oracleAddr, slashAmount, reason)
+}
+
+// SlashForBadPrice slashes an oracle for submitting a bad price.
+func (k *Keeper) SlashForBadPrice(ctx sdk.Context, oracleAddr sdk.AccAddress, deviation uint64) error {
+	params := k.GetParams(ctx)
+
+	// Only slash if deviation exceeds max allowed
+	if deviation <= params.MaxPriceDeviationBps {
+		return nil
+	}
+
+	// Calculate slash amount based on deviation
+	// Slash 1% for every 100 bps of excess deviation
+	excessDeviation := deviation - params.MaxPriceDeviationBps
+	slashBps := int64(min(excessDeviation/100, 500)) //nolint:gosec // Value is bounded by min(n, 500)
+	if slashBps == 0 {
+		return nil
+	}
+
+	stake := k.GetOracleStake(ctx, oracleAddr)
+	if stake.IsZero() {
+		return nil
+	}
+
+	slashAmount := sdk.Coins{}
+	for _, coin := range stake {
+		slashAmt := coin.Amount.MulRaw(slashBps).QuoRaw(10000)
+		if slashAmt.IsPositive() {
+			slashAmount = slashAmount.Add(sdk.NewCoin(coin.Denom, slashAmt))
+		}
+	}
+
+	if slashAmount.IsZero() {
+		return nil
+	}
+
+	reason := fmt.Sprintf("bad price: deviation %d bps exceeds max %d", deviation, params.MaxPriceDeviationBps)
+	return k.SlashDeposit(ctx, oracleAddr, slashAmount, reason)
+}
+
+// getTotalSlashed retrieves the total slashed amount.
+func (k *Keeper) getTotalSlashed(ctx sdk.Context) sdk.Coins {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(TotalSlashedKey)
+	if bz == nil {
+		return sdk.Coins{}
+	}
+
+	var total sdk.Coins
+	if err := json.Unmarshal(bz, &total); err != nil {
+		return sdk.Coins{}
+	}
+	return total
+}
+
+// setTotalSlashed stores the total slashed amount.
+func (k *Keeper) setTotalSlashed(ctx sdk.Context, total sdk.Coins) {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&total)
+	if err != nil {
+		return
+	}
+	store.Set(TotalSlashedKey, bz)
+}
+
+// setSlashRecord stores a slash record.
+func (k *Keeper) setSlashRecord(ctx sdk.Context, oracleAddr sdk.AccAddress, height int64, record SlashRecord) {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := json.Marshal(&record)
+	if err != nil {
+		return
+	}
+	store.Set(SlashRecordKey(oracleAddr, height), bz)
+}
+
+// GetSlashRecords returns all slash records for an oracle.
+func (k *Keeper) GetSlashRecords(ctx sdk.Context, oracleAddr sdk.AccAddress) []SlashRecord {
+	store := ctx.KVStore(k.storeKey)
+	prefix := make([]byte, 0, len(SlashRecordPrefix)+len(oracleAddr.Bytes()))
+	prefix = append(prefix, SlashRecordPrefix...)
+	prefix = append(prefix, oracleAddr.Bytes()...)
+
+	var records []SlashRecord
+	iter := storetypes.KVStorePrefixIterator(store, prefix)
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		var record SlashRecord
+		if err := json.Unmarshal(iter.Value(), &record); err == nil {
+			records = append(records, record)
+		}
+	}
+
+	return records
+}
+
+// GetTotalSlashed returns the total amount slashed across all oracles.
+func (k *Keeper) GetTotalSlashed(ctx sdk.Context) sdk.Coins {
+	return k.getTotalSlashed(ctx)
+}


### PR DESCRIPTION
# Task: Integrate Bank Keeper for Token Operations

## Objective
Integrate Cosmos SDK bank keeper into BME (Billing/Metering/Escrow) and oracle modules for proper token operations.

## Priority: HIGH (P1)
Token operations are required for billing and price feeds.

## Estimated Lines: 2,500-4,000

## Modules to Update

### x/bme (Billing/Metering/Escrow)
- Token transfers for billing
- Escrow holds and releases
- Fee collection
- Settlement payments

### x/oracle (Price Feed)
- Reward distribution to oracles
- Slash deposits for misbehavior
- Delegation token handling

## Current State
- BME module may use direct token manipulation
- Oracle module needs bank keeper integration
- Must follow Cosmos SDK patterns

## Implementation Plan

### Phase 1: BME Bank Integration (1,500 lines)
- Add `BankKeeper` interface to BME keeper
- Implement escrow token holding
- Implement settlement token transfer
- Add fee collection mechanism

### Phase 2: Oracle Bank Integration (1,000 lines)
- Add `BankKeeper` interface to oracle keeper
- Implement oracle reward distribution
- Implement slash mechanics
- Add delegation token handling

### Phase 3: Testing (1,000 lines)
- Bank keeper mock for unit tests
- Integration tests with real bank module
- Token balance assertions
- Error scenario testing

## Bank Keeper Interface
```go
type BankKeeper interface {
    SendCoins(ctx sdk.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error
    SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
    SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
    MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
    BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
    SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
}
```

## Key Operations

### BME Operations
1. `HoldEscrow(ctx, orderId, amount)` - Lock tokens for order
2. `ReleaseEscrow(ctx, orderId, recipient)` - Release to recipient
3. `SettleBilling(ctx, leaseId, usage)` - Calculate and transfer
4. `CollectFees(ctx, amount)` - Move to fee pool

### Oracle Operations
1. `DistributeRewards(ctx, epoch)` - Pay oracle operators
2. `SlashDeposit(ctx, oracleAddr, amount)` - Penalize misbehavior
3. `DelegateStake(ctx, delegator, amount)` - Stake for oracle

## Acceptance Criteria
- [ ] BME uses bank keeper for all token ops
- [ ] Oracle uses bank keeper for all token ops
- [ ] No direct token manipulation
- [ ] Unit tests with mock bank keeper
- [ ] Integration tests with real bank module
- [ ] Token balances correct after operations

## Files to Modify
- `x/bme/keeper/keeper.go`
- `x/bme/keeper/escrow.go`
- `x/bme/keeper/settlement.go`
- `x/oracle/keeper/keeper.go`
- `x/oracle/keeper/rewards.go`
- `x/oracle/keeper/slashing.go`

## Files to Create
- `x/bme/expected_keepers.go`
- `x/oracle/expected_keepers.go`
- `x/bme/keeper/bank_integration_test.go`
- `x/oracle/keeper/bank_integration_test.go`

## Dependencies
- Cosmos SDK bank module
- Module account setup in app.go
- Proper capabilities registration

## Agent Instructions
1. Review existing BME and oracle keeper structures
2. Check how other modules use bank keeper (e.g., x/escrow)
3. Define BankKeeper interface in expected_keepers.go
4. Wire bank keeper in app/app.go
5. Update keeper constructors
6. Add comprehensive tests