### PR TITLE
feat(waldur): Support ticket routing - chain to provider service desk - 25C 

### DIFF
--- a/cmd/provider-daemon/main.go
+++ b/cmd/provider-daemon/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/viper"
 
 	provider_daemon "github.com/virtengine/virtengine/pkg/provider_daemon"
+	"github.com/virtengine/virtengine/pkg/servicedesk"
 )
 
 const (
@@ -155,6 +156,23 @@ const (
 	FlagPortalShellSessionTTL = "portal-shell-session-ttl"
 	FlagPortalTokenTTL        = "portal-token-ttl"
 	FlagPortalAuditLogFile    = "portal-audit-log-file"
+
+	// Support service desk flags
+	FlagSupportEnabled             = "support-enabled"
+	FlagSupportWaldurBaseURL       = "support-waldur-base-url"
+	FlagSupportWaldurToken         = "support-waldur-token" //nolint:gosec
+	FlagSupportWaldurOrgUUID       = "support-waldur-org-uuid"
+	FlagSupportWaldurProjectUUID   = "support-waldur-project-uuid"
+	FlagSupportWebhookSecret       = "support-webhook-secret" //nolint:gosec
+	FlagSupportWebhookListen       = "support-webhook-listen"
+	FlagSupportWebhookRequireSig   = "support-webhook-require-signature"
+	FlagSupportDecryptionKeyPath   = "support-decryption-key-path"
+	FlagSupportDecryptionKeyBase64 = "support-decryption-key-base64"
+	FlagSupportEncryptionKeyPath   = "support-encryption-key-path"
+	FlagSupportEncryptionKeyBase64 = "support-encryption-key-base64"
+	FlagSupportSyncInbound         = "support-sync-inbound"
+	FlagSupportSyncOutbound        = "support-sync-outbound"
+	FlagSupportSyncInterval        = "support-sync-interval"
 )
 
 var (
@@ -232,6 +250,23 @@ func init() {
 	rootCmd.PersistentFlags().Duration(FlagPortalTokenTTL, 5*time.Minute, "Portal session token TTL")
 	rootCmd.PersistentFlags().String(FlagPortalAuditLogFile, "data/portal_audit.log", "Portal audit log file path")
 
+	// Support service desk flags
+	rootCmd.PersistentFlags().Bool(FlagSupportEnabled, false, "Enable support service desk bridge")
+	rootCmd.PersistentFlags().String(FlagSupportWaldurBaseURL, "", "Support Waldur API base URL")
+	rootCmd.PersistentFlags().String(FlagSupportWaldurToken, "", "Support Waldur API token")
+	rootCmd.PersistentFlags().String(FlagSupportWaldurOrgUUID, "", "Support Waldur organization UUID")
+	rootCmd.PersistentFlags().String(FlagSupportWaldurProjectUUID, "", "Support Waldur project UUID")
+	rootCmd.PersistentFlags().String(FlagSupportWebhookSecret, "", "Support webhook secret")
+	rootCmd.PersistentFlags().String(FlagSupportWebhookListen, ":8480", "Support webhook listen address")
+	rootCmd.PersistentFlags().Bool(FlagSupportWebhookRequireSig, true, "Require signatures for support webhooks")
+	rootCmd.PersistentFlags().String(FlagSupportDecryptionKeyPath, "", "Support payload decryption key path")
+	rootCmd.PersistentFlags().String(FlagSupportDecryptionKeyBase64, "", "Support payload decryption key (base64)")
+	rootCmd.PersistentFlags().String(FlagSupportEncryptionKeyPath, "", "Support payload encryption key path")
+	rootCmd.PersistentFlags().String(FlagSupportEncryptionKeyBase64, "", "Support payload encryption key (base64)")
+	rootCmd.PersistentFlags().Bool(FlagSupportSyncInbound, true, "Enable inbound support sync from service desk")
+	rootCmd.PersistentFlags().Bool(FlagSupportSyncOutbound, true, "Enable outbound support sync to service desk")
+	rootCmd.PersistentFlags().Duration(FlagSupportSyncInterval, 30*time.Second, "Support sync interval")
+
 	// Bind to viper
 	_ = viper.BindPFlag(FlagChainID, rootCmd.PersistentFlags().Lookup(FlagChainID))
 	_ = viper.BindPFlag(FlagNode, rootCmd.PersistentFlags().Lookup(FlagNode))
@@ -278,6 +313,23 @@ func init() {
 	_ = viper.BindPFlag(FlagPortalShellSessionTTL, rootCmd.PersistentFlags().Lookup(FlagPortalShellSessionTTL))
 	_ = viper.BindPFlag(FlagPortalTokenTTL, rootCmd.PersistentFlags().Lookup(FlagPortalTokenTTL))
 	_ = viper.BindPFlag(FlagPortalAuditLogFile, rootCmd.PersistentFlags().Lookup(FlagPortalAuditLogFile))
+
+	// Support service desk flags
+	_ = viper.BindPFlag(FlagSupportEnabled, rootCmd.PersistentFlags().Lookup(FlagSupportEnabled))
+	_ = viper.BindPFlag(FlagSupportWaldurBaseURL, rootCmd.PersistentFlags().Lookup(FlagSupportWaldurBaseURL))
+	_ = viper.BindPFlag(FlagSupportWaldurToken, rootCmd.PersistentFlags().Lookup(FlagSupportWaldurToken))
+	_ = viper.BindPFlag(FlagSupportWaldurOrgUUID, rootCmd.PersistentFlags().Lookup(FlagSupportWaldurOrgUUID))
+	_ = viper.BindPFlag(FlagSupportWaldurProjectUUID, rootCmd.PersistentFlags().Lookup(FlagSupportWaldurProjectUUID))
+	_ = viper.BindPFlag(FlagSupportWebhookSecret, rootCmd.PersistentFlags().Lookup(FlagSupportWebhookSecret))
+	_ = viper.BindPFlag(FlagSupportWebhookListen, rootCmd.PersistentFlags().Lookup(FlagSupportWebhookListen))
+	_ = viper.BindPFlag(FlagSupportWebhookRequireSig, rootCmd.PersistentFlags().Lookup(FlagSupportWebhookRequireSig))
+	_ = viper.BindPFlag(FlagSupportDecryptionKeyPath, rootCmd.PersistentFlags().Lookup(FlagSupportDecryptionKeyPath))
+	_ = viper.BindPFlag(FlagSupportDecryptionKeyBase64, rootCmd.PersistentFlags().Lookup(FlagSupportDecryptionKeyBase64))
+	_ = viper.BindPFlag(FlagSupportEncryptionKeyPath, rootCmd.PersistentFlags().Lookup(FlagSupportEncryptionKeyPath))
+	_ = viper.BindPFlag(FlagSupportEncryptionKeyBase64, rootCmd.PersistentFlags().Lookup(FlagSupportEncryptionKeyBase64))
+	_ = viper.BindPFlag(FlagSupportSyncInbound, rootCmd.PersistentFlags().Lookup(FlagSupportSyncInbound))
+	_ = viper.BindPFlag(FlagSupportSyncOutbound, rootCmd.PersistentFlags().Lookup(FlagSupportSyncOutbound))
+	_ = viper.BindPFlag(FlagSupportSyncInterval, rootCmd.PersistentFlags().Lookup(FlagSupportSyncInterval))
 
 	// Add commands
 	rootCmd.AddCommand(startCmd())
@@ -380,6 +432,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	var callbackSink provider_daemon.CallbackSink
 	var usageReporter provider_daemon.UsageReporter
+	var supportService *provider_daemon.SupportService
 
 	if viper.GetBool(FlagWaldurEnabled) && viper.GetBool(FlagWaldurChainSubmit) {
 		chainKeyName := viper.GetString(FlagWaldurChainKey)
@@ -610,6 +663,53 @@ func runStart(cmd *cobra.Command, args []string) error {
 		fmt.Println("  Waldur Bridge: started")
 	}
 
+	// Initialize support service desk bridge (VE-25C)
+	if viper.GetBool(FlagSupportEnabled) {
+		supportCfg := provider_daemon.DefaultSupportServiceConfig()
+		supportCfg.Enabled = true
+		supportCfg.ProviderAddress = providerAddress
+		supportCfg.ChainID = viper.GetString(FlagChainID)
+		supportCfg.CometRPC = normalizeCometRPC(viper.GetString(FlagNode))
+		supportCfg.CometWS = viper.GetString(FlagCometWS)
+		supportCfg.GRPCEndpoint = viper.GetString(FlagWaldurChainGRPC)
+		supportCfg.Encryption.SenderPrivateKeyPath = viper.GetString(FlagSupportEncryptionKeyPath)
+		supportCfg.Encryption.SenderPrivateKeyBase64 = viper.GetString(FlagSupportEncryptionKeyBase64)
+
+		if supportCfg.ServiceDeskConfig != nil {
+			supportCfg.ServiceDeskConfig.Enabled = true
+			supportCfg.ServiceDeskConfig.SyncConfig.EnableInbound = viper.GetBool(FlagSupportSyncInbound)
+			supportCfg.ServiceDeskConfig.SyncConfig.EnableOutbound = viper.GetBool(FlagSupportSyncOutbound)
+			supportCfg.ServiceDeskConfig.SyncConfig.SyncInterval = viper.GetDuration(FlagSupportSyncInterval)
+			supportCfg.ServiceDeskConfig.WebhookConfig.ListenAddr = viper.GetString(FlagSupportWebhookListen)
+			supportCfg.ServiceDeskConfig.WebhookConfig.RequireSignature = viper.GetBool(FlagSupportWebhookRequireSig)
+			if supportCfg.ServiceDeskConfig.Decryption == nil {
+				supportCfg.ServiceDeskConfig.Decryption = &servicedesk.DecryptionConfig{}
+			}
+			supportCfg.ServiceDeskConfig.Decryption.PrivateKeyPath = viper.GetString(FlagSupportDecryptionKeyPath)
+			supportCfg.ServiceDeskConfig.Decryption.PrivateKeyBase64 = viper.GetString(FlagSupportDecryptionKeyBase64)
+			supportCfg.ServiceDeskConfig.WaldurConfig = &servicedesk.WaldurConfig{
+				BaseURL:          viper.GetString(FlagSupportWaldurBaseURL),
+				Token:            viper.GetString(FlagSupportWaldurToken),
+				OrganizationUUID: viper.GetString(FlagSupportWaldurOrgUUID),
+				ProjectUUID:      viper.GetString(FlagSupportWaldurProjectUUID),
+				WebhookSecret:    viper.GetString(FlagSupportWebhookSecret),
+				Timeout:          30 * time.Second,
+			}
+		}
+
+		svc, err := provider_daemon.NewSupportService(supportCfg, keyManager, provider_daemon.NewSupportLogger())
+		if err != nil {
+			return fmt.Errorf("failed to create support service: %w", err)
+		}
+		supportService = svc
+		if supportService != nil {
+			if err := supportService.Start(ctx); err != nil {
+				return fmt.Errorf("failed to start support service: %w", err)
+			}
+			fmt.Println("  Support Service: started")
+		}
+	}
+
 	// Start background workers
 	bidResultChan := bidEngine.GetBidResults()
 	go handleBidResults(ctx, bidResultChan)
@@ -642,6 +742,11 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	usageMeter.Stop()
 	fmt.Println("  Usage Meter: stopped")
+
+	if supportService != nil {
+		_ = supportService.Stop(ctx)
+		fmt.Println("  Support Service: stopped")
+	}
 
 	keyManager.Lock()
 	fmt.Println("  Key Manager: locked")

--- a/lib/portal/src/pages/support/SupportTicketCreateForm.tsx
+++ b/lib/portal/src/pages/support/SupportTicketCreateForm.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+
+export type SupportCategory =
+  | 'account'
+  | 'identity'
+  | 'billing'
+  | 'provider'
+  | 'marketplace'
+  | 'technical'
+  | 'security'
+  | 'other';
+
+export type SupportPriority = 'low' | 'normal' | 'high' | 'urgent';
+
+export interface SupportTicketDraft {
+  subject: string;
+  description: string;
+  category: SupportCategory;
+  priority: SupportPriority;
+  relatedEntityId?: string;
+}
+
+export interface SupportTicketCreateFormProps {
+  value: SupportTicketDraft;
+  onChange: (next: SupportTicketDraft) => void;
+  onSubmit: (ticket: SupportTicketDraft) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function SupportTicketCreateForm({
+  value,
+  onChange,
+  onSubmit,
+  disabled,
+  className,
+}: SupportTicketCreateFormProps) {
+  return (
+    <form
+      className={className}
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit(value);
+      }}
+    >
+      <div>
+        <label htmlFor="support-subject">Subject</label>
+        <input
+          id="support-subject"
+          type="text"
+          value={value.subject}
+          onChange={(event) => onChange({ ...value, subject: event.target.value })}
+          disabled={disabled}
+        />
+      </div>
+      <div>
+        <label htmlFor="support-category">Category</label>
+        <select
+          id="support-category"
+          value={value.category}
+          onChange={(event) => onChange({ ...value, category: event.target.value as SupportCategory })}
+          disabled={disabled}
+        >
+          <option value="technical">Technical</option>
+          <option value="billing">Billing</option>
+          <option value="provider">Provider</option>
+          <option value="marketplace">Marketplace</option>
+          <option value="identity">Identity</option>
+          <option value="security">Security</option>
+          <option value="account">Account</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="support-priority">Priority</label>
+        <select
+          id="support-priority"
+          value={value.priority}
+          onChange={(event) => onChange({ ...value, priority: event.target.value as SupportPriority })}
+          disabled={disabled}
+        >
+          <option value="low">Low</option>
+          <option value="normal">Normal</option>
+          <option value="high">High</option>
+          <option value="urgent">Urgent</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="support-related">Related Entity (optional)</label>
+        <input
+          id="support-related"
+          type="text"
+          value={value.relatedEntityId ?? ''}
+          onChange={(event) => onChange({ ...value, relatedEntityId: event.target.value })}
+          disabled={disabled}
+        />
+      </div>
+      <div>
+        <label htmlFor="support-description">Description</label>
+        <textarea
+          id="support-description"
+          rows={4}
+          value={value.description}
+          onChange={(event) => onChange({ ...value, description: event.target.value })}
+          disabled={disabled}
+        />
+      </div>
+      <button type="submit" disabled={disabled || !value.subject || !value.description}>
+        Submit ticket
+      </button>
+    </form>
+  );
+}

--- a/lib/portal/src/pages/support/SupportTicketDetail.tsx
+++ b/lib/portal/src/pages/support/SupportTicketDetail.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+
+export interface SupportResponseItem {
+  id: string;
+  author: string;
+  message: string;
+  createdAt: Date;
+  isAgent?: boolean;
+}
+
+export interface SupportTicketDetail {
+  id: string;
+  number: string;
+  subject: string;
+  description: string;
+  status: string;
+  priority: string;
+  createdAt: Date;
+  responses: SupportResponseItem[];
+}
+
+export interface SupportTicketDetailProps {
+  ticket: SupportTicketDetail;
+  onRespond?: (message: string) => void;
+  className?: string;
+}
+
+export function SupportTicketDetail({ ticket, onRespond, className }: SupportTicketDetailProps) {
+  const [message, setMessage] = React.useState('');
+
+  return (
+    <section className={className}>
+      <header>
+        <h2>{ticket.subject}</h2>
+        <div>
+          <span>{ticket.number}</span> · <span>{ticket.priority}</span> · <span>{ticket.status}</span>
+        </div>
+      </header>
+
+      <p>{ticket.description}</p>
+
+      <div>
+        {ticket.responses.map((response) => (
+          <article key={response.id}>
+            <strong>{response.author}</strong>
+            <p>{response.message}</p>
+          </article>
+        ))}
+      </div>
+
+      {onRespond && (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!message.trim()) return;
+            onRespond(message.trim());
+            setMessage('');
+          }}
+        >
+          <textarea
+            rows={3}
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            placeholder="Add a response"
+          />
+          <button type="submit" disabled={!message.trim()}>
+            Send response
+          </button>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/lib/portal/src/pages/support/SupportTicketList.tsx
+++ b/lib/portal/src/pages/support/SupportTicketList.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+export interface SupportTicketListItem {
+  id: string;
+  number: string;
+  subject: string;
+  status: string;
+  priority: string;
+  updatedAt: Date;
+}
+
+export interface SupportTicketListProps {
+  tickets: SupportTicketListItem[];
+  onSelect?: (ticketId: string) => void;
+  className?: string;
+}
+
+export function SupportTicketList({ tickets, onSelect, className }: SupportTicketListProps) {
+  return (
+    <div className={className}>
+      {tickets.map((ticket) => (
+        <button
+          key={ticket.id}
+          type="button"
+          onClick={() => onSelect?.(ticket.id)}
+          style={{ display: 'block', width: '100%', textAlign: 'left' }}
+        >
+          <strong>{ticket.subject}</strong>
+          <div>
+            <span>{ticket.number}</span> · <span>{ticket.priority}</span> · <span>{ticket.status}</span>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/lib/portal/src/pages/support/index.ts
+++ b/lib/portal/src/pages/support/index.ts
@@ -1,0 +1,8 @@
+export { SupportTicketCreateForm } from './SupportTicketCreateForm';
+export type { SupportTicketCreateFormProps, SupportTicketDraft, SupportCategory, SupportPriority } from './SupportTicketCreateForm';
+
+export { SupportTicketList } from './SupportTicketList';
+export type { SupportTicketListProps, SupportTicketListItem } from './SupportTicketList';
+
+export { SupportTicketDetail } from './SupportTicketDetail';
+export type { SupportTicketDetailProps, SupportTicketDetail, SupportResponseItem } from './SupportTicketDetail';

--- a/pkg/provider_daemon/support.go
+++ b/pkg/provider_daemon/support.go
@@ -1,0 +1,389 @@
+package provider_daemon
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"cosmossdk.io/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/virtengine/virtengine/pkg/servicedesk"
+)
+
+// SupportServiceConfig configures support ticket routing and sync.
+type SupportServiceConfig struct {
+	Enabled         bool
+	ProviderAddress string
+	ChainID         string
+	CometRPC        string
+	CometWS         string
+	GRPCEndpoint    string
+	SubscriberID    string
+
+	ServiceDeskConfig *servicedesk.Config
+	EventListener     *servicedesk.EventListenerConfig
+	Encryption        SupportEncryptionConfig
+}
+
+// SupportEncryptionConfig provides sender key for encrypting responses.
+type SupportEncryptionConfig struct {
+	SenderPrivateKeyBase64 string
+	SenderPrivateKeyPath   string
+}
+
+// LoadPrivateKey loads the sender private key bytes.
+func (c SupportEncryptionConfig) LoadPrivateKey() ([]byte, error) {
+	if c.SenderPrivateKeyBase64 != "" {
+		key, err := base64.StdEncoding.DecodeString(c.SenderPrivateKeyBase64)
+		if err != nil {
+			return nil, fmt.Errorf("decode support private key: %w", err)
+		}
+		return key, nil
+	}
+	if c.SenderPrivateKeyPath == "" {
+		return nil, nil
+	}
+	key, err := os.ReadFile(c.SenderPrivateKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read support private key: %w", err)
+	}
+	return key, nil
+}
+
+// DefaultSupportServiceConfig returns default support service configuration.
+func DefaultSupportServiceConfig() SupportServiceConfig {
+	cfg := SupportServiceConfig{
+		CometWS: "/websocket",
+	}
+	cfg.ServiceDeskConfig = servicedesk.DefaultConfig()
+	return cfg
+}
+
+// SupportService wires chain events to service desk and inbound updates to chain.
+type SupportService struct {
+	cfg            SupportServiceConfig
+	logger         log.Logger
+	bridge         *servicedesk.Bridge
+	listener       *servicedesk.ChainEventListener
+	inboundHandler *SupportInboundHandler
+	grpcConn       *grpc.ClientConn
+}
+
+// NewSupportService creates a support service instance.
+func NewSupportService(cfg SupportServiceConfig, keyManager *KeyManager, logger log.Logger) (*SupportService, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+	if cfg.ServiceDeskConfig == nil {
+		cfg.ServiceDeskConfig = servicedesk.DefaultConfig()
+	}
+	if cfg.ServiceDeskConfig.Decryption == nil {
+		cfg.ServiceDeskConfig.Decryption = &servicedesk.DecryptionConfig{}
+	}
+	if cfg.EventListener == nil {
+		cfg.EventListener = servicedesk.DefaultEventListenerConfig()
+	}
+	if cfg.CometWS == "" {
+		cfg.CometWS = "/websocket"
+	}
+	if cfg.EventListener.CometWS == "" {
+		cfg.EventListener.CometWS = cfg.CometWS
+	}
+	if cfg.SubscriberID != "" {
+		cfg.EventListener.SubscriberID = cfg.SubscriberID
+	}
+
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	bridge, err := servicedesk.NewBridge(cfg.ServiceDeskConfig, logger)
+	if err != nil {
+		return nil, fmt.Errorf("create service desk bridge: %w", err)
+	}
+
+	var grpcConn *grpc.ClientConn
+	if cfg.GRPCEndpoint != "" {
+		conn, err := grpc.NewClient(cfg.GRPCEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, fmt.Errorf("connect support grpc: %w", err)
+		}
+		grpcConn = conn
+	}
+
+	recipientResolver := NewGRPCRecipientKeyResolver(grpcConn)
+	encryptor, err := NewSupportResponseEncryptor(cfg, recipientResolver)
+	if err != nil {
+		if grpcConn != nil {
+			_ = grpcConn.Close()
+		}
+		return nil, err
+	}
+
+	chainWriter := NewSupportChainLogger(logger.With("component", "support_chain_logger"))
+	inboundHandler := NewSupportInboundHandler(SupportInboundHandlerConfig{
+		ProviderAddress: cfg.ProviderAddress,
+		Bridge:          bridge,
+		Encryptor:       encryptor,
+		ChainWriter:     chainWriter,
+		Logger:          logger.With("component", "support_inbound"),
+		KeyManager:      keyManager,
+	})
+	bridge.SetInboundHandler(inboundHandler)
+
+	externalRefHandler := NewSupportExternalRefHandler(chainWriter, cfg.ProviderAddress, logger.With("component", "support_external_ref"))
+	bridge.SetExternalRefHandler(externalRefHandler)
+
+	listener := servicedesk.NewChainEventListener(bridge, cfg.CometRPC, logger, cfg.EventListener)
+
+	return &SupportService{
+		cfg:            cfg,
+		logger:         logger.With("component", "support_service"),
+		bridge:         bridge,
+		listener:       listener,
+		inboundHandler: inboundHandler,
+		grpcConn:       grpcConn,
+	}, nil
+}
+
+// Start starts the support service.
+func (s *SupportService) Start(ctx context.Context) error {
+	if s == nil || s.bridge == nil || s.listener == nil {
+		return nil
+	}
+
+	if err := s.bridge.Start(ctx); err != nil {
+		return fmt.Errorf("start support bridge: %w", err)
+	}
+	if err := s.listener.Start(ctx); err != nil {
+		return fmt.Errorf("start support event listener: %w", err)
+	}
+	s.logger.Info("support service started")
+	return nil
+}
+
+// Stop stops the support service.
+func (s *SupportService) Stop(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if s.listener != nil {
+		_ = s.listener.Stop(ctx)
+	}
+	if s.bridge != nil {
+		_ = s.bridge.Stop(ctx)
+	}
+	if s.grpcConn != nil {
+		_ = s.grpcConn.Close()
+	}
+	s.logger.Info("support service stopped")
+	return nil
+}
+
+// SupportInboundHandlerConfig configures inbound update handling.
+type SupportInboundHandlerConfig struct {
+	ProviderAddress string
+	Bridge          *servicedesk.Bridge
+	Encryptor       SupportResponseEncryptor
+	ChainWriter     SupportChainWriter
+	Logger          log.Logger
+	KeyManager      *KeyManager
+}
+
+// NewSupportInboundHandler constructs a handler for inbound updates.
+func NewSupportInboundHandler(cfg SupportInboundHandlerConfig) *SupportInboundHandler {
+	return &SupportInboundHandler{
+		providerAddress: cfg.ProviderAddress,
+		bridge:          cfg.Bridge,
+		encryptor:       cfg.Encryptor,
+		chainWriter:     cfg.ChainWriter,
+		logger:          cfg.Logger,
+		keyManager:      cfg.KeyManager,
+	}
+}
+
+// SupportChainLogger is a placeholder chain writer for support events.
+type SupportChainLogger struct {
+	logger log.Logger
+}
+
+// NewSupportChainLogger returns a logging chain writer.
+func NewSupportChainLogger(logger log.Logger) *SupportChainLogger {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+	return &SupportChainLogger{logger: logger}
+}
+
+// NewSupportLogger returns a default logger for support services.
+func NewSupportLogger() log.Logger {
+	return log.NewLogger(os.Stdout)
+}
+
+// UpdateSupportRequest logs support request updates.
+func (w *SupportChainLogger) UpdateSupportRequest(_ context.Context, msg *SupportUpdateRequest) error {
+	if msg == nil {
+		return nil
+	}
+	w.logger.Info("support update request",
+		"ticket_id", msg.TicketID,
+		"status", msg.Status,
+		"assigned_agent", msg.AssignedAgent,
+	)
+	return nil
+}
+
+// AddSupportResponse logs support response submissions.
+func (w *SupportChainLogger) AddSupportResponse(_ context.Context, msg *SupportAddResponse) error {
+	if msg == nil {
+		return nil
+	}
+	w.logger.Info("support response",
+		"ticket_id", msg.TicketID,
+		"author", msg.Author,
+		"is_agent", msg.IsAgent,
+	)
+	return nil
+}
+
+// RegisterExternalTicket logs external ticket registration.
+func (w *SupportChainLogger) RegisterExternalTicket(_ context.Context, msg *SupportRegisterExternal) error {
+	if msg == nil {
+		return nil
+	}
+	w.logger.Info("support external ticket",
+		"ticket_id", msg.ResourceID,
+		"external_system", msg.ExternalSystem,
+		"external_ticket_id", msg.ExternalTicketID,
+	)
+	return nil
+}
+
+// SupportUpdateRequest represents a support request update payload.
+type SupportUpdateRequest struct {
+	TicketID      string
+	Status        string
+	AssignedAgent string
+	UpdatedBy     string
+	Metadata      map[string]string
+}
+
+// SupportAddResponse represents a support response payload.
+type SupportAddResponse struct {
+	TicketID string
+	Author   string
+	IsAgent  bool
+	Message  string
+	Payload  *SupportEncryptedPayload
+}
+
+// SupportRegisterExternal represents external ticket linkage.
+type SupportRegisterExternal struct {
+	ResourceID       string
+	ResourceType     string
+	ExternalSystem   string
+	ExternalTicketID string
+	ExternalURL      string
+	CreatedBy        string
+}
+
+// SupportChainWriter submits support updates to chain.
+type SupportChainWriter interface {
+	UpdateSupportRequest(ctx context.Context, msg *SupportUpdateRequest) error
+	AddSupportResponse(ctx context.Context, msg *SupportAddResponse) error
+	RegisterExternalTicket(ctx context.Context, msg *SupportRegisterExternal) error
+}
+
+// SupportResponseEncryptor encrypts inbound support responses for on-chain storage.
+type SupportResponseEncryptor interface {
+	EncryptResponse(ctx context.Context, recipients []string, message string) (*SupportEncryptedPayload, error)
+}
+
+// SupportResponseEncryptorImpl encrypts responses with recipient public keys.
+type SupportResponseEncryptorImpl struct {
+	keyPair  *SupportKeyPair
+	resolver RecipientKeyResolver
+}
+
+// NewSupportResponseEncryptor creates a response encryptor.
+func NewSupportResponseEncryptor(cfg SupportServiceConfig, resolver RecipientKeyResolver) (*SupportResponseEncryptorImpl, error) {
+	privateKey, err := cfg.Encryption.LoadPrivateKey()
+	if err != nil {
+		return nil, err
+	}
+	if len(privateKey) == 0 {
+		return &SupportResponseEncryptorImpl{resolver: resolver}, nil
+	}
+
+	keyPair, err := NewSupportKeyPair(privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SupportResponseEncryptorImpl{
+		keyPair:  keyPair,
+		resolver: resolver,
+	}, nil
+}
+
+// EncryptResponse encrypts the response message for recipients.
+func (e *SupportResponseEncryptorImpl) EncryptResponse(ctx context.Context, recipients []string, message string) (*SupportEncryptedPayload, error) {
+	if message == "" {
+		return nil, fmt.Errorf("response message is required")
+	}
+	if e == nil || e.keyPair == nil {
+		return nil, fmt.Errorf("support encryption key not configured")
+	}
+	if len(recipients) == 0 {
+		return nil, fmt.Errorf("recipients are required for encryption")
+	}
+	publicKeys, err := e.resolver.ResolveRecipientPublicKeys(ctx, recipients)
+	if err != nil {
+		return nil, err
+	}
+	plaintext, err := BuildSupportResponsePayload(message)
+	if err != nil {
+		return nil, err
+	}
+	return EncryptSupportPayload(plaintext, publicKeys, e.keyPair)
+}
+
+// RecipientKeyResolver resolves recipient key IDs to public keys.
+type RecipientKeyResolver interface {
+	ResolveRecipientPublicKeys(ctx context.Context, keyIDs []string) ([][]byte, error)
+}
+
+// GRPCRecipientKeyResolver resolves keys using encryption gRPC queries.
+type GRPCRecipientKeyResolver struct {
+	client EncryptionQueryClient
+}
+
+// NewGRPCRecipientKeyResolver creates a new resolver.
+func NewGRPCRecipientKeyResolver(conn *grpc.ClientConn) *GRPCRecipientKeyResolver {
+	if conn == nil {
+		return &GRPCRecipientKeyResolver{}
+	}
+	return &GRPCRecipientKeyResolver{client: NewEncryptionQueryClient(conn)}
+}
+
+// ResolveRecipientPublicKeys resolves public keys for fingerprints.
+func (r *GRPCRecipientKeyResolver) ResolveRecipientPublicKeys(ctx context.Context, keyIDs []string) ([][]byte, error) {
+	if r == nil || r.client == nil {
+		return nil, fmt.Errorf("encryption query client not configured")
+	}
+	publicKeys := make([][]byte, 0, len(keyIDs))
+	for _, keyID := range keyIDs {
+		resp, err := r.client.KeyByFingerprint(ctx, &EncryptionKeyByFingerprintRequest{Fingerprint: keyID})
+		if err != nil {
+			return nil, fmt.Errorf("lookup recipient key %s: %w", keyID, err)
+		}
+		if resp == nil || resp.Key == nil || len(resp.Key.PublicKey) == 0 {
+			return nil, fmt.Errorf("recipient key %s not found", keyID)
+		}
+		publicKeys = append(publicKeys, append([]byte(nil), resp.Key.PublicKey...))
+	}
+	return publicKeys, nil
+}

--- a/pkg/provider_daemon/waldur_servicedesk.go
+++ b/pkg/provider_daemon/waldur_servicedesk.go
@@ -1,0 +1,270 @@
+package provider_daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"cosmossdk.io/log"
+	"golang.org/x/crypto/curve25519"
+	"google.golang.org/grpc"
+
+	"github.com/virtengine/virtengine/pkg/servicedesk"
+	"github.com/virtengine/virtengine/pkg/waldur"
+	encryptionv1 "github.com/virtengine/virtengine/sdk/go/node/encryption/v1"
+	encryptioncrypto "github.com/virtengine/virtengine/x/encryption/crypto"
+	supporttypes "github.com/virtengine/virtengine/x/support/types"
+)
+
+// SupportEncryptedPayload aliases the on-chain payload type.
+type SupportEncryptedPayload = supporttypes.EncryptedSupportPayload
+
+// Encryption query client aliases.
+type EncryptionQueryClient = encryptionv1.QueryClient
+type EncryptionKeyByFingerprintRequest = encryptionv1.QueryKeyByFingerprintRequest
+type EncryptionKeyByFingerprintResponse = encryptionv1.QueryKeyByFingerprintResponse
+
+// NewEncryptionQueryClient constructs a query client.
+func NewEncryptionQueryClient(conn grpc.ClientConnInterface) EncryptionQueryClient {
+	return encryptionv1.NewQueryClient(conn)
+}
+
+// SupportKeyPair wraps the encryption key pair.
+type SupportKeyPair = encryptioncrypto.KeyPair
+
+// NewSupportKeyPair builds a key pair from a private key.
+func NewSupportKeyPair(privateKey []byte) (*SupportKeyPair, error) {
+	if len(privateKey) != 32 {
+		return nil, fmt.Errorf("support private key must be 32 bytes")
+	}
+	var pk [32]byte
+	copy(pk[:], privateKey)
+	var pub [32]byte
+	curve25519.ScalarBaseMult(&pub, &pk)
+	return &SupportKeyPair{
+		PrivateKey: pk,
+		PublicKey:  pub,
+	}, nil
+}
+
+// BuildSupportResponsePayload marshals a response payload.
+func BuildSupportResponsePayload(message string) ([]byte, error) {
+	payload := supporttypes.SupportResponsePayload{Message: message}
+	if err := payload.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(payload)
+}
+
+// EncryptSupportPayload encrypts payload for recipients.
+func EncryptSupportPayload(plaintext []byte, recipientPublicKeys [][]byte, sender *SupportKeyPair) (*SupportEncryptedPayload, error) {
+	if len(recipientPublicKeys) == 0 {
+		return nil, fmt.Errorf("recipient keys required")
+	}
+	envelope, err := encryptioncrypto.CreateMultiRecipientEnvelope(plaintext, recipientPublicKeys, sender)
+	if err != nil {
+		return nil, err
+	}
+	payload := &supporttypes.EncryptedSupportPayload{Envelope: envelope}
+	payload.EnsureEnvelopeHash()
+	return payload, nil
+}
+
+// SupportInboundHandler processes inbound updates from external service desks.
+type SupportInboundHandler struct {
+	providerAddress string
+	bridge          *servicedesk.Bridge
+	encryptor       SupportResponseEncryptor
+	chainWriter     SupportChainWriter
+	logger          log.Logger
+	keyManager      *KeyManager
+}
+
+// HandleInboundUpdate handles inbound updates.
+func (h *SupportInboundHandler) HandleInboundUpdate(ctx context.Context, event *servicedesk.SyncEvent) error {
+	if event == nil {
+		return nil
+	}
+	if h.chainWriter == nil {
+		return nil
+	}
+
+	status := extractStatus(event.Payload)
+	if status != "" {
+		status = normalizeStatus(event, status)
+		update := &SupportUpdateRequest{
+			TicketID:      event.TicketID,
+			Status:        status,
+			AssignedAgent: extractAssignedAgent(event.Payload),
+			UpdatedBy:     h.providerAddress,
+			Metadata:      extractMetadata(event.Payload),
+		}
+		if err := h.chainWriter.UpdateSupportRequest(ctx, update); err != nil {
+			return err
+		}
+	}
+
+	message := extractMessage(event.Payload)
+	if message == "" {
+		return nil
+	}
+
+	recipients := h.recipientsForTicket(event.TicketID)
+	if len(recipients) == 0 {
+		return fmt.Errorf("missing recipients for ticket %s", event.TicketID)
+	}
+
+	var encrypted *SupportEncryptedPayload
+	if h.encryptor != nil {
+		var err error
+		encrypted, err = h.encryptor.EncryptResponse(ctx, recipients, message)
+		if err != nil {
+			return err
+		}
+	}
+
+	response := &SupportAddResponse{
+		TicketID: event.TicketID,
+		Author:   h.providerAddress,
+		IsAgent:  true,
+		Message:  message,
+		Payload:  encrypted,
+	}
+	return h.chainWriter.AddSupportResponse(ctx, response)
+}
+
+func (h *SupportInboundHandler) recipientsForTicket(ticketID string) []string {
+	if h.bridge == nil {
+		return nil
+	}
+	return h.bridge.GetTicketRecipients(ticketID)
+}
+
+func extractStatus(payload map[string]interface{}) string {
+	if payload == nil {
+		return ""
+	}
+	if status, ok := payload["status"].(string); ok && status != "" {
+		return status
+	}
+	if state, ok := payload["state"].(string); ok && state != "" {
+		return state
+	}
+	if status, ok := payload["to_status"].(string); ok && status != "" {
+		return status
+	}
+	return ""
+}
+
+func extractAssignedAgent(payload map[string]interface{}) string {
+	if payload == nil {
+		return ""
+	}
+	if assignee, ok := payload["assignee"].(string); ok {
+		return assignee
+	}
+	if assignee, ok := payload["assignee_uuid"].(string); ok {
+		return assignee
+	}
+	if assignee, ok := payload["to_assignee"].(string); ok {
+		return assignee
+	}
+	return ""
+}
+
+func extractMessage(payload map[string]interface{}) string {
+	if payload == nil {
+		return ""
+	}
+	if msg, ok := payload["message"].(string); ok && msg != "" {
+		return msg
+	}
+	if msg, ok := payload["comment_body"].(string); ok && msg != "" {
+		return msg
+	}
+	if msg, ok := payload["description"].(string); ok && msg != "" {
+		return msg
+	}
+	if msg, ok := payload["comment"].(string); ok && msg != "" {
+		return msg
+	}
+	return ""
+}
+
+func extractMetadata(payload map[string]interface{}) map[string]string {
+	if payload == nil {
+		return nil
+	}
+	meta := map[string]string{}
+	for _, key := range []string{"external_id", "comment_id", "source"} {
+		if value, ok := payload[key].(string); ok && value != "" {
+			meta[key] = value
+		}
+	}
+	if len(meta) == 0 {
+		return nil
+	}
+	return meta
+}
+
+func normalizeStatus(event *servicedesk.SyncEvent, status string) string {
+	if event == nil {
+		return status
+	}
+	switch event.Direction {
+	case servicedesk.SyncDirectionInbound:
+		if event.Type == "status_changed" && strings.TrimSpace(status) != "" {
+			return status
+		}
+	}
+	if event.Payload != nil {
+		if sd, ok := event.Payload["service_desk"].(string); ok && sd == string(servicedesk.ServiceDeskWaldur) {
+			return waldur.MapWaldurStateToVirtEngine(waldur.IssueState(status))
+		}
+	}
+	return status
+}
+
+// SupportExternalRefHandler registers external ticket references on-chain.
+type SupportExternalRefHandler struct {
+	chainWriter     SupportChainWriter
+	providerAddress string
+	logger          log.Logger
+}
+
+// NewSupportExternalRefHandler builds a handler for external refs.
+func NewSupportExternalRefHandler(chainWriter SupportChainWriter, providerAddress string, logger log.Logger) *SupportExternalRefHandler {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+	return &SupportExternalRefHandler{
+		chainWriter:     chainWriter,
+		providerAddress: providerAddress,
+		logger:          logger,
+	}
+}
+
+// HandleExternalRef registers an external reference.
+func (h *SupportExternalRefHandler) HandleExternalRef(ctx context.Context, ticketID string, ref servicedesk.ExternalTicketRef) error {
+	if h == nil || h.chainWriter == nil {
+		return nil
+	}
+	msg := &SupportRegisterExternal{
+		ResourceID:       ticketID,
+		ResourceType:     "support_request",
+		ExternalSystem:   ref.Type.String(),
+		ExternalTicketID: ref.ExternalID,
+		ExternalURL:      ref.ExternalURL,
+		CreatedBy:        h.providerAddress,
+	}
+	if err := h.chainWriter.RegisterExternalTicket(ctx, msg); err != nil {
+		h.logger.Error("failed to register external ticket", "error", err, "ticket_id", ticketID)
+		return err
+	}
+	return nil
+}
+
+// nolint:unused
+var _ = time.Second

--- a/pkg/servicedesk/event_listener.go
+++ b/pkg/servicedesk/event_listener.go
@@ -298,6 +298,7 @@ func (l *ChainEventListener) handleSupportRequestCreated(ctx context.Context, en
 		Priority:        payload.Priority,
 		Subject:         subject,
 		Description:     description,
+		Recipients:      append([]string(nil), payload.Recipients...),
 		BlockHeight:     blockHeight,
 		Timestamp:       time.Unix(payload.Timestamp, 0).UTC(),
 		TxHash:          txHash,

--- a/pkg/servicedesk/types.go
+++ b/pkg/servicedesk/types.go
@@ -296,6 +296,9 @@ type TicketSyncRecord struct {
 	// ExternalRefs are references to external tickets
 	ExternalRefs []ExternalTicketRef `json:"external_refs"`
 
+	// Recipients are the encryption recipient key IDs for this ticket
+	Recipients []string `json:"recipients,omitempty"`
+
 	// LastOnChainUpdate is the last on-chain update timestamp
 	LastOnChainUpdate time.Time `json:"last_on_chain_update"`
 

--- a/portal/src/app/(customer)/support/[id]/page.tsx
+++ b/portal/src/app/(customer)/support/[id]/page.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Textarea } from '@/components/ui/Textarea';
+import { formatDate, formatRelativeTime } from '@/lib/utils';
+import { getSlaTargetHours, useSupportStore, type SupportStatus } from '@/stores/supportStore';
+
+const statusStyles: Record<SupportStatus, string> = {
+  open: 'bg-blue-100 text-blue-900',
+  assigned: 'bg-indigo-100 text-indigo-900',
+  in_progress: 'bg-amber-100 text-amber-900',
+  waiting_customer: 'bg-purple-100 text-purple-900',
+  waiting_support: 'bg-sky-100 text-sky-900',
+  resolved: 'bg-emerald-100 text-emerald-900',
+  closed: 'bg-slate-200 text-slate-700',
+  archived: 'bg-slate-100 text-slate-500',
+};
+
+export default function SupportTicketDetailPage() {
+  const params = useParams<{ id: string }>();
+  const ticketId = decodeURIComponent(params.id);
+  const { tickets, addResponse, updateStatus } = useSupportStore();
+  const [message, setMessage] = useState('');
+
+  const ticket = useMemo(() => tickets.find((t) => t.id === ticketId), [tickets, ticketId]);
+
+  const slaTarget = ticket ? getSlaTargetHours(ticket.priority) : 0;
+  const slaDueAt = ticket ? new Date(ticket.createdAt.getTime() + slaTarget * 3600 * 1000) : null;
+
+  if (!ticket) {
+    return (
+      <div className="container py-10">
+        <Card>
+          <CardHeader>
+            <CardTitle>Ticket not found</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              We could not locate this support ticket. Return to the support center to browse available tickets.
+            </p>
+            <Button asChild>
+              <Link href="/support">Back to support</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const handleSend = () => {
+    if (!message.trim()) return;
+    addResponse(ticket.id, { message, isAgent: false, author: ticket.submitter });
+    updateStatus(ticket.id, 'waiting_support');
+    setMessage('');
+  };
+
+  return (
+    <div className="container space-y-8 py-8">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <Link href="/support" className="hover:text-foreground">
+              Support Center
+            </Link>{' '}
+            / {ticket.ticketNumber}
+          </p>
+          <h1 className="text-3xl font-semibold">{ticket.subject}</h1>
+          <p className="text-muted-foreground">Opened {formatRelativeTime(ticket.createdAt)}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Badge className={statusStyles[ticket.status]}>{ticket.status.replace('_', ' ')}</Badge>
+          <Badge className="bg-foreground text-background">{ticket.priority}</Badge>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Conversation</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {ticket.responses.map((response) => (
+              <div key={response.id} className="space-y-2 rounded-lg border border-border p-4">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-medium">
+                    {response.author} {response.isAgent ? '(Support)' : '(Customer)'}
+                  </span>
+                  <span className="text-muted-foreground">{formatDate(response.createdAt)}</span>
+                </div>
+                <p className="text-sm text-muted-foreground">{response.message}</p>
+              </div>
+            ))}
+
+            <div className="space-y-3 rounded-lg border border-dashed border-border p-4">
+              <Textarea
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                placeholder="Add a response to update the provider support team."
+                rows={4}
+              />
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <span className="text-xs text-muted-foreground">
+                  Responses are encrypted on-chain and synced to Waldur.
+                </span>
+                <Button onClick={handleSend} disabled={!message.trim()}>
+                  Send response
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Ticket details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Category</span>
+                <span className="font-medium">{ticket.category}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Created</span>
+                <span className="font-medium">{formatDate(ticket.createdAt)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Last response</span>
+                <span className="font-medium">
+                  {ticket.lastResponseAt ? formatRelativeTime(ticket.lastResponseAt) : 'Waiting'}
+                </span>
+              </div>
+              {ticket.relatedEntity && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Related entity</span>
+                  <span className="font-medium">
+                    {ticket.relatedEntity.type}:{' '}
+                    <span className="text-xs">{ticket.relatedEntity.id}</span>
+                  </span>
+                </div>
+              )}
+              {ticket.externalRef && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Service desk</span>
+                  <span className="font-medium">
+                    {ticket.externalRef.system.toUpperCase()} {ticket.externalRef.externalId}
+                  </span>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>SLA tracking</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Target response</span>
+                <span className="font-medium">{slaTarget} hours</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Due by</span>
+                <span className="font-medium">{slaDueAt ? formatDate(slaDueAt) : '--'}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                SLA timers are calculated locally and reconciled with Waldur status updates.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/portal/src/app/(customer)/support/page.tsx
+++ b/portal/src/app/(customer)/support/page.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import { Textarea } from '@/components/ui/Textarea';
+import { formatDate, formatRelativeTime } from '@/lib/utils';
+import {
+  getSlaTargetHours,
+  useSupportStore,
+  type SupportCategory,
+  type SupportPriority,
+  type SupportStatus,
+} from '@/stores/supportStore';
+
+const statusStyles: Record<SupportStatus, string> = {
+  open: 'bg-blue-100 text-blue-900',
+  assigned: 'bg-indigo-100 text-indigo-900',
+  in_progress: 'bg-amber-100 text-amber-900',
+  waiting_customer: 'bg-purple-100 text-purple-900',
+  waiting_support: 'bg-sky-100 text-sky-900',
+  resolved: 'bg-emerald-100 text-emerald-900',
+  closed: 'bg-slate-200 text-slate-700',
+  archived: 'bg-slate-100 text-slate-500',
+};
+
+const priorityStyles: Record<SupportPriority, string> = {
+  low: 'bg-slate-100 text-slate-600',
+  normal: 'bg-emerald-100 text-emerald-700',
+  high: 'bg-amber-100 text-amber-700',
+  urgent: 'bg-rose-100 text-rose-700',
+};
+
+const categoryOptions: { value: SupportCategory; label: string }[] = [
+  { value: 'account', label: 'Account' },
+  { value: 'identity', label: 'Identity' },
+  { value: 'billing', label: 'Billing' },
+  { value: 'provider', label: 'Provider' },
+  { value: 'marketplace', label: 'Marketplace' },
+  { value: 'technical', label: 'Technical' },
+  { value: 'security', label: 'Security' },
+  { value: 'other', label: 'Other' },
+];
+
+const priorityOptions: { value: SupportPriority; label: string }[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'high', label: 'High' },
+  { value: 'urgent', label: 'Urgent' },
+];
+
+const slaLabel = (createdAt: Date, priority: SupportPriority) => {
+  const targetHours = getSlaTargetHours(priority);
+  const dueAt = new Date(createdAt.getTime() + targetHours * 3600 * 1000);
+  const remainingMs = dueAt.getTime() - Date.now();
+  const remainingHours = Math.max(0, Math.ceil(remainingMs / 3600 / 1000));
+  return {
+    dueAt,
+    remainingHours,
+    breached: remainingMs < 0,
+  };
+};
+
+export default function SupportPage() {
+  const { tickets, createTicket } = useSupportStore();
+  const [subject, setSubject] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState<SupportCategory>('technical');
+  const [priority, setPriority] = useState<SupportPriority>('normal');
+  const [relatedEntity, setRelatedEntity] = useState('');
+
+  const slaTarget = useMemo(() => getSlaTargetHours(priority), [priority]);
+
+  const handleSubmit = () => {
+    if (!subject || !description) return;
+    createTicket({
+      subject,
+      description,
+      category,
+      priority,
+      relatedEntity: relatedEntity
+        ? {
+            type: 'deployment',
+            id: relatedEntity,
+          }
+        : undefined,
+    });
+    setSubject('');
+    setDescription('');
+    setRelatedEntity('');
+  };
+
+  return (
+    <div className="container space-y-8 py-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold">Support Center</h1>
+          <p className="text-muted-foreground">
+            Track tickets on-chain and keep your provider service desk in sync.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+          <span>Routing: Chain → Waldur</span>
+          <span>Inbound sync: enabled</span>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Create a ticket</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="subject">Subject</Label>
+                <Input
+                  id="subject"
+                  placeholder="Summarize the issue"
+                  value={subject}
+                  onChange={(event) => setSubject(event.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="related">Related deployment (optional)</Label>
+                <Input
+                  id="related"
+                  placeholder="ord-001"
+                  value={relatedEntity}
+                  onChange={(event) => setRelatedEntity(event.target.value)}
+                />
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Category</Label>
+                <Select value={category} onValueChange={(value) => setCategory(value as SupportCategory)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select category" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {categoryOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Priority</Label>
+                <Select value={priority} onValueChange={(value) => setPriority(value as SupportPriority)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select priority" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {priorityOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                placeholder="Describe the impact, expected behavior, and any error messages."
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                rows={5}
+              />
+            </div>
+            <div className="rounded-lg border border-dashed border-border bg-muted/40 p-4 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="font-medium text-foreground">SLA target</span>
+                <Badge className="bg-foreground text-background">{slaTarget}h</Badge>
+              </div>
+              <p className="mt-2 text-muted-foreground">
+                Priority {priority} tickets should receive an initial response within {slaTarget} hours.
+              </p>
+            </div>
+            <Button className="w-full" onClick={handleSubmit} disabled={!subject || !description}>
+              Submit ticket
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Active tickets</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {tickets.map((ticket) => {
+              const sla = slaLabel(ticket.createdAt, ticket.priority);
+              return (
+                <Link key={ticket.id} href={`/support/${encodeURIComponent(ticket.id)}`}>
+                  <div className="rounded-lg border border-border p-4 transition hover:border-foreground/40">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold text-foreground">{ticket.subject}</p>
+                        <p className="text-xs text-muted-foreground">{ticket.ticketNumber}</p>
+                      </div>
+                      <div className="flex flex-col items-end gap-2">
+                        <Badge className={priorityStyles[ticket.priority]}>{ticket.priority}</Badge>
+                        <Badge className={statusStyles[ticket.status]}>{ticket.status.replace('_', ' ')}</Badge>
+                      </div>
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                      <span>Updated {formatRelativeTime(ticket.updatedAt)}</span>
+                      <span>Created {formatDate(ticket.createdAt)}</span>
+                      <span className={sla.breached ? 'text-rose-500' : 'text-emerald-600'}>
+                        SLA {sla.breached ? 'breached' : `due in ${sla.remainingHours}h`}
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/portal/src/components/layout/Header.tsx
+++ b/portal/src/components/layout/Header.tsx
@@ -12,6 +12,7 @@ export function Header() {
   const navigation = [
     { name: 'Marketplace', href: '/marketplace' },
     { name: 'HPC', href: '/hpc/jobs' },
+    { name: 'Support', href: '/support' },
     { name: 'Governance', href: '/governance/proposals' },
   ];
 

--- a/portal/src/stores/supportStore.ts
+++ b/portal/src/stores/supportStore.ts
@@ -1,0 +1,244 @@
+import { create } from 'zustand';
+import { generateId } from '@/lib/utils';
+
+export type SupportCategory =
+  | 'account'
+  | 'identity'
+  | 'billing'
+  | 'provider'
+  | 'marketplace'
+  | 'technical'
+  | 'security'
+  | 'other';
+
+export type SupportPriority = 'low' | 'normal' | 'high' | 'urgent';
+
+export type SupportStatus =
+  | 'open'
+  | 'assigned'
+  | 'in_progress'
+  | 'waiting_customer'
+  | 'waiting_support'
+  | 'resolved'
+  | 'closed'
+  | 'archived';
+
+export interface SupportResponse {
+  id: string;
+  author: string;
+  isAgent: boolean;
+  message: string;
+  createdAt: Date;
+}
+
+export interface SupportTicket {
+  id: string;
+  ticketNumber: string;
+  subject: string;
+  description: string;
+  category: SupportCategory;
+  priority: SupportPriority;
+  status: SupportStatus;
+  submitter: string;
+  assignedAgent?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  lastResponseAt?: Date;
+  relatedEntity?: {
+    type: string;
+    id: string;
+  };
+  externalRef?: {
+    system: 'waldur' | 'jira';
+    externalId: string;
+    url?: string;
+  };
+  responses: SupportResponse[];
+}
+
+export interface SupportState {
+  tickets: SupportTicket[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export interface SupportActions {
+  createTicket: (payload: CreateTicketPayload) => void;
+  addResponse: (ticketId: string, payload: AddResponsePayload) => void;
+  updateStatus: (ticketId: string, status: SupportStatus) => void;
+}
+
+export type SupportStore = SupportState & SupportActions;
+
+export interface CreateTicketPayload {
+  subject: string;
+  description: string;
+  category: SupportCategory;
+  priority: SupportPriority;
+  relatedEntity?: SupportTicket['relatedEntity'];
+}
+
+export interface AddResponsePayload {
+  message: string;
+  isAgent?: boolean;
+  author?: string;
+}
+
+const slaTargets: Record<SupportPriority, number> = {
+  low: 72,
+  normal: 48,
+  high: 24,
+  urgent: 4,
+};
+
+export const getSlaTargetHours = (priority: SupportPriority) => slaTargets[priority] ?? 48;
+
+const seedTickets = (): SupportTicket[] => {
+  const now = new Date();
+  const firstCreated = new Date(now.getTime() - 1000 * 60 * 60 * 5);
+  const secondCreated = new Date(now.getTime() - 1000 * 60 * 60 * 26);
+
+  return [
+    {
+      id: 'virtengine1abc/support/1',
+      ticketNumber: 'SUP-000124',
+      subject: 'GPU worker nodes stuck in provisioning',
+      description:
+        'Two GPU nodes in us-west-1 remain in provisioning state after deployment update. Need status and guidance.',
+      category: 'technical',
+      priority: 'high',
+      status: 'waiting_support',
+      submitter: 'virtengine1abc...7h3k',
+      assignedAgent: 'support-agent-17',
+      createdAt: firstCreated,
+      updatedAt: firstCreated,
+      lastResponseAt: new Date(now.getTime() - 1000 * 60 * 60 * 1),
+      relatedEntity: { type: 'deployment', id: 'ord-001' },
+      externalRef: {
+        system: 'waldur',
+        externalId: 'WALDUR-4491',
+        url: 'https://waldur.example.com/support/WALDUR-4491/',
+      },
+      responses: [
+        {
+          id: generateId('resp'),
+          author: 'virtengine1abc...7h3k',
+          isAgent: false,
+          message: 'Deployment started timing out after switching to A100 pool.',
+          createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 4.5),
+        },
+        {
+          id: generateId('resp'),
+          author: 'Support Agent Lina',
+          isAgent: true,
+          message:
+            'We are validating GPU inventory in us-west-1. Can you confirm the target instance size?',
+          createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 1),
+        },
+      ],
+    },
+    {
+      id: 'virtengine1abc/support/2',
+      ticketNumber: 'SUP-000118',
+      subject: 'Invoice shows duplicate storage charges',
+      description:
+        'Our January invoice includes duplicate storage line items. Please confirm billing correctness.',
+      category: 'billing',
+      priority: 'normal',
+      status: 'waiting_customer',
+      submitter: 'virtengine1abc...7h3k',
+      assignedAgent: 'support-agent-02',
+      createdAt: secondCreated,
+      updatedAt: new Date(now.getTime() - 1000 * 60 * 60 * 3),
+      lastResponseAt: new Date(now.getTime() - 1000 * 60 * 60 * 3),
+      externalRef: {
+        system: 'waldur',
+        externalId: 'WALDUR-4453',
+      },
+      responses: [
+        {
+          id: generateId('resp'),
+          author: 'Support Agent Marco',
+          isAgent: true,
+          message:
+            'We identified a duplicate usage sample. We will correct the invoice and follow up.',
+          createdAt: new Date(now.getTime() - 1000 * 60 * 60 * 3),
+        },
+      ],
+    },
+  ];
+};
+
+export const useSupportStore = create<SupportStore>()((set) => ({
+  tickets: seedTickets(),
+  isLoading: false,
+  error: null,
+
+  createTicket: (payload) => {
+    const now = new Date();
+    const newTicket: SupportTicket = {
+      id: `virtengine1abc/support/${Math.floor(Math.random() * 1000 + 3)}`,
+      ticketNumber: `SUP-${Math.floor(Math.random() * 900000 + 100000)}`,
+      subject: payload.subject,
+      description: payload.description,
+      category: payload.category,
+      priority: payload.priority,
+      status: 'open',
+      submitter: 'virtengine1abc...7h3k',
+      createdAt: now,
+      updatedAt: now,
+      relatedEntity: payload.relatedEntity,
+      responses: [
+        {
+          id: generateId('resp'),
+          author: 'virtengine1abc...7h3k',
+          isAgent: false,
+          message: payload.description,
+          createdAt: now,
+        },
+      ],
+    };
+
+    set((state) => ({ tickets: [newTicket, ...state.tickets] }));
+  },
+
+  addResponse: (ticketId, payload) => {
+    set((state) => ({
+      tickets: state.tickets.map((ticket) => {
+        if (ticket.id !== ticketId) return ticket;
+        const now = new Date();
+        const response: SupportResponse = {
+          id: generateId('resp'),
+          author: payload.author ?? (payload.isAgent ? 'Support Agent' : ticket.submitter),
+          isAgent: payload.isAgent ?? true,
+          message: payload.message,
+          createdAt: now,
+        };
+
+        const nextStatus: SupportStatus = response.isAgent ? 'waiting_customer' : 'waiting_support';
+
+        return {
+          ...ticket,
+          status: ticket.status === 'resolved' ? 'in_progress' : nextStatus,
+          updatedAt: now,
+          lastResponseAt: now,
+          responses: [...ticket.responses, response],
+        };
+      }),
+    }));
+  },
+
+  updateStatus: (ticketId, status) => {
+    set((state) => ({
+      tickets: state.tickets.map((ticket) =>
+        ticket.id === ticketId
+          ? {
+              ...ticket,
+              status,
+              updatedAt: new Date(),
+            }
+          : ticket
+      ),
+    }));
+  },
+}));

--- a/x/support/keeper/ticket.go
+++ b/x/support/keeper/ticket.go
@@ -1,0 +1,91 @@
+package keeper
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	types "github.com/virtengine/virtengine/x/support/types" //nolint:staticcheck // Deprecated types retained for compatibility.
+)
+
+// EmitSupportRequestCreated emits the support request created event and returns the sequence used.
+func (k Keeper) EmitSupportRequestCreated(ctx sdk.Context, request *types.SupportRequest) (uint64, error) {
+	seq := k.IncrementEventSequence(ctx)
+	event := types.SupportRequestCreatedEvent{
+		EventType:     string(types.SupportEventTypeRequestCreated),
+		EventID:       fmt.Sprintf("%s/%d", request.ID.String(), seq),
+		BlockHeight:   ctx.BlockHeight(),
+		Sequence:      seq,
+		TicketID:      request.ID.String(),
+		TicketNumber:  request.TicketNumber,
+		Submitter:     request.SubmitterAddress,
+		Category:      string(request.Category),
+		Priority:      string(request.Priority),
+		Status:        request.Status.String(),
+		PayloadHash:   request.Payload.EnvelopeHashHex(),
+		EnvelopeRef:   request.Payload.EnvelopeRef,
+		Payload:       &request.Payload,
+		Recipients:    request.Recipients,
+		RelatedEntity: request.RelatedEntity,
+		Timestamp:     ctx.BlockTime().Unix(),
+	}
+	return seq, k.EmitSupportEvent(ctx, event)
+}
+
+// EmitSupportRequestUpdated emits the support request updated event and returns the sequence used.
+func (k Keeper) EmitSupportRequestUpdated(ctx sdk.Context, request *types.SupportRequest, updatedBy string, payload *types.EncryptedSupportPayload) (uint64, error) {
+	seq := k.IncrementEventSequence(ctx)
+	event := types.SupportRequestUpdatedEvent{
+		EventType:     string(types.SupportEventTypeRequestUpdated),
+		EventID:       fmt.Sprintf("%s/%d", request.ID.String(), seq),
+		BlockHeight:   ctx.BlockHeight(),
+		Sequence:      seq,
+		TicketID:      request.ID.String(),
+		UpdatedBy:     updatedBy,
+		Priority:      string(request.Priority),
+		Category:      string(request.Category),
+		AssignedAgent: request.AssignedAgent,
+		Status:        request.Status.String(),
+		PayloadHash:   request.Payload.EnvelopeHashHex(),
+		EnvelopeRef:   request.Payload.EnvelopeRef,
+		Payload:       payload,
+		Timestamp:     ctx.BlockTime().Unix(),
+	}
+	return seq, k.EmitSupportEvent(ctx, event)
+}
+
+// EmitSupportResponseAdded emits the support response added event and returns the sequence used.
+func (k Keeper) EmitSupportResponseAdded(ctx sdk.Context, request *types.SupportRequest, response *types.SupportResponse) (uint64, error) {
+	seq := k.IncrementEventSequence(ctx)
+	event := types.SupportResponseAddedEvent{
+		EventType:   string(types.SupportEventTypeResponseAdded),
+		EventID:     fmt.Sprintf("%s/%d", request.ID.String(), seq),
+		BlockHeight: ctx.BlockHeight(),
+		Sequence:    seq,
+		TicketID:    request.ID.String(),
+		ResponseID:  response.ID.String(),
+		Author:      response.AuthorAddress,
+		IsAgent:     response.IsAgent,
+		PayloadHash: response.Payload.EnvelopeHashHex(),
+		EnvelopeRef: response.Payload.EnvelopeRef,
+		Payload:     &response.Payload,
+		Timestamp:   ctx.BlockTime().Unix(),
+	}
+	return seq, k.EmitSupportEvent(ctx, event)
+}
+
+// EmitSupportStatusChanged emits the support status changed event.
+func (k Keeper) EmitSupportStatusChanged(ctx sdk.Context, ticketID string, seq uint64, oldStatus, newStatus types.SupportStatus, updatedBy string) error {
+	event := types.SupportStatusChangedEvent{
+		EventType:   string(types.SupportEventTypeStatusChanged),
+		EventID:     fmt.Sprintf("%s/%d/status", ticketID, seq),
+		BlockHeight: ctx.BlockHeight(),
+		Sequence:    seq,
+		TicketID:    ticketID,
+		OldStatus:   oldStatus.String(),
+		NewStatus:   newStatus.String(),
+		UpdatedBy:   updatedBy,
+		Timestamp:   ctx.BlockTime().Unix(),
+	}
+	return k.EmitSupportEvent(ctx, event)
+}

--- a/x/support/types/messages.go
+++ b/x/support/types/messages.go
@@ -1,0 +1,49 @@
+package types
+
+// NewMsgCreateSupportRequest builds a MsgCreateSupportRequest with defaults.
+func NewMsgCreateSupportRequest(sender string, category SupportCategory, priority SupportPriority, payload EncryptedSupportPayload) *MsgCreateSupportRequest {
+	return &MsgCreateSupportRequest{
+		Sender:   sender,
+		Category: string(category),
+		Priority: string(priority),
+		Payload:  payload,
+	}
+}
+
+// NewMsgUpdateSupportRequest builds a MsgUpdateSupportRequest.
+func NewMsgUpdateSupportRequest(sender, ticketID string) *MsgUpdateSupportRequest {
+	return &MsgUpdateSupportRequest{
+		Sender:   sender,
+		TicketID: ticketID,
+	}
+}
+
+// NewMsgAddSupportResponse builds a MsgAddSupportResponse.
+func NewMsgAddSupportResponse(sender, ticketID string, payload EncryptedSupportPayload) *MsgAddSupportResponse {
+	return &MsgAddSupportResponse{
+		Sender:   sender,
+		TicketID: ticketID,
+		Payload:  payload,
+	}
+}
+
+// NewMsgArchiveSupportRequest builds a MsgArchiveSupportRequest.
+func NewMsgArchiveSupportRequest(sender, ticketID, reason string) *MsgArchiveSupportRequest {
+	return &MsgArchiveSupportRequest{
+		Sender:   sender,
+		TicketID: ticketID,
+		Reason:   reason,
+	}
+}
+
+// NewMsgRegisterExternalTicket builds a MsgRegisterExternalTicket.
+func NewMsgRegisterExternalTicket(sender, resourceID string, resourceType ResourceType, system ExternalSystem, externalTicketID, externalURL string) *MsgRegisterExternalTicket {
+	return &MsgRegisterExternalTicket{
+		Sender:           sender,
+		ResourceID:       resourceID,
+		ResourceType:     string(resourceType),
+		ExternalSystem:   string(system),
+		ExternalTicketID: externalTicketID,
+		ExternalURL:      externalURL,
+	}
+}


### PR DESCRIPTION
# Task: Support Ticket Routing - Chain to Provider Service Desk

## Objective

Implement support ticket routing from chain to provider Waldur service desk.

## Priority: HIGH (P1)

Support flow is critical for customer satisfaction.

## Estimated Lines: 2,000-3,500

## Support Flow

### Ticket Creation (Customer)

1. Customer creates ticket via portal
2. Ticket stored on-chain
3. Provider daemon picks up ticket
4. Routed to Waldur service desk
5. Provider responds in Waldur
6. Response synced back to chain

### Ticket Management (Provider)

1. View tickets in Waldur
2. Respond to customers
3. Status updates sync to chain
4. Resolution closes ticket

## Components

### On-Chain Support Module

- Ticket creation message
- Ticket status tracking
- Response storage
- SLA tracking

### Provider Daemon Integration

- Ticket event listener
- Waldur service desk API
- Response synchronization
- Status updates

### Portal UI

- Create ticket form
- Ticket list/history
- Ticket detail view
- Response display

## Implementation

### Phase 1: Chain Module (800 lines)

- Location: `x/support/`
- Ticket messages and keeper
- Status management

### Phase 2: Daemon Integration (800 lines)

- Location: `pkg/provider_daemon/support.go`
- Waldur service desk client
- Two-way sync

### Phase 3: Portal UI (800 lines)

- Create ticket page
- Ticket list
- Ticket detail

## Files to Create/Modify

- `x/support/keeper/ticket.go`
- `x/support/types/messages.go`
- `pkg/provider_daemon/support.go`
- `pkg/provider_daemon/waldur_servicedesk.go`
- `lib/portal/src/pages/support/`

## Acceptance Criteria

- [ ] Tickets created on-chain
- [ ] Routed to Waldur
- [ ] Responses sync back
- [ ] Portal UI complete
- [ ] Status tracking works
- [ ] SLA visible

## Agent Instructions

1. Review x/support module structure
2. Check Waldur service desk API
3. Implement bidirectional sync
4. Design intuitive ticket UI
5. Test complete support flow
6. Handle sync failures