### PR TITLE
test(sdk): add unit tests for Escrow, MFA, Encryption, and Roles clients

### DIFF
--- a/sdk/ts/src/clients/EncryptionClient.spec.ts
+++ b/sdk/ts/src/clients/EncryptionClient.spec.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import { MemoryCache } from "../utils/cache.ts";
+import type { EncryptionClientDeps } from "./EncryptionClient.ts";
+import { EncryptionClient } from "./EncryptionClient.ts";
+
+type MockFn = (...args: unknown[]) => Promise<unknown>;
+
+const txResponse = () => ({
+  height: 1,
+  transactionHash: "TXHASH",
+  code: 0,
+  rawLog: "",
+  gasWanted: 100,
+  gasUsed: 90,
+  data: new Uint8Array(),
+  events: [],
+  eventsRaw: [],
+  msgResponses: [],
+});
+
+describe("EncryptionClient", () => {
+  let client: EncryptionClient;
+  let deps: EncryptionClientDeps;
+
+  beforeEach(() => {
+    deps = {
+      sdk: {
+        virtengine: {
+          encryption: {
+            v1: {
+              getRecipientKey: jest.fn<MockFn>().mockResolvedValue({
+                keys: [
+                  { keyFingerprint: "fp-1", publicKey: new Uint8Array([1, 2, 3]), algorithmId: "X25519-XSalsa20-Poly1305" },
+                ],
+              }),
+              getKeyByFingerprint: jest.fn<MockFn>().mockResolvedValue({
+                key: { keyFingerprint: "fp-1", publicKey: new Uint8Array([1, 2, 3]), algorithmId: "X25519-XSalsa20-Poly1305" },
+              }),
+              getValidateEnvelope: jest.fn<MockFn>().mockResolvedValue({
+                valid: true,
+                error: "",
+                recipientCount: 1,
+                algorithm: "X25519-XSalsa20-Poly1305",
+                signatureValid: true,
+                allKeysRegistered: true,
+                missingKeys: [],
+              }),
+              registerRecipientKey: jest.fn<MockFn>().mockImplementation((...args: unknown[]) => {
+                const options = args[1] as Record<string, (...a: unknown[]) => void> | undefined;
+                options?.afterBroadcast?.(txResponse());
+                return Promise.resolve({ keyFingerprint: "fp-new" });
+              }),
+              updateKeyLabel: jest.fn<MockFn>().mockImplementation((...args: unknown[]) => {
+                const options = args[1] as Record<string, (...a: unknown[]) => void> | undefined;
+                options?.afterBroadcast?.(txResponse());
+                return Promise.resolve({});
+              }),
+              revokeRecipientKey: jest.fn<MockFn>().mockImplementation((...args: unknown[]) => {
+                const options = args[1] as Record<string, (...a: unknown[]) => void> | undefined;
+                options?.afterBroadcast?.(txResponse());
+                return Promise.resolve({});
+              }),
+            },
+          },
+        },
+      } as unknown as EncryptionClientDeps["sdk"],
+    };
+    client = new EncryptionClient(deps);
+  });
+
+  it("should create client instance", () => {
+    expect(client).toBeInstanceOf(EncryptionClient);
+  });
+
+  it("fetches recipient keys for an address", async () => {
+    const keys = await client.getRecipientKey("virt1abc");
+    expect(keys).toHaveLength(1);
+    expect(keys[0].keyFingerprint).toBe("fp-1");
+    expect(deps.sdk.virtengine.encryption.v1.getRecipientKey).toHaveBeenCalledWith({ address: "virt1abc" });
+  });
+
+  it("caches recipient keys on subsequent calls", async () => {
+    const cache = new MemoryCache({ ttlMs: 30000 });
+    const client2 = new EncryptionClient(deps, { enableCaching: true, cache });
+    await client2.getRecipientKey("virt1abc");
+    await client2.getRecipientKey("virt1abc");
+    expect(deps.sdk.virtengine.encryption.v1.getRecipientKey).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches key by fingerprint", async () => {
+    const key = await client.getKeyByFingerprint("fp-1");
+    expect(key?.keyFingerprint).toBe("fp-1");
+    expect(deps.sdk.virtengine.encryption.v1.getKeyByFingerprint).toHaveBeenCalledWith({ fingerprint: "fp-1" });
+  });
+
+  it("returns null for missing key fingerprint", async () => {
+    (deps.sdk.virtengine.encryption.v1.getKeyByFingerprint as jest.Mock<MockFn>)
+      .mockResolvedValueOnce({ key: undefined });
+    const key = await client.getKeyByFingerprint("missing");
+    expect(key).toBeNull();
+  });
+
+  it("validates an encryption envelope", async () => {
+    const result = await client.validateEnvelope({
+      version: 1,
+      algorithmId: "X25519-XSalsa20-Poly1305",
+      algorithmVersion: 1,
+      recipientKeyIds: ["fp-1"],
+      recipientPublicKeys: [],
+      encryptedKeys: [],
+      wrappedKeys: [],
+      nonce: new Uint8Array([30, 40]),
+      ciphertext: new Uint8Array([10, 20]),
+      senderSignature: new Uint8Array(),
+      senderPubKey: new Uint8Array(),
+      metadata: {},
+    });
+    expect(result.valid).toBe(true);
+    expect(result.recipientCount).toBe(1);
+  });
+
+  it("registers a key and returns tx metadata", async () => {
+    const result = await client.registerKey({
+      sender: "virt1abc",
+      publicKey: new Uint8Array([1, 2, 3]),
+      algorithmId: "X25519-XSalsa20-Poly1305",
+      label: "My Key",
+    });
+    expect(result.fingerprint).toBe("fp-new");
+    expect(result.transactionHash).toBe("TXHASH");
+  });
+
+  it("updates key label and returns tx metadata", async () => {
+    const result = await client.updateKeyLabel({
+      sender: "virt1abc",
+      keyFingerprint: "fp-1",
+      label: "Updated Label",
+    });
+    expect(result.transactionHash).toBe("TXHASH");
+    expect(result.code).toBe(0);
+  });
+
+  it("revokes a key and returns tx metadata", async () => {
+    const result = await client.revokeKey({
+      sender: "virt1abc",
+      keyFingerprint: "fp-1",
+    });
+    expect(result.transactionHash).toBe("TXHASH");
+    expect(result.code).toBe(0);
+  });
+});

--- a/sdk/ts/src/clients/EscrowClient.spec.ts
+++ b/sdk/ts/src/clients/EscrowClient.spec.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import type { EscrowClientDeps } from "./EscrowClient.ts";
+import { EscrowClient } from "./EscrowClient.ts";
+
+type MockFn = (...args: unknown[]) => Promise<unknown>;
+
+const txResponse = () => ({
+  height: 1,
+  transactionHash: "TXHASH",
+  code: 0,
+  rawLog: "",
+  gasWanted: 100,
+  gasUsed: 90,
+  data: new Uint8Array(),
+  events: [],
+  eventsRaw: [],
+  msgResponses: [],
+});
+
+describe("EscrowClient", () => {
+  let client: EscrowClient;
+  let deps: EscrowClientDeps;
+
+  beforeEach(() => {
+    deps = {
+      sdk: {
+        virtengine: {
+          escrow: {
+            v1: {
+              getAccounts: jest.fn<MockFn>().mockResolvedValue({
+                accounts: [{ id: { xid: "escrow-1" }, state: "open", balance: { denom: "uvirt", amount: "1000" } }],
+              }),
+              getPayments: jest.fn<MockFn>().mockResolvedValue({
+                payments: [{ paymentId: "pay-1", state: "open", rate: { denom: "uvirt", amount: "10" } }],
+              }),
+              accountDeposit: jest.fn<MockFn>().mockImplementation((...args: unknown[]) => {
+                const options = args[1] as Record<string, (...a: unknown[]) => void> | undefined;
+                options?.afterBroadcast?.(txResponse());
+                return Promise.resolve({});
+              }),
+            },
+          },
+        },
+      } as unknown as EscrowClientDeps["sdk"],
+    };
+    client = new EscrowClient(deps);
+  });
+
+  it("should create client instance", () => {
+    expect(client).toBeInstanceOf(EscrowClient);
+  });
+
+  it("fetches an escrow account by xid", async () => {
+    const account = await client.getAccount("escrow-1");
+    expect(account).toBeTruthy();
+    expect(deps.sdk.virtengine.escrow.v1.getAccounts).toHaveBeenCalledWith({
+      xid: "escrow-1",
+      state: "",
+      pagination: expect.anything(),
+    });
+  });
+
+  it("returns null when no account found", async () => {
+    (deps.sdk.virtengine.escrow.v1.getAccounts as jest.Mock<MockFn>)
+      .mockResolvedValueOnce({ accounts: [] });
+    const account = await client.getAccount("missing");
+    expect(account).toBeNull();
+  });
+
+  it("lists escrow accounts", async () => {
+    const accounts = await client.listAccounts({ state: "open" });
+    expect(accounts).toHaveLength(1);
+    expect(deps.sdk.virtengine.escrow.v1.getAccounts).toHaveBeenCalledWith(
+      expect.objectContaining({ state: "open" }),
+    );
+  });
+
+  it("lists escrow accounts with default filters", async () => {
+    const accounts = await client.listAccounts();
+    expect(accounts).toHaveLength(1);
+    expect(deps.sdk.virtengine.escrow.v1.getAccounts).toHaveBeenCalledWith(
+      expect.objectContaining({ state: "", xid: "" }),
+    );
+  });
+
+  it("fetches payments for an escrow account", async () => {
+    const payments = await client.getPayments("escrow-1");
+    expect(payments).toHaveLength(1);
+    expect(deps.sdk.virtengine.escrow.v1.getPayments).toHaveBeenCalledWith(
+      expect.objectContaining({ xid: "escrow-1" }),
+    );
+  });
+
+  it("deposits funds and returns tx metadata", async () => {
+    const result = await client.deposit({
+      signer: "virt1depositor",
+      id: undefined,
+      deposit: { amount: { denom: "uvirt", amount: "500" }, sources: [] },
+    });
+    expect(result.transactionHash).toBe("TXHASH");
+    expect(result.code).toBe(0);
+  });
+});

--- a/sdk/ts/src/clients/MFAClient.spec.ts
+++ b/sdk/ts/src/clients/MFAClient.spec.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import Long from "long";
+
+import { FactorEnrollmentStatus, FactorType, SensitiveTransactionType } from "../generated/protos/virtengine/mfa/v1/types.ts";
+import { MemoryCache } from "../utils/cache.ts";
+import type { MFAClientDeps } from "./MFAClient.ts";
+import { MFAClient } from "./MFAClient.ts";
+
+type MockFn = (...args: unknown[]) => Promise<unknown>;
+
+const txResponse = () => ({
+  height: 1,
+  transactionHash: "TXHASH",
+  code: 0,
+  rawLog: "",
+  gasWanted: 100,
+  gasUsed: 90,
+  data: new Uint8Array(),
+  events: [],
+  eventsRaw: [],
+  msgResponses: [],
+});
+
+describe("MFAClient", () => {
+  let client: MFAClient;
+  let deps: MFAClientDeps;
+
+  beforeEach(() => {
+    deps = {
+      sdk: {
+        virtengine: {
+          mfa: {
+            v1: {
+              getMFAPolicy: jest.fn<MockFn>().mockResolvedValue({
+                found: true,
+                policy: { requiredFactors: 2, enabledTransactions: [] },
+              }),
+              getFactorEnrollments: jest.fn<MockFn>().mockResolvedValue({
+                enrollments: [
+                  { factorId: "factor-1", factorType: FactorType.FACTOR_TYPE_TOTP, status: FactorEnrollmentStatus.ENROLLMENT_STATUS_ACTIVE },
+                ],
+              }),
+              enrollFactor: jest.fn<MockFn>().mockImplementation((...args: unknown[]) => {
+                const options = args[1] as Record<string, (...a: unknown[]) => void> | undefined;
+                options?.afterBroadcast?.(txResponse());
+                return Promise.resolve({
+                  factorId: "factor-new",
+                  status: FactorEnrollmentStatus.ENROLLMENT_STATUS_PENDING,
+                });
+              }),
+              createChallenge: jest.fn<MockFn>().mockImplementation((...args: unknown[]) => {
+                const options = args[1] as Record<string, (...a: unknown[]) => void> | undefined;
+                options?.afterBroadcast?.(txResponse());
+                return Promise.resolve({
+                  challengeId: "challenge-1",
+                  challengeData: new Uint8Array([1, 2, 3]),
+                  expiresAt: Long.fromNumber(9999),
+                });
+              }),
+              verifyChallenge: jest.fn<MockFn>().mockImplementation((...args: unknown[]) => {
+                const options = args[1] as Record<string, (...a: unknown[]) => void> | undefined;
+                options?.afterBroadcast?.(txResponse());
+                return Promise.resolve({
+                  verified: true,
+                  sessionId: "session-1",
+                  sessionExpiresAt: Long.fromNumber(9999),
+                  remainingFactors: [],
+                });
+              }),
+              getChallenge: jest.fn<MockFn>().mockResolvedValue({
+                found: true,
+                challenge: { challengeId: "challenge-1" },
+              }),
+              setMFAPolicy: jest.fn<MockFn>().mockImplementation((...args: unknown[]) => {
+                const options = args[1] as Record<string, (...a: unknown[]) => void> | undefined;
+                options?.afterBroadcast?.(txResponse());
+                return Promise.resolve({ success: true });
+              }),
+            },
+          },
+        },
+      } as unknown as MFAClientDeps["sdk"],
+    };
+    client = new MFAClient(deps);
+  });
+
+  it("should create client instance", () => {
+    expect(client).toBeInstanceOf(MFAClient);
+  });
+
+  it("fetches MFA policy for an address", async () => {
+    const policy = await client.getPolicy("virt1abc");
+    expect(policy).toBeTruthy();
+    expect(policy?.requiredFactors).toBe(2);
+  });
+
+  it("returns null when no policy found", async () => {
+    (deps.sdk.virtengine.mfa.v1.getMFAPolicy as jest.Mock<MockFn>)
+      .mockResolvedValueOnce({ found: false });
+    const policy = await client.getPolicy("virt1none");
+    expect(policy).toBeNull();
+  });
+
+  it("caches policy on subsequent calls", async () => {
+    const cache = new MemoryCache({ ttlMs: 30000 });
+    const client2 = new MFAClient(deps, { enableCaching: true, cache });
+    await client2.getPolicy("virt1abc");
+    await client2.getPolicy("virt1abc");
+    expect(deps.sdk.virtengine.mfa.v1.getMFAPolicy).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists factor enrollments", async () => {
+    const enrollments = await client.listEnrollments("virt1abc");
+    expect(enrollments).toHaveLength(1);
+    expect(enrollments[0].factorId).toBe("factor-1");
+  });
+
+  it("lists enrollments with filters", async () => {
+    await client.listEnrollments("virt1abc", {
+      factorTypeFilter: FactorType.FACTOR_TYPE_TOTP,
+      statusFilter: FactorEnrollmentStatus.ENROLLMENT_STATUS_ACTIVE,
+    });
+    expect(deps.sdk.virtengine.mfa.v1.getFactorEnrollments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        factorTypeFilter: FactorType.FACTOR_TYPE_TOTP,
+        statusFilter: FactorEnrollmentStatus.ENROLLMENT_STATUS_ACTIVE,
+      }),
+    );
+  });
+
+  it("enrolls a factor and returns tx metadata", async () => {
+    const result = await client.enrollFactor({
+      sender: "virt1abc",
+      factorType: FactorType.FACTOR_TYPE_TOTP,
+      label: "My TOTP",
+    });
+    expect(result.factorId).toBe("factor-new");
+    expect(result.transactionHash).toBe("TXHASH");
+  });
+
+  it("creates a challenge and returns tx metadata", async () => {
+    const result = await client.createChallenge({
+      sender: "virt1abc",
+      factorType: FactorType.FACTOR_TYPE_TOTP,
+      transactionType: SensitiveTransactionType.SENSITIVE_TX_LARGE_WITHDRAWAL,
+    });
+    expect(result.challengeId).toBe("challenge-1");
+    expect(result.transactionHash).toBe("TXHASH");
+  });
+
+  it("verifies a challenge and returns session info", async () => {
+    const result = await client.verifyChallenge({
+      sender: "virt1abc",
+      challengeId: "challenge-1",
+      response: {
+        challengeId: "challenge-1",
+        factorType: FactorType.FACTOR_TYPE_TOTP,
+        responseData: new Uint8Array(),
+        clientInfo: undefined,
+        timestamp: Long.ZERO,
+      },
+    });
+    expect(result.verified).toBe(true);
+    expect(result.sessionId).toBe("session-1");
+    expect(result.transactionHash).toBe("TXHASH");
+  });
+
+  it("fetches a challenge by ID", async () => {
+    const challenge = await client.getChallenge("challenge-1");
+    expect(challenge?.challengeId).toBe("challenge-1");
+  });
+
+  it("returns null for unfound challenge", async () => {
+    (deps.sdk.virtengine.mfa.v1.getChallenge as jest.Mock<MockFn>)
+      .mockResolvedValueOnce({ found: false });
+    const challenge = await client.getChallenge("missing");
+    expect(challenge).toBeNull();
+  });
+
+  it("sets MFA policy and returns tx metadata", async () => {
+    const result = await client.setPolicy({
+      sender: "virt1abc",
+      policy: {
+        accountAddress: "virt1abc",
+        requiredFactors: [],
+        trustedDeviceRule: undefined,
+        recoveryFactors: [],
+        keyRotationFactors: [],
+        sessionDuration: Long.ZERO,
+        veidThreshold: 0,
+        enabled: true,
+        createdAt: Long.ZERO,
+        updatedAt: Long.ZERO,
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.transactionHash).toBe("TXHASH");
+  });
+});

--- a/sdk/ts/src/clients/RolesClient.spec.ts
+++ b/sdk/ts/src/clients/RolesClient.spec.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import { MemoryCache } from "../utils/cache.ts";
+import type { RolesClientDeps } from "./RolesClient.ts";
+import { RolesClient } from "./RolesClient.ts";
+
+type MockFn = (...args: unknown[]) => Promise<unknown>;
+
+describe("RolesClient", () => {
+  let client: RolesClient;
+  let deps: RolesClientDeps;
+
+  beforeEach(() => {
+    deps = {
+      sdk: {
+        virtengine: {
+          roles: {
+            v1: {
+              getAccountRoles: jest.fn<MockFn>().mockResolvedValue({
+                roles: [
+                  { address: "virt1abc", role: "provider", grantedAt: "2024-01-01T00:00:00Z" },
+                  { address: "virt1abc", role: "validator", grantedAt: "2024-01-02T00:00:00Z" },
+                ],
+              }),
+              getHasRole: jest.fn<MockFn>().mockResolvedValue({ hasRole: true }),
+              getRoleMembers: jest.fn<MockFn>().mockResolvedValue({
+                members: [
+                  { address: "virt1abc", role: "provider", grantedAt: "2024-01-01T00:00:00Z" },
+                  { address: "virt1def", role: "provider", grantedAt: "2024-01-03T00:00:00Z" },
+                ],
+              }),
+              getAccountState: jest.fn<MockFn>().mockResolvedValue({
+                accountState: {
+                  address: "virt1abc",
+                  state: 1,
+                  reason: "",
+                  modifiedBy: "",
+                  modifiedAt: 0,
+                  previousState: 0,
+                },
+              }),
+            },
+          },
+        },
+      } as unknown as RolesClientDeps["sdk"],
+    };
+    client = new RolesClient(deps);
+  });
+
+  it("should create client instance", () => {
+    expect(client).toBeInstanceOf(RolesClient);
+  });
+
+  it("fetches account roles", async () => {
+    const roles = await client.getAccountRoles("virt1abc");
+    expect(roles).toHaveLength(2);
+    expect(roles[0].role).toBe("provider");
+    expect(deps.sdk.virtengine.roles.v1.getAccountRoles).toHaveBeenCalledWith({ address: "virt1abc" });
+  });
+
+  it("caches account roles on subsequent calls", async () => {
+    const cache = new MemoryCache({ ttlMs: 30000 });
+    const client2 = new RolesClient(deps, { enableCaching: true, cache });
+    await client2.getAccountRoles("virt1abc");
+    await client2.getAccountRoles("virt1abc");
+    expect(deps.sdk.virtengine.roles.v1.getAccountRoles).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks if address has a role", async () => {
+    const hasRole = await client.hasRole("virt1abc", "provider");
+    expect(hasRole).toBe(true);
+    expect(deps.sdk.virtengine.roles.v1.getHasRole).toHaveBeenCalledWith({
+      address: "virt1abc",
+      role: "provider",
+    });
+  });
+
+  it("returns false when address does not have role", async () => {
+    (deps.sdk.virtengine.roles.v1.getHasRole as jest.Mock<MockFn>)
+      .mockResolvedValueOnce({ hasRole: false });
+    const hasRole = await client.hasRole("virt1abc", "admin");
+    expect(hasRole).toBe(false);
+  });
+
+  it("lists role members", async () => {
+    const members = await client.listRoleMembers("provider");
+    expect(members).toHaveLength(2);
+    expect(deps.sdk.virtengine.roles.v1.getRoleMembers).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "provider" }),
+    );
+  });
+
+  it("lists role members with pagination", async () => {
+    await client.listRoleMembers("provider", { limit: 10, offset: 0 });
+    expect(deps.sdk.virtengine.roles.v1.getRoleMembers).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "provider", pagination: expect.anything() }),
+    );
+  });
+
+  it("fetches account state", async () => {
+    const state = await client.getAccountState("virt1abc");
+    expect(state?.state).toBe(1);
+    expect(state?.address).toBe("virt1abc");
+    expect(deps.sdk.virtengine.roles.v1.getAccountState).toHaveBeenCalledWith({ address: "virt1abc" });
+  });
+
+  it("returns null for missing account state", async () => {
+    (deps.sdk.virtengine.roles.v1.getAccountState as jest.Mock<MockFn>)
+      .mockResolvedValueOnce({ accountState: undefined });
+    const state = await client.getAccountState("virt1missing");
+    expect(state).toBeNull();
+  });
+
+  it("caches account state on subsequent calls", async () => {
+    const cache = new MemoryCache({ ttlMs: 30000 });
+    const client2 = new RolesClient(deps, { enableCaching: true, cache });
+    await client2.getAccountState("virt1abc");
+    await client2.getAccountState("virt1abc");
+    expect(deps.sdk.virtengine.roles.v1.getAccountState).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds missing unit tests for 4 chain SDK module clients, completing test coverage for all 7 custom module clients in \@virtengine/chain-sdk\.

### New Test Files
- \sdk/ts/src/clients/EscrowClient.spec.ts\ — 7 tests (getAccount, listAccounts, getPayments, deposit tx)
- \sdk/ts/src/clients/MFAClient.spec.ts\ — 12 tests (getPolicy, enrollments, challenges, verification, caching)
- \sdk/ts/src/clients/EncryptionClient.spec.ts\ — 9 tests (key management, envelope validation, caching)
- \sdk/ts/src/clients/RolesClient.spec.ts\ — 10 tests (role queries, account state, hasRole, caching)

### Test Results
- **Before:** 4 suites, 38 tests passing
- **After:** 8 suites, 76 tests passing (all green)

### Acceptance Criteria
- [x] Proto types generated to TypeScript (pre-existing)
- [x] Query clients for all custom modules (pre-existing)
- [x] MsgBuilder for core transaction types (pre-existing)
- [x] Unit tests with mocked responses ✅
- [x] Works with localnet chain endpoints (pre-existing)

Closes #23B