### PR TITLE
feat(portal): MFA enrollment + challenge flow UI - 28J

### DIFF
--- a/lib/portal/index.ts
+++ b/lib/portal/index.ts
@@ -31,14 +31,14 @@
 // Core Exports
 // ============================================================================
 
-export { PortalProvider, usePortal } from './components/PortalProvider';
-export type { PortalProviderProps, PortalConfig } from './types/config';
+export { PortalProvider, usePortal } from "./components/PortalProvider";
+export type { PortalProviderProps, PortalConfig } from "./types/config";
 
 // ============================================================================
 // Authentication (VE-700)
 // ============================================================================
 
-export { useAuth, AuthProvider } from './hooks/useAuth';
+export { useAuth, AuthProvider } from "./hooks/useAuth";
 export type {
   AuthState,
   AuthActions,
@@ -46,19 +46,19 @@ export type {
   SSOCredentials,
   SessionToken,
   AuthError,
-} from './types/auth';
+} from "./types/auth";
 
-export { SessionManager } from './utils/session';
-export type { SessionConfig, SessionInfo } from './utils/session';
+export { SessionManager } from "./utils/session";
+export type { SessionConfig, SessionInfo } from "./utils/session";
 
-export { WalletAdapter, MnemonicWallet, KeypairWallet } from './utils/wallet';
-export type { WalletConfig, SigningResult } from './types/wallet';
+export { WalletAdapter, MnemonicWallet, KeypairWallet } from "./utils/wallet";
+export type { WalletConfig, SigningResult } from "./types/wallet";
 
 // ============================================================================
 // Wallet Connections (Portal UI)
 // ============================================================================
 
-export { WalletProvider, useWallet } from './src/wallet';
+export { WalletProvider, useWallet } from "./src/wallet";
 export type {
   WalletType as PortalWalletType,
   WalletConnectionStatus,
@@ -73,7 +73,7 @@ export type {
   DirectSignResponse,
   WalletContextValue,
   WalletProviderConfig,
-} from './src/wallet';
+} from "./src/wallet";
 
 // ============================================================================
 // Wallet Utilities (Enhanced - VE-700)
@@ -111,7 +111,7 @@ export {
   createTransactionPreview,
   validateTransaction,
   createDefaultGasSettings,
-} from './src/wallet';
+} from "./src/wallet";
 
 export type {
   WalletSession,
@@ -123,13 +123,13 @@ export type {
   TransactionPreview,
   TransactionOptions,
   TransactionValidationResult,
-} from './src/wallet';
+} from "./src/wallet";
 
 // ============================================================================
 // Identity / VEID (VE-701)
 // ============================================================================
 
-export { useIdentity, IdentityProvider } from './hooks/useIdentity';
+export { useIdentity, IdentityProvider } from "./hooks/useIdentity";
 export type {
   IdentityState,
   IdentityStatus,
@@ -141,41 +141,50 @@ export type {
   MarketplaceAction,
   RemediationPath,
   ScopeRequirement,
-} from './types/identity';
+} from "./types/identity";
 
-export { IdentityStatusCard } from './components/identity/IdentityStatusCard';
-export { IdentityScoreDisplay } from './components/identity/IdentityScoreDisplay';
-export { ScopeRequirements } from './components/identity/ScopeRequirements';
-export { UploadHistory } from './components/identity/UploadHistory';
-export { RemediationGuide } from './components/identity/RemediationGuide';
+export { IdentityStatusCard } from "./components/identity/IdentityStatusCard";
+export { IdentityScoreDisplay } from "./components/identity/IdentityScoreDisplay";
+export { ScopeRequirements } from "./components/identity/ScopeRequirements";
+export { UploadHistory } from "./components/identity/UploadHistory";
+export { RemediationGuide } from "./components/identity/RemediationGuide";
 
 // ============================================================================
 // MFA (VE-702)
 // ============================================================================
 
-export { useMFA, MFAProvider } from './hooks/useMFA';
+export { useMFA, MFAProvider } from "./hooks/useMFA";
 export type {
   MFAState,
   MFAFactor,
   MFAFactorType,
+  MFAFactorStatus,
+  MFAFactorMetadata,
   MFAPolicy,
   MFAEnrollment,
+  MFAEnrollmentStep,
+  MFAEnrollmentChallengeData,
   TrustedBrowser,
   MFAChallenge,
+  MFAChallengeType,
   MFAChallengeResponse,
-} from './types/mfa';
+  MFAAuditEntry,
+  MFAError,
+  MFAErrorCode,
+  SensitiveTransactionType,
+} from "./types/mfa";
 
-export { MFAEnrollmentWizard } from './components/mfa/MFAEnrollmentWizard';
-export { MFAPolicyConfig } from './components/mfa/MFAPolicyConfig';
-export { TrustedBrowserManager } from './components/mfa/TrustedBrowserManager';
-export { MFAPrompt } from './components/mfa/MFAPrompt';
-export { MFAAuditLog } from './components/mfa/MFAAuditLog';
+export { MFAEnrollmentWizard } from "./components/mfa/MFAEnrollmentWizard";
+export { MFAPolicyConfig } from "./components/mfa/MFAPolicyConfig";
+export { TrustedBrowserManager } from "./components/mfa/TrustedBrowserManager";
+export { MFAPrompt } from "./components/mfa/MFAPrompt";
+export { MFAAuditLog } from "./components/mfa/MFAAuditLog";
 
 // ============================================================================
 // Marketplace (VE-703)
 // ============================================================================
 
-export { useMarketplace, MarketplaceProvider } from './hooks/useMarketplace';
+export { useMarketplace, MarketplaceProvider } from "./hooks/useMarketplace";
 export type {
   MarketplaceState,
   Offering,
@@ -186,14 +195,14 @@ export type {
   OrderEvent,
   CheckoutRequest,
   CheckoutValidation,
-} from './types/marketplace';
+} from "./types/marketplace";
 
-export { OfferingList } from './components/marketplace/OfferingList';
-export { OfferingCard } from './components/marketplace/OfferingCard';
-export { OfferingDetail } from './components/marketplace/OfferingDetail';
-export { CheckoutFlow } from './components/marketplace/CheckoutFlow';
-export { OrderDetail } from './components/marketplace/OrderDetail';
-export { OrderTimeline } from './components/marketplace/OrderTimeline';
+export { OfferingList } from "./components/marketplace/OfferingList";
+export { OfferingCard } from "./components/marketplace/OfferingCard";
+export { OfferingDetail } from "./components/marketplace/OfferingDetail";
+export { CheckoutFlow } from "./components/marketplace/CheckoutFlow";
+export { OrderDetail } from "./components/marketplace/OrderDetail";
+export { OrderTimeline } from "./components/marketplace/OrderTimeline";
 
 // Marketplace Pages (Customer Browse Experience)
 export {
@@ -209,7 +218,7 @@ export {
   ProviderInfo,
   ProviderBadge,
   MarketplaceOfferingCard,
-} from './src/pages/marketplace';
+} from "./src/pages/marketplace";
 export type {
   MarketplacePageProps,
   UseOfferingsOptions,
@@ -225,13 +234,13 @@ export type {
   ProviderInfoProps,
   ProviderBadgeProps,
   MarketplaceOfferingCardProps,
-} from './src/pages/marketplace';
+} from "./src/pages/marketplace";
 
 // ============================================================================
 // Provider Console (VE-704)
 // ============================================================================
 
-export { useProvider, ProviderProvider } from './hooks/useProvider';
+export { useProvider, ProviderProvider } from "./hooks/useProvider";
 export type {
   ProviderState,
   ProviderProfile,
@@ -244,23 +253,23 @@ export type {
   AllocationRecord,
   UsageRecord,
   SettlementSummary,
-} from './types/provider';
+} from "./types/provider";
 
-export { ProviderRegistrationFlow } from './components/provider/ProviderRegistrationFlow';
-export { OfferingEditor } from './components/provider/OfferingEditor';
-export { PricingEditor } from './components/provider/PricingEditor';
-export { CapacityMonitor } from './components/provider/CapacityMonitor';
-export { BidDashboard } from './components/provider/BidDashboard';
-export { AllocationList } from './components/provider/AllocationList';
-export { UsageReports } from './components/provider/UsageReports';
-export { SettlementView } from './components/provider/SettlementView';
-export { DomainVerificationPanel } from './components/provider/DomainVerificationPanel';
+export { ProviderRegistrationFlow } from "./components/provider/ProviderRegistrationFlow";
+export { OfferingEditor } from "./components/provider/OfferingEditor";
+export { PricingEditor } from "./components/provider/PricingEditor";
+export { CapacityMonitor } from "./components/provider/CapacityMonitor";
+export { BidDashboard } from "./components/provider/BidDashboard";
+export { AllocationList } from "./components/provider/AllocationList";
+export { UsageReports } from "./components/provider/UsageReports";
+export { SettlementView } from "./components/provider/SettlementView";
+export { DomainVerificationPanel } from "./components/provider/DomainVerificationPanel";
 
 // ============================================================================
 // HPC / Supercomputer (VE-705)
 // ============================================================================
 
-export { useHPC, HPCProvider } from './hooks/useHPC';
+export { useHPC, HPCProvider } from "./hooks/useHPC";
 export type {
   HPCState,
   WorkloadTemplate,
@@ -270,13 +279,13 @@ export type {
   JobEvent,
   JobOutput,
   JobOutputReference,
-} from './types/hpc';
+} from "./types/hpc";
 
-export { WorkloadLibrary } from './components/hpc/WorkloadLibrary';
-export { JobSubmissionForm } from './components/hpc/JobSubmissionForm';
-export { JobTracker } from './components/hpc/JobTracker';
-export { JobOutputViewer } from './components/hpc/JobOutputViewer';
-export { JobCancelDialog } from './components/hpc/JobCancelDialog';
+export { WorkloadLibrary } from "./components/hpc/WorkloadLibrary";
+export { JobSubmissionForm } from "./components/hpc/JobSubmissionForm";
+export { JobTracker } from "./components/hpc/JobTracker";
+export { JobOutputViewer } from "./components/hpc/JobOutputViewer";
+export { JobCancelDialog } from "./components/hpc/JobCancelDialog";
 
 // ============================================================================
 // Wallet UI Components
@@ -295,7 +304,7 @@ export {
   LEAP_ICON_SVG,
   COSMOSTATION_ICON_SVG,
   WALLETCONNECT_ICON_SVG,
-} from './src/components/wallet';
+} from "./src/components/wallet";
 export type {
   WalletButtonProps,
   WalletAccountDisplayProps,
@@ -306,20 +315,20 @@ export type {
   WalletSkeletonProps,
   AccountSelectorProps,
   TransactionModalProps,
-} from './src/components/wallet';
+} from "./src/components/wallet";
 
 // ============================================================================
 // Chain Integration
 // ============================================================================
 
-export { useChain, ChainProvider } from './hooks/useChain';
+export { useChain, ChainProvider } from "./hooks/useChain";
 export type {
   ChainState,
   ChainConfig,
   EventSubscription,
   QueryClient,
   TransactionResult,
-} from './types/chain';
+} from "./types/chain";
 
 // TODO: Implement chain utilities
 // export { ChainEventListener } from './utils/chain-events';
@@ -330,13 +339,33 @@ export type {
 // Utilities
 // ============================================================================
 
-export { formatScore, formatTokenAmount, formatDuration, formatTimestamp } from './utils/format';
-export { validateAddress, validateMnemonic, isValidScore } from './utils/validation';
-export { sanitizePlainText, sanitizeDigits, sanitizeJsonInput, sanitizeObject } from './utils/security';
-export { encryptPayload, decryptPayload } from './utils/encryption';
-export type { EncryptionResult, DecryptionResult } from './utils/encryption';
-export { createOAuthRequest, persistOAuthRequest, consumeOAuthRequest, buildAuthorizationUrl, createPKCE } from './utils/oidc';
-export type { OAuthRequest } from './utils/oidc';
+export {
+  formatScore,
+  formatTokenAmount,
+  formatDuration,
+  formatTimestamp,
+} from "./utils/format";
+export {
+  validateAddress,
+  validateMnemonic,
+  isValidScore,
+} from "./utils/validation";
+export {
+  sanitizePlainText,
+  sanitizeDigits,
+  sanitizeJsonInput,
+  sanitizeObject,
+} from "./utils/security";
+export { encryptPayload, decryptPayload } from "./utils/encryption";
+export type { EncryptionResult, DecryptionResult } from "./utils/encryption";
+export {
+  createOAuthRequest,
+  persistOAuthRequest,
+  consumeOAuthRequest,
+  buildAuthorizationUrl,
+  createPKCE,
+} from "./utils/oidc";
+export type { OAuthRequest } from "./utils/oidc";
 
 // ============================================================================
 // Accessibility (VE-UI-002)
@@ -352,7 +381,7 @@ export {
   AccessibleCheckbox,
   AccessibleAlert,
   AccessibleProgress,
-} from './components/accessible';
+} from "./components/accessible";
 
 export type {
   SrOnlyProps,
@@ -363,7 +392,7 @@ export type {
   AccessibleCheckboxProps,
   AccessibleAlertProps,
   AccessibleProgressProps,
-} from './components/accessible';
+} from "./components/accessible";
 
 export {
   // Accessibility utilities
@@ -384,12 +413,9 @@ export {
   srOnlyStyles,
   focusVisibleStyles,
   A11Y_COLORS,
-} from './utils/a11y';
+} from "./utils/a11y";
 
-export type {
-  FocusTrap,
-  ArrowNavOptions,
-} from './utils/a11y';
+export type { FocusTrap, ArrowNavOptions } from "./utils/a11y";
 
 export {
   // Accessibility testing utilities
@@ -405,10 +431,10 @@ export {
   formatViolations,
   toHaveNoViolations,
   WCAG_21_AA_CONFIG,
-} from './utils/a11y-testing';
+} from "./utils/a11y-testing";
 
 export type {
   A11yTestConfig,
   A11yReport,
   KeyboardNavTestResult,
-} from './utils/a11y-testing';
+} from "./utils/a11y-testing";

--- a/portal/src/app/(customer)/account/settings/page.tsx
+++ b/portal/src/app/(customer)/account/settings/page.tsx
@@ -254,12 +254,12 @@ export default function AccountSettingsPage() {
                 </p>
                 <div className="mt-4 flex items-center justify-between">
                   <span className="text-sm font-medium text-success">Authenticator app</span>
-                  <button
-                    type="button"
+                  <a
+                    href="/account/settings/security"
                     className="rounded-lg border border-border px-3 py-1.5 text-xs hover:bg-accent"
                   >
                     Manage MFA
-                  </button>
+                  </a>
                 </div>
               </div>
 

--- a/portal/src/app/(customer)/account/settings/security/SecuritySettingsContent.tsx
+++ b/portal/src/app/(customer)/account/settings/security/SecuritySettingsContent.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Client component wrapper for the security settings page.
+ * Initialises MFA store and renders the MFASettings management UI.
+ */
+
+'use client';
+
+import { useEffect } from 'react';
+import { useMFAStore } from '@/features/mfa';
+import { MFASettings } from '@/components/mfa';
+
+export function SecuritySettingsContent() {
+  const loadMFAData = useMFAStore((s) => s.loadMFAData);
+
+  useEffect(() => {
+    void loadMFAData();
+  }, [loadMFAData]);
+
+  return <MFASettings />;
+}

--- a/portal/src/app/(customer)/account/settings/security/page.tsx
+++ b/portal/src/app/(customer)/account/settings/security/page.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Security settings page – MFA enrollment, challenge flow, and management.
+ */
+
+import type { Metadata } from 'next';
+import { SecuritySettingsContent } from './SecuritySettingsContent';
+
+export const metadata: Metadata = {
+  title: 'Security Settings',
+  description: 'Manage your VirtEngine multi-factor authentication and account security',
+};
+
+export default function SecuritySettingsPage() {
+  return (
+    <div className="container max-w-4xl py-8">
+      <div className="mb-8">
+        <nav className="mb-4 text-sm text-muted-foreground">
+          <a href="/account/settings" className="hover:text-foreground">
+            Account Settings
+          </a>
+          <span className="mx-2">/</span>
+          <span className="text-foreground">Security</span>
+        </nav>
+        <h1 className="text-3xl font-bold">Security Settings</h1>
+        <p className="mt-2 text-muted-foreground">
+          Manage multi-factor authentication, trusted devices, and review security activity.
+        </p>
+      </div>
+
+      <SecuritySettingsContent />
+    </div>
+  );
+}

--- a/portal/src/components/mfa/BackupCodes.tsx
+++ b/portal/src/components/mfa/BackupCodes.tsx
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Backup codes generation and display component.
+ * Shows codes once after generation and provides copy/download functionality.
+ */
+
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useMFAStore } from '@/features/mfa';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/Button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/Alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+
+interface BackupCodesProps {
+  onComplete?: () => void;
+  onCancel?: () => void;
+  className?: string;
+}
+
+export function BackupCodes({ onComplete, onCancel, className }: BackupCodesProps) {
+  const { backupCodes, isMutating, error, generateBackupCodes, clearBackupCodes, clearError } =
+    useMFAStore();
+
+  const [copied, setCopied] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  const handleGenerate = useCallback(async () => {
+    clearError();
+    await generateBackupCodes();
+  }, [generateBackupCodes, clearError]);
+
+  const handleCopy = useCallback(async () => {
+    if (!backupCodes) return;
+    try {
+      await navigator.clipboard.writeText(backupCodes.codes.join('\n'));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch {
+      // Fallback: select text for manual copy
+    }
+  }, [backupCodes]);
+
+  const handleDownload = useCallback(() => {
+    if (!backupCodes) return;
+    const content = [
+      'VirtEngine Backup Codes',
+      `Generated: ${new Date(backupCodes.generatedAt).toISOString()}`,
+      '',
+      'Each code can only be used once. Store these in a safe place.',
+      '',
+      ...backupCodes.codes.map((code, i) => `${i + 1}. ${code}`),
+    ].join('\n');
+
+    const blob = new Blob([content], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'virtengine-backup-codes.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [backupCodes]);
+
+  const handleDone = () => {
+    clearBackupCodes();
+    onComplete?.();
+  };
+
+  const handleCancel = () => {
+    clearBackupCodes();
+    onCancel?.();
+  };
+
+  // Pre-generation state
+  if (!backupCodes) {
+    return (
+      <Card className={cn(className)}>
+        <CardHeader>
+          <CardTitle className="text-lg">Generate Backup Codes</CardTitle>
+          <CardDescription>
+            Backup codes allow you to access your account if you lose your primary MFA device. Each
+            code can only be used once.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <Alert variant="warning">
+            <AlertTitle>Important</AlertTitle>
+            <AlertDescription>
+              Generating new backup codes will invalidate any previously generated codes. Make sure
+              to save the new codes in a secure location.
+            </AlertDescription>
+          </Alert>
+
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button onClick={handleGenerate} loading={isMutating}>
+              Generate Codes
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Post-generation: display codes
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle className="text-lg">Save Your Backup Codes</CardTitle>
+        <CardDescription>
+          Store these codes in a secure location. You will not be able to see them again.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Alert variant="warning">
+          <AlertTitle>Save these codes now</AlertTitle>
+          <AlertDescription>
+            Without these codes, you may lose access to your account if you lose your authenticator
+            device. Each code can only be used once.
+          </AlertDescription>
+        </Alert>
+
+        <div className="rounded-lg border bg-muted/30 p-4">
+          <div className="grid grid-cols-2 gap-2">
+            {backupCodes.codes.map((code, index) => (
+              <div
+                key={index}
+                className="rounded border bg-background px-3 py-2 text-center font-mono text-sm"
+              >
+                {code}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={handleCopy} className="flex-1">
+            {copied ? '✓ Copied' : 'Copy Codes'}
+          </Button>
+          <Button variant="outline" size="sm" onClick={handleDownload} className="flex-1">
+            Download .txt
+          </Button>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={confirmed}
+            onChange={(e) => setConfirmed(e.target.checked)}
+            className="rounded border-input"
+          />
+          I have saved these backup codes in a secure location
+        </label>
+
+        <div className="flex justify-end">
+          <Button onClick={handleDone} disabled={!confirmed}>
+            Done
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/portal/src/components/mfa/FactorList.tsx
+++ b/portal/src/components/mfa/FactorList.tsx
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Enrolled MFA factors list with enable/disable, primary toggle, and removal.
+ */
+
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useMFAStore } from '@/features/mfa';
+import type { MFAFactor } from '@/lib/portal-adapter';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/Button';
+import { Badge } from '@/components/ui/Badge';
+import { Alert, AlertDescription } from '@/components/ui/Alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/Modal';
+
+interface FactorListProps {
+  className?: string;
+  onAddFactor?: () => void;
+}
+
+const FACTOR_ICONS: Record<string, string> = {
+  otp: '📱',
+  fido2: '🔐',
+  sms: '💬',
+  email: '📧',
+  biometric: '👤',
+};
+
+const FACTOR_LABELS: Record<string, string> = {
+  otp: 'Authenticator App',
+  fido2: 'Security Key',
+  sms: 'SMS',
+  email: 'Email',
+  biometric: 'Biometric',
+};
+
+function getStatusBadgeVariant(status: string) {
+  switch (status) {
+    case 'active':
+      return 'success' as const;
+    case 'suspended':
+      return 'warning' as const;
+    case 'expired':
+      return 'destructive' as const;
+    default:
+      return 'secondary' as const;
+  }
+}
+
+function formatDate(timestamp: number | null): string {
+  if (!timestamp) return 'Never';
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function FactorList({ className, onAddFactor }: FactorListProps) {
+  const { factors, isMutating, error, removeFactor, toggleFactor, setPrimaryFactor, clearError } =
+    useMFAStore();
+
+  const [removeTarget, setRemoveTarget] = useState<MFAFactor | null>(null);
+
+  const handleToggle = useCallback(
+    async (factor: MFAFactor) => {
+      clearError();
+      await toggleFactor(factor.id, factor.status !== 'active');
+    },
+    [toggleFactor, clearError]
+  );
+
+  const handleSetPrimary = useCallback(
+    async (factorId: string) => {
+      clearError();
+      await setPrimaryFactor(factorId);
+    },
+    [setPrimaryFactor, clearError]
+  );
+
+  const handleRemoveConfirm = useCallback(async () => {
+    if (!removeTarget) return;
+    clearError();
+    try {
+      await removeFactor(removeTarget.id);
+      setRemoveTarget(null);
+    } catch {
+      // error is set in store
+    }
+  }, [removeTarget, removeFactor, clearError]);
+
+  if (factors.length === 0) {
+    return (
+      <div className={cn('rounded-lg border border-dashed bg-muted/20 p-8 text-center', className)}>
+        <div className="mx-auto mb-4 text-4xl" aria-hidden="true">
+          🔒
+        </div>
+        <h3 className="text-lg font-semibold">No MFA Factors Enrolled</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Add a second factor to protect your account with multi-factor authentication.
+        </p>
+        {onAddFactor && (
+          <Button onClick={onAddFactor} className="mt-4">
+            Add First Factor
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      {error && (
+        <Alert variant="destructive" onClose={clearError}>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {factors.map((factor) => (
+        <div
+          key={factor.id}
+          className="flex flex-col gap-3 rounded-lg border bg-card p-4 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-2xl" aria-hidden="true">
+              {FACTOR_ICONS[factor.type] ?? '🔑'}
+            </span>
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="font-medium">
+                  {factor.name || FACTOR_LABELS[factor.type] || factor.type}
+                </span>
+                <Badge variant={getStatusBadgeVariant(factor.status)} size="sm">
+                  {factor.status}
+                </Badge>
+                {factor.isPrimary && (
+                  <Badge variant="default" size="sm">
+                    Primary
+                  </Badge>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {FACTOR_LABELS[factor.type] ?? factor.type} · Enrolled{' '}
+                {formatDate(factor.enrolledAt)} · Last used {formatDate(factor.lastUsedAt)}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {!factor.isPrimary && factor.status === 'active' && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleSetPrimary(factor.id)}
+                disabled={isMutating}
+              >
+                Set primary
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleToggle(factor)}
+              disabled={isMutating}
+            >
+              {factor.status === 'active' ? 'Disable' : 'Enable'}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setRemoveTarget(factor)}
+              disabled={isMutating}
+              className="text-destructive hover:bg-destructive/10"
+            >
+              Remove
+            </Button>
+          </div>
+        </div>
+      ))}
+
+      {onAddFactor && (
+        <Button variant="outline" onClick={onAddFactor} className="w-full">
+          + Add Another Factor
+        </Button>
+      )}
+
+      {/* Removal confirmation dialog */}
+      <Dialog open={!!removeTarget} onOpenChange={(open) => !open && setRemoveTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove MFA Factor</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to remove{' '}
+              <strong>
+                {removeTarget?.name || FACTOR_LABELS[removeTarget?.type ?? ''] || 'this factor'}
+              </strong>
+              ? This action cannot be undone.
+              {factors.length === 1 && (
+                <>
+                  {' '}
+                  This is your only enrolled factor. Removing it will disable MFA on your account.
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveTarget(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleRemoveConfirm} loading={isMutating}>
+              Remove Factor
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/portal/src/components/mfa/MFAChallenge.tsx
+++ b/portal/src/components/mfa/MFAChallenge.tsx
@@ -1,44 +1,109 @@
 'use client';
 
-import { useMFA, MFAPrompt } from '@/lib/portal-adapter';
+import { useState, useCallback } from 'react';
+import { useMFAStore } from '@/features/mfa';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Badge } from '@/components/ui/Badge';
+import { Alert, AlertDescription } from '@/components/ui/Alert';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/Modal';
+import type { SensitiveTransactionType } from '@/lib/portal-adapter';
 
 interface MFAChallengeProps {
+  /** Whether the challenge dialog is open */
   open: boolean;
+  /** Callback when open state changes */
   onOpenChange: (open: boolean) => void;
+  /** The sensitive transaction type requiring MFA */
+  transactionType?: SensitiveTransactionType;
+  /** Description of the action being gated */
+  actionDescription?: string;
+  /** Called when MFA verification succeeds */
   onSuccess?: () => void;
+  /** Called when MFA verification fails */
   onFailure?: (error: Error) => void;
   className?: string;
 }
 
+const FACTOR_LABELS: Record<string, string> = {
+  otp: 'Authenticator App',
+  fido2: 'Security Key',
+  sms: 'SMS',
+  email: 'Email',
+  biometric: 'Biometric',
+};
+
 /**
  * MFA Challenge Component
- * Modal dialog for MFA verification during sensitive actions
+ * Modal dialog for MFA verification during sensitive actions.
+ * Supports OTP code entry and factor selection for multi-factor accounts.
  */
 export function MFAChallenge({
   open,
   onOpenChange,
+  transactionType,
+  actionDescription,
   onSuccess,
-  onFailure: _onFailure,
+  onFailure,
   className,
 }: MFAChallengeProps) {
-  const { state } = useMFA();
+  const { factors, isMutating, error, verifyChallenge, clearError } = useMFAStore();
 
-  const handleVerify = () => {
-    onSuccess?.();
-    onOpenChange(false);
+  const [selectedFactorId, setSelectedFactorId] = useState<string>('');
+  const [code, setCode] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const activeFactors = factors.filter((f) => f.status === 'active');
+
+  // Auto-select first factor if none selected
+  if (!selectedFactorId && activeFactors.length > 0) {
+    setSelectedFactorId(activeFactors[0].id);
+  }
+
+  const handleCodeChange = (value: string) => {
+    const sanitized = value.replace(/\D/g, '').slice(0, 6);
+    setCode(sanitized);
+    setLocalError(null);
+    clearError();
   };
+
+  const handleVerify = useCallback(async () => {
+    if (!selectedFactorId || !code) return;
+    setLocalError(null);
+
+    try {
+      const verified = await verifyChallenge(selectedFactorId, code);
+      if (verified) {
+        setCode('');
+        onSuccess?.();
+        onOpenChange(false);
+      } else {
+        setLocalError('Verification failed. Please try again.');
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : 'Verification failed';
+      setLocalError(errMsg);
+      onFailure?.(err instanceof Error ? err : new Error(errMsg));
+    }
+  }, [selectedFactorId, code, verifyChallenge, onSuccess, onFailure, onOpenChange]);
 
   const handleCancel = () => {
+    setCode('');
+    setLocalError(null);
+    clearError();
     onOpenChange(false);
   };
+
+  const selectedFactor = activeFactors.find((f) => f.id === selectedFactorId);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -46,14 +111,108 @@ export function MFAChallenge({
         <DialogHeader>
           <DialogTitle>Verification Required</DialogTitle>
           <DialogDescription>
-            Please complete two-factor authentication to continue
+            {actionDescription ??
+              'Please complete two-factor authentication to continue with this action'}
           </DialogDescription>
         </DialogHeader>
-        <MFAPrompt
-          factors={state.enrolledFactors}
-          onVerify={handleVerify}
-          onCancel={handleCancel}
-        />
+
+        {(localError || error) && (
+          <Alert variant="destructive">
+            <AlertDescription>{localError || error}</AlertDescription>
+          </Alert>
+        )}
+
+        {transactionType && (
+          <div className="rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+            Action: <span className="font-medium">{transactionType.replace(/_/g, ' ')}</span>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {/* Factor selector (if multiple factors) */}
+          {activeFactors.length > 1 && (
+            <div className="space-y-2">
+              <Label htmlFor="mfa-factor-select">Verification method</Label>
+              <select
+                id="mfa-factor-select"
+                value={selectedFactorId}
+                onChange={(e) => {
+                  setSelectedFactorId(e.target.value);
+                  setCode('');
+                  setLocalError(null);
+                }}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              >
+                {activeFactors.map((factor) => (
+                  <option key={factor.id} value={factor.id}>
+                    {factor.name || FACTOR_LABELS[factor.type] || factor.type}
+                    {factor.isPrimary ? ' (Primary)' : ''}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Single factor display */}
+          {activeFactors.length === 1 && selectedFactor && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              Using:{' '}
+              <Badge variant="secondary">
+                {selectedFactor.name || FACTOR_LABELS[selectedFactor.type] || selectedFactor.type}
+              </Badge>
+            </div>
+          )}
+
+          {/* Code input */}
+          {selectedFactor && selectedFactor.type !== 'fido2' && (
+            <div className="space-y-2">
+              <Label htmlFor="mfa-code">
+                {selectedFactor.type === 'otp'
+                  ? '6-digit code from your authenticator app'
+                  : 'Verification code'}
+              </Label>
+              <Input
+                id="mfa-code"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                pattern="[0-9]*"
+                maxLength={6}
+                value={code}
+                onChange={(e) => handleCodeChange(e.target.value)}
+                placeholder="000000"
+                className="text-center font-mono text-lg tracking-[0.3em]"
+                error={!!localError}
+                autoFocus
+              />
+            </div>
+          )}
+
+          {/* FIDO2 prompt */}
+          {selectedFactor && selectedFactor.type === 'fido2' && (
+            <div className="flex flex-col items-center gap-3 rounded-lg border bg-muted/30 p-6">
+              <div className="text-4xl" aria-hidden="true">
+                🔐
+              </div>
+              <p className="text-center text-sm text-muted-foreground">
+                Touch your security key or use your device biometrics when prompted.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleVerify}
+            disabled={selectedFactor?.type === 'fido2' ? false : code.length !== 6}
+            loading={isMutating}
+          >
+            Verify
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/portal/src/components/mfa/MFASettings.tsx
+++ b/portal/src/components/mfa/MFASettings.tsx
@@ -1,22 +1,35 @@
 'use client';
 
-import { useMFA, MFAPolicyConfig, TrustedBrowserManager, MFAAuditLog } from '@/lib/portal-adapter';
+import { useState } from 'react';
+import { useMFAStore } from '@/features/mfa';
 import { cn } from '@/lib/utils';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
+import { FactorList } from './FactorList';
+import { TOTPSetup } from './TOTPSetup';
+import { WebAuthnSetup } from './WebAuthnSetup';
+import { BackupCodes } from './BackupCodes';
+import { RecoveryFlow } from './RecoveryFlow';
+import { Button } from '@/components/ui/Button';
+import { Badge } from '@/components/ui/Badge';
+import { Separator } from '@/components/ui/Separator';
 
 interface MFASettingsProps {
   className?: string;
 }
 
+type SetupView = 'none' | 'totp' | 'webauthn' | 'backup' | 'recovery';
+
 /**
  * MFA Settings Component
- * Manage MFA configuration, trusted browsers, and view audit log
+ * Full management page for MFA configuration, enrolled factors, trusted browsers, and audit.
  */
 export function MFASettings({ className }: MFASettingsProps) {
-  const { state } = useMFA();
+  const { isLoading, isEnabled, factors, trustedBrowsers, auditLog, revokeTrustedBrowser } =
+    useMFAStore();
+  const [setupView, setSetupView] = useState<SetupView>('none');
 
-  if (state.isLoading) {
+  if (isLoading) {
     return (
       <div className={cn('animate-pulse rounded-lg bg-muted p-6', className)}>
         <div className="h-6 w-48 rounded bg-muted-foreground/20" />
@@ -25,30 +38,247 @@ export function MFASettings({ className }: MFASettingsProps) {
     );
   }
 
+  // If user is in a setup flow, show the setup component full-width
+  if (setupView !== 'none') {
+    const handleComplete = () => setSetupView('none');
+    const handleCancel = () => setSetupView('none');
+
+    switch (setupView) {
+      case 'totp':
+        return (
+          <TOTPSetup onComplete={handleComplete} onCancel={handleCancel} className={className} />
+        );
+      case 'webauthn':
+        return (
+          <WebAuthnSetup
+            onComplete={handleComplete}
+            onCancel={handleCancel}
+            className={className}
+          />
+        );
+      case 'backup':
+        return (
+          <BackupCodes onComplete={handleComplete} onCancel={handleCancel} className={className} />
+        );
+      case 'recovery':
+        return (
+          <RecoveryFlow onComplete={handleComplete} onCancel={handleCancel} className={className} />
+        );
+    }
+  }
+
   return (
-    <Card className={cn(className)}>
-      <CardHeader>
-        <CardTitle>Two-Factor Authentication Settings</CardTitle>
-        <CardDescription>Manage your security settings and trusted devices</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Tabs defaultValue="factors">
-          <TabsList className="grid w-full grid-cols-3">
-            <TabsTrigger value="factors">Factors</TabsTrigger>
-            <TabsTrigger value="browsers">Trusted Browsers</TabsTrigger>
-            <TabsTrigger value="audit">Audit Log</TabsTrigger>
-          </TabsList>
-          <TabsContent value="factors" className="mt-4">
-            <MFAPolicyConfig currentPolicy={state.policy} enrolledFactors={state.enrolledFactors} />
-          </TabsContent>
-          <TabsContent value="browsers" className="mt-4">
-            <TrustedBrowserManager trustedBrowsers={state.trustedBrowsers} />
-          </TabsContent>
-          <TabsContent value="audit" className="mt-4">
-            <MFAAuditLog />
-          </TabsContent>
-        </Tabs>
-      </CardContent>
-    </Card>
+    <div className={cn('space-y-6', className)}>
+      {/* Header */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>Two-Factor Authentication</CardTitle>
+              <CardDescription className="mt-1">
+                Manage your MFA factors, trusted devices, and security audit log
+              </CardDescription>
+            </div>
+            <Badge variant={isEnabled ? 'success' : 'warning'} dot>
+              {isEnabled ? 'Enabled' : 'Disabled'}
+            </Badge>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <Tabs defaultValue="factors">
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="factors">Factors ({factors.length})</TabsTrigger>
+          <TabsTrigger value="enroll">Add Factor</TabsTrigger>
+          <TabsTrigger value="browsers">Trusted ({trustedBrowsers.length})</TabsTrigger>
+          <TabsTrigger value="audit">Audit Log</TabsTrigger>
+        </TabsList>
+
+        {/* Enrolled factors */}
+        <TabsContent value="factors" className="mt-4">
+          <FactorList onAddFactor={() => {}} />
+        </TabsContent>
+
+        {/* Enrollment options */}
+        <TabsContent value="enroll" className="mt-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Add a Security Factor</CardTitle>
+              <CardDescription>
+                Choose a method to add to your account. We recommend using an authenticator app or
+                security key for the strongest protection.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <FactorOption
+                icon="📱"
+                title="Authenticator App (TOTP)"
+                description="Use Google Authenticator, Authy, or similar app to generate time-based codes"
+                security="Recommended"
+                onClick={() => setSetupView('totp')}
+              />
+              <FactorOption
+                icon="🔐"
+                title="Security Key (FIDO2/WebAuthn)"
+                description="Use a hardware security key or device biometrics (Touch ID, Face ID, Windows Hello)"
+                security="Strongest"
+                onClick={() => setSetupView('webauthn')}
+              />
+              <FactorOption
+                icon="📋"
+                title="Backup Codes"
+                description="Generate one-time recovery codes in case you lose access to your primary factor"
+                security="Recovery"
+                onClick={() => setSetupView('backup')}
+              />
+
+              <Separator className="my-4" />
+
+              <button
+                type="button"
+                onClick={() => setSetupView('recovery')}
+                className="w-full text-left text-sm text-muted-foreground hover:text-foreground"
+              >
+                🔄 Lost your device? Start account recovery →
+              </button>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Trusted browsers */}
+        <TabsContent value="browsers" className="mt-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Trusted Browsers</CardTitle>
+              <CardDescription>
+                Browsers you&apos;ve marked as trusted will skip MFA for a configured period.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {trustedBrowsers.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No trusted browsers. When you verify with MFA and choose &quot;Trust this
+                  browser&quot;, it will appear here.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {trustedBrowsers.map((browser) => (
+                    <div
+                      key={browser.id}
+                      className="flex items-center justify-between rounded-lg border bg-card p-3"
+                    >
+                      <div>
+                        <p className="text-sm font-medium">
+                          {browser.deviceName || browser.browserName}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Trusted {new Date(browser.trustedAt).toLocaleDateString()} · Expires{' '}
+                          {new Date(browser.expiresAt).toLocaleDateString()}
+                          {browser.region && ` · ${browser.region}`}
+                        </p>
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive"
+                        onClick={() => revokeTrustedBrowser(browser.id)}
+                      >
+                        Revoke
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Audit log */}
+        <TabsContent value="audit" className="mt-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Security Audit Log</CardTitle>
+              <CardDescription>Recent MFA verification activity on your account.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {auditLog.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No MFA activity recorded yet.</p>
+              ) : (
+                <div className="space-y-2">
+                  {auditLog.map((entry) => (
+                    <div
+                      key={entry.id}
+                      className="flex items-center justify-between border-b py-2 last:border-0"
+                    >
+                      <div>
+                        <p className="text-sm">
+                          <Badge
+                            variant={entry.success ? 'success' : 'destructive'}
+                            size="sm"
+                            className="mr-2"
+                          >
+                            {entry.success ? 'Success' : 'Failed'}
+                          </Badge>
+                          <span className="text-muted-foreground">
+                            {entry.transactionType.replace(/_/g, ' ')}
+                          </span>
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          via {entry.factorType}
+                          {entry.region && ` · ${entry.region}`}
+                          {entry.txHash && ` · tx: ${entry.txHash.slice(0, 12)}…`}
+                        </p>
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {new Date(entry.timestamp).toLocaleString()}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+/** Factor option button for enrollment selection */
+function FactorOption({
+  icon,
+  title,
+  description,
+  security,
+  onClick,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+  security: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-4 rounded-lg border bg-card p-4 text-left transition-colors hover:border-primary/50 hover:bg-accent"
+    >
+      <span className="text-2xl" aria-hidden="true">
+        {icon}
+      </span>
+      <div className="flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{title}</span>
+          <Badge variant="outline" size="sm">
+            {security}
+          </Badge>
+        </div>
+        <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
+      </div>
+      <span className="text-muted-foreground" aria-hidden="true">
+        →
+      </span>
+    </button>
   );
 }

--- a/portal/src/components/mfa/RecoveryFlow.tsx
+++ b/portal/src/components/mfa/RecoveryFlow.tsx
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * MFA recovery flow UI for users who have lost access to their MFA devices.
+ */
+
+'use client';
+
+import { useState, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/Alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+import { mfaApi } from '@/features/mfa';
+import type { RecoveryStep } from '@/features/mfa';
+
+interface RecoveryFlowProps {
+  onComplete?: () => void;
+  onCancel?: () => void;
+  className?: string;
+}
+
+export function RecoveryFlow({ onComplete, onCancel, className }: RecoveryFlowProps) {
+  const [step, setStep] = useState<RecoveryStep>('identify');
+  const [method, setMethod] = useState<'backup_code' | 'email' | null>(null);
+  const [backupCode, setBackupCode] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSelectMethod = (selected: 'backup_code' | 'email') => {
+    setMethod(selected);
+    setStep('verify');
+    setError(null);
+  };
+
+  const handleSubmitRecovery = useCallback(async () => {
+    if (!backupCode.trim()) return;
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const result = await mfaApi.submitRecovery(backupCode.trim());
+      if (result.success) {
+        setStep('complete');
+      } else {
+        setError('Invalid backup code. Please check and try again.');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Recovery failed. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [backupCode]);
+
+  const handleCodeChange = (value: string) => {
+    // Allow alphanumeric characters and dashes
+    const sanitized = value.replace(/[^a-zA-Z0-9-]/g, '').slice(0, 20);
+    setBackupCode(sanitized);
+    setError(null);
+  };
+
+  if (step === 'complete') {
+    return (
+      <Card className={cn(className)}>
+        <CardContent className="pt-6">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-success/10 text-2xl text-success">
+              ✓
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">Account Recovered</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Your MFA settings have been reset. We strongly recommend setting up new MFA factors
+                immediately to protect your account.
+              </p>
+            </div>
+            <Button onClick={onComplete} className="mt-2">
+              Set Up New MFA
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle className="text-lg">Account Recovery</CardTitle>
+        <CardDescription>
+          {step === 'identify'
+            ? 'Select a recovery method to regain access to your account'
+            : 'Enter your recovery credential to verify your identity'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {step === 'identify' && (
+          <div className="space-y-3">
+            <button
+              type="button"
+              onClick={() => handleSelectMethod('backup_code')}
+              className="flex w-full items-center gap-4 rounded-lg border bg-card p-4 text-left transition-colors hover:bg-accent"
+            >
+              <span className="text-2xl" aria-hidden="true">
+                📋
+              </span>
+              <div>
+                <p className="font-medium">Use a Backup Code</p>
+                <p className="text-sm text-muted-foreground">
+                  Enter one of your previously generated backup codes
+                </p>
+              </div>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => handleSelectMethod('email')}
+              className="flex w-full items-center gap-4 rounded-lg border bg-card p-4 text-left transition-colors hover:bg-accent"
+            >
+              <span className="text-2xl" aria-hidden="true">
+                📧
+              </span>
+              <div>
+                <p className="font-medium">Email Recovery</p>
+                <p className="text-sm text-muted-foreground">
+                  Receive a recovery link at your registered email address
+                </p>
+              </div>
+            </button>
+
+            <div className="pt-2">
+              <Button variant="outline" onClick={onCancel} className="w-full">
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === 'verify' && method === 'backup_code' && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="backup-code">Backup Code</Label>
+              <Input
+                id="backup-code"
+                type="text"
+                value={backupCode}
+                onChange={(e) => handleCodeChange(e.target.value)}
+                placeholder="Enter your backup code"
+                className="font-mono"
+                autoComplete="off"
+                error={!!error}
+              />
+              <p className="text-xs text-muted-foreground">
+                Enter one of the backup codes you saved when setting up MFA.
+              </p>
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setStep('identify');
+                  setError(null);
+                }}
+              >
+                Back
+              </Button>
+              <Button
+                onClick={handleSubmitRecovery}
+                disabled={!backupCode.trim()}
+                loading={isSubmitting}
+              >
+                Verify Code
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === 'verify' && method === 'email' && (
+          <div className="space-y-4">
+            <Alert variant="info">
+              <AlertTitle>Recovery Email Sent</AlertTitle>
+              <AlertDescription>
+                A recovery link has been sent to your registered email address. Please check your
+                inbox and follow the instructions. The link expires in 15 minutes.
+              </AlertDescription>
+            </Alert>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setStep('identify');
+                  setError(null);
+                }}
+              >
+                Back
+              </Button>
+              <Button variant="outline" onClick={onCancel}>
+                Close
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/portal/src/components/mfa/TOTPSetup.tsx
+++ b/portal/src/components/mfa/TOTPSetup.tsx
@@ -1,0 +1,225 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * TOTP (Authenticator App) enrollment component.
+ * Displays QR code, manual entry key, and 6-digit verification form.
+ */
+
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useMFAStore } from '@/features/mfa';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Alert, AlertDescription } from '@/components/ui/Alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+
+interface TOTPSetupProps {
+  onComplete?: () => void;
+  onCancel?: () => void;
+  className?: string;
+}
+
+type Step = 'scan' | 'verify' | 'done';
+
+export function TOTPSetup({ onComplete, onCancel, className }: TOTPSetupProps) {
+  const {
+    totpEnrollment,
+    isMutating,
+    error,
+    startTOTPEnrollment,
+    verifyTOTPEnrollment,
+    clearEnrollment,
+    clearError,
+  } = useMFAStore();
+
+  const [step, setStep] = useState<Step>('scan');
+  const [code, setCode] = useState('');
+  const [factorName, setFactorName] = useState('');
+  const [showManualKey, setShowManualKey] = useState(false);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+
+  // Start enrollment on mount if not already started
+  const handleStart = useCallback(async () => {
+    clearError();
+    await startTOTPEnrollment();
+  }, [startTOTPEnrollment, clearError]);
+
+  // Start enrollment automatically when component is first used
+  useState(() => {
+    if (!totpEnrollment) {
+      void handleStart();
+    }
+  });
+
+  const handleCodeChange = (value: string) => {
+    // Only allow digits, max 6
+    const sanitized = value.replace(/\D/g, '').slice(0, 6);
+    setCode(sanitized);
+    setVerifyError(null);
+  };
+
+  const handleVerify = async () => {
+    if (code.length !== 6) return;
+    setVerifyError(null);
+    try {
+      await verifyTOTPEnrollment(code, factorName || undefined);
+      setStep('done');
+    } catch {
+      setVerifyError('Invalid code. Please try again.');
+    }
+  };
+
+  const handleDone = () => {
+    clearEnrollment();
+    onComplete?.();
+  };
+
+  const handleCancel = () => {
+    clearEnrollment();
+    onCancel?.();
+  };
+
+  if (step === 'done') {
+    return (
+      <Card className={cn(className)}>
+        <CardContent className="pt-6">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-success/10 text-2xl text-success">
+              ✓
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">Authenticator App Added</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Your authenticator app has been successfully enrolled as a second factor.
+              </p>
+            </div>
+            <Button onClick={handleDone} className="mt-2">
+              Done
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle className="text-lg">Set Up Authenticator App</CardTitle>
+        <CardDescription>
+          {step === 'scan'
+            ? 'Scan the QR code with your authenticator app (Google Authenticator, Authy, etc.)'
+            : 'Enter the 6-digit code from your authenticator app to verify setup'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {(error || verifyError) && (
+          <Alert variant="destructive">
+            <AlertDescription>{verifyError || error}</AlertDescription>
+          </Alert>
+        )}
+
+        {step === 'scan' && (
+          <>
+            {isMutating && !totpEnrollment ? (
+              <div className="flex h-48 items-center justify-center">
+                <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+              </div>
+            ) : totpEnrollment ? (
+              <div className="space-y-4">
+                <div className="flex justify-center">
+                  <div className="rounded-lg border bg-white p-3">
+                    {/* QR code from data URL - next/image doesn't support data URLs */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={totpEnrollment.qrCodeDataUrl}
+                      alt="QR code for authenticator app setup. Use the manual code below if you cannot scan."
+                      className="h-48 w-48"
+                    />
+                  </div>
+                </div>
+
+                <div className="text-center">
+                  <button
+                    type="button"
+                    onClick={() => setShowManualKey(!showManualKey)}
+                    className="text-sm text-primary hover:underline"
+                  >
+                    {showManualKey ? 'Hide manual entry key' : "Can't scan? Enter key manually"}
+                  </button>
+                </div>
+
+                {showManualKey && (
+                  <div className="rounded-lg border bg-muted/50 p-4 text-center">
+                    <p className="mb-1 text-xs text-muted-foreground">Manual entry key:</p>
+                    <code className="select-all break-all font-mono text-sm font-medium">
+                      {totpEnrollment.manualEntryKey}
+                    </code>
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <Label htmlFor="factor-name">Device name (optional)</Label>
+                  <Input
+                    id="factor-name"
+                    value={factorName}
+                    onChange={(e) => setFactorName(e.target.value)}
+                    placeholder="e.g. Work phone"
+                    maxLength={50}
+                  />
+                </div>
+
+                <div className="flex justify-end gap-2">
+                  <Button variant="outline" onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                  <Button onClick={() => setStep('verify')}>Continue</Button>
+                </div>
+              </div>
+            ) : null}
+          </>
+        )}
+
+        {step === 'verify' && (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="totp-code">Verification code</Label>
+              <Input
+                id="totp-code"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                pattern="[0-9]*"
+                maxLength={6}
+                value={code}
+                onChange={(e) => handleCodeChange(e.target.value)}
+                placeholder="000000"
+                className="text-center font-mono text-lg tracking-[0.3em]"
+                error={!!verifyError}
+                aria-describedby={verifyError ? 'totp-error' : undefined}
+                aria-invalid={!!verifyError}
+              />
+              {verifyError && (
+                <p id="totp-error" className="text-sm text-destructive" role="alert">
+                  {verifyError}
+                </p>
+              )}
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setStep('scan')}>
+                Back
+              </Button>
+              <Button onClick={handleVerify} disabled={code.length !== 6} loading={isMutating}>
+                Verify & Enable
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/portal/src/components/mfa/WebAuthnSetup.tsx
+++ b/portal/src/components/mfa/WebAuthnSetup.tsx
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * WebAuthn/FIDO2 enrollment component.
+ * Uses navigator.credentials API for security key and biometric enrollment.
+ */
+
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useMFAStore } from '@/features/mfa';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/Label';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/Alert';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+
+interface WebAuthnSetupProps {
+  onComplete?: () => void;
+  onCancel?: () => void;
+  className?: string;
+}
+
+type Step = 'prepare' | 'register' | 'done';
+
+function isWebAuthnSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.PublicKeyCredential !== 'undefined' &&
+    typeof navigator.credentials !== 'undefined'
+  );
+}
+
+export function WebAuthnSetup({ onComplete, onCancel, className }: WebAuthnSetupProps) {
+  const {
+    webAuthnEnrollment,
+    isMutating,
+    error,
+    startWebAuthnEnrollment,
+    completeWebAuthnEnrollment,
+    clearEnrollment,
+    clearError,
+  } = useMFAStore();
+
+  const [step, setStep] = useState<Step>('prepare');
+  const [keyName, setKeyName] = useState('');
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const supported = isWebAuthnSupported();
+
+  const handleBeginRegistration = useCallback(async () => {
+    if (!supported) return;
+    clearError();
+    setLocalError(null);
+
+    try {
+      await startWebAuthnEnrollment();
+      setStep('register');
+    } catch {
+      setLocalError('Failed to start security key registration. Please try again.');
+    }
+  }, [supported, startWebAuthnEnrollment, clearError]);
+
+  const handleRegister = useCallback(async () => {
+    if (!webAuthnEnrollment) return;
+    setLocalError(null);
+
+    try {
+      const credential = (await navigator.credentials.create({
+        publicKey: webAuthnEnrollment.creationOptions,
+      })) as PublicKeyCredential | null;
+
+      if (!credential) {
+        setLocalError('Registration was cancelled or timed out.');
+        return;
+      }
+
+      await completeWebAuthnEnrollment(credential, keyName || undefined);
+      setStep('done');
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'NotAllowedError') {
+        setLocalError('Registration was cancelled. Please try again when ready.');
+      } else if (err instanceof DOMException && err.name === 'InvalidStateError') {
+        setLocalError('This security key is already registered.');
+      } else {
+        setLocalError(err instanceof Error ? err.message : 'Security key registration failed.');
+      }
+    }
+  }, [webAuthnEnrollment, completeWebAuthnEnrollment, keyName]);
+
+  const handleDone = () => {
+    clearEnrollment();
+    onComplete?.();
+  };
+
+  const handleCancel = () => {
+    clearEnrollment();
+    onCancel?.();
+  };
+
+  if (!supported) {
+    return (
+      <Card className={cn(className)}>
+        <CardContent className="pt-6">
+          <Alert variant="warning">
+            <AlertTitle>WebAuthn Not Supported</AlertTitle>
+            <AlertDescription>
+              Your browser does not support security keys (WebAuthn/FIDO2). Please use a modern
+              browser like Chrome, Firefox, Safari, or Edge.
+            </AlertDescription>
+          </Alert>
+          <div className="mt-4 flex justify-end">
+            <Button variant="outline" onClick={handleCancel}>
+              Go Back
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (step === 'done') {
+    return (
+      <Card className={cn(className)}>
+        <CardContent className="pt-6">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-success/10 text-2xl text-success">
+              ✓
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">Security Key Registered</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Your security key has been successfully enrolled as a second factor.
+              </p>
+            </div>
+            <Button onClick={handleDone} className="mt-2">
+              Done
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle className="text-lg">Set Up Security Key</CardTitle>
+        <CardDescription>
+          {step === 'prepare'
+            ? 'Register a FIDO2/WebAuthn security key or platform authenticator (fingerprint, Face ID)'
+            : 'Follow the prompts from your browser to complete registration'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {(error || localError) && (
+          <Alert variant="destructive">
+            <AlertDescription>{localError || error}</AlertDescription>
+          </Alert>
+        )}
+
+        {step === 'prepare' && (
+          <div className="space-y-4">
+            <div className="flex flex-col items-center gap-4 rounded-lg border bg-muted/30 p-6">
+              <div className="text-5xl" aria-hidden="true">
+                🔐
+              </div>
+              <div className="text-center">
+                <p className="text-sm text-muted-foreground">
+                  Have your security key ready, or use your device&apos;s built-in biometric
+                  authenticator (fingerprint reader, Face ID, Windows Hello).
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="key-name">Key name (optional)</Label>
+              <Input
+                id="key-name"
+                value={keyName}
+                onChange={(e) => setKeyName(e.target.value)}
+                placeholder="e.g. YubiKey 5C, MacBook Touch ID"
+                maxLength={50}
+              />
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={handleCancel}>
+                Cancel
+              </Button>
+              <Button onClick={handleBeginRegistration} loading={isMutating}>
+                Register Security Key
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === 'register' && (
+          <div className="space-y-4">
+            <div className="flex flex-col items-center gap-4 rounded-lg border bg-muted/30 p-6">
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+              <p className="text-sm text-muted-foreground">
+                Waiting for your security key&hellip; Follow your browser&apos;s prompts.
+              </p>
+            </div>
+
+            {!isMutating && webAuthnEnrollment && (
+              <div className="flex justify-center gap-2">
+                <Button variant="outline" onClick={handleCancel}>
+                  Cancel
+                </Button>
+                <Button onClick={handleRegister} loading={isMutating}>
+                  Retry Registration
+                </Button>
+              </div>
+            )}
+
+            {/* Trigger registration automatically */}
+            <AutoRegister onRegister={handleRegister} />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Automatically triggers registration when mounted */
+function AutoRegister({ onRegister }: { onRegister: () => void }) {
+  useState(() => {
+    // Use setTimeout to avoid blocking render
+    setTimeout(onRegister, 100);
+  });
+  return null;
+}

--- a/portal/src/components/mfa/index.ts
+++ b/portal/src/components/mfa/index.ts
@@ -1,8 +1,16 @@
 /**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
  * MFA Components
- * Integrated from lib/portal for use in the Next.js portal app
+ * Portal MFA enrollment, challenge, and management UI.
  */
 
 export { MFASetup } from './MFASetup';
 export { MFAChallenge } from './MFAChallenge';
 export { MFASettings } from './MFASettings';
+export { TOTPSetup } from './TOTPSetup';
+export { WebAuthnSetup } from './WebAuthnSetup';
+export { BackupCodes } from './BackupCodes';
+export { FactorList } from './FactorList';
+export { RecoveryFlow } from './RecoveryFlow';

--- a/portal/src/features/mfa/api.ts
+++ b/portal/src/features/mfa/api.ts
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * MFA API service layer for portal-to-chain SDK communication.
+ */
+
+import { apiClient } from '@/lib/api-client';
+import type {
+  MFAFactor,
+  MFAPolicy,
+  MFAChallenge,
+  MFAChallengeResponse,
+  MFAAuditEntry,
+  TrustedBrowser,
+  SensitiveTransactionType,
+} from '@/lib/portal-adapter';
+import type { TOTPEnrollmentData, WebAuthnEnrollmentData, BackupCodesData } from './types';
+
+const MFA_BASE = '/api/mfa';
+
+/** Fetch all enrolled MFA factors for the current account */
+export async function fetchFactors(): Promise<MFAFactor[]> {
+  return apiClient.get<MFAFactor[]>(`${MFA_BASE}/factors`);
+}
+
+/** Fetch current MFA policy */
+export async function fetchPolicy(): Promise<MFAPolicy> {
+  return apiClient.get<MFAPolicy>(`${MFA_BASE}/policy`);
+}
+
+/** Fetch trusted browsers */
+export async function fetchTrustedBrowsers(): Promise<TrustedBrowser[]> {
+  return apiClient.get<TrustedBrowser[]>(`${MFA_BASE}/trusted-browsers`);
+}
+
+/** Fetch MFA audit log */
+export async function fetchAuditLog(limit = 50): Promise<MFAAuditEntry[]> {
+  return apiClient.get<MFAAuditEntry[]>(`${MFA_BASE}/audit`, {
+    query: { limit },
+  });
+}
+
+/** Start TOTP enrollment */
+export async function startTOTPEnrollment(): Promise<TOTPEnrollmentData> {
+  return apiClient.post<TOTPEnrollmentData>(`${MFA_BASE}/enroll/totp`);
+}
+
+/** Verify TOTP enrollment with a 6-digit code */
+export async function verifyTOTPEnrollment(code: string, name?: string): Promise<MFAFactor> {
+  return apiClient.post<MFAFactor>(`${MFA_BASE}/enroll/totp/verify`, { code, name });
+}
+
+/** Start WebAuthn enrollment - returns credential creation options */
+export async function startWebAuthnEnrollment(): Promise<WebAuthnEnrollmentData> {
+  return apiClient.post<WebAuthnEnrollmentData>(`${MFA_BASE}/enroll/webauthn`);
+}
+
+/** Complete WebAuthn enrollment with the attestation result */
+export async function completeWebAuthnEnrollment(
+  challengeId: string,
+  credential: {
+    id: string;
+    rawId: string;
+    type: string;
+    response: {
+      attestationObject: string;
+      clientDataJSON: string;
+    };
+  },
+  name?: string
+): Promise<MFAFactor> {
+  return apiClient.post<MFAFactor>(`${MFA_BASE}/enroll/webauthn/verify`, {
+    challengeId,
+    credential,
+    name,
+  });
+}
+
+/** Generate backup codes */
+export async function generateBackupCodes(): Promise<BackupCodesData> {
+  return apiClient.post<BackupCodesData>(`${MFA_BASE}/enroll/backup-codes`);
+}
+
+/** Remove an enrolled factor (requires MFA verification) */
+export async function removeFactor(factorId: string): Promise<void> {
+  await apiClient.request(`${MFA_BASE}/factors/${factorId}`, { method: 'DELETE' });
+}
+
+/** Enable or disable (suspend) a factor */
+export async function toggleFactor(factorId: string, enabled: boolean): Promise<MFAFactor> {
+  return apiClient.post<MFAFactor>(`${MFA_BASE}/factors/${factorId}/toggle`, {
+    enabled,
+  });
+}
+
+/** Set a factor as the primary factor */
+export async function setPrimaryFactor(factorId: string): Promise<MFAFactor> {
+  return apiClient.post<MFAFactor>(`${MFA_BASE}/factors/${factorId}/primary`);
+}
+
+/** Create an MFA challenge for a sensitive transaction */
+export async function createChallenge(
+  transactionType: SensitiveTransactionType
+): Promise<MFAChallenge> {
+  return apiClient.post<MFAChallenge>(`${MFA_BASE}/challenge`, {
+    transactionType,
+  });
+}
+
+/** Verify an MFA challenge with a code (OTP/SMS/Email/Backup) */
+export async function verifyChallenge(
+  challengeId: string,
+  factorId: string,
+  code: string
+): Promise<MFAChallengeResponse> {
+  return apiClient.post<MFAChallengeResponse>(`${MFA_BASE}/challenge/verify`, {
+    challengeId,
+    factorId,
+    code,
+  });
+}
+
+/** Verify a FIDO2/WebAuthn challenge */
+export async function verifyWebAuthnChallenge(
+  challengeId: string,
+  factorId: string,
+  assertion: {
+    id: string;
+    rawId: string;
+    type: string;
+    response: {
+      authenticatorData: string;
+      clientDataJSON: string;
+      signature: string;
+    };
+  }
+): Promise<MFAChallengeResponse> {
+  return apiClient.post<MFAChallengeResponse>(`${MFA_BASE}/challenge/verify-fido2`, {
+    challengeId,
+    factorId,
+    assertion,
+  });
+}
+
+/** Revoke a trusted browser */
+export async function revokeTrustedBrowser(browserId: string): Promise<void> {
+  await apiClient.request(`${MFA_BASE}/trusted-browsers/${browserId}`, {
+    method: 'DELETE',
+  });
+}
+
+/** Trust current browser after MFA verification */
+export async function trustCurrentBrowser(deviceName: string): Promise<TrustedBrowser> {
+  return apiClient.post<TrustedBrowser>(`${MFA_BASE}/trusted-browsers`, {
+    deviceName,
+  });
+}
+
+/** Submit a recovery request using backup code */
+export async function submitRecovery(backupCode: string): Promise<{ success: boolean }> {
+  return apiClient.post<{ success: boolean }>(`${MFA_BASE}/recovery`, {
+    backupCode,
+  });
+}

--- a/portal/src/features/mfa/index.ts
+++ b/portal/src/features/mfa/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * MFA feature module - exports store, types, and API.
+ */
+
+export { useMFAStore } from './store';
+export type { MFAStoreState, MFAStoreActions } from './store';
+export type {
+  TOTPEnrollmentData,
+  WebAuthnEnrollmentData,
+  BackupCodesData,
+  FactorRemovalState,
+  RecoveryStep,
+  RecoveryState,
+} from './types';
+export * as mfaApi from './api';

--- a/portal/src/features/mfa/store.ts
+++ b/portal/src/features/mfa/store.ts
@@ -1,0 +1,363 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Zustand store for portal MFA state management.
+ */
+
+import { create } from 'zustand';
+import type {
+  MFAFactor,
+  MFAPolicy,
+  MFAChallenge,
+  MFAAuditEntry,
+  TrustedBrowser,
+} from '@/lib/portal-adapter';
+import type { TOTPEnrollmentData, WebAuthnEnrollmentData, BackupCodesData } from './types';
+import * as mfaApi from './api';
+
+export interface MFAStoreState {
+  /** Whether initial data is loading */
+  isLoading: boolean;
+  /** Whether MFA is enabled (at least one active factor) */
+  isEnabled: boolean;
+  /** Enrolled MFA factors */
+  factors: MFAFactor[];
+  /** Current MFA policy */
+  policy: MFAPolicy | null;
+  /** Trusted browsers */
+  trustedBrowsers: TrustedBrowser[];
+  /** Audit log entries */
+  auditLog: MFAAuditEntry[];
+  /** Active challenge (when verifying a sensitive action) */
+  activeChallenge: MFAChallenge | null;
+  /** In-flight TOTP enrollment data */
+  totpEnrollment: TOTPEnrollmentData | null;
+  /** In-flight WebAuthn enrollment data */
+  webAuthnEnrollment: WebAuthnEnrollmentData | null;
+  /** Generated backup codes (shown once) */
+  backupCodes: BackupCodesData | null;
+  /** General error message */
+  error: string | null;
+  /** Whether a mutation is in progress */
+  isMutating: boolean;
+}
+
+export interface MFAStoreActions {
+  /** Load all MFA data for the current account */
+  loadMFAData: () => Promise<void>;
+  /** Start TOTP enrollment */
+  startTOTPEnrollment: () => Promise<void>;
+  /** Verify TOTP enrollment */
+  verifyTOTPEnrollment: (code: string, name?: string) => Promise<MFAFactor>;
+  /** Start WebAuthn enrollment */
+  startWebAuthnEnrollment: () => Promise<void>;
+  /** Complete WebAuthn enrollment */
+  completeWebAuthnEnrollment: (
+    credential: PublicKeyCredential,
+    name?: string
+  ) => Promise<MFAFactor>;
+  /** Generate backup codes */
+  generateBackupCodes: () => Promise<void>;
+  /** Remove a factor */
+  removeFactor: (factorId: string) => Promise<void>;
+  /** Toggle factor enabled/disabled */
+  toggleFactor: (factorId: string, enabled: boolean) => Promise<void>;
+  /** Set primary factor */
+  setPrimaryFactor: (factorId: string) => Promise<void>;
+  /** Create an MFA challenge */
+  createChallenge: (
+    transactionType: Parameters<typeof mfaApi.createChallenge>[0]
+  ) => Promise<MFAChallenge>;
+  /** Verify an MFA challenge with code */
+  verifyChallenge: (factorId: string, code: string) => Promise<boolean>;
+  /** Revoke a trusted browser */
+  revokeTrustedBrowser: (browserId: string) => Promise<void>;
+  /** Clear enrollment state */
+  clearEnrollment: () => void;
+  /** Clear backup codes from memory */
+  clearBackupCodes: () => void;
+  /** Clear error */
+  clearError: () => void;
+  /** Reset store */
+  reset: () => void;
+}
+
+const initialState: MFAStoreState = {
+  isLoading: false,
+  isEnabled: false,
+  factors: [],
+  policy: null,
+  trustedBrowsers: [],
+  auditLog: [],
+  activeChallenge: null,
+  totpEnrollment: null,
+  webAuthnEnrollment: null,
+  backupCodes: null,
+  error: null,
+  isMutating: false,
+};
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export const useMFAStore = create<MFAStoreState & MFAStoreActions>((set, get) => ({
+  ...initialState,
+
+  loadMFAData: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const [factors, policy, trustedBrowsers, auditLog] = await Promise.all([
+        mfaApi.fetchFactors(),
+        mfaApi.fetchPolicy(),
+        mfaApi.fetchTrustedBrowsers(),
+        mfaApi.fetchAuditLog(),
+      ]);
+      set({
+        isLoading: false,
+        isEnabled: factors.some((f) => f.status === 'active'),
+        factors,
+        policy,
+        trustedBrowsers,
+        auditLog,
+      });
+    } catch (err) {
+      set({
+        isLoading: false,
+        error: err instanceof Error ? err.message : 'Failed to load MFA data',
+      });
+    }
+  },
+
+  startTOTPEnrollment: async () => {
+    set({ isMutating: true, error: null, totpEnrollment: null });
+    try {
+      const data = await mfaApi.startTOTPEnrollment();
+      set({ isMutating: false, totpEnrollment: data });
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'Failed to start TOTP enrollment',
+      });
+    }
+  },
+
+  verifyTOTPEnrollment: async (code, name) => {
+    set({ isMutating: true, error: null });
+    try {
+      const factor = await mfaApi.verifyTOTPEnrollment(code, name);
+      set((s) => ({
+        isMutating: false,
+        totpEnrollment: null,
+        factors: [...s.factors, factor],
+        isEnabled: true,
+      }));
+      return factor;
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'TOTP verification failed',
+      });
+      throw err;
+    }
+  },
+
+  startWebAuthnEnrollment: async () => {
+    set({ isMutating: true, error: null, webAuthnEnrollment: null });
+    try {
+      const data = await mfaApi.startWebAuthnEnrollment();
+      set({ isMutating: false, webAuthnEnrollment: data });
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'Failed to start WebAuthn enrollment',
+      });
+    }
+  },
+
+  completeWebAuthnEnrollment: async (credential, name) => {
+    const enrollment = get().webAuthnEnrollment;
+    if (!enrollment) throw new Error('No WebAuthn enrollment in progress');
+
+    set({ isMutating: true, error: null });
+    try {
+      const attestationResponse = credential.response as AuthenticatorAttestationResponse;
+      const factor = await mfaApi.completeWebAuthnEnrollment(
+        enrollment.challengeId,
+        {
+          id: credential.id,
+          rawId: arrayBufferToBase64(credential.rawId),
+          type: credential.type,
+          response: {
+            attestationObject: arrayBufferToBase64(attestationResponse.attestationObject),
+            clientDataJSON: arrayBufferToBase64(attestationResponse.clientDataJSON),
+          },
+        },
+        name
+      );
+      set((s) => ({
+        isMutating: false,
+        webAuthnEnrollment: null,
+        factors: [...s.factors, factor],
+        isEnabled: true,
+      }));
+      return factor;
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'WebAuthn enrollment failed',
+      });
+      throw err;
+    }
+  },
+
+  generateBackupCodes: async () => {
+    set({ isMutating: true, error: null, backupCodes: null });
+    try {
+      const data = await mfaApi.generateBackupCodes();
+      set({ isMutating: false, backupCodes: data });
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'Failed to generate backup codes',
+      });
+    }
+  },
+
+  removeFactor: async (factorId) => {
+    set({ isMutating: true, error: null });
+    try {
+      await mfaApi.removeFactor(factorId);
+      set((s) => {
+        const factors = s.factors.filter((f) => f.id !== factorId);
+        return {
+          isMutating: false,
+          factors,
+          isEnabled: factors.some((f) => f.status === 'active'),
+        };
+      });
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'Failed to remove factor',
+      });
+      throw err;
+    }
+  },
+
+  toggleFactor: async (factorId, enabled) => {
+    set({ isMutating: true, error: null });
+    try {
+      const updated = await mfaApi.toggleFactor(factorId, enabled);
+      set((s) => ({
+        isMutating: false,
+        factors: s.factors.map((f) => (f.id === factorId ? updated : f)),
+        isEnabled: s.factors.some((f) =>
+          f.id === factorId ? updated.status === 'active' : f.status === 'active'
+        ),
+      }));
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'Failed to update factor',
+      });
+      throw err;
+    }
+  },
+
+  setPrimaryFactor: async (factorId) => {
+    set({ isMutating: true, error: null });
+    try {
+      await mfaApi.setPrimaryFactor(factorId);
+      set((s) => ({
+        isMutating: false,
+        factors: s.factors.map((f) => ({
+          ...f,
+          isPrimary: f.id === factorId,
+        })),
+      }));
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'Failed to set primary factor',
+      });
+      throw err;
+    }
+  },
+
+  createChallenge: async (transactionType) => {
+    set({ isMutating: true, error: null });
+    try {
+      const challenge = await mfaApi.createChallenge(transactionType);
+      set({ isMutating: false, activeChallenge: challenge });
+      return challenge;
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'Failed to create challenge',
+      });
+      throw err;
+    }
+  },
+
+  verifyChallenge: async (factorId, code) => {
+    const challenge = get().activeChallenge;
+    if (!challenge) throw new Error('No active challenge');
+
+    set({ isMutating: true, error: null });
+    try {
+      const result = await mfaApi.verifyChallenge(challenge.id, factorId, code);
+      if (result.verified) {
+        set({ isMutating: false, activeChallenge: null });
+      } else {
+        set({ isMutating: false });
+      }
+      return result.verified;
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'Verification failed',
+      });
+      throw err;
+    }
+  },
+
+  revokeTrustedBrowser: async (browserId) => {
+    set({ isMutating: true, error: null });
+    try {
+      await mfaApi.revokeTrustedBrowser(browserId);
+      set((s) => ({
+        isMutating: false,
+        trustedBrowsers: s.trustedBrowsers.filter((b) => b.id !== browserId),
+      }));
+    } catch (err) {
+      set({
+        isMutating: false,
+        error: err instanceof Error ? err.message : 'Failed to revoke browser',
+      });
+      throw err;
+    }
+  },
+
+  clearEnrollment: () => {
+    set({ totpEnrollment: null, webAuthnEnrollment: null, error: null });
+  },
+
+  clearBackupCodes: () => {
+    set({ backupCodes: null });
+  },
+
+  clearError: () => {
+    set({ error: null });
+  },
+
+  reset: () => {
+    set(initialState);
+  },
+}));

--- a/portal/src/features/mfa/types.ts
+++ b/portal/src/features/mfa/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Portal-specific MFA types extending lib/portal MFA types.
+ */
+
+export type {
+  MFAState,
+  MFAFactor,
+  MFAFactorType,
+  MFAPolicy,
+  MFAEnrollment,
+  MFAEnrollmentStep,
+  MFAEnrollmentChallengeData,
+  MFAChallenge,
+  MFAChallengeResponse,
+  MFAChallengeType,
+  MFAAuditEntry,
+  MFAError,
+  MFAErrorCode,
+  TrustedBrowser,
+  SensitiveTransactionType,
+} from '@/lib/portal-adapter';
+
+/** TOTP enrollment data returned from the API */
+export interface TOTPEnrollmentData {
+  qrCodeDataUrl: string;
+  manualEntryKey: string;
+  issuer: string;
+  accountName: string;
+}
+
+/** WebAuthn enrollment data returned from the API */
+export interface WebAuthnEnrollmentData {
+  creationOptions: PublicKeyCredentialCreationOptions;
+  challengeId: string;
+}
+
+/** Backup codes data returned from the API */
+export interface BackupCodesData {
+  codes: string[];
+  generatedAt: number;
+}
+
+/** Factor removal confirmation state */
+export interface FactorRemovalState {
+  factorId: string;
+  factorName: string;
+  factorType: string;
+  isConfirming: boolean;
+}
+
+/** Recovery flow step */
+export type RecoveryStep = 'identify' | 'verify' | 'reset' | 'complete';
+
+/** Recovery flow state */
+export interface RecoveryState {
+  step: RecoveryStep;
+  method: 'backup_code' | 'email' | null;
+  isSubmitting: boolean;
+  error: string | null;
+}

--- a/portal/src/lib/portal-adapter.ts
+++ b/portal/src/lib/portal-adapter.ts
@@ -166,11 +166,20 @@ export type {
   MFAState,
   MFAFactor,
   MFAFactorType,
+  MFAFactorStatus,
+  MFAFactorMetadata,
   MFAPolicy,
   MFAEnrollment,
+  MFAEnrollmentStep,
+  MFAEnrollmentChallengeData,
   TrustedBrowser,
   MFAChallenge,
+  MFAChallengeType,
   MFAChallengeResponse,
+  MFAAuditEntry,
+  MFAError,
+  MFAErrorCode,
+  SensitiveTransactionType,
 } from '../../../lib/portal';
 
 export {

--- a/portal/tests/unit/mfa/components.test.tsx
+++ b/portal/tests/unit/mfa/components.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Unit tests for MFA UI components rendering.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// We need to mock the store before importing components
+const mockStoreState: Record<string, unknown> = {
+  isLoading: false,
+  isEnabled: false,
+  factors: [] as unknown[],
+  policy: null,
+  trustedBrowsers: [],
+  auditLog: [],
+  activeChallenge: null,
+  totpEnrollment: null,
+  webAuthnEnrollment: null,
+  backupCodes: null,
+  error: null,
+  isMutating: false,
+  loadMFAData: vi.fn(),
+  startTOTPEnrollment: vi.fn(),
+  verifyTOTPEnrollment: vi.fn(),
+  startWebAuthnEnrollment: vi.fn(),
+  completeWebAuthnEnrollment: vi.fn(),
+  generateBackupCodes: vi.fn(),
+  removeFactor: vi.fn(),
+  toggleFactor: vi.fn(),
+  setPrimaryFactor: vi.fn(),
+  createChallenge: vi.fn(),
+  verifyChallenge: vi.fn(),
+  revokeTrustedBrowser: vi.fn(),
+  clearEnrollment: vi.fn(),
+  clearBackupCodes: vi.fn(),
+  clearError: vi.fn(),
+  reset: vi.fn(),
+};
+
+vi.mock('../../../src/features/mfa/store', () => ({
+  useMFAStore: Object.assign(
+    (selector?: (state: typeof mockStoreState) => unknown) => {
+      if (selector) return selector(mockStoreState);
+      return mockStoreState;
+    },
+    {
+      getState: () => mockStoreState,
+      setState: vi.fn(),
+      subscribe: vi.fn(),
+    }
+  ),
+}));
+
+vi.mock('../../../src/features/mfa/api', () => ({
+  submitRecovery: vi.fn(),
+}));
+
+// Import after mock setup
+import { FactorList } from '../../../src/components/mfa/FactorList';
+import { MFASetup } from '../../../src/components/mfa/MFASetup';
+
+describe('FactorList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStoreState.factors = [];
+    mockStoreState.error = null;
+  });
+
+  it('renders empty state when no factors', () => {
+    render(<FactorList />);
+    expect(screen.getByText('No MFA Factors Enrolled')).toBeDefined();
+  });
+
+  it('renders add button when onAddFactor provided and no factors', () => {
+    const onAdd = vi.fn();
+    render(<FactorList onAddFactor={onAdd} />);
+    expect(screen.getByText('Add First Factor')).toBeDefined();
+  });
+
+  it('renders enrolled factors', () => {
+    mockStoreState.factors = [
+      {
+        id: 'f-1',
+        type: 'otp' as const,
+        name: 'Work Phone',
+        enrolledAt: Date.now(),
+        lastUsedAt: null,
+        isPrimary: true,
+        status: 'active' as const,
+        metadata: {},
+      },
+    ];
+
+    render(<FactorList />);
+    expect(screen.getByText('Work Phone')).toBeDefined();
+    expect(screen.getByText('active')).toBeDefined();
+    expect(screen.getByText('Primary')).toBeDefined();
+  });
+
+  it('shows disable button for active factors', () => {
+    mockStoreState.factors = [
+      {
+        id: 'f-1',
+        type: 'otp' as const,
+        name: 'Phone',
+        enrolledAt: Date.now(),
+        lastUsedAt: null,
+        isPrimary: false,
+        status: 'active' as const,
+        metadata: {},
+      },
+    ];
+
+    render(<FactorList />);
+    expect(screen.getByText('Disable')).toBeDefined();
+  });
+
+  it('shows enable button for suspended factors', () => {
+    mockStoreState.factors = [
+      {
+        id: 'f-1',
+        type: 'otp' as const,
+        name: 'Phone',
+        enrolledAt: Date.now(),
+        lastUsedAt: null,
+        isPrimary: false,
+        status: 'suspended' as const,
+        metadata: {},
+      },
+    ];
+
+    render(<FactorList />);
+    expect(screen.getByText('Enable')).toBeDefined();
+  });
+});
+
+describe('MFASetup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders factor selection options', () => {
+    render(<MFASetup />);
+    expect(screen.getByText('Authenticator App')).toBeDefined();
+    expect(screen.getByText('Security Key')).toBeDefined();
+    expect(screen.getByText('Backup Codes')).toBeDefined();
+  });
+
+  it('renders title and description', () => {
+    render(<MFASetup />);
+    expect(screen.getByText('Set Up Two-Factor Authentication')).toBeDefined();
+    expect(screen.getByText('Add an extra layer of security to your account')).toBeDefined();
+  });
+});

--- a/portal/tests/unit/mfa/store.test.ts
+++ b/portal/tests/unit/mfa/store.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Unit tests for the MFA Zustand store.
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { useMFAStore } from '../../../src/features/mfa/store';
+import * as mfaApi from '../../../src/features/mfa/api';
+
+// Mock the API module
+vi.mock('../../../src/features/mfa/api', () => ({
+  fetchFactors: vi.fn(),
+  fetchPolicy: vi.fn(),
+  fetchTrustedBrowsers: vi.fn(),
+  fetchAuditLog: vi.fn(),
+  startTOTPEnrollment: vi.fn(),
+  verifyTOTPEnrollment: vi.fn(),
+  startWebAuthnEnrollment: vi.fn(),
+  completeWebAuthnEnrollment: vi.fn(),
+  generateBackupCodes: vi.fn(),
+  removeFactor: vi.fn(),
+  toggleFactor: vi.fn(),
+  setPrimaryFactor: vi.fn(),
+  createChallenge: vi.fn(),
+  verifyChallenge: vi.fn(),
+  verifyWebAuthnChallenge: vi.fn(),
+  revokeTrustedBrowser: vi.fn(),
+  trustCurrentBrowser: vi.fn(),
+  submitRecovery: vi.fn(),
+}));
+
+const mockFactor = {
+  id: 'factor-1',
+  type: 'otp' as const,
+  name: 'My Phone',
+  enrolledAt: Date.now(),
+  lastUsedAt: null,
+  isPrimary: true,
+  status: 'active' as const,
+  metadata: { issuer: 'VirtEngine' },
+};
+
+const mockPolicy = {
+  id: 'policy-1',
+  updatedAt: Date.now(),
+  requiredFactorTypes: ['otp' as const],
+  requiredFactorCount: 1,
+  sensitiveTransactions: ['withdrawal' as const],
+  allowTrustedBrowsers: true,
+  trustedBrowserDurationSeconds: 2592000,
+  biometricForLowValue: false,
+  lowValueThreshold: '100',
+};
+
+describe('useMFAStore', () => {
+  beforeEach(() => {
+    useMFAStore.getState().reset();
+    vi.clearAllMocks();
+  });
+
+  describe('loadMFAData', () => {
+    it('loads factors, policy, browsers, and audit log', async () => {
+      (mfaApi.fetchFactors as Mock).mockResolvedValue([mockFactor]);
+      (mfaApi.fetchPolicy as Mock).mockResolvedValue(mockPolicy);
+      (mfaApi.fetchTrustedBrowsers as Mock).mockResolvedValue([]);
+      (mfaApi.fetchAuditLog as Mock).mockResolvedValue([]);
+
+      await useMFAStore.getState().loadMFAData();
+
+      const state = useMFAStore.getState();
+      expect(state.isLoading).toBe(false);
+      expect(state.isEnabled).toBe(true);
+      expect(state.factors).toHaveLength(1);
+      expect(state.factors[0]!.id).toBe('factor-1');
+      expect(state.policy).toEqual(mockPolicy);
+    });
+
+    it('sets error on failure', async () => {
+      (mfaApi.fetchFactors as Mock).mockRejectedValue(new Error('Network error'));
+      (mfaApi.fetchPolicy as Mock).mockRejectedValue(new Error('Network error'));
+      (mfaApi.fetchTrustedBrowsers as Mock).mockRejectedValue(new Error('Network error'));
+      (mfaApi.fetchAuditLog as Mock).mockRejectedValue(new Error('Network error'));
+
+      await useMFAStore.getState().loadMFAData();
+
+      const state = useMFAStore.getState();
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBe('Network error');
+    });
+
+    it('sets isEnabled to false when no active factors', async () => {
+      const suspendedFactor = { ...mockFactor, status: 'suspended' as const };
+      (mfaApi.fetchFactors as Mock).mockResolvedValue([suspendedFactor]);
+      (mfaApi.fetchPolicy as Mock).mockResolvedValue(mockPolicy);
+      (mfaApi.fetchTrustedBrowsers as Mock).mockResolvedValue([]);
+      (mfaApi.fetchAuditLog as Mock).mockResolvedValue([]);
+
+      await useMFAStore.getState().loadMFAData();
+
+      expect(useMFAStore.getState().isEnabled).toBe(false);
+    });
+  });
+
+  describe('startTOTPEnrollment', () => {
+    it('stores TOTP enrollment data', async () => {
+      const totpData = {
+        qrCodeDataUrl: 'data:image/png;base64,abc',
+        manualEntryKey: 'JBSWY3DPEHPK3PXP',
+        issuer: 'VirtEngine',
+        accountName: 'user@example.com',
+      };
+      (mfaApi.startTOTPEnrollment as Mock).mockResolvedValue(totpData);
+
+      await useMFAStore.getState().startTOTPEnrollment();
+
+      const state = useMFAStore.getState();
+      expect(state.totpEnrollment).toEqual(totpData);
+      expect(state.isMutating).toBe(false);
+    });
+  });
+
+  describe('verifyTOTPEnrollment', () => {
+    it('adds new factor to store on success', async () => {
+      const newFactor = { ...mockFactor, id: 'factor-2' };
+      (mfaApi.verifyTOTPEnrollment as Mock).mockResolvedValue(newFactor);
+
+      useMFAStore.setState({
+        totpEnrollment: { qrCodeDataUrl: '', manualEntryKey: '', issuer: '', accountName: '' },
+      });
+
+      const result = await useMFAStore.getState().verifyTOTPEnrollment('123456', 'Test');
+
+      expect(result.id).toBe('factor-2');
+      const state = useMFAStore.getState();
+      expect(state.factors).toHaveLength(1);
+      expect(state.totpEnrollment).toBeNull();
+      expect(state.isEnabled).toBe(true);
+    });
+
+    it('sets error on failure and re-throws', async () => {
+      (mfaApi.verifyTOTPEnrollment as Mock).mockRejectedValue(new Error('Invalid code'));
+
+      await expect(useMFAStore.getState().verifyTOTPEnrollment('999999')).rejects.toThrow(
+        'Invalid code'
+      );
+
+      expect(useMFAStore.getState().error).toBe('Invalid code');
+    });
+  });
+
+  describe('removeFactor', () => {
+    it('removes factor from store', async () => {
+      (mfaApi.removeFactor as Mock).mockResolvedValue(undefined);
+
+      useMFAStore.setState({ factors: [mockFactor], isEnabled: true });
+
+      await useMFAStore.getState().removeFactor('factor-1');
+
+      const state = useMFAStore.getState();
+      expect(state.factors).toHaveLength(0);
+      expect(state.isEnabled).toBe(false);
+    });
+  });
+
+  describe('toggleFactor', () => {
+    it('updates factor status in store', async () => {
+      const updatedFactor = { ...mockFactor, status: 'suspended' as const };
+      (mfaApi.toggleFactor as Mock).mockResolvedValue(updatedFactor);
+
+      useMFAStore.setState({ factors: [mockFactor] });
+
+      await useMFAStore.getState().toggleFactor('factor-1', false);
+
+      const state = useMFAStore.getState();
+      expect(state.factors[0]!.status).toBe('suspended');
+    });
+  });
+
+  describe('setPrimaryFactor', () => {
+    it('updates isPrimary flags', async () => {
+      (mfaApi.setPrimaryFactor as Mock).mockResolvedValue(undefined);
+
+      const factor2 = { ...mockFactor, id: 'factor-2', isPrimary: false };
+      useMFAStore.setState({ factors: [mockFactor, factor2] });
+
+      await useMFAStore.getState().setPrimaryFactor('factor-2');
+
+      const state = useMFAStore.getState();
+      expect(state.factors.find((f) => f.id === 'factor-1')!.isPrimary).toBe(false);
+      expect(state.factors.find((f) => f.id === 'factor-2')!.isPrimary).toBe(true);
+    });
+  });
+
+  describe('generateBackupCodes', () => {
+    it('stores generated backup codes', async () => {
+      const codesData = {
+        codes: ['AAA-BBB', 'CCC-DDD', 'EEE-FFF'],
+        generatedAt: Date.now(),
+      };
+      (mfaApi.generateBackupCodes as Mock).mockResolvedValue(codesData);
+
+      await useMFAStore.getState().generateBackupCodes();
+
+      expect(useMFAStore.getState().backupCodes).toEqual(codesData);
+    });
+  });
+
+  describe('clearEnrollment', () => {
+    it('clears enrollment state', () => {
+      useMFAStore.setState({
+        totpEnrollment: { qrCodeDataUrl: '', manualEntryKey: '', issuer: '', accountName: '' },
+        error: 'Some error',
+      });
+
+      useMFAStore.getState().clearEnrollment();
+
+      const state = useMFAStore.getState();
+      expect(state.totpEnrollment).toBeNull();
+      expect(state.webAuthnEnrollment).toBeNull();
+      expect(state.error).toBeNull();
+    });
+  });
+
+  describe('clearBackupCodes', () => {
+    it('clears backup codes from memory', () => {
+      useMFAStore.setState({
+        backupCodes: { codes: ['ABC'], generatedAt: Date.now() },
+      });
+
+      useMFAStore.getState().clearBackupCodes();
+
+      expect(useMFAStore.getState().backupCodes).toBeNull();
+    });
+  });
+
+  describe('revokeTrustedBrowser', () => {
+    it('removes browser from store', async () => {
+      (mfaApi.revokeTrustedBrowser as Mock).mockResolvedValue(undefined);
+
+      const browser = {
+        id: 'browser-1',
+        browserName: 'Chrome',
+        deviceName: 'Work laptop',
+        trustedAt: Date.now(),
+        expiresAt: Date.now() + 86400000,
+        lastUsedAt: Date.now(),
+        fingerprintHash: 'abc123',
+      };
+      useMFAStore.setState({ trustedBrowsers: [browser] });
+
+      await useMFAStore.getState().revokeTrustedBrowser('browser-1');
+
+      expect(useMFAStore.getState().trustedBrowsers).toHaveLength(0);
+    });
+  });
+
+  describe('reset', () => {
+    it('resets store to initial state', () => {
+      useMFAStore.setState({
+        isEnabled: true,
+        factors: [mockFactor],
+        error: 'some error',
+      });
+
+      useMFAStore.getState().reset();
+
+      const state = useMFAStore.getState();
+      expect(state.isEnabled).toBe(false);
+      expect(state.factors).toHaveLength(0);
+      expect(state.error).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
```javascript
Priority: P1 - HIGH (Portal features)

Problem:
Portal MFA management (task 23I) is TODO. Users cannot manage MFA factors through the portal.

Context:

MFA module is functional on-chain

TOTP, FIDO2/WebAuthn, SMS, Email factors supported

Portal needs UI for enrollment, challenge, and management

Acceptance Criteria:

[ ] Create MFA settings page

[ ] Implement TOTP enrollment (QR code display + verification)

[ ] Implement FIDO2/WebAuthn enrollment (navigator.credentials API)

[ ] Implement backup codes generation and display

[ ] Create MFA challenge modal (for gated actions)

[ ] Show enrolled factors with enable/disable

[ ] Implement factor removal with confirmation

[ ] Add recovery flow UI

[ ] Integrate with chain SDK (28E)

Files to Create:

portal/src/features/mfa/ - MFA feature module

portal/src/components/mfa/TOTPSetup.tsx

portal/src/components/mfa/WebAuthnSetup.tsx

portal/src/components/mfa/MFAChallenge.tsx

portal/src/pages/settings/security.tsx

Dependencies:

28D: Portal scaffold

28E: Chain SDK

Estimated Effort: 2 weeks
```