### PR TITLE
feat(portal): add multi-provider client

### DIFF
--- a/lib/portal/index.ts
+++ b/lib/portal/index.ts
@@ -333,6 +333,75 @@ export { SettlementView } from "./components/provider/SettlementView";
 export { DomainVerificationPanel } from "./components/provider/DomainVerificationPanel";
 
 // ============================================================================
+// Provider API (VE-29D/29E)
+// ============================================================================
+
+export {
+  ProviderAPIClient,
+  ProviderAPIError,
+  LogStream,
+  ShellConnection,
+} from "./src/provider-api";
+export type {
+  ProviderAPIClientOptions,
+  ProviderHealthStatus,
+  ProviderHealth,
+  LogOptions,
+  DeploymentState,
+  UsageMetric,
+  ResourceMetrics,
+  Deployment,
+  DeploymentStatus,
+  ServiceStatus,
+  DeploymentListResponse,
+  DeploymentAction,
+  ShellSessionResponse,
+  ProviderAPIErrorDetails,
+} from "./src/provider-api";
+
+export { signRequest } from "./src/auth/wallet-sign";
+export type {
+  SignedRequestHeaders,
+  SignRequestOptions,
+} from "./src/auth/wallet-sign";
+
+// ============================================================================
+// Multi-Provider Aggregation (VE-29G)
+// ============================================================================
+
+export {
+  MultiProviderClient,
+  MultiProviderProvider,
+  useMultiProvider,
+} from "./src/multi-provider";
+export type {
+  ProviderRecord,
+  ProviderStatus,
+  DeploymentWithProvider,
+  AggregatedMetrics,
+  MultiProviderWallet,
+  MultiProviderClientOptions,
+  MultiProviderProviderProps,
+} from "./src/multi-provider";
+
+export { useAggregatedDeployments } from "./src/hooks/useAggregatedDeployments";
+export type {
+  AggregatedDeploymentsState,
+  AggregatedDeploymentsActions,
+  UseAggregatedDeploymentsOptions,
+} from "./src/hooks/useAggregatedDeployments";
+
+export { useAggregatedMetrics } from "./src/hooks/useAggregatedMetrics";
+export type {
+  AggregatedMetricsState,
+  AggregatedMetricsActions,
+  UseAggregatedMetricsOptions,
+} from "./src/hooks/useAggregatedMetrics";
+
+export { useDeploymentWithProvider } from "./src/hooks/useDeploymentWithProvider";
+export type { DeploymentWithProviderState } from "./src/hooks/useDeploymentWithProvider";
+
+// ============================================================================
 // HPC / Supercomputer (VE-705)
 // ============================================================================
 

--- a/lib/portal/src/auth/wallet-sign.ts
+++ b/lib/portal/src/auth/wallet-sign.ts
@@ -1,0 +1,149 @@
+import type {
+  AminoSignDoc,
+  AminoSignResponse,
+  WalletSignOptions,
+} from "../wallet/types";
+
+export interface WalletRequestSigner {
+  signAmino: (
+    signDoc: AminoSignDoc,
+    options?: WalletSignOptions,
+  ) => Promise<AminoSignResponse>;
+  signArbitrary?: (
+    data: string | Uint8Array,
+  ) => Promise<{ signature: string; pubKey: Uint8Array }>;
+}
+
+export interface SignedRequestHeaders {
+  "X-VE-Address": string;
+  "X-VE-Timestamp": string;
+  "X-VE-Nonce": string;
+  "X-VE-Signature": string;
+  "X-VE-PubKey": string;
+}
+
+export interface SignRequestOptions {
+  method: string;
+  path: string;
+  body?: unknown;
+  signer: WalletRequestSigner;
+  address: string;
+  chainId: string;
+  memo?: string;
+}
+
+interface RequestData {
+  method: string;
+  path: string;
+  timestamp: number;
+  nonce: string;
+  body_hash: string;
+}
+
+const textEncoder = new TextEncoder();
+
+const serializeRequestData = (data: RequestData): string => {
+  return `{"method":"${data.method}","path":"${data.path}","timestamp":${data.timestamp},"nonce":"${data.nonce}","body_hash":"${data.body_hash}"}`;
+};
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(obj[key])}`)
+    .join(",")}}`;
+};
+
+const toBase64 = (value: string): string => {
+  if (typeof btoa === "function") {
+    return btoa(value);
+  }
+  return Buffer.from(value, "utf-8").toString("base64");
+};
+
+const toHex = (bytes: Uint8Array): string => {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+const sha256Hex = async (payload: string): Promise<string> => {
+  const data = textEncoder.encode(payload);
+  if (globalThis.crypto?.subtle) {
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", data);
+    return toHex(new Uint8Array(digest));
+  }
+
+  const nodeCrypto = await import("crypto");
+  return nodeCrypto.createHash("sha256").update(data).digest("hex");
+};
+
+const randomNonce = (): string => {
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i += 1) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  return toHex(bytes);
+};
+
+export async function signRequest(
+  options: SignRequestOptions,
+): Promise<SignedRequestHeaders> {
+  const timestamp = Date.now();
+  const nonce = randomNonce();
+  const bodyPayload = options.body ? stableStringify(options.body) : "";
+  const bodyHash = bodyPayload ? await sha256Hex(bodyPayload) : "";
+
+  const requestData: RequestData = {
+    method: options.method.toUpperCase(),
+    path: options.path,
+    timestamp,
+    nonce,
+    body_hash: bodyHash,
+  };
+
+  const dataToSign = serializeRequestData(requestData);
+  const dataBase64 = toBase64(dataToSign);
+
+  const signDoc: AminoSignDoc = {
+    chain_id: options.chainId,
+    account_number: "0",
+    sequence: "0",
+    fee: {
+      gas: "0",
+      amount: [],
+    },
+    msgs: [
+      {
+        type: "sign/MsgSignData",
+        value: {
+          signer: options.address,
+          data: dataBase64,
+        },
+      },
+    ],
+    memo: options.memo ?? "",
+  };
+
+  const signResponse = await options.signer.signAmino(signDoc);
+
+  return {
+    "X-VE-Address": options.address,
+    "X-VE-Timestamp": timestamp.toString(),
+    "X-VE-Nonce": nonce,
+    "X-VE-Signature": signResponse.signature.signature,
+    "X-VE-PubKey": signResponse.signature.pub_key.value,
+  };
+}

--- a/lib/portal/src/hooks/useAggregatedDeployments.ts
+++ b/lib/portal/src/hooks/useAggregatedDeployments.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { DeploymentWithProvider } from "../multi-provider/types";
+import { useMultiProvider } from "../multi-provider/context";
+
+export interface AggregatedDeploymentsState {
+  deployments: DeploymentWithProvider[];
+  isLoading: boolean;
+  error: string | null;
+  lastUpdatedAt: number | null;
+}
+
+export interface AggregatedDeploymentsActions {
+  refresh: () => Promise<void>;
+}
+
+export interface UseAggregatedDeploymentsOptions {
+  pollIntervalMs?: number;
+  autoRefresh?: boolean;
+  status?: string;
+}
+
+export function useAggregatedDeployments(
+  options: UseAggregatedDeploymentsOptions = {},
+) {
+  const { client, isInitialized } = useMultiProvider();
+  const [state, setState] = useState<AggregatedDeploymentsState>({
+    deployments: [],
+    isLoading: false,
+    error: null,
+    lastUpdatedAt: null,
+  });
+
+  const refresh = useCallback(async () => {
+    if (!client) return;
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const deployments = await client.listAllDeployments({
+        refresh: true,
+        status: options.status,
+      });
+      setState({
+        deployments,
+        isLoading: false,
+        error: null,
+        lastUpdatedAt: Date.now(),
+      });
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        error:
+          error instanceof Error ? error.message : "Failed to load deployments",
+      }));
+    }
+  }, [client, options.status]);
+
+  useEffect(() => {
+    if (!client || !isInitialized) return;
+    void refresh();
+  }, [client, isInitialized, refresh]);
+
+  useEffect(() => {
+    if (
+      !client ||
+      !isInitialized ||
+      !options.autoRefresh ||
+      !options.pollIntervalMs
+    )
+      return;
+    const interval = setInterval(() => {
+      void refresh();
+    }, options.pollIntervalMs);
+    return () => clearInterval(interval);
+  }, [
+    client,
+    isInitialized,
+    options.autoRefresh,
+    options.pollIntervalMs,
+    refresh,
+  ]);
+
+  const actions = useMemo(() => ({ refresh }), [refresh]);
+
+  return { state, actions };
+}

--- a/lib/portal/src/hooks/useAggregatedMetrics.ts
+++ b/lib/portal/src/hooks/useAggregatedMetrics.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { AggregatedMetrics } from "../multi-provider/types";
+import { useMultiProvider } from "../multi-provider/context";
+
+export interface AggregatedMetricsState {
+  metrics: AggregatedMetrics | null;
+  isLoading: boolean;
+  error: string | null;
+  lastUpdatedAt: number | null;
+}
+
+export interface AggregatedMetricsActions {
+  refresh: () => Promise<void>;
+}
+
+export interface UseAggregatedMetricsOptions {
+  pollIntervalMs?: number;
+  autoRefresh?: boolean;
+}
+
+export function useAggregatedMetrics(
+  options: UseAggregatedMetricsOptions = {},
+) {
+  const { client, isInitialized } = useMultiProvider();
+  const [state, setState] = useState<AggregatedMetricsState>({
+    metrics: null,
+    isLoading: false,
+    error: null,
+    lastUpdatedAt: null,
+  });
+
+  const refresh = useCallback(async () => {
+    if (!client) return;
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const metrics = await client.getAggregatedMetrics();
+      setState({
+        metrics,
+        isLoading: false,
+        error: null,
+        lastUpdatedAt: Date.now(),
+      });
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        error:
+          error instanceof Error ? error.message : "Failed to load metrics",
+      }));
+    }
+  }, [client]);
+
+  useEffect(() => {
+    if (!client || !isInitialized) return;
+    void refresh();
+  }, [client, isInitialized, refresh]);
+
+  useEffect(() => {
+    if (
+      !client ||
+      !isInitialized ||
+      !options.autoRefresh ||
+      !options.pollIntervalMs
+    )
+      return;
+    const interval = setInterval(() => {
+      void refresh();
+    }, options.pollIntervalMs);
+    return () => clearInterval(interval);
+  }, [
+    client,
+    isInitialized,
+    options.autoRefresh,
+    options.pollIntervalMs,
+    refresh,
+  ]);
+
+  const actions = useMemo(() => ({ refresh }), [refresh]);
+
+  return { state, actions };
+}

--- a/lib/portal/src/hooks/useDeploymentWithProvider.ts
+++ b/lib/portal/src/hooks/useDeploymentWithProvider.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+import type { DeploymentWithProvider } from "../multi-provider/types";
+import { useMultiProvider } from "../multi-provider/context";
+
+export interface DeploymentWithProviderState {
+  deployment: DeploymentWithProvider | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useDeploymentWithProvider(deploymentId: string | null) {
+  const { client, isInitialized } = useMultiProvider();
+  const [state, setState] = useState<DeploymentWithProviderState>({
+    deployment: null,
+    isLoading: false,
+    error: null,
+  });
+
+  const refresh = useCallback(async () => {
+    if (!client || !deploymentId) return;
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const deployment = await client.getDeployment(deploymentId);
+      setState({ deployment, isLoading: false, error: null });
+    } catch (error) {
+      setState({
+        deployment: null,
+        isLoading: false,
+        error:
+          error instanceof Error ? error.message : "Failed to load deployment",
+      });
+    }
+  }, [client, deploymentId]);
+
+  useEffect(() => {
+    if (!client || !isInitialized || !deploymentId) return;
+    void refresh();
+  }, [client, isInitialized, deploymentId, refresh]);
+
+  return { state, refresh };
+}

--- a/lib/portal/src/multi-provider/client.ts
+++ b/lib/portal/src/multi-provider/client.ts
@@ -1,0 +1,565 @@
+import { ProviderAPIClient } from "../provider-api/client";
+import type { Deployment, ResourceMetrics } from "../provider-api/types";
+import type {
+  AggregatedMetrics,
+  DeploymentWithProvider,
+  MultiProviderClientOptions,
+  ProviderRecord,
+  ProviderStatus,
+} from "./types";
+
+interface ChainProviderAttribute {
+  key: string;
+  value: string;
+}
+
+interface ChainProviderInfo {
+  name?: string;
+  website?: string;
+}
+
+interface ChainProvider {
+  owner: string;
+  host_uri?: string;
+  hostURI?: string;
+  attributes?: ChainProviderAttribute[];
+  info?: ChainProviderInfo;
+}
+
+interface ChainProviderResponse {
+  providers?: ChainProvider[];
+  pagination?: {
+    next_key?: string | null;
+    total?: string;
+  };
+}
+
+interface DeploymentCache {
+  timestamp: number;
+  deployments: DeploymentWithProvider[];
+}
+
+const sumUsageTotals = (
+  target: { used: number; limit: number },
+  metric?: { usage: number; limit: number },
+) => {
+  if (!metric) return;
+  target.used += metric.usage ?? 0;
+  target.limit += metric.limit ?? 0;
+};
+
+const sumUsageMetrics = (
+  target: { usage: number; limit: number },
+  metric?: { usage: number; limit: number },
+) => {
+  if (!metric) return;
+  target.usage += metric.usage ?? 0;
+  target.limit += metric.limit ?? 0;
+};
+
+const normalizeAttributes = (
+  attributes?: ChainProviderAttribute[],
+): Record<string, string> => {
+  if (!attributes || attributes.length === 0) return {};
+  return attributes.reduce<Record<string, string>>((acc, attr) => {
+    acc[attr.key] = attr.value;
+    return acc;
+  }, {});
+};
+
+const pickAttribute = (
+  attrs: Record<string, string>,
+  keys: string[],
+): string | undefined => {
+  for (const key of keys) {
+    const value = attrs[key];
+    if (value) return value;
+  }
+  return undefined;
+};
+
+const normalizeEndpoint = (raw?: string): string | null => {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    return trimmed.replace(/\/$/, "");
+  }
+  return `https://${trimmed.replace(/\/$/, "")}`;
+};
+
+export class MultiProviderClient {
+  private readonly chainEndpoint: string;
+  private readonly wallet?: MultiProviderClientOptions["wallet"];
+  private readonly healthCheckIntervalMs: number;
+  private readonly providerCacheTtlMs: number;
+  private readonly deploymentCacheTtlMs: number;
+  private readonly requestTimeoutMs?: number;
+  private readonly fetcher: typeof fetch;
+  private providers = new Map<string, ProviderRecord>();
+  private clients = new Map<string, ProviderAPIClient>();
+  private deploymentProviderMap = new Map<string, string>();
+  private providerCacheTimestamp = 0;
+  private deploymentCache: DeploymentCache | null = null;
+  private healthCheckTimer?: ReturnType<typeof setInterval>;
+  private subscribers = new Set<(providers: ProviderRecord[]) => void>();
+
+  constructor(options: MultiProviderClientOptions) {
+    this.chainEndpoint = options.chainEndpoint.replace(/\/$/, "");
+    this.wallet = options.wallet;
+    this.healthCheckIntervalMs = options.healthCheckIntervalMs ?? 60000;
+    this.providerCacheTtlMs = options.providerCacheTtlMs ?? 300000;
+    this.deploymentCacheTtlMs = options.deploymentCacheTtlMs ?? 60000;
+    this.requestTimeoutMs = options.requestTimeoutMs;
+    this.fetcher = options.fetcher ?? fetch;
+  }
+
+  subscribe(listener: (providers: ProviderRecord[]) => void): () => void {
+    this.subscribers.add(listener);
+    listener(this.getProviders());
+    return () => this.subscribers.delete(listener);
+  }
+
+  async initialize(): Promise<void> {
+    await this.refreshProviders(true);
+    this.startHealthChecks();
+  }
+
+  destroy(): void {
+    if (this.healthCheckTimer) {
+      clearInterval(this.healthCheckTimer);
+      this.healthCheckTimer = undefined;
+    }
+  }
+
+  getProviders(): ProviderRecord[] {
+    return Array.from(this.providers.values());
+  }
+
+  getOnlineProviders(): ProviderRecord[] {
+    return this.getProviders().filter(
+      (provider) => provider.status === "online",
+    );
+  }
+
+  getProvider(address: string): ProviderRecord | undefined {
+    return this.providers.get(address);
+  }
+
+  getClient(address: string): ProviderAPIClient | null {
+    const provider = this.providers.get(address);
+    if (!provider) return null;
+    const existing = this.clients.get(address);
+    if (existing) return existing;
+
+    const client = new ProviderAPIClient({
+      endpoint: provider.endpoint,
+      wallet: this.wallet,
+      timeoutMs: this.requestTimeoutMs,
+    });
+    this.clients.set(address, client);
+    return client;
+  }
+
+  async refreshProviders(force = false): Promise<void> {
+    const now = Date.now();
+    if (!force && now - this.providerCacheTimestamp < this.providerCacheTtlMs) {
+      return;
+    }
+
+    const discovered = await this.discoverProviders();
+    const nextProviders = new Map<string, ProviderRecord>();
+
+    discovered.forEach((provider) => {
+      const existing = this.providers.get(provider.address);
+      const status = existing?.status ?? "unknown";
+      nextProviders.set(provider.address, {
+        ...provider,
+        status,
+        lastHealthCheck: existing?.lastHealthCheck,
+        error: existing?.error,
+      });
+    });
+
+    this.providers = nextProviders;
+    this.providerCacheTimestamp = now;
+    this.notifyProviders();
+  }
+
+  async listAllDeployments(
+    options: { refresh?: boolean; status?: string } = {},
+  ): Promise<DeploymentWithProvider[]> {
+    if (!options.refresh && this.deploymentCache) {
+      const age = Date.now() - this.deploymentCache.timestamp;
+      if (age < this.deploymentCacheTtlMs) {
+        return this.deploymentCache.deployments;
+      }
+    }
+
+    await this.refreshProviders();
+
+    const providers = this.getProviders().filter(
+      (provider) => provider.status !== "offline",
+    );
+    const results = await Promise.allSettled(
+      providers.map(async (provider) => {
+        const client = this.getClient(provider.address);
+        if (!client) return [];
+        const response = await client.listDeployments({
+          status: options.status,
+        });
+        return response.deployments.map((deployment) => ({
+          ...deployment,
+          providerId: provider.address,
+          providerEndpoint: provider.endpoint,
+        }));
+      }),
+    );
+
+    const deployments: DeploymentWithProvider[] = [];
+    results.forEach((result) => {
+      if (result.status === "fulfilled") {
+        deployments.push(...result.value);
+      }
+    });
+
+    deployments.forEach((deployment) => {
+      this.deploymentProviderMap.set(deployment.id, deployment.providerId);
+    });
+
+    this.deploymentCache = {
+      timestamp: Date.now(),
+      deployments,
+    };
+
+    return deployments;
+  }
+
+  async getDeployment(
+    deploymentId: string,
+  ): Promise<DeploymentWithProvider | null> {
+    const providerId = this.deploymentProviderMap.get(deploymentId);
+    if (providerId) {
+      const client = this.getClient(providerId);
+      if (client) {
+        const deployment = await client.getDeployment(deploymentId);
+        return {
+          ...deployment,
+          providerId,
+          providerEndpoint: this.providers.get(providerId)?.endpoint ?? "",
+        };
+      }
+    }
+
+    const found = await this.findDeploymentProvider(deploymentId);
+    if (!found) return null;
+
+    this.deploymentProviderMap.set(deploymentId, found.providerId);
+    return found;
+  }
+
+  async getAggregatedMetrics(): Promise<AggregatedMetrics> {
+    const deployments = await this.listAllDeployments();
+    const collectedAt = new Date();
+
+    const metricsResults = await Promise.allSettled(
+      deployments.map(async (deployment) => {
+        const client = this.getClient(deployment.providerId);
+        if (!client) return null;
+        const metrics = await client.getDeploymentMetrics(deployment.id);
+        return { deployment, metrics };
+      }),
+    );
+
+    const aggregated: AggregatedMetrics = {
+      collectedAt,
+      totalCPU: { used: 0, limit: 0 },
+      totalMemory: { used: 0, limit: 0 },
+      totalStorage: { used: 0, limit: 0 },
+      totalCost: { amount: "0", currency: "uvirt" },
+      byProvider: new Map(),
+      byDeployment: new Map(),
+    };
+
+    metricsResults.forEach((result) => {
+      if (result.status !== "fulfilled" || !result.value) return;
+      const { deployment, metrics } = result.value;
+
+      aggregated.byDeployment.set(deployment.id, metrics);
+
+      sumUsageTotals(aggregated.totalCPU, metrics.cpu);
+      sumUsageTotals(aggregated.totalMemory, metrics.memory);
+      sumUsageTotals(aggregated.totalStorage, metrics.storage);
+
+      if (
+        metrics.cost &&
+        metrics.cost.currency === aggregated.totalCost.currency
+      ) {
+        const current = Number(aggregated.totalCost.amount);
+        const addition = Number(metrics.cost.amount);
+        if (!Number.isNaN(addition)) {
+          aggregated.totalCost.amount = (current + addition).toString();
+        }
+      }
+
+      const existing = aggregated.byProvider.get(deployment.providerId);
+      if (existing) {
+        sumUsageMetrics(existing.cpu, metrics.cpu);
+        sumUsageMetrics(existing.memory, metrics.memory);
+        sumUsageMetrics(existing.storage, metrics.storage);
+      } else {
+        aggregated.byProvider.set(deployment.providerId, {
+          ...metrics,
+          cpu: { ...metrics.cpu },
+          memory: { ...metrics.memory },
+          storage: { ...metrics.storage },
+        });
+      }
+    });
+
+    return aggregated;
+  }
+
+  async getAllMetrics(): Promise<AggregatedMetrics> {
+    return this.getAggregatedMetrics();
+  }
+
+  async getTotalUsage(): Promise<{
+    cpu: { used: number; limit: number };
+    memory: { used: number; limit: number };
+    storage: { used: number; limit: number };
+  }> {
+    const aggregated = await this.getAggregatedMetrics();
+    return {
+      cpu: aggregated.totalCPU,
+      memory: aggregated.totalMemory,
+      storage: aggregated.totalStorage,
+    };
+  }
+
+  async getTotalCost(): Promise<{ amount: string; currency: string }> {
+    const aggregated = await this.getAggregatedMetrics();
+    return aggregated.totalCost;
+  }
+
+  async connectLogs(deploymentId: string) {
+    const providerId = await this.resolveDeploymentProvider(deploymentId);
+    if (!providerId) {
+      throw new Error(`Unknown deployment: ${deploymentId}`);
+    }
+
+    const client = this.getClient(providerId);
+    if (!client) {
+      throw new Error(`No client for provider ${providerId}`);
+    }
+
+    return client.connectLogStream(deploymentId);
+  }
+
+  async connectShell(
+    deploymentId: string,
+    sessionToken?: string,
+    container?: string,
+  ) {
+    const providerId = await this.resolveDeploymentProvider(deploymentId);
+    if (!providerId) {
+      throw new Error(`Unknown deployment: ${deploymentId}`);
+    }
+
+    const client = this.getClient(providerId);
+    if (!client) {
+      throw new Error(`No client for provider ${providerId}`);
+    }
+
+    return client.connectShell(deploymentId, sessionToken, container);
+  }
+
+  async performAction(deploymentId: string, action: string): Promise<void> {
+    const providerId = await this.resolveDeploymentProvider(deploymentId);
+    if (!providerId) {
+      throw new Error(`Unknown deployment: ${deploymentId}`);
+    }
+
+    const client = this.getClient(providerId);
+    if (!client) {
+      throw new Error(`No client for provider ${providerId}`);
+    }
+
+    await client.performAction(deploymentId, action);
+  }
+
+  private async resolveDeploymentProvider(
+    deploymentId: string,
+  ): Promise<string | null> {
+    const existing = this.deploymentProviderMap.get(deploymentId);
+    if (existing) return existing;
+
+    const found = await this.findDeploymentProvider(deploymentId);
+    if (!found) return null;
+
+    this.deploymentProviderMap.set(deploymentId, found.providerId);
+    return found.providerId;
+  }
+
+  private async findDeploymentProvider(
+    deploymentId: string,
+  ): Promise<DeploymentWithProvider | null> {
+    await this.refreshProviders();
+
+    const providers = this.getProviders().filter(
+      (provider) => provider.status !== "offline",
+    );
+    const results = await Promise.allSettled(
+      providers.map(async (provider) => {
+        const client = this.getClient(provider.address);
+        if (!client) return null;
+        try {
+          const deployment = await client.getDeployment(deploymentId);
+          return {
+            ...deployment,
+            providerId: provider.address,
+            providerEndpoint: provider.endpoint,
+          };
+        } catch {
+          return null;
+        }
+      }),
+    );
+
+    for (const result of results) {
+      if (result.status === "fulfilled" && result.value) {
+        return result.value;
+      }
+    }
+
+    return null;
+  }
+
+  private async discoverProviders(): Promise<ProviderRecord[]> {
+    const response = await this.fetchChainProviders();
+    return response
+      .map((provider) => {
+        const attrs = normalizeAttributes(provider.attributes);
+        const hostUri =
+          provider.host_uri ??
+          provider.hostURI ??
+          pickAttribute(attrs, [
+            "host_uri",
+            "hostURI",
+            "endpoint",
+            "provider_endpoint",
+            "api_endpoint",
+            "portal_endpoint",
+            "url",
+            "uri",
+          ]);
+
+        const endpoint = normalizeEndpoint(hostUri);
+        if (!endpoint) return null;
+
+        return {
+          address: provider.owner,
+          endpoint,
+          name:
+            provider.info?.name ??
+            pickAttribute(attrs, ["name", "provider_name"]),
+          status: "unknown" as ProviderStatus,
+          attributes: attrs,
+          lastUpdatedAt: new Date(),
+        };
+      })
+      .filter(Boolean) as ProviderRecord[];
+  }
+
+  private async fetchChainProviders(): Promise<ChainProvider[]> {
+    const paths = [
+      "/virtengine/provider/v1beta4/providers",
+      "/virtengine/provider/v1/providers",
+    ];
+
+    let lastError: Error | null = null;
+
+    for (const path of paths) {
+      try {
+        const providers = await this.fetchAllPages(path);
+        if (providers.length > 0) {
+          return providers;
+        }
+      } catch (error) {
+        lastError = error as Error;
+      }
+    }
+
+    if (lastError) {
+      throw lastError;
+    }
+
+    return [];
+  }
+
+  private async fetchAllPages(path: string): Promise<ChainProvider[]> {
+    const providers: ChainProvider[] = [];
+    let nextKey: string | null | undefined = null;
+
+    do {
+      const url = new URL(`${this.chainEndpoint}${path}`);
+      if (nextKey) {
+        url.searchParams.set("pagination.key", nextKey);
+      } else {
+        url.searchParams.set("pagination.limit", "200");
+      }
+
+      const response = await this.fetcher(url.toString());
+      if (!response.ok) {
+        throw new Error(`Provider discovery failed: ${response.statusText}`);
+      }
+
+      const payload = (await response.json()) as ChainProviderResponse;
+      if (payload.providers) {
+        providers.push(...payload.providers);
+      }
+
+      nextKey = payload.pagination?.next_key ?? null;
+    } while (nextKey);
+
+    return providers;
+  }
+
+  private startHealthChecks() {
+    if (this.healthCheckTimer) {
+      clearInterval(this.healthCheckTimer);
+    }
+
+    this.healthCheckTimer = setInterval(() => {
+      void this.checkProviderHealth();
+    }, this.healthCheckIntervalMs);
+
+    void this.checkProviderHealth();
+  }
+
+  private async checkProviderHealth() {
+    const checks = Array.from(this.providers.values()).map(async (provider) => {
+      const client = this.getClient(provider.address);
+      if (!client) return;
+
+      try {
+        await client.health();
+        provider.status = "online";
+        provider.error = undefined;
+      } catch (error) {
+        provider.status = "offline";
+        provider.error =
+          error instanceof Error ? error.message : "Health check failed";
+      }
+      provider.lastHealthCheck = new Date();
+    });
+
+    await Promise.allSettled(checks);
+    this.notifyProviders();
+  }
+
+  private notifyProviders() {
+    const snapshot = this.getProviders();
+    this.subscribers.forEach((listener) => listener(snapshot));
+  }
+}

--- a/lib/portal/src/multi-provider/context.tsx
+++ b/lib/portal/src/multi-provider/context.tsx
@@ -1,0 +1,116 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { MultiProviderClient } from "./client";
+import type { MultiProviderClientOptions, ProviderRecord } from "./types";
+
+interface MultiProviderContextValue {
+  client: MultiProviderClient | null;
+  providers: ProviderRecord[];
+  isInitialized: boolean;
+  error: Error | null;
+  refreshProviders: () => Promise<void>;
+}
+
+const MultiProviderContext = createContext<MultiProviderContextValue | null>(
+  null,
+);
+
+export interface MultiProviderProviderProps {
+  options: MultiProviderClientOptions;
+  children: React.ReactNode;
+}
+
+export function MultiProviderProvider({
+  options,
+  children,
+}: MultiProviderProviderProps) {
+  const [client, setClient] = useState<MultiProviderClient | null>(null);
+  const [providers, setProviders] = useState<ProviderRecord[]>([]);
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const memoOptions = useMemo(
+    () => ({
+      chainEndpoint: options.chainEndpoint,
+      wallet: options.wallet,
+      healthCheckIntervalMs: options.healthCheckIntervalMs,
+      providerCacheTtlMs: options.providerCacheTtlMs,
+      deploymentCacheTtlMs: options.deploymentCacheTtlMs,
+      requestTimeoutMs: options.requestTimeoutMs,
+      fetcher: options.fetcher,
+    }),
+    [
+      options.chainEndpoint,
+      options.wallet,
+      options.healthCheckIntervalMs,
+      options.providerCacheTtlMs,
+      options.deploymentCacheTtlMs,
+      options.requestTimeoutMs,
+      options.fetcher,
+    ],
+  );
+
+  useEffect(() => {
+    let isActive = true;
+    const multiClient = new MultiProviderClient(memoOptions);
+    setClient(multiClient);
+    setIsInitialized(false);
+    setError(null);
+
+    const unsubscribe = multiClient.subscribe((snapshot) => {
+      if (!isActive) return;
+      setProviders(snapshot);
+    });
+
+    multiClient
+      .initialize()
+      .then(() => {
+        if (!isActive) return;
+        setIsInitialized(true);
+      })
+      .catch((err) => {
+        if (!isActive) return;
+        setError(err as Error);
+      });
+
+    return () => {
+      isActive = false;
+      unsubscribe();
+      multiClient.destroy();
+    };
+  }, [memoOptions]);
+
+  const refreshProviders = React.useCallback(async () => {
+    if (!client) return;
+    await client.refreshProviders(true);
+  }, [client]);
+
+  return (
+    <MultiProviderContext.Provider
+      value={{
+        client,
+        providers,
+        isInitialized,
+        error,
+        refreshProviders,
+      }}
+    >
+      {children}
+    </MultiProviderContext.Provider>
+  );
+}
+
+export function useMultiProvider(): MultiProviderContextValue {
+  const context = useContext(MultiProviderContext);
+  if (!context) {
+    throw new Error(
+      "useMultiProvider must be used within MultiProviderProvider",
+    );
+  }
+  return context;
+}

--- a/lib/portal/src/multi-provider/index.ts
+++ b/lib/portal/src/multi-provider/index.ts
@@ -1,0 +1,11 @@
+export { MultiProviderClient } from "./client";
+export type {
+  ProviderRecord,
+  ProviderStatus,
+  DeploymentWithProvider,
+  AggregatedMetrics,
+  MultiProviderWallet,
+  MultiProviderClientOptions,
+} from "./types";
+export { MultiProviderProvider, useMultiProvider } from "./context";
+export type { MultiProviderProviderProps } from "./context";

--- a/lib/portal/src/multi-provider/types.ts
+++ b/lib/portal/src/multi-provider/types.ts
@@ -1,0 +1,47 @@
+import type { ResourceMetrics, Deployment } from "../provider-api/types";
+import type { WalletRequestSigner } from "../auth/wallet-sign";
+
+export type ProviderStatus = "online" | "offline" | "unknown";
+
+export interface ProviderRecord {
+  address: string;
+  endpoint: string;
+  name?: string;
+  status: ProviderStatus;
+  lastHealthCheck?: Date;
+  lastUpdatedAt?: Date;
+  attributes?: Record<string, string>;
+  metadata?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface DeploymentWithProvider extends Deployment {
+  providerId: string;
+  providerEndpoint: string;
+}
+
+export interface AggregatedMetrics {
+  collectedAt: Date;
+  totalCPU: { used: number; limit: number };
+  totalMemory: { used: number; limit: number };
+  totalStorage: { used: number; limit: number };
+  totalCost: { amount: string; currency: string };
+  byProvider: Map<string, ResourceMetrics>;
+  byDeployment: Map<string, ResourceMetrics>;
+}
+
+export interface MultiProviderWallet {
+  signer: WalletRequestSigner;
+  address: string;
+  chainId: string;
+}
+
+export interface MultiProviderClientOptions {
+  wallet?: MultiProviderWallet;
+  chainEndpoint: string;
+  healthCheckIntervalMs?: number;
+  providerCacheTtlMs?: number;
+  deploymentCacheTtlMs?: number;
+  requestTimeoutMs?: number;
+  fetcher?: typeof fetch;
+}

--- a/lib/portal/src/provider-api/client.ts
+++ b/lib/portal/src/provider-api/client.ts
@@ -1,0 +1,569 @@
+import { signRequest } from "../auth/wallet-sign";
+import type { WalletRequestSigner } from "../auth/wallet-sign";
+import type {
+  Deployment,
+  DeploymentAction,
+  DeploymentListResponse,
+  DeploymentStatus,
+  LogOptions,
+  ProviderAPIErrorDetails,
+  ProviderHealth,
+  ResourceMetrics,
+  ShellSessionResponse,
+} from "./types";
+
+export interface ProviderAPIClientOptions {
+  endpoint: string;
+  timeoutMs?: number;
+  retries?: number;
+  retryDelayMs?: number;
+  wallet?: {
+    signer: WalletRequestSigner;
+    address: string;
+    chainId: string;
+  };
+  hmac?: {
+    secret: string;
+    principal: string;
+  };
+  fetcher?: typeof fetch;
+}
+
+export interface ProviderAPIRequestOptions {
+  params?: Record<string, string | number | boolean | undefined>;
+  requiresAuth?: boolean;
+  body?: unknown;
+}
+
+export class ProviderAPIError extends Error {
+  status: number;
+  code?: string;
+  payload?: ProviderAPIErrorDetails | string;
+
+  constructor(
+    message: string,
+    status: number,
+    payload?: ProviderAPIErrorDetails | string,
+  ) {
+    super(message);
+    this.name = "ProviderAPIError";
+    this.status = status;
+    this.payload = payload;
+    this.code = typeof payload === "object" ? payload?.code : undefined;
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const normalizeDate = (
+  value: string | number | Date | undefined,
+): Date | undefined => {
+  if (!value) return undefined;
+  if (value instanceof Date) return value;
+  if (typeof value === "number") {
+    return value < 1_000_000_000_000 ? new Date(value * 1000) : new Date(value);
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : new Date(parsed);
+};
+
+const hmacSha256Hex = async (
+  payload: string,
+  secret: string,
+): Promise<string> => {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(payload);
+  if (globalThis.crypto?.subtle) {
+    const key = await globalThis.crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const signature = await globalThis.crypto.subtle.sign("HMAC", key, data);
+    return Array.from(new Uint8Array(signature))
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
+  const nodeCrypto = await import("crypto");
+  return nodeCrypto.createHmac("sha256", secret).update(data).digest("hex");
+};
+
+const buildQuery = (
+  params?: Record<string, string | number | boolean | undefined>,
+) => {
+  if (!params) return "";
+  const entries = Object.entries(params).filter(
+    ([, value]) => value !== undefined,
+  );
+  if (entries.length === 0) return "";
+  const search = new URLSearchParams();
+  entries.forEach(([key, value]) => {
+    if (value !== undefined) {
+      search.set(key, String(value));
+    }
+  });
+  const queryString = search.toString();
+  return queryString ? `?${queryString}` : "";
+};
+
+class ReconnectingWebSocket {
+  private url: string;
+  private retryDelayMs: number;
+  private maxRetries: number;
+  private attempts = 0;
+  private shouldReconnect = true;
+  private ws: WebSocket | null = null;
+
+  onOpen?: () => void;
+  onMessage?: (event: MessageEvent) => void;
+  onClose?: (event: CloseEvent) => void;
+  onError?: (event: Event) => void;
+
+  constructor(
+    url: string,
+    options?: { retryDelayMs?: number; maxRetries?: number },
+  ) {
+    this.url = url;
+    this.retryDelayMs = options?.retryDelayMs ?? 2000;
+    this.maxRetries = options?.maxRetries ?? 5;
+    this.connect();
+  }
+
+  private connect() {
+    if (typeof WebSocket === "undefined") {
+      throw new Error("WebSocket is not available in this environment");
+    }
+
+    this.ws = new WebSocket(this.url);
+
+    this.ws.onopen = () => {
+      this.attempts = 0;
+      this.onOpen?.();
+    };
+
+    this.ws.onmessage = (event) => {
+      this.onMessage?.(event);
+    };
+
+    this.ws.onerror = (event) => {
+      this.onError?.(event);
+    };
+
+    this.ws.onclose = (event) => {
+      this.onClose?.(event);
+      if (this.shouldReconnect && this.attempts < this.maxRetries) {
+        this.attempts += 1;
+        setTimeout(() => this.connect(), this.retryDelayMs * this.attempts);
+      }
+    };
+  }
+
+  send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+    this.ws?.send(data);
+  }
+
+  close() {
+    this.shouldReconnect = false;
+    this.ws?.close();
+  }
+}
+
+export class LogStream {
+  private socket: ReconnectingWebSocket;
+
+  constructor(url: string) {
+    this.socket = new ReconnectingWebSocket(url, {
+      retryDelayMs: 1500,
+      maxRetries: 10,
+    });
+  }
+
+  onMessage(handler: (line: string) => void) {
+    this.socket.onMessage = (event) => handler(String(event.data));
+  }
+
+  onOpen(handler: () => void) {
+    this.socket.onOpen = handler;
+  }
+
+  onClose(handler: (event: CloseEvent) => void) {
+    this.socket.onClose = handler;
+  }
+
+  onError(handler: (event: Event) => void) {
+    this.socket.onError = handler;
+  }
+
+  close() {
+    this.socket.close();
+  }
+}
+
+export class ShellConnection {
+  private socket: ReconnectingWebSocket;
+
+  constructor(url: string) {
+    this.socket = new ReconnectingWebSocket(url, {
+      retryDelayMs: 1500,
+      maxRetries: 10,
+    });
+  }
+
+  onMessage(handler: (data: ArrayBuffer) => void) {
+    this.socket.onMessage = (event) => {
+      if (event.data instanceof ArrayBuffer) {
+        handler(event.data);
+      } else if (event.data instanceof Blob) {
+        event.data
+          .arrayBuffer()
+          .then(handler)
+          .catch(() => undefined);
+      } else {
+        const encoder = new TextEncoder();
+        handler(encoder.encode(String(event.data)).buffer);
+      }
+    };
+  }
+
+  onOpen(handler: () => void) {
+    this.socket.onOpen = handler;
+  }
+
+  onClose(handler: (event: CloseEvent) => void) {
+    this.socket.onClose = handler;
+  }
+
+  onError(handler: (event: Event) => void) {
+    this.socket.onError = handler;
+  }
+
+  send(data: ArrayBufferLike | ArrayBufferView) {
+    this.socket.send(data as ArrayBufferLike);
+  }
+
+  close() {
+    this.socket.close();
+  }
+}
+
+export class ProviderAPIClient {
+  private endpoint: string;
+  private timeoutMs: number;
+  private retries: number;
+  private retryDelayMs: number;
+  private wallet?: ProviderAPIClientOptions["wallet"];
+  private hmac?: ProviderAPIClientOptions["hmac"];
+  private fetcher: typeof fetch;
+
+  constructor(options: ProviderAPIClientOptions) {
+    this.endpoint = options.endpoint.replace(/\/$/, "");
+    this.timeoutMs = options.timeoutMs ?? 30000;
+    this.retries = options.retries ?? 2;
+    this.retryDelayMs = options.retryDelayMs ?? 1000;
+    this.wallet = options.wallet;
+    this.hmac = options.hmac;
+    this.fetcher = options.fetcher ?? fetch;
+  }
+
+  async health(): Promise<ProviderHealth> {
+    return this.request<ProviderHealth>("GET", "/api/v1/health", {
+      requiresAuth: false,
+    });
+  }
+
+  async listDeployments(
+    options: { limit?: number; cursor?: string; status?: string } = {},
+  ): Promise<DeploymentListResponse> {
+    const response = await this.request<{
+      deployments?: Deployment[];
+      next_cursor?: string;
+    }>("GET", "/api/v1/deployments", {
+      params: {
+        limit: options.limit,
+        cursor: options.cursor,
+        status: options.status,
+      },
+    });
+
+    return {
+      deployments: (response.deployments ?? []).map(this.normalizeDeployment),
+      nextCursor: response.next_cursor ?? null,
+    };
+  }
+
+  async getDeployment(deploymentId: string): Promise<Deployment> {
+    const response = await this.request<Deployment>(
+      "GET",
+      `/api/v1/deployments/${deploymentId}`,
+    );
+    return this.normalizeDeployment(response);
+  }
+
+  async getDeploymentStatus(leaseId: string): Promise<DeploymentStatus> {
+    const response = await this.request<DeploymentStatus>(
+      "GET",
+      `/api/v1/deployments/${leaseId}/status`,
+    );
+    return {
+      ...response,
+      leaseId: response.leaseId ?? (response as any).lease_id ?? leaseId,
+      lastUpdated: normalizeDate(
+        (response as any).lastUpdated ?? (response as any).last_updated,
+      ),
+    };
+  }
+
+  async getDeploymentLogs(
+    leaseId: string,
+    options?: LogOptions,
+  ): Promise<string[]> {
+    const query = buildQuery({
+      tail: options?.tail,
+      since: options?.since ? options.since.toISOString() : undefined,
+      timestamps: options?.timestamps,
+      level: options?.level,
+      search: options?.search,
+      follow: options?.follow,
+    });
+    const response = await this.request<string | string[]>(
+      "GET",
+      `/api/v1/deployments/${leaseId}/logs${query}`,
+    );
+
+    if (Array.isArray(response)) {
+      return response;
+    }
+
+    if (typeof response === "string") {
+      return response
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+    }
+
+    return [];
+  }
+
+  async getDeploymentMetrics(leaseId: string): Promise<ResourceMetrics> {
+    const response = await this.request<
+      ResourceMetrics & { timestamp?: string | number }
+    >("GET", `/api/v1/deployments/${leaseId}/metrics`);
+
+    return {
+      ...response,
+      timestamp: normalizeDate(response.timestamp),
+    };
+  }
+
+  async performAction(
+    leaseId: string,
+    action: DeploymentAction,
+  ): Promise<{ success: boolean; message?: string }> {
+    return this.request("POST", `/api/v1/deployments/${leaseId}/actions`, {
+      body: { action },
+    });
+  }
+
+  async createShellSession(
+    leaseId: string,
+    container?: string,
+  ): Promise<ShellSessionResponse> {
+    const response = await this.request<ShellSessionResponse>(
+      "POST",
+      `/api/v1/deployments/${leaseId}/shell/session`,
+      {
+        body: container ? { container } : {},
+      },
+    );
+
+    return {
+      ...response,
+      expiresAt: response.expiresAt ?? (response as any).expires_at,
+      sessionTtl: response.sessionTtl ?? (response as any).session_ttl,
+    };
+  }
+
+  async connectLogStream(
+    leaseId: string,
+    options?: LogOptions,
+  ): Promise<LogStream> {
+    const query = buildQuery({
+      tail: options?.tail,
+      since: options?.since ? options.since.toISOString() : undefined,
+      timestamps: options?.timestamps,
+      level: options?.level,
+      search: options?.search,
+      follow: options?.follow,
+    });
+    const url = await this.buildWebSocketUrl(
+      `/api/v1/deployments/${leaseId}/logs/stream${query}`,
+    );
+    return new LogStream(url);
+  }
+
+  async connectShell(
+    leaseId: string,
+    sessionToken?: string,
+    container?: string,
+  ): Promise<ShellConnection> {
+    const query = buildQuery({
+      token: sessionToken,
+      container,
+    });
+    const url = await this.buildWebSocketUrl(
+      `/api/v1/deployments/${leaseId}/shell${query}`,
+    );
+    return new ShellConnection(url);
+  }
+
+  private normalizeDeployment = (
+    deployment: Deployment & { created_at?: string; createdAt?: string | Date },
+  ): Deployment => {
+    return {
+      ...deployment,
+      createdAt: normalizeDate(deployment.createdAt ?? deployment.created_at),
+    };
+  };
+
+  private async request<T>(
+    method: string,
+    path: string,
+    options: ProviderAPIRequestOptions = {},
+  ): Promise<T> {
+    const requiresAuth = options.requiresAuth ?? true;
+    const url = new URL(`${this.endpoint}${path}`);
+    if (options.params) {
+      Object.entries(options.params).forEach(([key, value]) => {
+        if (value !== undefined) {
+          url.searchParams.set(key, String(value));
+        }
+      });
+    }
+
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= this.retries; attempt += 1) {
+      try {
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+        };
+
+        if (requiresAuth) {
+          if (this.wallet) {
+            const signed = await signRequest({
+              method,
+              path: url.pathname,
+              body: options.body,
+              signer: this.wallet.signer,
+              address: this.wallet.address,
+              chainId: this.wallet.chainId,
+            });
+            Object.assign(headers, signed);
+          } else if (this.hmac) {
+            const timestamp = Math.floor(Date.now() / 1000).toString();
+            const query = url.searchParams.toString();
+            const payload = [
+              method,
+              url.pathname,
+              query,
+              this.hmac.principal,
+              timestamp,
+            ].join("\n");
+            const signature = await hmacSha256Hex(payload, this.hmac.secret);
+            headers["X-VE-Signature"] = signature;
+            headers["X-VE-Timestamp"] = timestamp;
+            headers["X-VE-Principal"] = this.hmac.principal;
+          }
+        }
+
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+        const response = await this.fetcher(url.toString(), {
+          method,
+          headers,
+          body: options.body ? JSON.stringify(options.body) : undefined,
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        const contentType = response.headers.get("content-type") ?? "";
+        let payload: unknown = null;
+
+        if (contentType.includes("application/json")) {
+          payload = await response.json();
+        } else {
+          payload = await response.text();
+        }
+
+        if (!response.ok) {
+          throw new ProviderAPIError(
+            typeof payload === "string"
+              ? payload
+              : ((payload as ProviderAPIErrorDetails)?.message ??
+                  response.statusText),
+            response.status,
+            payload as ProviderAPIErrorDetails,
+          );
+        }
+
+        return payload as T;
+      } catch (error) {
+        lastError = error as Error;
+        if (attempt >= this.retries || !this.shouldRetry(error)) {
+          break;
+        }
+        await sleep(this.retryDelayMs * Math.max(1, attempt + 1));
+      }
+    }
+
+    throw lastError ?? new Error("Provider API request failed");
+  }
+
+  private shouldRetry(error: unknown): boolean {
+    if (error instanceof ProviderAPIError) {
+      return error.status >= 500;
+    }
+    return true;
+  }
+
+  private async buildWebSocketUrl(path: string): Promise<string> {
+    const base = this.endpoint.replace(/^http/, "ws");
+    const url = new URL(`${base}${path}`);
+
+    if (this.wallet) {
+      const signed = await signRequest({
+        method: "GET",
+        path: url.pathname,
+        signer: this.wallet.signer,
+        address: this.wallet.address,
+        chainId: this.wallet.chainId,
+      });
+      url.searchParams.set("ve_address", signed["X-VE-Address"]);
+      url.searchParams.set("ve_ts", signed["X-VE-Timestamp"]);
+      url.searchParams.set("ve_nonce", signed["X-VE-Nonce"]);
+      url.searchParams.set("ve_sig", signed["X-VE-Signature"]);
+      url.searchParams.set("ve_pub", signed["X-VE-PubKey"]);
+    } else if (this.hmac) {
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const query = url.searchParams.toString();
+      const payload = [
+        "GET",
+        url.pathname,
+        query,
+        this.hmac.principal,
+        timestamp,
+      ].join("\n");
+      const signature = await hmacSha256Hex(payload, this.hmac.secret);
+      url.searchParams.set("sig", signature);
+      url.searchParams.set("ts", timestamp);
+      url.searchParams.set("principal", this.hmac.principal);
+    }
+
+    return url.toString();
+  }
+}

--- a/lib/portal/src/provider-api/index.ts
+++ b/lib/portal/src/provider-api/index.ts
@@ -1,0 +1,24 @@
+export type {
+  ProviderHealthStatus,
+  ProviderHealth,
+  LogOptions,
+  DeploymentState,
+  UsageMetric,
+  ResourceMetrics,
+  Deployment,
+  DeploymentStatus,
+  ServiceStatus,
+  DeploymentListResponse,
+  DeploymentAction,
+  ShellSessionResponse,
+  ProviderAPIErrorDetails,
+} from "./types";
+
+export {
+  ProviderAPIClient,
+  ProviderAPIError,
+  LogStream,
+  ShellConnection,
+} from "./client";
+
+export type { ProviderAPIClientOptions } from "./client";

--- a/lib/portal/src/provider-api/types.ts
+++ b/lib/portal/src/provider-api/types.ts
@@ -1,0 +1,87 @@
+export type ProviderHealthStatus = "ok" | "degraded" | "down";
+
+export interface ProviderHealth {
+  status: ProviderHealthStatus;
+  version?: string;
+  uptime?: number;
+}
+
+export interface LogOptions {
+  follow?: boolean;
+  tail?: number;
+  since?: Date;
+  timestamps?: boolean;
+  level?: string;
+  search?: string;
+}
+
+export type DeploymentState = "pending" | "active" | "closed" | string;
+
+export interface UsageMetric {
+  usage: number;
+  limit: number;
+}
+
+export interface ResourceMetrics {
+  cpu: UsageMetric;
+  memory: UsageMetric;
+  storage: UsageMetric;
+  network?: {
+    rxBytes?: number;
+    txBytes?: number;
+  };
+  gpu?: {
+    usage?: number;
+    limit?: number;
+  };
+  cost?: {
+    amount: string;
+    currency: string;
+  };
+  timestamp?: Date;
+}
+
+export interface Deployment {
+  id: string;
+  owner?: string;
+  provider?: string;
+  state: DeploymentState;
+  createdAt?: Date;
+  resources?: ResourceMetrics;
+}
+
+export interface DeploymentStatus {
+  leaseId: string;
+  state: string;
+  replicas: { ready: number; total: number };
+  services: ServiceStatus[];
+  lastUpdated?: Date;
+}
+
+export interface ServiceStatus {
+  name: string;
+  state: string;
+  replicas: number;
+  ports?: Array<{ port: number; protocol: string }>;
+}
+
+export interface DeploymentListResponse {
+  deployments: Deployment[];
+  nextCursor?: string | null;
+}
+
+export type DeploymentAction = "start" | "stop" | "restart" | string;
+
+export interface ShellSessionResponse {
+  token: string;
+  expiresAt: string;
+  deployment: string;
+  container?: string;
+  sessionTtl?: number;
+}
+
+export interface ProviderAPIErrorDetails {
+  code?: string;
+  message?: string;
+  [key: string]: unknown;
+}

--- a/portal/src/lib/portal-adapter.ts
+++ b/portal/src/lib/portal-adapter.ts
@@ -292,6 +292,56 @@ export {
 } from '../../../lib/portal';
 
 // ============================================================================
+// Provider API + Multi-Provider (VE-29D/29E/29G)
+// ============================================================================
+
+export {
+  ProviderAPIClient,
+  ProviderAPIError,
+  LogStream,
+  ShellConnection,
+  signRequest,
+  MultiProviderClient,
+  MultiProviderProvider,
+  useMultiProvider,
+  useAggregatedDeployments,
+  useAggregatedMetrics,
+  useDeploymentWithProvider,
+} from '../../../lib/portal';
+export type {
+  ProviderAPIClientOptions,
+  ProviderHealthStatus,
+  ProviderHealth,
+  LogOptions,
+  DeploymentState,
+  UsageMetric,
+  ResourceMetrics,
+  Deployment,
+  DeploymentStatus,
+  ServiceStatus,
+  DeploymentListResponse,
+  DeploymentAction,
+  ShellSessionResponse,
+  ProviderAPIErrorDetails,
+  SignedRequestHeaders,
+  SignRequestOptions,
+  ProviderRecord,
+  ProviderStatus,
+  DeploymentWithProvider,
+  AggregatedMetrics,
+  MultiProviderWallet,
+  MultiProviderClientOptions,
+  MultiProviderProviderProps,
+  AggregatedDeploymentsState,
+  AggregatedDeploymentsActions,
+  UseAggregatedDeploymentsOptions,
+  AggregatedMetricsState,
+  AggregatedMetricsActions,
+  UseAggregatedMetricsOptions,
+  DeploymentWithProviderState,
+} from '../../../lib/portal';
+
+// ============================================================================
 // HPC / Supercomputer (VE-705)
 // ============================================================================
 

--- a/portal/tests/unit/dashboard/components.test.tsx
+++ b/portal/tests/unit/dashboard/components.test.tsx
@@ -131,7 +131,7 @@ describe('UsageSummary', () => {
 describe('BillingSummary', () => {
   it('renders current period cost', () => {
     render(<BillingSummary billing={mockBilling} />);
-    const matches = screen.getAllByText(/USD 4,250\.00/);
+    const matches = screen.getAllByText(/USD\s+4,250\.00/);
     expect(matches.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -143,7 +143,7 @@ describe('BillingSummary', () => {
   it('renders outstanding balance when present', () => {
     render(<BillingSummary billing={mockBilling} />);
     expect(screen.getByText('Outstanding')).toBeInTheDocument();
-    expect(screen.getByText(/USD 1,250\.00/)).toBeInTheDocument();
+    expect(screen.getByText(/USD\s+1,250\.00/)).toBeInTheDocument();
   });
 
   it('renders provider breakdown', () => {


### PR DESCRIPTION
## Summary
- add provider API client with wallet-signed auth + HMAC fallback
- add multi-provider client, context, and aggregation hooks
- update portal adapter exports and billing summary tests for USD formatting

## Testing
- pnpm -C portal lint
- pnpm -C portal type-check
- pnpm -C portal test
- pnpm -C lib/portal test