### PR TITLE
feat(portal): defer bidding ui to phase 3

### DIFF
--- a/lib/portal/package.json
+++ b/lib/portal/package.json
@@ -8,7 +8,7 @@
     "@walletconnect/sign-client": "^2.7.0"
   },
   "scripts": {
-    "test": "vitest run",
+    "test": "node scripts/run-vitest.cjs",
     "test:a11y": "vitest run -t 'Accessibility'",
     "test:watch": "vitest",
     "lint:a11y": "node scripts/a11y-lint.js"

--- a/lib/portal/scripts/run-vitest.cjs
+++ b/lib/portal/scripts/run-vitest.cjs
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+const { spawnSync } = require('node:child_process');
+
+process.env.VITE_CJS_IGNORE_WARNING = '1';
+
+const result = spawnSync('vitest', ['run'], {
+  stdio: 'inherit',
+  shell: true,
+  env: process.env,
+});
+
+process.exit(result.status ?? 1);

--- a/portal/src/app/(customer)/marketplace/compare/CompareClient.tsx
+++ b/portal/src/app/(customer)/marketplace/compare/CompareClient.tsx
@@ -227,13 +227,13 @@ export default function CompareClient() {
             </CompareRow>
 
             {/* Bidding */}
-            <CompareRow label="Accepts Bids">
+            <CompareRow label="Bidding (Phase 3)">
               {matchedOfferings.map((o) => (
                 <td key={`bid-${o.id.providerAddress}-${o.id.sequence}`} className="py-3 pr-4">
                   {o.allowBidding ? (
-                    <span className="text-green-600 dark:text-green-400">Yes</span>
+                    <span className="text-muted-foreground">Planned</span>
                   ) : (
-                    <span className="text-muted-foreground">No</span>
+                    <span className="text-muted-foreground">Not enabled</span>
                   )}
                 </td>
               ))}

--- a/portal/src/app/provider/pricing/page.tsx
+++ b/portal/src/app/provider/pricing/page.tsx
@@ -34,50 +34,15 @@ export default function ProviderPricingPage() {
 
         <ComponentPriceCalculator />
 
-        {/* Bid Strategy */}
-        <div className="rounded-lg border border-border bg-card p-6">
-          <h2 className="text-lg font-semibold">Bid Strategy</h2>
-          <p className="mt-1 text-sm text-muted-foreground">Configure automatic bidding behavior</p>
+        {/* Bid Strategy (Phase 3) */}
+        <div className="rounded-lg border border-dashed border-border bg-card p-6">
+          <h2 className="text-lg font-semibold">Bid Strategy (Phase 3)</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Optional bidding is deferred. Configure fixed pricing for now.
+          </p>
 
-          <div className="mt-6 space-y-4">
-            <div>
-              <label className="text-sm font-medium" htmlFor="bid-strategy">
-                Strategy
-              </label>
-              <select
-                id="bid-strategy"
-                className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
-              >
-                <option>Aggressive - Maximize utilization</option>
-                <option>Balanced - Balance price and utilization</option>
-                <option>Conservative - Maximize revenue per lease</option>
-                <option>Manual - Review all bids manually</option>
-              </select>
-            </div>
-
-            <div>
-              <label className="text-sm font-medium" htmlFor="min-margin">
-                Minimum Margin (%)
-              </label>
-              <input
-                type="number"
-                id="min-margin"
-                defaultValue="15"
-                className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
-              />
-            </div>
-
-            <div>
-              <label className="text-sm font-medium" htmlFor="auto-accept">
-                Auto-accept threshold ($)
-              </label>
-              <input
-                type="number"
-                id="auto-accept"
-                defaultValue="100"
-                className="mt-1 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
-              />
-            </div>
+          <div className="mt-4 rounded-md bg-muted/40 p-4 text-sm text-muted-foreground">
+            Bidding strategies, auto-accept thresholds, and manual bid review unlock in Phase 3.
           </div>
         </div>
 

--- a/portal/src/components/marketplace/OfferingCard.tsx
+++ b/portal/src/components/marketplace/OfferingCard.tsx
@@ -122,7 +122,7 @@ export function OfferingCard({ offering }: OfferingCardProps) {
 
         {/* Bidding indicator */}
         {offering.allowBidding && (
-          <div className="mt-2 text-xs text-blue-600 dark:text-blue-400">💰 Accepts bids</div>
+          <div className="mt-2 text-xs text-muted-foreground">💰 Bidding available in Phase 3</div>
         )}
       </Link>
     </div>

--- a/portal/src/features/orders/useOrderTracking.ts
+++ b/portal/src/features/orders/useOrderTracking.ts
@@ -67,7 +67,7 @@ function generateMockTimeline(orderId: string, status: OrderStatus) {
       id: `${orderId}-evt-2`,
       status: 'matched',
       title: 'Provider Matched',
-      description: 'Order matched with provider bid',
+      description: 'Order matched with provider',
       timestamp: new Date(createdAt.getTime() + 300000).toISOString(),
     },
   ];


### PR DESCRIPTION
## Summary\n- mark bidding UI as Phase 3 across marketplace cards, compare table, and provider pricing\n- adjust mock order timeline copy to remove bid wording\n- suppress Vite CJS deprecation warning for lib/portal tests\n\n## Testing\n- pnpm -C portal lint\n- pnpm -C portal type-check\n- pnpm -C portal test\n- pnpm -C lib/portal test\n- pnpm -C portal build