### PR TITLE
feat(payment): dispute lifecycle persistence + reporting

### DIFF
--- a/pkg/payment/dispute_gateway.go
+++ b/pkg/payment/dispute_gateway.go
@@ -1,0 +1,26 @@
+// Package payment provides payment gateway integration for Visa/Mastercard.
+//
+// PAY-003: Dispute lifecycle persistence and gateway actions
+package payment
+
+import "context"
+
+// disputeGateway is the internal interface for dispute-related gateway actions.
+// It is intentionally narrower than Gateway to avoid exposing dispute methods
+// on the public Gateway interface.
+type disputeGateway interface {
+	GetDispute(ctx context.Context, disputeID string) (Dispute, error)
+	ListDisputes(ctx context.Context, paymentIntentID string) ([]Dispute, error)
+	SubmitDisputeEvidence(ctx context.Context, disputeID string, evidence DisputeEvidence) error
+	AcceptDispute(ctx context.Context, disputeID string) error
+}
+
+func resolveDisputeGateway(gateway Gateway) (disputeGateway, error) {
+	if gateway == nil {
+		return nil, ErrGatewayNotConfigured
+	}
+	if dg, ok := gateway.(disputeGateway); ok {
+		return dg, nil
+	}
+	return nil, ErrGatewayNotConfigured
+}

--- a/pkg/payment/dispute_lifecycle.go
+++ b/pkg/payment/dispute_lifecycle.go
@@ -1,0 +1,474 @@
+// Package payment provides payment gateway integration for Visa/Mastercard.
+//
+// PAY-003: Dispute lifecycle persistence and gateway actions
+package payment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// ErrDisputeInvalidTransition is returned when a status transition is not allowed
+var ErrDisputeInvalidTransition = errors.New("invalid dispute status transition")
+
+// DisputeLifecycle defines the allowed dispute status transitions.
+//
+// Resolution workflows (high-level):
+// - Defend (submit evidence) -> needs_response -> under_review -> won/lost
+// - Accept (concede) -> accepted (terminal)
+// - Expire (missed deadline) -> expired (terminal)
+//
+// These workflows are codified by the transition map below and are exposed via
+// DefaultDisputeResolutionWorkflows for finance and ops documentation.
+type DisputeLifecycle struct {
+	allowed map[DisputeStatus]map[DisputeStatus]bool
+}
+
+// DefaultDisputeLifecycle returns the default dispute state machine.
+func DefaultDisputeLifecycle() *DisputeLifecycle {
+	allowed := map[DisputeStatus]map[DisputeStatus]bool{
+		DisputeStatusOpen: {
+			DisputeStatusOpen:          true,
+			DisputeStatusNeedsResponse: true,
+			DisputeStatusUnderReview:   true,
+			DisputeStatusWon:           true,
+			DisputeStatusLost:          true,
+			DisputeStatusAccepted:      true,
+			DisputeStatusExpired:       true,
+		},
+		DisputeStatusNeedsResponse: {
+			DisputeStatusNeedsResponse: true,
+			DisputeStatusUnderReview:   true,
+			DisputeStatusWon:           true,
+			DisputeStatusLost:          true,
+			DisputeStatusAccepted:      true,
+			DisputeStatusExpired:       true,
+		},
+		DisputeStatusUnderReview: {
+			DisputeStatusUnderReview: true,
+			DisputeStatusWon:         true,
+			DisputeStatusLost:        true,
+			DisputeStatusAccepted:    true,
+			DisputeStatusExpired:     true,
+		},
+		DisputeStatusWon: {
+			DisputeStatusWon: true,
+		},
+		DisputeStatusLost: {
+			DisputeStatusLost: true,
+		},
+		DisputeStatusAccepted: {
+			DisputeStatusAccepted: true,
+		},
+		DisputeStatusExpired: {
+			DisputeStatusExpired: true,
+		},
+	}
+
+	return &DisputeLifecycle{allowed: allowed}
+}
+
+// CanTransition returns true if a transition is allowed.
+func (l *DisputeLifecycle) CanTransition(from, to DisputeStatus) bool {
+	if l == nil {
+		return false
+	}
+	if to == "" {
+		return false
+	}
+	if from == "" {
+		return true
+	}
+	if from == to {
+		return true
+	}
+	if next, ok := l.allowed[from]; ok {
+		return next[to]
+	}
+	return false
+}
+
+// Transition updates the record status if the transition is valid.
+func (l *DisputeLifecycle) Transition(record *DisputeRecord, newStatus DisputeStatus, actor string, details map[string]string) error {
+	if record == nil {
+		return fmt.Errorf("nil dispute record")
+	}
+	if !l.CanTransition(record.Status, newStatus) {
+		return ErrDisputeInvalidTransition
+	}
+
+	if record.Status != newStatus {
+		record.UpdateStatus(newStatus, actor, details)
+	}
+
+	return nil
+}
+
+// DisputeResolutionAction represents the primary action taken to resolve a dispute.
+type DisputeResolutionAction string
+
+const (
+	DisputeResolutionSubmitEvidence DisputeResolutionAction = "submit_evidence"
+	DisputeResolutionAccept         DisputeResolutionAction = "accept"
+	DisputeResolutionMonitor        DisputeResolutionAction = "monitor"
+)
+
+// DisputeResolutionRequest contains information for a resolution workflow.
+type DisputeResolutionRequest struct {
+	DisputeID string
+	Action    DisputeResolutionAction
+	Evidence  DisputeEvidence
+	Actor     string
+	Notes     string
+}
+
+// DisputeResolutionResult summarizes a resolution workflow execution.
+type DisputeResolutionResult struct {
+	Record  *DisputeRecord
+	Message string
+}
+
+// ResolveDispute executes the requested workflow and updates the dispute store.
+func ResolveDispute(ctx context.Context, handler DisputeHandler, store DisputeStore, lifecycle *DisputeLifecycle, req DisputeResolutionRequest) (*DisputeResolutionResult, error) {
+	if handler == nil || store == nil {
+		return nil, fmt.Errorf("dispute handler and store are required")
+	}
+	if req.DisputeID == "" {
+		return nil, fmt.Errorf("dispute ID is required")
+	}
+	if lifecycle == nil {
+		lifecycle = DefaultDisputeLifecycle()
+	}
+
+	record, found := store.Get(req.DisputeID)
+	if !found {
+		disp, err := handler.GetDispute(ctx, req.DisputeID)
+		if err != nil {
+			return nil, err
+		}
+		record = NewDisputeRecord(disp, disp.Gateway, "system:resolution")
+		if err := store.Save(record); err != nil {
+			return nil, err
+		}
+	}
+
+	actor := req.Actor
+	if actor == "" {
+		actor = "system:resolution"
+	}
+
+	switch req.Action {
+	case DisputeResolutionSubmitEvidence:
+		if err := handler.SubmitEvidence(ctx, req.DisputeID, req.Evidence); err != nil {
+			return nil, err
+		}
+		record.MarkEvidenceSubmitted(actor, "resolution")
+		if err := lifecycle.Transition(record, record.Status, actor, map[string]string{"notes": req.Notes}); err != nil {
+			return nil, err
+		}
+	case DisputeResolutionAccept:
+		if err := handler.AcceptDispute(ctx, req.DisputeID); err != nil {
+			return nil, err
+		}
+		record.MarkAccepted(actor, req.Notes)
+	case DisputeResolutionMonitor:
+		record.AddAuditEntry(DisputeAuditEntry{
+			Timestamp: time.Now(),
+			Action:    "monitor",
+			Actor:     actor,
+			Details: map[string]string{
+				"notes": req.Notes,
+			},
+		})
+	default:
+		return nil, fmt.Errorf("unsupported resolution action: %s", req.Action)
+	}
+
+	if err := store.Save(record); err != nil {
+		return nil, err
+	}
+
+	return &DisputeResolutionResult{
+		Record:  record,
+		Message: "resolution workflow applied",
+	}, nil
+}
+
+// DisputeResolutionWorkflow documents the recommended steps for each outcome.
+type DisputeResolutionWorkflow struct {
+	Outcome      DisputeStatus
+	Description  string
+	Steps        []string
+	OwnerPrimary string
+	SLATarget    string
+}
+
+// DefaultDisputeResolutionWorkflows returns workflow documentation for finance teams.
+func DefaultDisputeResolutionWorkflows() []DisputeResolutionWorkflow {
+	return []DisputeResolutionWorkflow{
+		{
+			Outcome:      DisputeStatusNeedsResponse,
+			Description:  "Active disputes requiring evidence submission",
+			OwnerPrimary: "finance-ops",
+			SLATarget:    "Submit evidence within gateway deadline",
+			Steps: []string{
+				"Collect order metadata and delivery confirmation",
+				"Compile customer communication records",
+				"Submit evidence through gateway within deadline",
+				"Monitor webhook updates for under_review status",
+			},
+		},
+		{
+			Outcome:      DisputeStatusUnderReview,
+			Description:  "Evidence submitted and awaiting card network decision",
+			OwnerPrimary: "finance-ops",
+			SLATarget:    "Weekly follow-up until decision",
+			Steps: []string{
+				"Verify evidence submission confirmation",
+				"Track expected resolution date",
+				"Communicate status to accounting",
+			},
+		},
+		{
+			Outcome:      DisputeStatusWon,
+			Description:  "Chargeback reversed in merchant favor",
+			OwnerPrimary: "finance",
+			SLATarget:    "Reconcile funds within 2 business days",
+			Steps: []string{
+				"Confirm funds reinstatement in gateway",
+				"Update internal ledger and revenue reporting",
+				"Close dispute record and archive evidence",
+			},
+		},
+		{
+			Outcome:      DisputeStatusLost,
+			Description:  "Chargeback upheld in cardholder favor",
+			OwnerPrimary: "finance",
+			SLATarget:    "Record loss within 1 business day",
+			Steps: []string{
+				"Confirm loss and fee impact",
+				"Update risk controls for root cause",
+				"Notify revenue recognition team",
+			},
+		},
+		{
+			Outcome:      DisputeStatusAccepted,
+			Description:  "Merchant conceded dispute",
+			OwnerPrimary: "finance",
+			SLATarget:    "Record concession immediately",
+			Steps: []string{
+				"Confirm acceptance action in gateway",
+				"Update dispute ledger and write-off entry",
+			},
+		},
+		{
+			Outcome:      DisputeStatusExpired,
+			Description:  "Response window missed",
+			OwnerPrimary: "finance-ops",
+			SLATarget:    "Escalate within 1 business day",
+			Steps: []string{
+				"Log missed deadline in incident tracker",
+				"Update dispute ledger to expired",
+				"Review process gaps and remediate",
+			},
+		},
+	}
+}
+
+// DisputeReportOptions configures dispute reporting.
+type DisputeReportOptions struct {
+	ListOptions    DisputeListOptions
+	IncludeRecords bool
+	AsOf           time.Time
+	AgingBuckets   []DisputeAgingBucketDefinition
+}
+
+// DisputeAgingBucketDefinition defines an aging bucket for open disputes.
+type DisputeAgingBucketDefinition struct {
+	Label string
+	Min   time.Duration
+	Max   time.Duration
+}
+
+// DisputeAgingBucket summarizes open disputes by age.
+type DisputeAgingBucket struct {
+	Label            string
+	Count            int
+	AmountByCurrency map[Currency]int64
+}
+
+// DisputeReport summarizes dispute activity for finance teams.
+type DisputeReport struct {
+	GeneratedAt            time.Time
+	WindowStart            *time.Time
+	WindowEnd              *time.Time
+	TotalDisputes          int
+	OpenDisputes           int
+	ClosedDisputes         int
+	PastDueDisputes        int
+	EvidenceSubmittedCount int
+	EvidenceSubmissionRate float64
+	AverageResolutionHours float64
+	TotalAmountByCurrency  map[Currency]int64
+	OpenAmountByCurrency   map[Currency]int64
+	ClosedAmountByCurrency map[Currency]int64
+	StatusCounts           map[DisputeStatus]int
+	GatewayCounts          map[GatewayType]int
+	ReasonCounts           map[DisputeReason]int
+	AgingBuckets           []DisputeAgingBucket
+	Records                []*DisputeRecord
+}
+
+// DefaultDisputeAgingBuckets provides standard aging buckets for reporting.
+func DefaultDisputeAgingBuckets() []DisputeAgingBucketDefinition {
+	return []DisputeAgingBucketDefinition{
+		{Label: "0-7d", Min: 0, Max: 7 * 24 * time.Hour},
+		{Label: "8-14d", Min: 7 * 24 * time.Hour, Max: 14 * 24 * time.Hour},
+		{Label: "15-30d", Min: 14 * 24 * time.Hour, Max: 30 * 24 * time.Hour},
+		{Label: "31d+", Min: 30 * 24 * time.Hour, Max: 0},
+	}
+}
+
+// GenerateDisputeReport aggregates dispute metrics for finance reporting.
+func GenerateDisputeReport(store DisputeStore, opts DisputeReportOptions) (*DisputeReport, error) {
+	if store == nil {
+		return nil, fmt.Errorf("dispute store is required")
+	}
+
+	asOf := opts.AsOf
+	if asOf.IsZero() {
+		asOf = time.Now()
+	}
+
+	records := store.List(opts.ListOptions)
+
+	report := &DisputeReport{
+		GeneratedAt:            asOf,
+		WindowStart:            opts.ListOptions.CreatedAfter,
+		WindowEnd:              opts.ListOptions.CreatedBefore,
+		TotalAmountByCurrency:  make(map[Currency]int64),
+		OpenAmountByCurrency:   make(map[Currency]int64),
+		ClosedAmountByCurrency: make(map[Currency]int64),
+		StatusCounts:           make(map[DisputeStatus]int),
+		GatewayCounts:          make(map[GatewayType]int),
+		ReasonCounts:           make(map[DisputeReason]int),
+	}
+
+	agingDefs := opts.AgingBuckets
+	if agingDefs == nil {
+		agingDefs = DefaultDisputeAgingBuckets()
+	}
+	report.AgingBuckets = buildAgingBuckets(agingDefs)
+
+	var totalResolutionHours float64
+	var resolutionCount int
+
+	for _, record := range records {
+		report.TotalDisputes++
+		report.StatusCounts[record.Status]++
+		report.GatewayCounts[record.Gateway]++
+		report.ReasonCounts[record.Reason]++
+
+		amount := record.Amount.Value
+		currency := record.Amount.Currency
+
+		report.TotalAmountByCurrency[currency] += amount
+
+		if record.Status.IsFinal() {
+			report.ClosedDisputes++
+			report.ClosedAmountByCurrency[currency] += amount
+		} else {
+			report.OpenDisputes++
+			report.OpenAmountByCurrency[currency] += amount
+			if record.Status == DisputeStatusNeedsResponse && !record.EvidenceDueBy.IsZero() && record.EvidenceDueBy.Before(asOf) {
+				report.PastDueDisputes++
+			}
+			updateAgingBuckets(report.AgingBuckets, agingDefs, record.CreatedAt, asOf, record.Amount)
+		}
+
+		if record.EvidenceSubmitted {
+			report.EvidenceSubmittedCount++
+		}
+
+		if record.ClosedAt != nil && !record.CreatedAt.IsZero() {
+			resolutionHours := record.ClosedAt.Sub(record.CreatedAt).Hours()
+			if resolutionHours >= 0 {
+				totalResolutionHours += resolutionHours
+				resolutionCount++
+			}
+		}
+	}
+
+	if report.TotalDisputes > 0 {
+		report.EvidenceSubmissionRate = float64(report.EvidenceSubmittedCount) / float64(report.TotalDisputes)
+	}
+	if resolutionCount > 0 {
+		report.AverageResolutionHours = totalResolutionHours / float64(resolutionCount)
+	}
+
+	if opts.IncludeRecords {
+		report.Records = records
+	}
+
+	return report, nil
+}
+
+func buildAgingBuckets(defs []DisputeAgingBucketDefinition) []DisputeAgingBucket {
+	buckets := make([]DisputeAgingBucket, len(defs))
+	for i := range defs {
+		buckets[i] = DisputeAgingBucket{
+			Label:            defs[i].Label,
+			AmountByCurrency: make(map[Currency]int64),
+		}
+	}
+	return buckets
+}
+
+func updateAgingBuckets(buckets []DisputeAgingBucket, defs []DisputeAgingBucketDefinition, createdAt time.Time, asOf time.Time, amount Amount) {
+	if createdAt.IsZero() || len(buckets) == 0 {
+		return
+	}
+
+	age := asOf.Sub(createdAt)
+	if age < 0 {
+		age = 0
+	}
+
+	for i := range buckets {
+		if i >= len(defs) {
+			return
+		}
+		def := defs[i]
+		if def.Max == 0 {
+			if age >= def.Min {
+				buckets[i].Count++
+				buckets[i].AmountByCurrency[amount.Currency] += amount.Value
+				return
+			}
+			continue
+		}
+		if age >= def.Min && age < def.Max {
+			buckets[i].Count++
+			buckets[i].AmountByCurrency[amount.Currency] += amount.Value
+			return
+		}
+	}
+}
+
+// SortedDisputeStatuses returns dispute statuses in stable order for reporting.
+func SortedDisputeStatuses() []DisputeStatus {
+	statuses := []DisputeStatus{
+		DisputeStatusOpen,
+		DisputeStatusNeedsResponse,
+		DisputeStatusUnderReview,
+		DisputeStatusWon,
+		DisputeStatusLost,
+		DisputeStatusAccepted,
+		DisputeStatusExpired,
+	}
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i] < statuses[j] })
+	return statuses
+}

--- a/pkg/payment/dispute_lifecycle_test.go
+++ b/pkg/payment/dispute_lifecycle_test.go
@@ -1,0 +1,176 @@
+// Package payment provides payment gateway integration for Visa/Mastercard.
+//
+// PAY-003: Tests for dispute lifecycle, webhooks, and reporting
+package payment
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDisputeLifecycleTransitions(t *testing.T) {
+	lifecycle := DefaultDisputeLifecycle()
+	record := NewDisputeRecord(Dispute{
+		ID:     "dp_lifecycle",
+		Status: DisputeStatusNeedsResponse,
+	}, GatewayStripe, "test")
+
+	if err := lifecycle.Transition(record, DisputeStatusUnderReview, "test", nil); err != nil {
+		t.Fatalf("expected valid transition: %v", err)
+	}
+	if record.Status != DisputeStatusUnderReview {
+		t.Fatalf("expected status under_review, got %s", record.Status)
+	}
+
+	if err := lifecycle.Transition(record, DisputeStatusLost, "test", nil); err != nil {
+		t.Fatalf("expected valid transition to lost: %v", err)
+	}
+
+	if err := lifecycle.Transition(record, DisputeStatusNeedsResponse, "test", nil); err == nil {
+		t.Fatalf("expected invalid transition to be rejected")
+	}
+}
+
+func TestGenerateDisputeReport(t *testing.T) {
+	store := NewInMemoryDisputeStore()
+	now := time.Now()
+
+	openDispute := NewDisputeRecord(Dispute{
+		ID:            "dp_open",
+		Status:        DisputeStatusNeedsResponse,
+		Amount:        NewAmount(10000, CurrencyUSD),
+		EvidenceDueBy: now.Add(48 * time.Hour),
+		CreatedAt:     now.Add(-48 * time.Hour),
+	}, GatewayStripe, "test")
+	openDispute.CreatedAt = now.Add(-48 * time.Hour)
+	openDispute.EvidenceSubmitted = true
+	_ = store.Save(openDispute)
+
+	closedDispute := NewDisputeRecord(Dispute{
+		ID:        "dp_closed",
+		Status:    DisputeStatusWon,
+		Amount:    NewAmount(20000, CurrencyUSD),
+		CreatedAt: now.Add(-10 * 24 * time.Hour),
+	}, GatewayStripe, "test")
+	closedDispute.CreatedAt = now.Add(-10 * 24 * time.Hour)
+	closedDispute.ClosedAt = ptrTime(now.Add(-24 * time.Hour))
+	closedDispute.Status = DisputeStatusWon
+	_ = store.Save(closedDispute)
+
+	report, err := GenerateDisputeReport(store, DisputeReportOptions{})
+	if err != nil {
+		t.Fatalf("report generation failed: %v", err)
+	}
+	if report.TotalDisputes != 2 {
+		t.Fatalf("expected 2 disputes, got %d", report.TotalDisputes)
+	}
+	if report.OpenDisputes != 1 {
+		t.Fatalf("expected 1 open dispute, got %d", report.OpenDisputes)
+	}
+	if report.ClosedDisputes != 1 {
+		t.Fatalf("expected 1 closed dispute, got %d", report.ClosedDisputes)
+	}
+	if report.TotalAmountByCurrency[CurrencyUSD] != 30000 {
+		t.Fatalf("expected total amount 30000, got %d", report.TotalAmountByCurrency[CurrencyUSD])
+	}
+	if report.EvidenceSubmittedCount != 1 {
+		t.Fatalf("expected 1 evidence submitted, got %d", report.EvidenceSubmittedCount)
+	}
+}
+
+func TestExtractDisputeFromWebhookEventStripe(t *testing.T) {
+	payload := []byte(`{
+		"id":"evt_123",
+		"type":"charge.dispute.created",
+		"created":1700000000,
+		"data":{
+			"object":{
+				"id":"dp_123",
+				"status":"needs_response",
+				"reason":"fraudulent",
+				"payment_intent":"pi_123",
+				"charge":"ch_123",
+				"amount":1200,
+				"currency":"usd",
+				"evidence_details":{"due_by":1700003600}
+			}
+		}
+	}`)
+
+	event := WebhookEvent{
+		ID:        "evt_123",
+		Type:      WebhookEventChargeDisputeCreated,
+		Gateway:   GatewayStripe,
+		Payload:   payload,
+		Timestamp: time.Now(),
+	}
+
+	dispute := extractDisputeFromWebhookEvent(event)
+	if dispute == nil {
+		t.Fatalf("expected dispute to be parsed")
+	}
+	if dispute.ID != "dp_123" {
+		t.Fatalf("expected dispute ID dp_123, got %s", dispute.ID)
+	}
+	if dispute.Status != DisputeStatusNeedsResponse {
+		t.Fatalf("expected status needs_response, got %s", dispute.Status)
+	}
+	if dispute.Reason != DisputeReasonFraudulent {
+		t.Fatalf("expected reason fraudulent, got %s", dispute.Reason)
+	}
+	if dispute.Amount.Value != 1200 {
+		t.Fatalf("expected amount 1200, got %d", dispute.Amount.Value)
+	}
+}
+
+func TestExtractDisputeFromWebhookEventAdyen(t *testing.T) {
+	payload := []byte(`{
+		"notificationItems": [
+			{
+				"NotificationRequestItem": {
+					"eventCode": "CHARGEBACK",
+					"eventDate": "2024-01-02T15:04:05Z",
+					"pspReference": "psp_123",
+					"amount": {"value": 5000, "currency": "EUR"},
+					"additionalData": {
+						"paymentPspReference": "pi_adyen",
+						"disputeReason": "Fraud",
+						"defenseDeadline": "2024-01-10T00:00:00Z"
+					}
+				}
+			}
+		]
+	}`)
+
+	event := WebhookEvent{
+		ID:        "evt_adyen",
+		Type:      WebhookEventChargeDisputeCreated,
+		Gateway:   GatewayAdyen,
+		Payload:   payload,
+		Timestamp: time.Now(),
+	}
+
+	dispute := extractDisputeFromWebhookEvent(event)
+	if dispute == nil {
+		t.Fatalf("expected dispute to be parsed")
+	}
+	if dispute.ID != "psp_123" {
+		t.Fatalf("expected dispute ID psp_123, got %s", dispute.ID)
+	}
+	if dispute.PaymentIntentID != "pi_adyen" {
+		t.Fatalf("expected payment intent pi_adyen, got %s", dispute.PaymentIntentID)
+	}
+	if dispute.Reason != DisputeReasonFraudulent {
+		t.Fatalf("expected reason fraudulent, got %s", dispute.Reason)
+	}
+	if dispute.Status != DisputeStatusNeedsResponse {
+		t.Fatalf("expected status needs_response, got %s", dispute.Status)
+	}
+	if dispute.Amount.Value != 5000 {
+		t.Fatalf("expected amount 5000, got %d", dispute.Amount.Value)
+	}
+}
+
+func ptrTime(t time.Time) *time.Time {
+	return &t
+}

--- a/pkg/payment/dispute_webhook.go
+++ b/pkg/payment/dispute_webhook.go
@@ -1,0 +1,316 @@
+// Package payment provides payment gateway integration for Visa/Mastercard.
+//
+// PAY-003: Dispute lifecycle persistence and gateway actions
+package payment
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// extractDisputeFromWebhookEvent returns dispute data from event payloads.
+func extractDisputeFromWebhookEvent(event WebhookEvent) *Dispute {
+	if dispute := extractDisputeFromEventData(event); dispute != nil {
+		return dispute
+	}
+
+	if len(event.Payload) == 0 {
+		return nil
+	}
+
+	switch event.Gateway {
+	case GatewayStripe:
+		dispute, _ := parseStripeDisputePayload(event.Payload, event)
+		return dispute
+	case GatewayAdyen:
+		dispute, _ := parseAdyenDisputePayload(event.Payload, event)
+		return dispute
+	default:
+		return nil
+	}
+}
+
+func extractDisputeFromEventData(event WebhookEvent) *Dispute {
+	data, ok := event.Data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	obj := data
+	if nested, ok := data["object"].(map[string]interface{}); ok {
+		obj = nested
+	}
+
+	dispute := disputeFromMap(obj, event)
+	if dispute == nil {
+		return nil
+	}
+
+	return dispute
+}
+
+func parseStripeDisputePayload(payload []byte, event WebhookEvent) (*Dispute, error) {
+	var envelope struct {
+		Created int64 `json:"created"`
+		Data    struct {
+			Object json.RawMessage `json:"object"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return nil, err
+	}
+
+	if len(envelope.Data.Object) == 0 {
+		return nil, nil
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(envelope.Data.Object, &obj); err != nil {
+		return nil, err
+	}
+
+	dispute := disputeFromMap(obj, event)
+	if dispute == nil {
+		return nil, nil
+	}
+
+	if dispute.CreatedAt.IsZero() && envelope.Created > 0 {
+		dispute.CreatedAt = time.Unix(envelope.Created, 0)
+	}
+
+	return dispute, nil
+}
+
+func parseAdyenDisputePayload(payload []byte, event WebhookEvent) (*Dispute, error) {
+	var notification struct {
+		NotificationItems []struct {
+			NotificationRequestItem struct {
+				EventCode       string `json:"eventCode"`
+				EventDate       string `json:"eventDate"`
+				PSPReference    string `json:"pspReference"`
+				MerchantAccount string `json:"merchantAccount"`
+				Amount          struct {
+					Value    int64  `json:"value"`
+					Currency string `json:"currency"`
+				} `json:"amount"`
+				AdditionalData map[string]interface{} `json:"additionalData"`
+			} `json:"NotificationRequestItem"`
+		} `json:"notificationItems"`
+	}
+
+	if err := json.Unmarshal(payload, &notification); err != nil {
+		return nil, err
+	}
+
+	if len(notification.NotificationItems) == 0 {
+		return nil, nil
+	}
+
+	item := notification.NotificationItems[0].NotificationRequestItem
+	dispute := &Dispute{
+		ID:        item.PSPReference,
+		Gateway:   event.Gateway,
+		CreatedAt: event.Timestamp,
+		UpdatedAt: time.Now(),
+		Amount: Amount{
+			Value:    item.Amount.Value,
+			Currency: Currency(item.Amount.Currency),
+		},
+	}
+
+	if item.EventDate != "" {
+		if parsed, err := time.Parse(time.RFC3339, item.EventDate); err == nil {
+			dispute.CreatedAt = parsed
+		}
+	}
+
+	if ref, ok := readString(item.AdditionalData, "paymentPspReference", "payment_psp_reference", "originalReference", "original_reference"); ok {
+		dispute.PaymentIntentID = ref
+	}
+
+	if reason, ok := readString(item.AdditionalData, "disputeReason", "reason", "chargebackReason"); ok {
+		dispute.Reason = mapAdyenDisputeReason(reason)
+	}
+
+	if dueBy, ok := readString(item.AdditionalData, "defenseDeadline", "defenseDeadlineDate"); ok {
+		if parsed, err := time.Parse(time.RFC3339, dueBy); err == nil {
+			dispute.EvidenceDueBy = parsed
+		}
+	}
+
+	if dispute.Status == "" {
+		dispute.Status = statusFromWebhookEvent(event.Type)
+	}
+
+	if dispute.ID == "" {
+		return nil, nil
+	}
+
+	return dispute, nil
+}
+
+func disputeFromMap(obj map[string]interface{}, event WebhookEvent) *Dispute {
+	if obj == nil {
+		return nil
+	}
+
+	dispute := &Dispute{
+		Gateway:   event.Gateway,
+		CreatedAt: event.Timestamp,
+		UpdatedAt: time.Now(),
+	}
+
+	if id, ok := readString(obj, "id", "pspReference"); ok {
+		dispute.ID = id
+	}
+	if status, ok := readString(obj, "status"); ok {
+		dispute.Status = normalizeDisputeStatus(status)
+	}
+	if reason, ok := readString(obj, "reason"); ok {
+		dispute.Reason = normalizeDisputeReason(reason)
+	}
+
+	if piID, ok := readString(obj, "payment_intent", "paymentIntentId", "paymentIntentID"); ok {
+		dispute.PaymentIntentID = piID
+	}
+	if chargeID, ok := readString(obj, "charge", "charge_id"); ok {
+		dispute.ChargeID = chargeID
+	}
+
+	if amountVal, ok := readInt64(obj, "amount", "amount.value"); ok {
+		dispute.Amount.Value = amountVal
+	}
+	if currency, ok := readString(obj, "currency", "amount.currency"); ok {
+		dispute.Amount.Currency = Currency(currency)
+	}
+
+	if dueBy, ok := readInt64(obj, "evidence_due_by", "evidence_details.due_by"); ok {
+		dispute.EvidenceDueBy = time.Unix(dueBy, 0)
+	}
+	if created, ok := readInt64(obj, "created"); ok {
+		dispute.CreatedAt = time.Unix(created, 0)
+	}
+
+	if dispute.Status == "" {
+		dispute.Status = statusFromWebhookEvent(event.Type)
+	}
+
+	if dispute.ID == "" {
+		return nil
+	}
+
+	return dispute
+}
+
+func normalizeDisputeStatus(status string) DisputeStatus {
+	switch DisputeStatus(status) {
+	case DisputeStatusOpen, DisputeStatusNeedsResponse, DisputeStatusUnderReview, DisputeStatusWon,
+		DisputeStatusLost, DisputeStatusAccepted, DisputeStatusExpired:
+		return DisputeStatus(status)
+	default:
+		return DisputeStatusOpen
+	}
+}
+
+func normalizeDisputeReason(reason string) DisputeReason {
+	switch DisputeReason(reason) {
+	case DisputeReasonFraudulent, DisputeReasonDuplicate, DisputeReasonProductNotReceived,
+		DisputeReasonUnrecognized:
+		return DisputeReason(reason)
+	default:
+		return DisputeReasonGeneral
+	}
+}
+
+func statusFromWebhookEvent(eventType WebhookEventType) DisputeStatus {
+	switch eventType {
+	case WebhookEventChargeDisputeCreated:
+		return DisputeStatusNeedsResponse
+	case WebhookEventChargeDisputeUpdated:
+		return DisputeStatusUnderReview
+	case WebhookEventChargeDisputeClosed:
+		return DisputeStatusWon
+	case WebhookEventChargeDisputeFundsWithdrawn:
+		return DisputeStatusLost
+	case WebhookEventChargeDisputeFundsReinstated:
+		return DisputeStatusWon
+	default:
+		return DisputeStatusOpen
+	}
+}
+
+func readString(obj map[string]interface{}, keys ...string) (string, bool) {
+	for _, key := range keys {
+		if value, ok := readValue(obj, key); ok {
+			if str, ok := value.(string); ok {
+				return str, true
+			}
+		}
+	}
+	return "", false
+}
+
+func readInt64(obj map[string]interface{}, keys ...string) (int64, bool) {
+	for _, key := range keys {
+		if value, ok := readValue(obj, key); ok {
+			switch typed := value.(type) {
+			case float64:
+				return int64(typed), true
+			case int64:
+				return typed, true
+			case json.Number:
+				if parsed, err := typed.Int64(); err == nil {
+					return parsed, true
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+func readValue(obj map[string]interface{}, key string) (interface{}, bool) {
+	if obj == nil {
+		return nil, false
+	}
+	if value, ok := obj[key]; ok {
+		return value, true
+	}
+
+	// Support dotted paths (e.g., evidence_details.due_by)
+	if path := splitKey(key); len(path) > 1 {
+		current := obj
+		for i, part := range path {
+			value, ok := current[part]
+			if !ok {
+				return nil, false
+			}
+			if i == len(path)-1 {
+				return value, true
+			}
+			next, ok := value.(map[string]interface{})
+			if !ok {
+				return nil, false
+			}
+			current = next
+		}
+	}
+
+	return nil, false
+}
+
+func splitKey(key string) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(key); i++ {
+		if key[i] == '.' {
+			parts = append(parts, key[start:i])
+			start = i + 1
+		}
+	}
+	if start == 0 {
+		return []string{key}
+	}
+	parts = append(parts, key[start:])
+	return parts
+}


### PR DESCRIPTION
## Summary
- add dispute lifecycle state machine, resolution workflows, and reporting helpers
- parse dispute webhooks and wire dispute gateway helper in service handlers
- align billing summary test assertions with currency formatting

## Testing
- go test ./pkg/payment/... -count=1
- go build ./...
- pre-push hook (go vet, golangci-lint, build, portal lint/type-check/tests)
