### PR TITLE
feat(portal): project scaffold + Next.js foundation - 28D

### DIFF
--- a/portal/.env.example
+++ b/portal/.env.example
@@ -1,30 +1,21 @@
-# VirtEngine Portal Environment Variables
-
-# Chain Configuration
 NEXT_PUBLIC_CHAIN_ID=virtengine-1
 NEXT_PUBLIC_CHAIN_RPC=https://rpc.virtengine.com
 NEXT_PUBLIC_CHAIN_REST=https://api.virtengine.com
 NEXT_PUBLIC_CHAIN_WS=wss://ws.virtengine.com
 
-# API Configuration
 NEXT_PUBLIC_API_URL=https://api.virtengine.io
 NEXT_PUBLIC_INDEXER_URL=https://indexer.virtengine.io
 
-# Wallet Configuration
-NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=your_project_id_here
+NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
 NEXT_PUBLIC_SUPPORTED_WALLETS=keplr,leap,cosmostation
 
-# Feature Flags
 NEXT_PUBLIC_ENABLE_TESTNET=false
 NEXT_PUBLIC_ENABLE_MFA=true
 NEXT_PUBLIC_ENABLE_HPC=true
 NEXT_PUBLIC_ENABLE_IDENTITY=true
 
-# Analytics (Optional)
 NEXT_PUBLIC_ANALYTICS_ID=
-
-# Sentry (Optional)
 NEXT_PUBLIC_SENTRY_DSN=
 
-# Development
 NEXT_PUBLIC_DEV_MODE=false
+NEXT_PUBLIC_APP_URL=https://portal.virtengine.io

--- a/portal/src/app/(auth)/connect/page.tsx
+++ b/portal/src/app/(auth)/connect/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function ConnectPage() {
   return (
-    <main id="main-content" className="flex min-h-screen items-center justify-center px-4">
+    <div className="w-full">
       <div className="w-full max-w-lg space-y-8">
         <div className="text-center">
           <h1 className="text-2xl font-bold tracking-tight">Connect Your Wallet</h1>
@@ -35,6 +35,6 @@ export default function ConnectPage() {
           </p>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/portal/src/app/(auth)/layout.tsx
+++ b/portal/src/app/(auth)/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { AuthLayout } from '@/layouts';
+
+export default function AuthRoutesLayout({ children }: { children: ReactNode }) {
+  return <AuthLayout>{children}</AuthLayout>;
+}

--- a/portal/src/app/(auth)/login/page.tsx
+++ b/portal/src/app/(auth)/login/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function LoginPage() {
   return (
-    <main id="main-content" className="flex min-h-screen items-center justify-center px-4">
+    <div className="w-full">
       <div className="w-full max-w-md space-y-8">
         <div className="text-center">
           <h1 className="text-2xl font-bold tracking-tight">Welcome back</h1>
@@ -53,6 +53,6 @@ export default function LoginPage() {
           </Link>
         </p>
       </div>
-    </main>
+    </div>
   );
 }

--- a/portal/src/app/(customer)/layout.tsx
+++ b/portal/src/app/(customer)/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { CustomerLayout } from '@/layouts';
+
+export default function CustomerRoutesLayout({ children }: { children: ReactNode }) {
+  return <CustomerLayout>{children}</CustomerLayout>;
+}

--- a/portal/src/app/governance/layout.tsx
+++ b/portal/src/app/governance/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { CustomerLayout } from '@/layouts';
+
+export default function GovernanceRoutesLayout({ children }: { children: ReactNode }) {
+  return <CustomerLayout>{children}</CustomerLayout>;
+}

--- a/portal/src/app/hpc/layout.tsx
+++ b/portal/src/app/hpc/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { CustomerLayout } from '@/layouts';
+
+export default function HpcRoutesLayout({ children }: { children: ReactNode }) {
+  return <CustomerLayout>{children}</CustomerLayout>;
+}

--- a/portal/src/app/page.tsx
+++ b/portal/src/app/page.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
+import { MarketingLayout } from '@/layouts';
 
 export default function HomePage() {
   return (
-    <main id="main-content" className="flex min-h-screen flex-col">
-      {/* Hero Section */}
+    <MarketingLayout>
       <section className="relative flex flex-1 flex-col items-center justify-center px-4 py-20">
         <div className="absolute inset-0 -z-10 bg-gradient-to-b from-primary/5 via-transparent to-transparent" />
 
@@ -32,7 +32,6 @@ export default function HomePage() {
           </div>
         </div>
 
-        {/* Feature Cards */}
         <div className="mt-20 grid max-w-5xl gap-6 px-4 sm:grid-cols-2 lg:grid-cols-3">
           <FeatureCard
             title="Marketplace"
@@ -72,40 +71,7 @@ export default function HomePage() {
           />
         </div>
       </section>
-
-      {/* Footer */}
-      <footer className="border-t border-border px-4 py-8">
-        <div className="mx-auto max-w-7xl text-center text-sm text-muted-foreground">
-          <p>© {new Date().getFullYear()} VirtEngine. All rights reserved.</p>
-          <div className="mt-4 flex justify-center gap-6">
-            <a
-              href="https://docs.virtengine.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-foreground"
-            >
-              Documentation
-            </a>
-            <a
-              href="https://support.virtengine.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-foreground"
-            >
-              Support
-            </a>
-            <a
-              href="https://github.com/virtengine"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-foreground"
-            >
-              GitHub
-            </a>
-          </div>
-        </div>
-      </footer>
-    </main>
+    </MarketingLayout>
   );
 }
 

--- a/portal/src/app/provider/layout.tsx
+++ b/portal/src/app/provider/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { ProviderLayout } from '@/layouts';
+
+export default function ProviderRoutesLayout({ children }: { children: ReactNode }) {
+  return <ProviderLayout>{children}</ProviderLayout>;
+}

--- a/portal/src/app/providers.tsx
+++ b/portal/src/app/providers.tsx
@@ -1,23 +1,3 @@
 'use client';
 
-import { ThemeProvider } from 'next-themes';
-import type { ReactNode } from 'react';
-import { PortalProvider } from '@/lib/portal-adapter';
-import { portalConfig, chainConfig, walletConfig } from '@/config';
-
-/**
- * Root Providers
- *
- * Wraps the application with necessary providers:
- * - ThemeProvider: next-themes for dark/light mode
- * - PortalProvider: VirtEngine portal lib for auth, identity, marketplace, etc.
- */
-export function Providers({ children }: { children: ReactNode }) {
-  return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-      <PortalProvider config={portalConfig} chainConfig={chainConfig} walletConfig={walletConfig}>
-        {children}
-      </PortalProvider>
-    </ThemeProvider>
-  );
-}
+export { AppProviders as Providers } from '@/providers';

--- a/portal/src/components/ui/__stories__/Label.stories.tsx
+++ b/portal/src/components/ui/__stories__/Label.stories.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { Label } from '../Label';
+import { Input } from '../Input';
+
+const meta = {
+  title: 'UI/Label',
+  component: Label,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="grid w-80 gap-4">
+      <div className="grid gap-2">
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" placeholder="you@virtengine.io" />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="name" required>
+          Full name
+        </Label>
+        <Input id="name" placeholder="Ada Lovelace" />
+      </div>
+    </div>
+  ),
+};

--- a/portal/src/components/ui/__stories__/Separator.stories.tsx
+++ b/portal/src/components/ui/__stories__/Separator.stories.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { Separator } from '../Separator';
+
+const meta = {
+  title: 'UI/Separator',
+  component: Separator,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Separator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  render: () => (
+    <div className="w-80 space-y-4">
+      <div>
+        <h4 className="text-sm font-medium">Overview</h4>
+        <p className="text-sm text-muted-foreground">Wallet balances and recent activity.</p>
+      </div>
+      <Separator />
+      <div>
+        <h4 className="text-sm font-medium">Details</h4>
+        <p className="text-sm text-muted-foreground">Invoices and usage history.</p>
+      </div>
+    </div>
+  ),
+};
+
+export const Vertical: Story = {
+  render: () => (
+    <div className="flex h-20 items-center">
+      <div className="px-4 text-sm">Customer</div>
+      <Separator orientation="vertical" />
+      <div className="px-4 text-sm">Provider</div>
+    </div>
+  ),
+};

--- a/portal/src/components/ui/__stories__/Textarea.stories.tsx
+++ b/portal/src/components/ui/__stories__/Textarea.stories.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { Textarea } from '../Textarea';
+import { Label } from '../Label';
+
+const meta = {
+  title: 'UI/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="grid w-96 gap-2">
+      <Label htmlFor="notes">Deployment notes</Label>
+      <Textarea id="notes" placeholder="Describe the workload and any special requirements." />
+    </div>
+  ),
+};

--- a/portal/src/components/ui/__stories__/Toast.stories.tsx
+++ b/portal/src/components/ui/__stories__/Toast.stories.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from '../Toast';
+
+const meta = {
+  title: 'UI/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <ToastProvider>
+      <div className="min-h-[160px] w-[360px]">
+        <Toast defaultOpen>
+          <div className="grid gap-1">
+            <ToastTitle>Deployment queued</ToastTitle>
+            <ToastDescription>
+              Your workload will start once capacity is available.
+            </ToastDescription>
+          </div>
+          <ToastAction altText="View deployment">View</ToastAction>
+          <ToastClose />
+        </Toast>
+        <ToastViewport />
+      </div>
+    </ToastProvider>
+  ),
+};

--- a/portal/src/components/ui/__stories__/Toaster.stories.tsx
+++ b/portal/src/components/ui/__stories__/Toaster.stories.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { Toaster } from '../Toaster';
+import { Button } from '../Button';
+import { toast } from '@/hooks/use-toast';
+
+const meta = {
+  title: 'UI/Toaster',
+  component: Toaster,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Toaster>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex min-h-[200px] w-[360px] flex-col items-center justify-center gap-4">
+      <Button
+        onClick={() =>
+          toast({
+            title: 'Wallet connected',
+            description: 'Keplr is now linked to your VirtEngine account.',
+          })
+        }
+      >
+        Show toast
+      </Button>
+      <Toaster />
+    </div>
+  ),
+};

--- a/portal/src/layouts/AppLayout.tsx
+++ b/portal/src/layouts/AppLayout.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { ReactNode } from 'react';
+import { Header, Footer, Navigation, Sidebar } from '@/components/layout';
+
+interface AppLayoutProps {
+  children: ReactNode;
+  sidebarVariant: 'customer' | 'provider';
+}
+
+export function AppLayout({ children, sidebarVariant }: AppLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <Header />
+      <div className="border-b border-border bg-background lg:hidden">
+        <div className="container py-2">
+          <Navigation className="flex w-full gap-2 overflow-x-auto" />
+        </div>
+      </div>
+      <div className="flex flex-1">
+        <div className="hidden lg:block">
+          <Sidebar variant={sidebarVariant} />
+        </div>
+        <main id="main-content" className="flex-1">
+          <div className="container py-8">{children}</div>
+        </main>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/portal/src/layouts/AuthLayout.tsx
+++ b/portal/src/layouts/AuthLayout.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { ReactNode } from 'react';
+import { Header, Footer } from '@/components/layout';
+
+interface AuthLayoutProps {
+  children: ReactNode;
+}
+
+export function AuthLayout({ children }: AuthLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <Header />
+      <main id="main-content" className="flex flex-1 items-center justify-center px-4 py-12">
+        <div className="w-full max-w-md">{children}</div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/portal/src/layouts/CustomerLayout.tsx
+++ b/portal/src/layouts/CustomerLayout.tsx
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { ReactNode } from 'react';
+import { AppLayout } from './AppLayout';
+
+interface CustomerLayoutProps {
+  children: ReactNode;
+}
+
+export function CustomerLayout({ children }: CustomerLayoutProps) {
+  return <AppLayout sidebarVariant="customer">{children}</AppLayout>;
+}

--- a/portal/src/layouts/MarketingLayout.tsx
+++ b/portal/src/layouts/MarketingLayout.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { ReactNode } from 'react';
+import { Header, Footer } from '@/components/layout';
+
+interface MarketingLayoutProps {
+  children: ReactNode;
+}
+
+export function MarketingLayout({ children }: MarketingLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <Header />
+      <main id="main-content" className="flex-1">
+        {children}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/portal/src/layouts/ProviderLayout.tsx
+++ b/portal/src/layouts/ProviderLayout.tsx
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { ReactNode } from 'react';
+import { AppLayout } from './AppLayout';
+
+interface ProviderLayoutProps {
+  children: ReactNode;
+}
+
+export function ProviderLayout({ children }: ProviderLayoutProps) {
+  return <AppLayout sidebarVariant="provider">{children}</AppLayout>;
+}

--- a/portal/src/layouts/index.ts
+++ b/portal/src/layouts/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+export { AppLayout } from './AppLayout';
+export { MarketingLayout } from './MarketingLayout';
+export { AuthLayout } from './AuthLayout';
+export { CustomerLayout } from './CustomerLayout';
+export { ProviderLayout } from './ProviderLayout';

--- a/portal/src/lib/api-client.ts
+++ b/portal/src/lib/api-client.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import { env } from '@/config/env';
+
+export interface ApiClientConfig {
+  baseUrl?: string;
+  headers?: Record<string, string>;
+  fetcher?: typeof fetch;
+}
+
+export interface ApiRequestOptions extends RequestInit {
+  query?: Record<string, string | number | boolean | undefined>;
+}
+
+export class ApiError extends Error {
+  status: number;
+  payload?: unknown;
+
+  constructor(message: string, status: number, payload?: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
+/**
+ * ApiClient
+ *
+ * Thin fetch wrapper for Portal API calls. This is a scaffold and will be
+ * expanded in task 23B with typed endpoints and auth wiring.
+ */
+export class ApiClient {
+  private baseUrl: string;
+  private headers: Record<string, string>;
+  private fetcher: typeof fetch;
+
+  constructor(config: ApiClientConfig = {}) {
+    this.baseUrl = config.baseUrl ?? env.apiUrl;
+    this.headers = {
+      'Content-Type': 'application/json',
+      ...config.headers,
+    };
+    this.fetcher = config.fetcher ?? fetch;
+  }
+
+  async request<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    const url = new URL(path, this.baseUrl);
+    if (options.query) {
+      Object.entries(options.query).forEach(([key, value]) => {
+        if (value !== undefined) {
+          url.searchParams.set(key, String(value));
+        }
+      });
+    }
+
+    const response = await this.fetcher(url.toString(), {
+      ...options,
+      headers: {
+        ...this.headers,
+        ...options.headers,
+      },
+    });
+
+    const contentType = response.headers.get('content-type') ?? '';
+    let payload: unknown;
+    if (contentType.includes('application/json')) {
+      payload = (await response.json()) as unknown;
+    } else {
+      payload = await response.text();
+    }
+
+    if (!response.ok) {
+      throw new ApiError(response.statusText, response.status, payload);
+    }
+
+    return payload as T;
+  }
+
+  get<T>(path: string, options: ApiRequestOptions = {}) {
+    return this.request<T>(path, { ...options, method: 'GET' });
+  }
+
+  post<T>(path: string, body?: unknown, options: ApiRequestOptions = {}) {
+    return this.request<T>(path, {
+      ...options,
+      method: 'POST',
+      body: body ? JSON.stringify(body) : options.body,
+    });
+  }
+}
+
+export const apiClient = new ApiClient();

--- a/portal/src/providers/AppProviders.tsx
+++ b/portal/src/providers/AppProviders.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import type { ReactNode } from 'react';
+import { ThemeProvider } from 'next-themes';
+import { PortalProvider } from '@/lib/portal-adapter';
+import { portalConfig, chainConfig, walletConfig } from '@/config';
+import { Toaster } from '@/components/ui/Toaster';
+import { CosmosKitProvider } from './CosmosKitProvider';
+
+interface AppProvidersProps {
+  children: ReactNode;
+}
+
+/**
+ * AppProviders
+ *
+ * Root-level providers for the Portal app. This centralizes
+ * theming, portal context, wallet connectivity and global UI.
+ */
+export function AppProviders({ children }: AppProvidersProps) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+      <CosmosKitProvider>
+        <PortalProvider config={portalConfig} chainConfig={chainConfig} walletConfig={walletConfig}>
+          {children}
+          <Toaster />
+        </PortalProvider>
+      </CosmosKitProvider>
+    </ThemeProvider>
+  );
+}

--- a/portal/src/providers/CosmosKitProvider.tsx
+++ b/portal/src/providers/CosmosKitProvider.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import * as React from 'react';
+import { SUPPORTED_WALLETS, isWalletInstalled } from '@/config';
+import type { WalletType } from '@/config';
+
+export interface CosmosKitWallet {
+  id: WalletType;
+  name: string;
+  description: string;
+  recommended: boolean;
+  installed: boolean;
+}
+
+interface CosmosKitContextValue {
+  wallets: CosmosKitWallet[];
+  refresh: () => void;
+}
+
+const CosmosKitContext = React.createContext<CosmosKitContextValue | null>(null);
+
+function buildWallets(): CosmosKitWallet[] {
+  return SUPPORTED_WALLETS.filter((wallet) => wallet.id !== 'walletconnect').map((wallet) => ({
+    id: wallet.id,
+    name: wallet.name,
+    description: wallet.description,
+    recommended: wallet.recommended,
+    installed: isWalletInstalled(wallet.id),
+  }));
+}
+
+/**
+ * CosmosKitProvider
+ *
+ * Lightweight provider for Cosmos wallets (Keplr, Leap, Cosmostation).
+ * This keeps wallet discovery centralized for the Portal UI and
+ * complements the Portal wallet adapters.
+ */
+export function CosmosKitProvider({ children }: { children: React.ReactNode }) {
+  const [wallets, setWallets] = React.useState<CosmosKitWallet[]>(() => buildWallets());
+
+  const refresh = React.useCallback(() => {
+    setWallets(buildWallets());
+  }, []);
+
+  React.useEffect(() => {
+    refresh();
+    if (typeof window === 'undefined') return;
+
+    const handleFocus = () => refresh();
+    window.addEventListener('focus', handleFocus);
+
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [refresh]);
+
+  const value = React.useMemo(() => ({ wallets, refresh }), [wallets, refresh]);
+
+  return <CosmosKitContext.Provider value={value}>{children}</CosmosKitContext.Provider>;
+}
+
+export function useCosmosKitWallets(): CosmosKitContextValue {
+  const context = React.useContext(CosmosKitContext);
+  if (!context) {
+    throw new Error('useCosmosKitWallets must be used within a CosmosKitProvider');
+  }
+  return context;
+}

--- a/portal/src/providers/index.ts
+++ b/portal/src/providers/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+export { AppProviders } from './AppProviders';
+export { CosmosKitProvider, useCosmosKitWallets } from './CosmosKitProvider';
+export type { CosmosKitWallet } from './CosmosKitProvider';


### PR DESCRIPTION
```javascript
Priority: P1 - HIGH (Portal foundation blocker)

Problem:
Portal exists at portal/ but task 23A (VE portal project scaffold) is still marked TODO. Need to verify scaffold is complete and production-ready.

Context:

Portal uses Next.js (next.config.mjs present)

Has Storybook, Tailwind, Vitest, Playwright configured

Need to verify scaffold matches Waldur HomePort patterns (ADR-001 done)

Chain SDK (23B) depends on solid scaffold

Acceptance Criteria:

[ ] Verify all React foundations are in place (contexts, providers, hooks)

[ ] Implement CosmosKit wallet provider (Keplr, Leap, Cosmostation)

[ ] Create layout system with nav, sidebar, footer

[ ] Set up API client stub (to be completed in 23B)

[ ] Configure environment variables (.env.example)

[ ] Verify Storybook documents all base components

[ ] Run pnpm -C portal build successfully

[ ] Run pnpm -C portal test successfully

Files to Verify/Create:

portal/src/providers/ - Context providers

portal/src/hooks/ - Shared hooks

portal/src/layouts/ - Page layouts

portal/src/components/ui/ - Base UI components

Estimated Effort: 1-2 weeks (mostly verification, some gaps to fill)
```