### PR TITLE
fix(veid): re-enable msg_server tests with proper signature generation

### DIFF
--- a/x/veid/keeper/msg_server.go
+++ b/x/veid/keeper/msg_server.go
@@ -390,6 +390,7 @@ func (ms msgServer) AddScopeToWallet(goCtx context.Context, msg *types.MsgAddSco
 		ScopeType:    types.ScopeTypeFromProto(msg.ScopeType),
 		EnvelopeHash: msg.EnvelopeHash,
 		AddedAt:      ctx.BlockTime(),
+		Status:       types.ScopeRefStatusPending,
 	}
 
 	if err := ms.keeper.AddScopeToWallet(ctx, sender, scopeRef, msg.UserSignature); err != nil {
@@ -485,7 +486,7 @@ func (ms msgServer) RebindWallet(goCtx context.Context, msg *types.MsgRebindWall
 		return nil, types.ErrInvalidAddress.Wrap(errMsgInvalidSenderAddr)
 	}
 
-	if err := ms.keeper.RebindWallet(ctx, sender, msg.NewBindingPubKey, msg.NewBindingSignature, msg.OldSignature); err != nil {
+	if err := ms.keeper.RebindWallet(ctx, sender, msg.NewBindingSignature, msg.NewBindingPubKey, msg.OldSignature); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Re-enables 4 previously-skipped MsgServer tests in \x/veid/keeper/msg_server_test.go\ that were disabled with TODO comments about signature generation issues. Also fixes 2 bugs in \msg_server.go\ uncovered by the tests.

## Changes

### Test helpers added (\msg_server_test.go\)
- \	estKeyPair\ struct with \generateTestKeyPair()\ factory for Ed25519 key pairs
- Signing helpers: \signMessage\, \signWalletBinding\, \signAddScope\, \signRevokeScope\, \signConsentUpdate\, \signRebind\
- \createWalletWithKey\ helper on \MsgServerTestSuite\ for creating wallets with valid binding signatures

### Tests re-enabled
- \TestMsgAddScopeToWallet_Success\ - tests adding a scope reference with proper Ed25519 signatures
- \TestMsgRevokeScopeFromWallet_Success\ - tests revoking a scope reference with proper signatures
- \TestMsgUpdateConsentSettings_Success\ - tests updating consent settings with proper signatures
- \TestMsgRebindWallet_Success\ - tests wallet key rotation with old/new key signatures

### Bug fixes (\msg_server.go\)
1. **AddScopeToWallet handler**: Set \Status: ScopeRefStatusPending\ on new \ScopeReference\ structs. Previously the Status field was empty, causing wallet validation to fail.
2. **RebindWallet handler**: Fixed swapped arguments - \NewBindingSignature\ and \NewBindingPubKey\ were passed in wrong order to the keeper method.

## Test Results
All 26 MsgServer tests pass, including the 4 previously-skipped tests.
All \x/veid/...\ tests pass. Build and lint clean.