### PR TITLE
feat(portal): add billing/invoice dashboard

### DIFF
--- a/lib/portal/__tests__/billing.test.ts
+++ b/lib/portal/__tests__/billing.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Billing Utilities Tests
+ * Task 29J: Unit tests for billing types, CSV export, and billing utilities
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  toCSV,
+  generateInvoicesCSV,
+  generateUsageReportCSV,
+} from "../utils/csv";
+import {
+  aggregateUsage,
+  aggregateHistoryByTimestamp,
+  calculateOutstanding,
+  hasOverdueInvoices,
+  formatBillingAmount,
+  formatBillingDate,
+  formatBillingPeriod,
+  generateInvoiceText,
+} from "../utils/billing";
+import type {
+  Invoice,
+  UsageSummary,
+  UsageHistoryPoint,
+  ResourceUsage,
+} from "../types/billing";
+
+// =============================================================================
+// CSV Export Tests
+// =============================================================================
+
+describe("CSV Export", () => {
+  describe("toCSV", () => {
+    it("generates header and rows", () => {
+      const data = [
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 25 },
+      ];
+      const columns = [
+        { key: "name" as const, label: "Name" },
+        { key: "age" as const, label: "Age" },
+      ];
+      const csv = toCSV(data, columns);
+      const lines = csv.split("\n");
+      expect(lines[0]).toBe("Name,Age");
+      expect(lines[1]).toBe("Alice,30");
+      expect(lines[2]).toBe("Bob,25");
+    });
+
+    it("escapes fields with commas", () => {
+      const data = [{ desc: "Hello, world" }];
+      const columns = [{ key: "desc" as const, label: "Description" }];
+      const csv = toCSV(data, columns);
+      expect(csv).toContain('"Hello, world"');
+    });
+
+    it("escapes fields with quotes", () => {
+      const data = [{ desc: 'Say "hello"' }];
+      const columns = [{ key: "desc" as const, label: "Description" }];
+      const csv = toCSV(data, columns);
+      expect(csv).toContain('"Say ""hello"""');
+    });
+
+    it("handles null and undefined values", () => {
+      const data = [{ a: null, b: undefined }];
+      const columns = [
+        { key: "a" as const, label: "A" },
+        { key: "b" as const, label: "B" },
+      ];
+      const csv = toCSV(data, columns);
+      expect(csv.split("\n")[1]).toBe(",");
+    });
+
+    it("formats Date values as ISO strings", () => {
+      const date = new Date("2025-01-15T10:00:00Z");
+      const data = [{ date }];
+      const columns = [{ key: "date" as const, label: "Date" }];
+      const csv = toCSV(data, columns);
+      expect(csv.split("\n")[1]).toContain("2025-01-15");
+    });
+  });
+
+  describe("generateInvoicesCSV", () => {
+    it("generates CSV with invoice columns", () => {
+      const invoices = [
+        {
+          number: "INV-001",
+          status: "paid",
+          total: "100.00",
+          currency: "VIRT",
+          createdAt: new Date("2025-01-01"),
+          dueDate: new Date("2025-01-31"),
+          paidAt: new Date("2025-01-15"),
+          provider: "provider1",
+          deploymentId: "dep-001",
+        },
+      ];
+      const csv = generateInvoicesCSV(invoices);
+      expect(csv).toContain("Invoice #");
+      expect(csv).toContain("INV-001");
+      expect(csv).toContain("paid");
+      expect(csv).toContain("100.00");
+    });
+  });
+
+  describe("generateUsageReportCSV", () => {
+    it("generates CSV with usage columns", () => {
+      const data = [
+        {
+          timestamp: new Date("2025-01-01"),
+          cpu: 4,
+          memory: 16,
+          storage: 100,
+          bandwidth: 50,
+          gpu: 1,
+          cost: "25.50",
+        },
+      ];
+      const csv = generateUsageReportCSV(data);
+      expect(csv).toContain("CPU (cores)");
+      expect(csv).toContain("4");
+      expect(csv).toContain("25.50");
+    });
+  });
+});
+
+// =============================================================================
+// Billing Utility Tests
+// =============================================================================
+
+function makeResources(overrides?: Partial<ResourceUsage>): ResourceUsage {
+  return {
+    cpu: { used: 2, limit: 4, unit: "cores", cost: "10" },
+    memory: { used: 8, limit: 16, unit: "GB", cost: "20" },
+    storage: { used: 50, limit: 100, unit: "GB", cost: "5" },
+    bandwidth: { used: 10, limit: 100, unit: "Mbps", cost: "3" },
+    ...overrides,
+  };
+}
+
+function makeUsageSummary(overrides?: Partial<UsageSummary>): UsageSummary {
+  return {
+    period: { start: new Date("2025-01-01"), end: new Date("2025-01-31") },
+    totalCost: "38",
+    currency: "VIRT",
+    resources: makeResources(),
+    byDeployment: [],
+    byProvider: [],
+    ...overrides,
+  };
+}
+
+function makeInvoice(overrides?: Partial<Invoice>): Invoice {
+  return {
+    id: "inv-1",
+    number: "INV-001",
+    leaseId: "lease-1",
+    deploymentId: "dep-1",
+    provider: "provider1",
+    period: { start: new Date("2025-01-01"), end: new Date("2025-01-31") },
+    status: "pending",
+    currency: "VIRT",
+    subtotal: "90.00",
+    fees: { platformFee: "5.00", providerFee: "3.00", networkFee: "2.00" },
+    total: "100.00",
+    dueDate: new Date("2025-02-01"),
+    createdAt: new Date("2025-01-01"),
+    lineItems: [
+      {
+        id: "li-1",
+        description: "Compute",
+        resourceType: "cpu",
+        quantity: "720",
+        unit: "hours",
+        unitPrice: "0.125",
+        total: "90.00",
+      },
+    ],
+    payments: [],
+    ...overrides,
+  };
+}
+
+describe("Billing Utilities", () => {
+  describe("aggregateUsage", () => {
+    it("returns empty summary for no input", () => {
+      const result = aggregateUsage([]);
+      expect(result.totalCost).toBe("0");
+      expect(result.currency).toBe("VIRT");
+      expect(result.byDeployment).toHaveLength(0);
+    });
+
+    it("aggregates single usage", () => {
+      const usage = makeUsageSummary();
+      const result = aggregateUsage([usage]);
+      expect(result.totalCost).toBe("38.00");
+      expect(result.resources.cpu.used).toBe(2);
+    });
+
+    it("aggregates multiple usages", () => {
+      const u1 = makeUsageSummary({ totalCost: "10" });
+      const u2 = makeUsageSummary({ totalCost: "20" });
+      const result = aggregateUsage([u1, u2]);
+      expect(result.totalCost).toBe("30.00");
+      expect(result.resources.cpu.used).toBe(4);
+      expect(result.resources.memory.used).toBe(16);
+    });
+
+    it("merges deployments and providers", () => {
+      const u1 = makeUsageSummary({
+        byDeployment: [
+          {
+            deploymentId: "d1",
+            provider: "p1",
+            resources: makeResources(),
+            cost: "10",
+          },
+        ],
+      });
+      const u2 = makeUsageSummary({
+        byDeployment: [
+          {
+            deploymentId: "d2",
+            provider: "p2",
+            resources: makeResources(),
+            cost: "20",
+          },
+        ],
+      });
+      const result = aggregateUsage([u1, u2]);
+      expect(result.byDeployment).toHaveLength(2);
+    });
+
+    it("handles GPU resources", () => {
+      const u1 = makeUsageSummary();
+      u1.resources.gpu = { used: 1, limit: 2, unit: "units", cost: "50" };
+      const u2 = makeUsageSummary();
+      u2.resources.gpu = { used: 2, limit: 4, unit: "units", cost: "100" };
+      const result = aggregateUsage([u1, u2]);
+      expect(result.resources.gpu?.used).toBe(3);
+      expect(result.resources.gpu?.cost).toBe("150.00");
+    });
+  });
+
+  describe("aggregateHistoryByTimestamp", () => {
+    it("returns empty for no input", () => {
+      expect(aggregateHistoryByTimestamp([])).toHaveLength(0);
+    });
+
+    it("merges same-timestamp points", () => {
+      const ts = new Date("2025-01-01T12:00:00Z");
+      const points: UsageHistoryPoint[] = [
+        {
+          timestamp: ts,
+          cpu: 1,
+          memory: 2,
+          storage: 3,
+          bandwidth: 4,
+          gpu: 0,
+          cost: "10",
+        },
+        {
+          timestamp: ts,
+          cpu: 2,
+          memory: 3,
+          storage: 4,
+          bandwidth: 5,
+          gpu: 1,
+          cost: "20",
+        },
+      ];
+      const result = aggregateHistoryByTimestamp(points);
+      expect(result).toHaveLength(1);
+      expect(result[0].cpu).toBe(3);
+      expect(result[0].cost).toBe("30.00");
+    });
+
+    it("sorts by timestamp", () => {
+      const points: UsageHistoryPoint[] = [
+        {
+          timestamp: new Date("2025-01-02"),
+          cpu: 1,
+          memory: 1,
+          storage: 1,
+          bandwidth: 1,
+          gpu: 0,
+          cost: "5",
+        },
+        {
+          timestamp: new Date("2025-01-01"),
+          cpu: 1,
+          memory: 1,
+          storage: 1,
+          bandwidth: 1,
+          gpu: 0,
+          cost: "3",
+        },
+      ];
+      const result = aggregateHistoryByTimestamp(points);
+      expect(result[0].timestamp.getDate()).toBe(1);
+      expect(result[1].timestamp.getDate()).toBe(2);
+    });
+  });
+
+  describe("calculateOutstanding", () => {
+    it("returns 0 for undefined", () => {
+      expect(calculateOutstanding(undefined)).toBe("0");
+    });
+
+    it("returns 0 for no outstanding invoices", () => {
+      const invoices = [makeInvoice({ status: "paid", total: "100.00" })];
+      expect(calculateOutstanding(invoices)).toBe("0.00");
+    });
+
+    it("sums pending and overdue", () => {
+      const invoices = [
+        makeInvoice({ status: "pending", total: "50.00" }),
+        makeInvoice({ status: "overdue", total: "30.00" }),
+        makeInvoice({ status: "paid", total: "100.00" }),
+      ];
+      expect(calculateOutstanding(invoices)).toBe("80.00");
+    });
+  });
+
+  describe("hasOverdueInvoices", () => {
+    it("returns false for undefined", () => {
+      expect(hasOverdueInvoices(undefined)).toBe(false);
+    });
+
+    it("returns false when no overdue", () => {
+      expect(hasOverdueInvoices([makeInvoice({ status: "paid" })])).toBe(false);
+    });
+
+    it("returns true when overdue exists", () => {
+      expect(hasOverdueInvoices([makeInvoice({ status: "overdue" })])).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("formatBillingAmount", () => {
+    it("formats amount with currency", () => {
+      expect(formatBillingAmount("100.50", "VIRT")).toContain("100");
+      expect(formatBillingAmount("100.50", "VIRT")).toContain("VIRT");
+    });
+
+    it("handles NaN", () => {
+      expect(formatBillingAmount("abc")).toBe("0 VIRT");
+    });
+
+    it("uses default VIRT currency", () => {
+      expect(formatBillingAmount("50")).toContain("VIRT");
+    });
+  });
+
+  describe("formatBillingDate", () => {
+    it("formats date", () => {
+      const date = new Date("2025-06-15");
+      const result = formatBillingDate(date);
+      expect(result).toContain("2025");
+      expect(result).toContain("15");
+    });
+  });
+
+  describe("formatBillingPeriod", () => {
+    it("formats date range", () => {
+      const start = new Date("2025-01-01");
+      const end = new Date("2025-01-31");
+      const result = formatBillingPeriod(start, end);
+      expect(result).toContain("Jan");
+      expect(result).toContain("2025");
+      expect(result).toContain("-");
+    });
+  });
+
+  describe("generateInvoiceText", () => {
+    it("generates text representation", () => {
+      const invoice = makeInvoice();
+      const text = generateInvoiceText(invoice);
+      expect(text).toContain("INVOICE #INV-001");
+      expect(text).toContain("PENDING");
+      expect(text).toContain("Compute");
+      expect(text).toContain("90.00");
+      expect(text).toContain("TOTAL: 100.00 VIRT");
+    });
+
+    it("includes payments if present", () => {
+      const invoice = makeInvoice({
+        payments: [
+          {
+            id: "pay-1",
+            invoiceId: "inv-1",
+            amount: "100.00",
+            currency: "VIRT",
+            status: "confirmed",
+            txHash: "0xabc123",
+            paidAt: new Date("2025-01-15"),
+          },
+        ],
+      });
+      const text = generateInvoiceText(invoice);
+      expect(text).toContain("PAYMENTS");
+      expect(text).toContain("0xabc123");
+    });
+  });
+});

--- a/lib/portal/hooks/useBilling.ts
+++ b/lib/portal/hooks/useBilling.ts
@@ -1,0 +1,299 @@
+/**
+ * Billing Hooks
+ * Task 29J: React hooks for billing data fetching and management
+ *
+ * @packageDocumentation
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import type {
+  Invoice,
+  InvoiceFilterOptions,
+  UsageSummary,
+  CostProjection,
+  UsageHistoryPoint,
+  UsageHistoryOptions,
+  InvoiceStatus,
+} from "../types/billing";
+import { aggregateUsage, aggregateHistoryByTimestamp } from "../utils/billing";
+
+const API_BASE_URL =
+  typeof process !== "undefined" && process.env?.NEXT_PUBLIC_BILLING_API_URL
+    ? process.env.NEXT_PUBLIC_BILLING_API_URL
+    : "/api/billing";
+
+interface ApiOptions {
+  method?: "GET" | "POST";
+  body?: unknown;
+}
+
+async function billingApi<T>(
+  endpoint: string,
+  options: ApiOptions = {},
+): Promise<T> {
+  const { method = "GET", body } = options;
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Billing API error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/**
+ * Hook for fetching invoice list with filters
+ */
+export function useInvoices(options?: InvoiceFilterOptions) {
+  const [data, setData] = useState<Invoice[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchInvoices = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (options?.status) params.set("status", options.status);
+      if (options?.startDate)
+        params.set("start", options.startDate.toISOString());
+      if (options?.endDate) params.set("end", options.endDate.toISOString());
+      if (options?.search) params.set("search", options.search);
+      if (options?.limit) params.set("limit", options.limit.toString());
+      if (options?.cursor) params.set("cursor", options.cursor);
+
+      const query = params.toString();
+      const result = await billingApi<{ invoices: Invoice[] }>(
+        `/invoices${query ? `?${query}` : ""}`,
+      );
+
+      const invoices = result.invoices.map((inv) => ({
+        ...inv,
+        period: {
+          start: new Date(inv.period.start),
+          end: new Date(inv.period.end),
+        },
+        dueDate: new Date(inv.dueDate),
+        createdAt: new Date(inv.createdAt),
+        paidAt: inv.paidAt ? new Date(inv.paidAt) : undefined,
+        payments: inv.payments.map((p) => ({
+          ...p,
+          paidAt: new Date(p.paidAt),
+        })),
+      }));
+
+      setData(
+        invoices.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()),
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err : new Error("Failed to fetch invoices"),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    options?.status,
+    options?.startDate,
+    options?.endDate,
+    options?.search,
+    options?.limit,
+    options?.cursor,
+  ]);
+
+  useEffect(() => {
+    void fetchInvoices();
+  }, [fetchInvoices]);
+
+  return { data, isLoading, error, refetch: fetchInvoices };
+}
+
+/**
+ * Hook for fetching a single invoice by ID
+ */
+export function useInvoice(invoiceId: string | undefined) {
+  const [data, setData] = useState<Invoice | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!invoiceId) return;
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    billingApi<Invoice>(`/invoices/${invoiceId}`)
+      .then((inv) => {
+        if (cancelled) return;
+        setData({
+          ...inv,
+          period: {
+            start: new Date(inv.period.start),
+            end: new Date(inv.period.end),
+          },
+          dueDate: new Date(inv.dueDate),
+          createdAt: new Date(inv.createdAt),
+          paidAt: inv.paidAt ? new Date(inv.paidAt) : undefined,
+          payments: inv.payments.map((p) => ({
+            ...p,
+            paidAt: new Date(p.paidAt),
+          })),
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(
+          err instanceof Error ? err : new Error("Failed to fetch invoice"),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [invoiceId]);
+
+  return { data, isLoading, error };
+}
+
+/**
+ * Hook for fetching current usage summary
+ */
+export function useCurrentUsage() {
+  const [data, setData] = useState<UsageSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchUsage = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await billingApi<{ usages: UsageSummary[] }>("/usage");
+      const usages = result.usages.map((u) => ({
+        ...u,
+        period: {
+          start: new Date(u.period.start),
+          end: new Date(u.period.end),
+        },
+      }));
+      setData(aggregateUsage(usages));
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error("Failed to fetch usage"));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchUsage();
+    const interval = setInterval(() => void fetchUsage(), 60_000);
+    return () => clearInterval(interval);
+  }, [fetchUsage]);
+
+  return { data, isLoading, error, refetch: fetchUsage };
+}
+
+/**
+ * Hook for fetching usage history
+ */
+export function useUsageHistory(options: UsageHistoryOptions) {
+  const [data, setData] = useState<UsageHistoryPoint[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams({
+      start: options.startDate.toISOString(),
+      end: options.endDate.toISOString(),
+      granularity: options.granularity,
+    });
+
+    billingApi<{ data: UsageHistoryPoint[] }>(`/usage/history?${params}`)
+      .then((result) => {
+        if (cancelled) return;
+        const points = result.data.map((p) => ({
+          ...p,
+          timestamp: new Date(p.timestamp),
+        }));
+        setData(aggregateHistoryByTimestamp(points));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(
+          err instanceof Error
+            ? err
+            : new Error("Failed to fetch usage history"),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [options.startDate, options.endDate, options.granularity]);
+
+  return { data, isLoading, error };
+}
+
+/**
+ * Hook for fetching cost projection
+ */
+export function useCostProjection() {
+  const [data, setData] = useState<CostProjection | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    billingApi<CostProjection>("/usage/projection")
+      .then((result) => {
+        if (!cancelled) setData(result);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(
+          err instanceof Error
+            ? err
+            : new Error("Failed to fetch cost projection"),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { data, isLoading, error };
+}
+
+// Re-export types for convenience
+export type {
+  Invoice,
+  InvoiceStatus,
+  InvoiceFilterOptions,
+  UsageSummary,
+  CostProjection,
+  UsageHistoryPoint,
+  UsageHistoryOptions,
+};

--- a/lib/portal/types/billing.ts
+++ b/lib/portal/types/billing.ts
@@ -1,0 +1,218 @@
+/**
+ * Billing Types
+ * Task 29J: Billing/invoice dashboard types
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Invoice representation
+ */
+export interface Invoice {
+  /** Unique invoice identifier */
+  id: string;
+  /** Human-readable invoice number */
+  number: string;
+  /** Associated lease ID */
+  leaseId: string;
+  /** Associated deployment ID */
+  deploymentId: string;
+  /** Provider address */
+  provider: string;
+  /** Billing period */
+  period: BillingPeriod;
+  /** Invoice status */
+  status: InvoiceStatus;
+  /** Currency denomination */
+  currency: string;
+  /** Subtotal before fees */
+  subtotal: string;
+  /** Fee breakdown */
+  fees: InvoiceFees;
+  /** Total amount due */
+  total: string;
+  /** Due date */
+  dueDate: Date;
+  /** Date paid (if applicable) */
+  paidAt?: Date;
+  /** Invoice creation date */
+  createdAt: Date;
+  /** Line items breakdown */
+  lineItems: LineItem[];
+  /** Payment history */
+  payments: Payment[];
+}
+
+/**
+ * Billing period
+ */
+export interface BillingPeriod {
+  start: Date;
+  end: Date;
+}
+
+/**
+ * Invoice status
+ */
+export type InvoiceStatus =
+  | "draft"
+  | "pending"
+  | "paid"
+  | "overdue"
+  | "cancelled";
+
+/**
+ * Invoice fee breakdown
+ */
+export interface InvoiceFees {
+  platformFee: string;
+  providerFee: string;
+  networkFee: string;
+}
+
+/**
+ * Invoice line item
+ */
+export interface LineItem {
+  id: string;
+  description: string;
+  resourceType: ResourceType;
+  quantity: string;
+  unit: string;
+  unitPrice: string;
+  total: string;
+}
+
+/**
+ * Resource types
+ */
+export type ResourceType = "cpu" | "memory" | "storage" | "bandwidth" | "gpu";
+
+/**
+ * Payment record
+ */
+export interface Payment {
+  id: string;
+  invoiceId: string;
+  amount: string;
+  currency: string;
+  status: PaymentStatus;
+  txHash: string;
+  paidAt: Date;
+}
+
+/**
+ * Payment status
+ */
+export type PaymentStatus = "pending" | "confirmed" | "failed";
+
+/**
+ * Aggregated usage summary
+ */
+export interface UsageSummary {
+  period: BillingPeriod;
+  totalCost: string;
+  currency: string;
+  resources: ResourceUsage;
+  byDeployment: DeploymentUsage[];
+  byProvider: ProviderUsage[];
+}
+
+/**
+ * Resource usage breakdown
+ */
+export interface ResourceUsage {
+  cpu: UsageMetric;
+  memory: UsageMetric;
+  storage: UsageMetric;
+  bandwidth: UsageMetric;
+  gpu?: UsageMetric;
+}
+
+/**
+ * Single usage metric
+ */
+export interface UsageMetric {
+  used: number;
+  limit: number;
+  unit: string;
+  cost: string;
+}
+
+/**
+ * Per-deployment usage
+ */
+export interface DeploymentUsage {
+  deploymentId: string;
+  name?: string;
+  provider: string;
+  resources: ResourceUsage;
+  cost: string;
+}
+
+/**
+ * Per-provider usage
+ */
+export interface ProviderUsage {
+  provider: string;
+  name?: string;
+  deploymentCount: number;
+  resources: ResourceUsage;
+  cost: string;
+}
+
+/**
+ * Cost projection
+ */
+export interface CostProjection {
+  currentPeriod: {
+    spent: string;
+    projected: string;
+    daysRemaining: number;
+  };
+  nextPeriod: {
+    estimated: string;
+    basedOn: "current_usage" | "historical_average";
+  };
+  trend: "increasing" | "decreasing" | "stable";
+  percentChange: number;
+}
+
+/**
+ * Usage history data point
+ */
+export interface UsageHistoryPoint {
+  timestamp: Date;
+  cpu: number;
+  memory: number;
+  storage: number;
+  bandwidth: number;
+  gpu: number;
+  cost: string;
+}
+
+/**
+ * Invoice filter options
+ */
+export interface InvoiceFilterOptions {
+  status?: InvoiceStatus;
+  startDate?: Date;
+  endDate?: Date;
+  search?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+/**
+ * Usage history query options
+ */
+export interface UsageHistoryOptions {
+  startDate: Date;
+  endDate: Date;
+  granularity: UsageGranularity;
+}
+
+/**
+ * Granularity for usage history
+ */
+export type UsageGranularity = "hour" | "day" | "week" | "month";

--- a/lib/portal/utils/billing.ts
+++ b/lib/portal/utils/billing.ts
@@ -1,0 +1,238 @@
+/**
+ * Billing Utilities
+ * Task 29J: Aggregation, formatting, and PDF helpers for billing
+ */
+
+import type {
+  UsageSummary,
+  ResourceUsage,
+  UsageMetric,
+  UsageHistoryPoint,
+  Invoice,
+} from "../types/billing";
+
+/**
+ * Create an empty usage metric
+ */
+function emptyMetric(unit: string): UsageMetric {
+  return { used: 0, limit: 0, unit, cost: "0" };
+}
+
+/**
+ * Create empty resource usage
+ */
+function emptyResources(): ResourceUsage {
+  return {
+    cpu: emptyMetric("cores"),
+    memory: emptyMetric("GB"),
+    storage: emptyMetric("GB"),
+    bandwidth: emptyMetric("Mbps"),
+  };
+}
+
+/**
+ * Add two usage metrics together
+ */
+function addMetrics(a: UsageMetric, b: UsageMetric): UsageMetric {
+  return {
+    used: a.used + b.used,
+    limit: a.limit + b.limit,
+    unit: a.unit,
+    cost: (parseFloat(a.cost) + parseFloat(b.cost)).toFixed(2),
+  };
+}
+
+/**
+ * Add two resource usages together
+ */
+function addResources(a: ResourceUsage, b: ResourceUsage): ResourceUsage {
+  const result: ResourceUsage = {
+    cpu: addMetrics(a.cpu, b.cpu),
+    memory: addMetrics(a.memory, b.memory),
+    storage: addMetrics(a.storage, b.storage),
+    bandwidth: addMetrics(a.bandwidth, b.bandwidth),
+  };
+  if (a.gpu || b.gpu) {
+    result.gpu = addMetrics(
+      a.gpu ?? emptyMetric("units"),
+      b.gpu ?? emptyMetric("units"),
+    );
+  }
+  return result;
+}
+
+/**
+ * Aggregate multiple provider usage summaries into one
+ */
+export function aggregateUsage(usages: UsageSummary[]): UsageSummary {
+  if (usages.length === 0) {
+    return {
+      period: { start: new Date(), end: new Date() },
+      totalCost: "0",
+      currency: "VIRT",
+      resources: emptyResources(),
+      byDeployment: [],
+      byProvider: [],
+    };
+  }
+
+  let resources = emptyResources();
+  let totalCost = 0;
+  const allDeployments: UsageSummary["byDeployment"] = [];
+  const allProviders: UsageSummary["byProvider"] = [];
+
+  let earliest = usages[0].period.start;
+  let latest = usages[0].period.end;
+
+  for (const usage of usages) {
+    resources = addResources(resources, usage.resources);
+    totalCost += parseFloat(usage.totalCost);
+    allDeployments.push(...usage.byDeployment);
+    allProviders.push(...usage.byProvider);
+
+    if (usage.period.start < earliest) earliest = usage.period.start;
+    if (usage.period.end > latest) latest = usage.period.end;
+  }
+
+  return {
+    period: { start: earliest, end: latest },
+    totalCost: totalCost.toFixed(2),
+    currency: usages[0].currency,
+    resources,
+    byDeployment: allDeployments,
+    byProvider: allProviders,
+  };
+}
+
+/**
+ * Aggregate usage history points by timestamp
+ */
+export function aggregateHistoryByTimestamp(
+  points: UsageHistoryPoint[],
+): UsageHistoryPoint[] {
+  const map = new Map<string, UsageHistoryPoint>();
+
+  for (const point of points) {
+    const key = point.timestamp.toISOString();
+    const existing = map.get(key);
+    if (existing) {
+      existing.cpu += point.cpu;
+      existing.memory += point.memory;
+      existing.storage += point.storage;
+      existing.bandwidth += point.bandwidth;
+      existing.gpu += point.gpu;
+      existing.cost = (
+        parseFloat(existing.cost) + parseFloat(point.cost)
+      ).toFixed(2);
+    } else {
+      map.set(key, { ...point });
+    }
+  }
+
+  return Array.from(map.values()).sort(
+    (a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
+  );
+}
+
+/**
+ * Calculate outstanding balance from invoices
+ */
+export function calculateOutstanding(invoices: Invoice[] | undefined): string {
+  if (!invoices) return "0";
+  let total = 0;
+  for (const inv of invoices) {
+    if (inv.status === "pending" || inv.status === "overdue") {
+      total += parseFloat(inv.total);
+    }
+  }
+  return total.toFixed(2);
+}
+
+/**
+ * Check if any invoices are overdue
+ */
+export function hasOverdueInvoices(invoices: Invoice[] | undefined): boolean {
+  if (!invoices) return false;
+  return invoices.some((inv) => inv.status === "overdue");
+}
+
+/**
+ * Format billing amount for display
+ */
+export function formatBillingAmount(
+  amount: string,
+  currency: string = "VIRT",
+): string {
+  const num = parseFloat(amount);
+  if (isNaN(num)) return `0 ${currency}`;
+  return `${num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 })} ${currency}`;
+}
+
+/**
+ * Format billing date for display
+ */
+export function formatBillingDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * Format billing date range
+ */
+export function formatBillingPeriod(start: Date, end: Date): string {
+  const startStr = start.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+  const endStr = end.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return `${startStr} - ${endStr}`;
+}
+
+/**
+ * Generate a simple text-based invoice representation for PDF export.
+ * Returns the invoice data as a formatted text blob.
+ */
+export function generateInvoiceText(invoice: Invoice): string {
+  const lines: string[] = [
+    `INVOICE #${invoice.number}`,
+    `Status: ${invoice.status.toUpperCase()}`,
+    `Period: ${formatBillingPeriod(invoice.period.start, invoice.period.end)}`,
+    `Due: ${formatBillingDate(invoice.dueDate)}`,
+    "",
+    "LINE ITEMS",
+    "-".repeat(60),
+  ];
+
+  for (const item of invoice.lineItems) {
+    lines.push(
+      `${item.description} (${item.resourceType})  ${item.quantity} ${item.unit} x ${item.unitPrice} = ${item.total} ${invoice.currency}`,
+    );
+  }
+
+  lines.push("-".repeat(60));
+  lines.push(`Subtotal: ${invoice.subtotal} ${invoice.currency}`);
+  lines.push(`Platform Fee: ${invoice.fees.platformFee} ${invoice.currency}`);
+  lines.push(`Provider Fee: ${invoice.fees.providerFee} ${invoice.currency}`);
+  lines.push(`Network Fee: ${invoice.fees.networkFee} ${invoice.currency}`);
+  lines.push(`TOTAL: ${invoice.total} ${invoice.currency}`);
+
+  if (invoice.payments.length > 0) {
+    lines.push("");
+    lines.push("PAYMENTS");
+    lines.push("-".repeat(60));
+    for (const payment of invoice.payments) {
+      lines.push(
+        `${payment.amount} ${payment.currency} - ${payment.status} - TX: ${payment.txHash}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/lib/portal/utils/csv.ts
+++ b/lib/portal/utils/csv.ts
@@ -1,0 +1,109 @@
+/**
+ * CSV Export Utilities
+ * Task 29J: Billing data export helpers
+ */
+
+/**
+ * Escape a CSV field value
+ */
+function escapeCSVField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * Convert an array of objects to CSV string
+ */
+export function toCSV<T extends Record<string, unknown>>(
+  data: T[],
+  columns: { key: keyof T; label: string }[],
+): string {
+  const header = columns.map((c) => escapeCSVField(c.label)).join(",");
+  const rows = data.map((row) =>
+    columns
+      .map((c) => {
+        const val = row[c.key];
+        if (val === null || val === undefined) return "";
+        if (val instanceof Date) return escapeCSVField(val.toISOString());
+        return escapeCSVField(String(val));
+      })
+      .join(","),
+  );
+  return [header, ...rows].join("\n");
+}
+
+/**
+ * Trigger a file download in the browser
+ */
+export function downloadFile(
+  content: string | Blob,
+  filename: string,
+  mimeType: string,
+): void {
+  const blob =
+    content instanceof Blob ? content : new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Generate invoice CSV export data
+ */
+export function generateInvoicesCSV(
+  invoices: Array<{
+    number: string;
+    status: string;
+    total: string;
+    currency: string;
+    createdAt: Date;
+    dueDate: Date;
+    paidAt?: Date;
+    provider: string;
+    deploymentId: string;
+  }>,
+): string {
+  return toCSV(invoices, [
+    { key: "number", label: "Invoice #" },
+    { key: "status", label: "Status" },
+    { key: "total", label: "Total" },
+    { key: "currency", label: "Currency" },
+    { key: "createdAt", label: "Created" },
+    { key: "dueDate", label: "Due Date" },
+    { key: "paidAt", label: "Paid At" },
+    { key: "provider", label: "Provider" },
+    { key: "deploymentId", label: "Deployment" },
+  ]);
+}
+
+/**
+ * Generate usage report CSV
+ */
+export function generateUsageReportCSV(
+  data: Array<{
+    timestamp: Date;
+    cpu: number;
+    memory: number;
+    storage: number;
+    bandwidth: number;
+    gpu: number;
+    cost: string;
+  }>,
+): string {
+  return toCSV(data, [
+    { key: "timestamp", label: "Timestamp" },
+    { key: "cpu", label: "CPU (cores)" },
+    { key: "memory", label: "Memory (GB)" },
+    { key: "storage", label: "Storage (GB)" },
+    { key: "bandwidth", label: "Bandwidth (Mbps)" },
+    { key: "gpu", label: "GPU (units)" },
+    { key: "cost", label: "Cost" },
+  ]);
+}

--- a/portal/src/app/(customer)/billing/BillingPage.tsx
+++ b/portal/src/app/(customer)/billing/BillingPage.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { BillingDashboard } from '@/components/billing';
+
+export function BillingPage() {
+  const router = useRouter();
+
+  return (
+    <BillingDashboard
+      onViewInvoice={(id) => router.push(`/billing/invoices/${id}`)}
+      onViewAllInvoices={() => router.push('/billing/invoices')}
+      onViewUsage={() => router.push('/billing/usage')}
+    />
+  );
+}

--- a/portal/src/app/(customer)/billing/invoices/InvoicesPage.tsx
+++ b/portal/src/app/(customer)/billing/invoices/InvoicesPage.tsx
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { InvoiceList } from '@/components/billing';
+
+export function InvoicesPage() {
+  const router = useRouter();
+
+  return <InvoiceList onViewInvoice={(id) => router.push(`/billing/invoices/${id}`)} />;
+}

--- a/portal/src/app/(customer)/billing/invoices/[id]/InvoiceDetailPage.tsx
+++ b/portal/src/app/(customer)/billing/invoices/[id]/InvoiceDetailPage.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { InvoiceDetail } from '@/components/billing';
+
+interface InvoiceDetailPageProps {
+  invoiceId: string;
+}
+
+export function InvoiceDetailPage({ invoiceId }: InvoiceDetailPageProps) {
+  const router = useRouter();
+
+  return <InvoiceDetail invoiceId={invoiceId} onBack={() => router.push('/billing/invoices')} />;
+}

--- a/portal/src/app/(customer)/billing/invoices/[id]/page.tsx
+++ b/portal/src/app/(customer)/billing/invoices/[id]/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { Metadata } from 'next';
+import { InvoiceDetailPage } from './InvoiceDetailPage';
+
+export const metadata: Metadata = {
+  title: 'Invoice Detail',
+  description: 'View invoice details, line items, and payment history',
+};
+
+export default function InvoiceDetailRoute({ params }: { params: { id: string } }) {
+  return <InvoiceDetailPage invoiceId={params.id} />;
+}

--- a/portal/src/app/(customer)/billing/invoices/page.tsx
+++ b/portal/src/app/(customer)/billing/invoices/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { Metadata } from 'next';
+import { InvoicesPage } from './InvoicesPage';
+
+export const metadata: Metadata = {
+  title: 'Invoices',
+  description: 'View and manage all invoices',
+};
+
+export default function InvoicesRoute() {
+  return <InvoicesPage />;
+}

--- a/portal/src/app/(customer)/billing/page.tsx
+++ b/portal/src/app/(customer)/billing/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { Metadata } from 'next';
+import { BillingPage } from './BillingPage';
+
+export const metadata: Metadata = {
+  title: 'Billing',
+  description: 'View billing overview, invoices, and usage analytics',
+};
+
+export default function BillingRoute() {
+  return <BillingPage />;
+}

--- a/portal/src/app/(customer)/billing/usage/UsagePage.tsx
+++ b/portal/src/app/(customer)/billing/usage/UsagePage.tsx
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { UsageAnalytics } from '@/components/billing';
+
+export function UsagePage() {
+  return <UsageAnalytics />;
+}

--- a/portal/src/app/(customer)/billing/usage/page.tsx
+++ b/portal/src/app/(customer)/billing/usage/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import type { Metadata } from 'next';
+import { UsagePage } from './UsagePage';
+
+export const metadata: Metadata = {
+  title: 'Usage Analytics',
+  description: 'View resource usage analytics, cost breakdown, and trends',
+};
+
+export default function UsageRoute() {
+  return <UsagePage />;
+}

--- a/portal/src/components/billing/BillingDashboard.tsx
+++ b/portal/src/components/billing/BillingDashboard.tsx
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/Table';
+import { Eye, ArrowRight } from 'lucide-react';
+import {
+  useInvoices,
+  useCurrentUsage,
+  useCostProjection,
+} from '@virtengine/portal/hooks/useBilling';
+import type { Invoice, InvoiceStatus } from '@virtengine/portal/types/billing';
+import {
+  calculateOutstanding,
+  hasOverdueInvoices,
+  formatBillingAmount,
+  formatBillingPeriod,
+} from '@virtengine/portal/utils/billing';
+import { UsageSummaryCard } from './UsageSummaryCard';
+import { CostProjectionCard } from './CostProjectionCard';
+import { CostTrendChart } from './CostTrendChart';
+import { useUsageHistory } from '@virtengine/portal/hooks/useBilling';
+
+function thirtyDaysAgo(): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  return d;
+}
+
+const STATUS_VARIANT: Record<
+  InvoiceStatus,
+  'default' | 'success' | 'warning' | 'destructive' | 'secondary'
+> = {
+  draft: 'secondary',
+  pending: 'warning',
+  paid: 'success',
+  overdue: 'destructive',
+  cancelled: 'secondary',
+};
+
+interface BillingDashboardProps {
+  onViewInvoice?: (id: string) => void;
+  onViewAllInvoices?: () => void;
+  onViewUsage?: () => void;
+}
+
+export function BillingDashboard({
+  onViewInvoice,
+  onViewAllInvoices,
+  onViewUsage,
+}: BillingDashboardProps) {
+  const { data: usage, isLoading: usageLoading } = useCurrentUsage();
+  const { data: projection, isLoading: projectionLoading } = useCostProjection();
+  const { data: invoices, isLoading: invoicesLoading } = useInvoices({ limit: 5 });
+  const { data: trendData, isLoading: trendLoading } = useUsageHistory({
+    startDate: thirtyDaysAgo(),
+    endDate: new Date(),
+    granularity: 'day',
+  });
+
+  const outstanding = calculateOutstanding(invoices);
+  const hasOverdue = hasOverdueInvoices(invoices);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Billing</h1>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <UsageSummaryCard
+          title="Current Period"
+          value={usage?.totalCost ?? '0'}
+          currency="VIRT"
+          loading={usageLoading}
+        />
+        <UsageSummaryCard
+          title="Projected"
+          value={projection?.currentPeriod.projected ?? '0'}
+          currency="VIRT"
+          subtitle={
+            projection ? `${projection.currentPeriod.daysRemaining} days remaining` : undefined
+          }
+          loading={projectionLoading}
+        />
+        <UsageSummaryCard
+          title="Outstanding"
+          value={outstanding}
+          currency="VIRT"
+          status={hasOverdue ? 'warning' : 'normal'}
+          loading={invoicesLoading}
+        />
+        <UsageSummaryCard
+          title="Deployments"
+          value={usage?.byDeployment.length.toString() ?? '0'}
+          subtitle="Active deployments"
+          loading={usageLoading}
+        />
+      </div>
+
+      {/* Charts row */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0">
+            <CardTitle className="text-base">Cost Trend (30 Days)</CardTitle>
+            {onViewUsage && (
+              <Button variant="ghost" size="sm" onClick={onViewUsage}>
+                View Details
+                <ArrowRight className="ml-1 h-4 w-4" />
+              </Button>
+            )}
+          </CardHeader>
+          <CardContent>
+            <CostTrendChart data={trendData} loading={trendLoading} />
+          </CardContent>
+        </Card>
+
+        <CostProjectionCard projection={projection} loading={projectionLoading} />
+      </div>
+
+      {/* Recent invoices */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-base">Recent Invoices</CardTitle>
+          {onViewAllInvoices && (
+            <Button variant="ghost" size="sm" onClick={onViewAllInvoices}>
+              View All
+              <ArrowRight className="ml-1 h-4 w-4" />
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent className="p-0">
+          {invoicesLoading ? (
+            <div className="space-y-2 p-4">
+              {Array.from({ length: 3 }, (_, i) => (
+                <Skeleton key={`invoice-skeleton-${i}`} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : !invoices || invoices.length === 0 ? (
+            <p className="p-6 text-center text-sm text-muted-foreground">No invoices yet</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Invoice #</TableHead>
+                  <TableHead>Period</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                  <TableHead className="text-center">Status</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {invoices.slice(0, 5).map((invoice: Invoice) => (
+                  <TableRow key={invoice.id}>
+                    <TableCell className="font-medium">{invoice.number}</TableCell>
+                    <TableCell>
+                      {formatBillingPeriod(invoice.period.start, invoice.period.end)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatBillingAmount(invoice.total, invoice.currency)}
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <Badge variant={STATUS_VARIANT[invoice.status]} size="sm">
+                        {invoice.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {onViewInvoice && (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => onViewInvoice(invoice.id)}
+                          aria-label={`View invoice ${invoice.number}`}
+                        >
+                          <Eye className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/portal/src/components/billing/CostProjectionCard.tsx
+++ b/portal/src/components/billing/CostProjectionCard.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Badge } from '@/components/ui/Badge';
+import { Skeleton } from '@/components/ui/Skeleton';
+import type { CostProjection } from '@virtengine/portal/types/billing';
+
+interface CostProjectionCardProps {
+  projection: CostProjection | null;
+  loading?: boolean;
+}
+
+export function CostProjectionCard({ projection, loading }: CostProjectionCardProps) {
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium">Cost Projection</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-4 w-48" />
+          <Skeleton className="h-4 w-36" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!projection) return null;
+
+  const trendVariant =
+    projection.trend === 'increasing'
+      ? 'destructive'
+      : projection.trend === 'decreasing'
+        ? 'success'
+        : 'secondary';
+
+  const trendLabel =
+    projection.trend === 'increasing'
+      ? 'Increasing'
+      : projection.trend === 'decreasing'
+        ? 'Decreasing'
+        : 'Stable';
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">Cost Projection</CardTitle>
+        <Badge variant={trendVariant} size="sm">
+          {trendLabel}
+        </Badge>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <p className="text-xs text-muted-foreground">Projected this period</p>
+          <p className="text-2xl font-bold">
+            {projection.currentPeriod.projected}
+            <span className="ml-1 text-sm font-normal text-muted-foreground">VIRT</span>
+          </p>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">Spent so far</span>
+          <span className="font-medium">{projection.currentPeriod.spent} VIRT</span>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">Days remaining</span>
+          <span className="font-medium">{projection.currentPeriod.daysRemaining}</span>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">Next period estimate</span>
+          <span className="font-medium">{projection.nextPeriod.estimated} VIRT</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/portal/src/components/billing/CostTrendChart.tsx
+++ b/portal/src/components/billing/CostTrendChart.tsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Skeleton } from '@/components/ui/Skeleton';
+import type { UsageHistoryPoint } from '@virtengine/portal/types/billing';
+
+interface CostTrendChartProps {
+  data?: UsageHistoryPoint[];
+  loading?: boolean;
+}
+
+/**
+ * Simple bar chart for cost trend visualization.
+ * Uses native HTML/CSS for zero-dependency rendering.
+ */
+export function CostTrendChart({ data, loading }: CostTrendChartProps) {
+  const [maxCost, setMaxCost] = useState(0);
+
+  useEffect(() => {
+    if (data && data.length > 0) {
+      const max = Math.max(...data.map((d) => parseFloat(d.cost)));
+      setMaxCost(max > 0 ? max : 1);
+    }
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div className="flex h-48 items-end gap-1">
+        {Array.from({ length: 14 }, (_, i) => (
+          <Skeleton
+            key={`cost-trend-skeleton-${i}`}
+            className="flex-1"
+            style={{ height: `${30 + Math.random() * 60}%` }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+        No cost data available
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex h-48 items-end gap-1" role="img" aria-label="Cost trend chart">
+        {data.map((point, index) => {
+          const height = maxCost > 0 ? (parseFloat(point.cost) / maxCost) * 100 : 0;
+          const dateLabel = point.timestamp.toLocaleDateString(undefined, {
+            month: 'short',
+            day: 'numeric',
+          });
+          return (
+            <div
+              key={`cost-bar-${point.timestamp.toISOString()}`}
+              className="group relative flex-1"
+              title={`${dateLabel}: ${point.cost} VIRT`}
+            >
+              <div
+                className="w-full rounded-t bg-primary transition-colors hover:bg-primary/80"
+                style={{ height: `${Math.max(height, 2)}%` }}
+              />
+              {/* Tooltip on hover */}
+              <div className="absolute bottom-full left-1/2 z-10 mb-1 hidden -translate-x-1/2 whitespace-nowrap rounded bg-popover px-2 py-1 text-xs shadow group-hover:block">
+                <p className="font-medium">{point.cost} VIRT</p>
+                <p className="text-muted-foreground">{dateLabel}</p>
+              </div>
+              {/* Label every 3rd bar on wide screens */}
+              {index % 3 === 0 && (
+                <p className="mt-1 hidden text-center text-2xs text-muted-foreground lg:block">
+                  {dateLabel}
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/portal/src/components/billing/InvoiceDetail.tsx
+++ b/portal/src/components/billing/InvoiceDetail.tsx
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/Table';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { Download, ExternalLink, ArrowLeft } from 'lucide-react';
+import { useInvoice } from '@virtengine/portal/hooks/useBilling';
+import type { InvoiceStatus, PaymentStatus } from '@virtengine/portal/types/billing';
+import {
+  formatBillingAmount,
+  formatBillingDate,
+  formatBillingPeriod,
+  generateInvoiceText,
+} from '@virtengine/portal/utils/billing';
+import { downloadFile } from '@virtengine/portal/utils/csv';
+
+interface InvoiceDetailProps {
+  invoiceId: string;
+  onBack?: () => void;
+}
+
+const STATUS_VARIANT: Record<
+  InvoiceStatus,
+  'default' | 'success' | 'warning' | 'destructive' | 'secondary'
+> = {
+  draft: 'secondary',
+  pending: 'warning',
+  paid: 'success',
+  overdue: 'destructive',
+  cancelled: 'secondary',
+};
+
+const PAYMENT_STATUS_VARIANT: Record<
+  PaymentStatus,
+  'default' | 'success' | 'warning' | 'destructive'
+> = {
+  pending: 'warning',
+  confirmed: 'success',
+  failed: 'destructive',
+};
+
+export function InvoiceDetail({ invoiceId, onBack }: InvoiceDetailProps) {
+  const { data: invoice, isLoading, error } = useInvoice(invoiceId);
+
+  if (isLoading) {
+    return (
+      <div className="max-w-3xl space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid gap-4 md:grid-cols-3">
+          <Skeleton className="h-24" />
+          <Skeleton className="h-24" />
+          <Skeleton className="h-24" />
+        </div>
+        <Skeleton className="h-64" />
+      </div>
+    );
+  }
+
+  if (error || !invoice) {
+    return (
+      <div className="max-w-3xl space-y-4">
+        {onBack && (
+          <Button variant="ghost" onClick={onBack}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Invoices
+          </Button>
+        )}
+        <Card>
+          <CardContent className="p-8 text-center text-muted-foreground">
+            {error ? error.message : 'Invoice not found'}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const handleDownload = () => {
+    const text = generateInvoiceText(invoice);
+    downloadFile(text, `invoice-${invoice.number}.txt`, 'text/plain');
+  };
+
+  const totalFees =
+    parseFloat(invoice.fees.platformFee) +
+    parseFloat(invoice.fees.providerFee) +
+    parseFloat(invoice.fees.networkFee);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          {onBack && (
+            <Button variant="ghost" size="sm" className="mb-2" onClick={onBack}>
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back
+            </Button>
+          )}
+          <h1 className="text-2xl font-bold">Invoice #{invoice.number}</h1>
+          <p className="text-muted-foreground">
+            {formatBillingPeriod(invoice.period.start, invoice.period.end)}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={STATUS_VARIANT[invoice.status]}>{invoice.status}</Badge>
+          <Button variant="outline" onClick={handleDownload}>
+            <Download className="mr-2 h-4 w-4" />
+            Download
+          </Button>
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">Subtotal</p>
+            <p className="text-xl font-semibold">
+              {formatBillingAmount(invoice.subtotal, invoice.currency)}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">Fees</p>
+            <p className="text-xl font-semibold">
+              {formatBillingAmount(totalFees.toFixed(2), invoice.currency)}
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="bg-primary/5">
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">Total</p>
+            <p className="text-2xl font-bold">
+              {formatBillingAmount(invoice.total, invoice.currency)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Meta info */}
+      <Card>
+        <CardContent className="grid gap-4 pt-6 sm:grid-cols-2">
+          <div>
+            <p className="text-sm text-muted-foreground">Due Date</p>
+            <p className="font-medium">{formatBillingDate(invoice.dueDate)}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Provider</p>
+            <p className="font-medium">{invoice.provider}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Deployment</p>
+            <p className="font-medium">{invoice.deploymentId}</p>
+          </div>
+          <div>
+            <p className="text-sm text-muted-foreground">Created</p>
+            <p className="font-medium">{formatBillingDate(invoice.createdAt)}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Line Items */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Line Items</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Resource</TableHead>
+                <TableHead className="text-right">Quantity</TableHead>
+                <TableHead className="text-right">Unit Price</TableHead>
+                <TableHead className="text-right">Total</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {invoice.lineItems.map((item) => (
+                <TableRow key={item.id}>
+                  <TableCell>
+                    <p className="font-medium">{item.description}</p>
+                    <p className="text-sm capitalize text-muted-foreground">{item.resourceType}</p>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {item.quantity} {item.unit}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {formatBillingAmount(item.unitPrice, invoice.currency)}
+                  </TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatBillingAmount(item.total, invoice.currency)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Fee breakdown */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Fee Breakdown</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Platform Fee</span>
+            <span>{formatBillingAmount(invoice.fees.platformFee, invoice.currency)}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Provider Fee</span>
+            <span>{formatBillingAmount(invoice.fees.providerFee, invoice.currency)}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Network Fee</span>
+            <span>{formatBillingAmount(invoice.fees.networkFee, invoice.currency)}</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Payments */}
+      {invoice.payments.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Payment History</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {invoice.payments.map((payment) => (
+              <div key={payment.id} className="flex items-center justify-between">
+                <div>
+                  <p className="font-medium">
+                    {formatBillingAmount(payment.amount, payment.currency)}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {formatBillingDate(payment.paidAt)}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant={PAYMENT_STATUS_VARIANT[payment.status]} size="sm">
+                    {payment.status}
+                  </Badge>
+                  {payment.txHash && (
+                    <a
+                      href={`https://explorer.virtengine.io/tx/${payment.txHash}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:underline"
+                      aria-label="View transaction"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                    </a>
+                  )}
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/portal/src/components/billing/InvoiceFilters.tsx
+++ b/portal/src/components/billing/InvoiceFilters.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import { Input } from '@/components/ui/Input';
+import { Search } from 'lucide-react';
+import type { InvoiceStatus } from '@virtengine/portal/types/billing';
+
+interface InvoiceFiltersProps {
+  status?: InvoiceStatus;
+  onStatusChange: (status: InvoiceStatus | undefined) => void;
+  search: string;
+  onSearchChange: (search: string) => void;
+  dateRange: { start?: Date; end?: Date };
+  onDateRangeChange: (range: { start?: Date; end?: Date }) => void;
+}
+
+const STATUS_OPTIONS: { value: string; label: string }[] = [
+  { value: 'all', label: 'All Statuses' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'paid', label: 'Paid' },
+  { value: 'overdue', label: 'Overdue' },
+  { value: 'draft', label: 'Draft' },
+  { value: 'cancelled', label: 'Cancelled' },
+];
+
+export function InvoiceFilters({
+  status,
+  onStatusChange,
+  search,
+  onSearchChange,
+  dateRange,
+  onDateRangeChange,
+}: InvoiceFiltersProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      {/* Search */}
+      <div className="flex-1">
+        <Input
+          placeholder="Search invoices..."
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          startIcon={<Search className="h-4 w-4" />}
+        />
+      </div>
+
+      {/* Status filter */}
+      <Select
+        value={status ?? 'all'}
+        onValueChange={(v) => onStatusChange(v === 'all' ? undefined : (v as InvoiceStatus))}
+      >
+        <SelectTrigger className="w-[160px]">
+          <SelectValue placeholder="Status" />
+        </SelectTrigger>
+        <SelectContent>
+          {STATUS_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Date range */}
+      <div className="flex items-center gap-2">
+        <Input
+          type="date"
+          className="w-[140px]"
+          value={dateRange.start ? dateRange.start.toISOString().split('T')[0] : ''}
+          onChange={(e) =>
+            onDateRangeChange({
+              ...dateRange,
+              start: e.target.value ? new Date(e.target.value) : undefined,
+            })
+          }
+          aria-label="Start date"
+        />
+        <span className="text-sm text-muted-foreground">to</span>
+        <Input
+          type="date"
+          className="w-[140px]"
+          value={dateRange.end ? dateRange.end.toISOString().split('T')[0] : ''}
+          onChange={(e) =>
+            onDateRangeChange({
+              ...dateRange,
+              end: e.target.value ? new Date(e.target.value) : undefined,
+            })
+          }
+          aria-label="End date"
+        />
+      </div>
+    </div>
+  );
+}

--- a/portal/src/components/billing/InvoiceList.tsx
+++ b/portal/src/components/billing/InvoiceList.tsx
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/Table';
+import { SkeletonTable } from '@/components/ui/Skeleton';
+import { Download } from 'lucide-react';
+import { useInvoices } from '@virtengine/portal/hooks/useBilling';
+import type { InvoiceStatus } from '@virtengine/portal/types/billing';
+import { generateInvoicesCSV, downloadFile } from '@virtengine/portal/utils/csv';
+import { InvoiceFilters } from './InvoiceFilters';
+import { InvoiceRow } from './InvoiceRow';
+
+interface InvoiceListProps {
+  onViewInvoice?: (id: string) => void;
+}
+
+export function InvoiceList({ onViewInvoice }: InvoiceListProps) {
+  const [statusFilter, setStatusFilter] = useState<InvoiceStatus | undefined>();
+  const [search, setSearch] = useState('');
+  const [dateRange, setDateRange] = useState<{ start?: Date; end?: Date }>({});
+
+  const { data: invoices, isLoading } = useInvoices({
+    status: statusFilter,
+    startDate: dateRange.start,
+    endDate: dateRange.end,
+    search: search || undefined,
+  });
+
+  const filteredInvoices = invoices;
+
+  const handleExportAll = () => {
+    if (!filteredInvoices || filteredInvoices.length === 0) return;
+    const csv = generateInvoicesCSV(filteredInvoices);
+    downloadFile(csv, 'invoices.csv', 'text/csv');
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Invoices</h2>
+        <Button
+          variant="outline"
+          onClick={handleExportAll}
+          disabled={!filteredInvoices || filteredInvoices.length === 0}
+        >
+          <Download className="mr-2 h-4 w-4" />
+          Export CSV
+        </Button>
+      </div>
+
+      <InvoiceFilters
+        status={statusFilter}
+        onStatusChange={setStatusFilter}
+        search={search}
+        onSearchChange={setSearch}
+        dateRange={dateRange}
+        onDateRangeChange={setDateRange}
+      />
+
+      <div className="rounded-lg border">
+        {isLoading ? (
+          <div className="p-4">
+            <SkeletonTable rows={5} columns={6} />
+          </div>
+        ) : !filteredInvoices || filteredInvoices.length === 0 ? (
+          <div className="p-8 text-center text-muted-foreground">No invoices found</div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Invoice #</TableHead>
+                <TableHead>Period</TableHead>
+                <TableHead>Deployment</TableHead>
+                <TableHead className="text-right">Amount</TableHead>
+                <TableHead className="text-center">Status</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredInvoices.map((invoice) => (
+                <InvoiceRow key={invoice.id} invoice={invoice} onView={onViewInvoice} />
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/portal/src/components/billing/InvoiceRow.tsx
+++ b/portal/src/components/billing/InvoiceRow.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { TableCell, TableRow } from '@/components/ui/Table';
+import { Download, Eye } from 'lucide-react';
+import type { Invoice, InvoiceStatus } from '@virtengine/portal/types/billing';
+import {
+  formatBillingAmount,
+  formatBillingPeriod,
+  generateInvoiceText,
+} from '@virtengine/portal/utils/billing';
+import { downloadFile } from '@virtengine/portal/utils/csv';
+
+interface InvoiceRowProps {
+  invoice: Invoice;
+  onView?: (id: string) => void;
+}
+
+const STATUS_VARIANT: Record<
+  InvoiceStatus,
+  'default' | 'success' | 'warning' | 'destructive' | 'secondary'
+> = {
+  draft: 'secondary',
+  pending: 'warning',
+  paid: 'success',
+  overdue: 'destructive',
+  cancelled: 'secondary',
+};
+
+export function InvoiceRow({ invoice, onView }: InvoiceRowProps) {
+  const handleDownload = () => {
+    const text = generateInvoiceText(invoice);
+    downloadFile(text, `invoice-${invoice.number}.txt`, 'text/plain');
+  };
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{invoice.number}</TableCell>
+      <TableCell>{formatBillingPeriod(invoice.period.start, invoice.period.end)}</TableCell>
+      <TableCell className="max-w-[120px] truncate" title={invoice.deploymentId}>
+        {invoice.deploymentId}
+      </TableCell>
+      <TableCell className="text-right font-medium">
+        {formatBillingAmount(invoice.total, invoice.currency)}
+      </TableCell>
+      <TableCell className="text-center">
+        <Badge variant={STATUS_VARIANT[invoice.status]} size="sm">
+          {invoice.status}
+        </Badge>
+      </TableCell>
+      <TableCell className="text-right">
+        <div className="flex items-center justify-end gap-1">
+          {onView && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onView(invoice.id)}
+              aria-label={`View invoice ${invoice.number}`}
+            >
+              <Eye className="h-4 w-4" />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleDownload}
+            aria-label={`Download invoice ${invoice.number}`}
+          >
+            <Download className="h-4 w-4" />
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/portal/src/components/billing/UsageAnalytics.tsx
+++ b/portal/src/components/billing/UsageAnalytics.tsx
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/Table';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { Button } from '@/components/ui/Button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/Select';
+import { Input } from '@/components/ui/Input';
+import { Download } from 'lucide-react';
+import { useCurrentUsage, useUsageHistory } from '@virtengine/portal/hooks/useBilling';
+import type {
+  UsageGranularity,
+  DeploymentUsage,
+  ProviderUsage,
+  ResourceUsage,
+} from '@virtengine/portal/types/billing';
+import { formatBillingAmount } from '@virtengine/portal/utils/billing';
+import { generateUsageReportCSV, downloadFile } from '@virtengine/portal/utils/csv';
+import { UsageChart } from './UsageChart';
+
+function thirtyDaysAgo(): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  return d;
+}
+
+function ResourceBar({
+  label,
+  used,
+  limit,
+  unit,
+}: {
+  label: string;
+  used: number;
+  limit: number;
+  unit: string;
+}) {
+  const percent = limit > 0 ? Math.min((used / limit) * 100, 100) : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="font-medium">
+          {used.toFixed(1)} / {limit.toFixed(1)} {unit}
+        </span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-secondary">
+        <div
+          className="h-full rounded-full bg-primary transition-all"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ResourceBreakdown({ resources }: { resources?: ResourceUsage }) {
+  if (!resources) return <Skeleton className="h-32" />;
+  return (
+    <div className="space-y-4">
+      <ResourceBar
+        label="CPU"
+        used={resources.cpu.used}
+        limit={resources.cpu.limit}
+        unit={resources.cpu.unit}
+      />
+      <ResourceBar
+        label="Memory"
+        used={resources.memory.used}
+        limit={resources.memory.limit}
+        unit={resources.memory.unit}
+      />
+      <ResourceBar
+        label="Storage"
+        used={resources.storage.used}
+        limit={resources.storage.limit}
+        unit={resources.storage.unit}
+      />
+      <ResourceBar
+        label="Bandwidth"
+        used={resources.bandwidth.used}
+        limit={resources.bandwidth.limit}
+        unit={resources.bandwidth.unit}
+      />
+      {resources.gpu && (
+        <ResourceBar
+          label="GPU"
+          used={resources.gpu.used}
+          limit={resources.gpu.limit}
+          unit={resources.gpu.unit}
+        />
+      )}
+    </div>
+  );
+}
+
+function DeploymentUsageTable({ deployments }: { deployments: DeploymentUsage[] }) {
+  if (deployments.length === 0) {
+    return <p className="p-4 text-center text-sm text-muted-foreground">No deployment data</p>;
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Deployment</TableHead>
+          <TableHead>Provider</TableHead>
+          <TableHead className="text-right">CPU</TableHead>
+          <TableHead className="text-right">Memory</TableHead>
+          <TableHead className="text-right">Cost</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {deployments.map((d) => (
+          <TableRow key={d.deploymentId}>
+            <TableCell className="font-medium">{d.name || d.deploymentId}</TableCell>
+            <TableCell className="max-w-[100px] truncate" title={d.provider}>
+              {d.provider}
+            </TableCell>
+            <TableCell className="text-right">
+              {d.resources.cpu.used.toFixed(1)} {d.resources.cpu.unit}
+            </TableCell>
+            <TableCell className="text-right">
+              {d.resources.memory.used.toFixed(1)} {d.resources.memory.unit}
+            </TableCell>
+            <TableCell className="text-right font-medium">{formatBillingAmount(d.cost)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function ProviderUsageTable({ providers }: { providers: ProviderUsage[] }) {
+  if (providers.length === 0) {
+    return <p className="p-4 text-center text-sm text-muted-foreground">No provider data</p>;
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Provider</TableHead>
+          <TableHead className="text-right">Deployments</TableHead>
+          <TableHead className="text-right">CPU</TableHead>
+          <TableHead className="text-right">Memory</TableHead>
+          <TableHead className="text-right">Cost</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {providers.map((p) => (
+          <TableRow key={p.provider}>
+            <TableCell className="font-medium">{p.name || p.provider}</TableCell>
+            <TableCell className="text-right">{p.deploymentCount}</TableCell>
+            <TableCell className="text-right">
+              {p.resources.cpu.used.toFixed(1)} {p.resources.cpu.unit}
+            </TableCell>
+            <TableCell className="text-right">
+              {p.resources.memory.used.toFixed(1)} {p.resources.memory.unit}
+            </TableCell>
+            <TableCell className="text-right font-medium">{formatBillingAmount(p.cost)}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function UsageAnalytics() {
+  const [granularity, setGranularity] = useState<UsageGranularity>('day');
+  const [dateRange, setDateRange] = useState({
+    start: thirtyDaysAgo(),
+    end: new Date(),
+  });
+
+  const { data: usage, isLoading: usageLoading } = useCurrentUsage();
+  const { data: history, isLoading: historyLoading } = useUsageHistory({
+    startDate: dateRange.start,
+    endDate: dateRange.end,
+    granularity,
+  });
+
+  const handleExportUsage = () => {
+    if (!history || history.length === 0) return;
+    const csv = generateUsageReportCSV(history);
+    downloadFile(csv, 'usage-report.csv', 'text/csv');
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-xl font-semibold">Usage Analytics</h2>
+        <div className="flex items-center gap-2">
+          <Select value={granularity} onValueChange={(v) => setGranularity(v as UsageGranularity)}>
+            <SelectTrigger className="w-[120px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="hour">Hourly</SelectItem>
+              <SelectItem value="day">Daily</SelectItem>
+              <SelectItem value="week">Weekly</SelectItem>
+              <SelectItem value="month">Monthly</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            type="date"
+            className="w-[140px]"
+            value={dateRange.start.toISOString().split('T')[0]}
+            onChange={(e) =>
+              setDateRange((prev) => ({
+                ...prev,
+                start: new Date(e.target.value),
+              }))
+            }
+            aria-label="Usage start date"
+          />
+          <Input
+            type="date"
+            className="w-[140px]"
+            value={dateRange.end.toISOString().split('T')[0]}
+            onChange={(e) =>
+              setDateRange((prev) => ({
+                ...prev,
+                end: new Date(e.target.value),
+              }))
+            }
+            aria-label="Usage end date"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleExportUsage}
+            disabled={!history || history.length === 0}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            Export
+          </Button>
+        </div>
+      </div>
+
+      {/* Usage chart */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Resource Usage Over Time</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <UsageChart data={history} granularity={granularity} loading={historyLoading} />
+        </CardContent>
+      </Card>
+
+      {/* Resource breakdown */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Current Resource Usage</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {usageLoading ? (
+            <Skeleton className="h-32" />
+          ) : (
+            <ResourceBreakdown resources={usage?.resources} />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Tabbed breakdown */}
+      <Tabs defaultValue="deployments">
+        <TabsList>
+          <TabsTrigger value="deployments">By Deployment</TabsTrigger>
+          <TabsTrigger value="providers">By Provider</TabsTrigger>
+          <TabsTrigger value="resources">By Resource</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="deployments" className="rounded-lg border">
+          <DeploymentUsageTable deployments={usage?.byDeployment ?? []} />
+        </TabsContent>
+
+        <TabsContent value="providers" className="rounded-lg border">
+          <ProviderUsageTable providers={usage?.byProvider ?? []} />
+        </TabsContent>
+
+        <TabsContent value="resources">
+          <Card>
+            <CardContent className="pt-6">
+              <ResourceBreakdown resources={usage?.resources} />
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/portal/src/components/billing/UsageChart.tsx
+++ b/portal/src/components/billing/UsageChart.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Skeleton } from '@/components/ui/Skeleton';
+import type { UsageHistoryPoint, UsageGranularity } from '@virtengine/portal/types/billing';
+
+interface UsageChartProps {
+  data?: UsageHistoryPoint[];
+  granularity: UsageGranularity;
+  loading?: boolean;
+}
+
+const RESOURCE_COLORS: Record<string, string> = {
+  cpu: 'bg-blue-500',
+  memory: 'bg-green-500',
+  storage: 'bg-amber-500',
+  bandwidth: 'bg-purple-500',
+  gpu: 'bg-red-500',
+};
+
+const RESOURCE_LABELS: Record<string, string> = {
+  cpu: 'CPU',
+  memory: 'Memory',
+  storage: 'Storage',
+  bandwidth: 'Bandwidth',
+  gpu: 'GPU',
+};
+
+/**
+ * Stacked area chart for resource usage over time.
+ * Uses native HTML/CSS for zero-dependency rendering.
+ */
+export function UsageChart({ data, granularity, loading }: UsageChartProps) {
+  const [maxValue, setMaxValue] = useState(1);
+
+  useEffect(() => {
+    if (data && data.length > 0) {
+      const max = Math.max(...data.map((d) => d.cpu + d.memory + d.storage + d.bandwidth + d.gpu));
+      setMaxValue(max > 0 ? max : 1);
+    }
+  }, [data]);
+
+  if (loading) {
+    return <Skeleton className="h-64 w-full" />;
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+        No usage data available for this period
+      </div>
+    );
+  }
+
+  const formatLabel = (timestamp: Date): string => {
+    switch (granularity) {
+      case 'hour':
+        return timestamp.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+      case 'day':
+        return timestamp.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+      case 'week':
+        return `W${Math.ceil(timestamp.getDate() / 7)}`;
+      case 'month':
+        return timestamp.toLocaleDateString(undefined, { month: 'short', year: '2-digit' });
+      default:
+        return timestamp.toLocaleDateString();
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Chart */}
+      <div className="flex h-64 items-end gap-px" role="img" aria-label="Resource usage chart">
+        {data.map((point) => {
+          const total = point.cpu + point.memory + point.storage + point.bandwidth + point.gpu;
+          const heightPercent = (total / maxValue) * 100;
+
+          return (
+            <div
+              key={`usage-bar-${point.timestamp.toISOString()}`}
+              className="group relative flex flex-1 flex-col justify-end"
+              style={{ height: `${Math.max(heightPercent, 1)}%` }}
+              title={`${formatLabel(point.timestamp)}: ${total.toFixed(1)} total`}
+            >
+              {/* Stacked segments */}
+              {point.gpu > 0 && (
+                <div
+                  className={`w-full ${RESOURCE_COLORS.gpu}`}
+                  style={{ height: `${(point.gpu / total) * 100}%` }}
+                />
+              )}
+              <div
+                className={`w-full ${RESOURCE_COLORS.bandwidth}`}
+                style={{ height: `${(point.bandwidth / total) * 100}%` }}
+              />
+              <div
+                className={`w-full ${RESOURCE_COLORS.storage}`}
+                style={{ height: `${(point.storage / total) * 100}%` }}
+              />
+              <div
+                className={`w-full ${RESOURCE_COLORS.memory}`}
+                style={{ height: `${(point.memory / total) * 100}%` }}
+              />
+              <div
+                className={`w-full rounded-t ${RESOURCE_COLORS.cpu}`}
+                style={{ height: `${(point.cpu / total) * 100}%` }}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap gap-4">
+        {Object.entries(RESOURCE_LABELS).map(([key, label]) => (
+          <div key={`legend-${key}`} className="flex items-center gap-1.5">
+            <div className={`h-3 w-3 rounded-sm ${RESOURCE_COLORS[key]}`} />
+            <span className="text-xs text-muted-foreground">{label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/portal/src/components/billing/UsageSummaryCard.tsx
+++ b/portal/src/components/billing/UsageSummaryCard.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Skeleton } from '@/components/ui/Skeleton';
+
+interface UsageSummaryCardProps {
+  title: string;
+  value: string;
+  currency?: string;
+  subtitle?: string;
+  loading?: boolean;
+  status?: 'normal' | 'warning';
+}
+
+export function UsageSummaryCard({
+  title,
+  value,
+  currency,
+  subtitle,
+  loading,
+  status = 'normal',
+}: UsageSummaryCardProps) {
+  return (
+    <Card className={status === 'warning' ? 'border-warning' : undefined}>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-8 w-24" />
+        ) : (
+          <>
+            <div className="text-2xl font-bold">
+              {value}
+              {currency && (
+                <span className="ml-1 text-sm font-normal text-muted-foreground">{currency}</span>
+              )}
+            </div>
+            {subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/portal/src/components/billing/index.ts
+++ b/portal/src/components/billing/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+export { BillingDashboard } from './BillingDashboard';
+export { InvoiceList } from './InvoiceList';
+export { InvoiceDetail } from './InvoiceDetail';
+export { InvoiceRow } from './InvoiceRow';
+export { InvoiceFilters } from './InvoiceFilters';
+export { UsageSummaryCard } from './UsageSummaryCard';
+export { UsageAnalytics } from './UsageAnalytics';
+export { UsageChart } from './UsageChart';
+export { CostTrendChart } from './CostTrendChart';
+export { CostProjectionCard } from './CostProjectionCard';

--- a/portal/tests/unit/billing/UsageSummaryCard.test.tsx
+++ b/portal/tests/unit/billing/UsageSummaryCard.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Billing component unit tests
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UsageSummaryCard } from '@/components/billing/UsageSummaryCard';
+
+// Mock fetch globally for billing API hooks
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ invoices: [], usages: [] }),
+    })
+  );
+});
+
+describe('UsageSummaryCard', () => {
+  it('renders title and value', () => {
+    render(<UsageSummaryCard title="Current Period" value="150.00" currency="VIRT" />);
+    expect(screen.getByText('Current Period')).toBeInTheDocument();
+    expect(screen.getByText('150.00')).toBeInTheDocument();
+    expect(screen.getByText('VIRT')).toBeInTheDocument();
+  });
+
+  it('renders subtitle when provided', () => {
+    render(<UsageSummaryCard title="Projected" value="200" subtitle="5 days remaining" />);
+    expect(screen.getByText('5 days remaining')).toBeInTheDocument();
+  });
+
+  it('shows skeleton when loading', () => {
+    const { container } = render(<UsageSummaryCard title="Loading" value="0" loading />);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
+  });
+
+  it('applies warning border when status is warning', () => {
+    const { container } = render(
+      <UsageSummaryCard title="Outstanding" value="50" status="warning" />
+    );
+    const card = container.firstElementChild;
+    expect(card?.className).toContain('border-warning');
+  });
+
+  it('does not apply warning border by default', () => {
+    const { container } = render(<UsageSummaryCard title="Normal" value="100" />);
+    const card = container.firstElementChild;
+    expect(card?.className).not.toContain('border-warning');
+  });
+});


### PR DESCRIPTION
## Summary

Implements Task 29J: Billing/Invoice Dashboard for the portal.

### Features
- **Escrow balance display** with usage summary cards (current period cost, outstanding balance, projected cost)
- **Invoice listing** with status filters (pending/paid/overdue/cancelled), search, and CSV export
- **Invoice detail view** with line items, fees breakdown, and payment history
- **Usage analytics** with resource usage charts, deployment/provider/resource breakdown tabs
- **Cost projection** card with monthly trend indicator
- **30-day cost trend** bar chart (pure CSS, no external chart library)
- **Export functionality** - CSV export for invoices and usage reports, text-based invoice download

### Architecture
- **Types**: \lib/portal/types/billing.ts\ - All billing domain types
- **Utilities**: \lib/portal/utils/csv.ts\, \lib/portal/utils/billing.ts\ - CSV export, formatting, aggregation
- **Hooks**: \lib/portal/hooks/useBilling.ts\ - 5 data-fetching hooks (useInvoices, useInvoice, useCurrentUsage, useUsageHistory, useCostProjection)
- **Components**: 10 components in \portal/src/components/billing/\
- **Pages**: 4 routes under \/billing\ (\/billing\, \/billing/invoices\, \/billing/invoices/[id]\, \/billing/usage\)

### Testing
- 28 unit tests for billing utilities (lib/portal)
- 5 component tests for UsageSummaryCard (portal)
- Also fixes pre-existing locale-dependent currency formatting assertions in dashboard tests

### Technical Notes
- Uses fetch + useState pattern matching existing portal codebase (not React Query)
- Charts use pure CSS bars (no recharts/chart.js dependency added)
- All components use existing shadcn/ui primitives (Card, Badge, Button, Table, Tabs, etc.)
- Hooks use configurable API_BASE_URL defaulting to \/api/billing\

Depends on: #29D (multi-provider context)
Task: 29J