### PR TITLE
feat(portal): add real-time chain event subscriptions

### DIFF
--- a/portal/src/components/shared/EventStatusBadge.tsx
+++ b/portal/src/components/shared/EventStatusBadge.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Live status badge showing the real-time connection status and
+ * recent event indicators for chain subscriptions.
+ */
+
+'use client';
+
+import { useChainEventStore, selectIsConnected } from '@/stores/chainEventStore';
+import { Badge } from '@/components/ui/Badge';
+import { cn } from '@/lib/utils';
+import type { ConnectionStatus } from '@/types/chain-events';
+
+const STATUS_CONFIG: Record<
+  ConnectionStatus,
+  { label: string; variant: 'success' | 'warning' | 'destructive' | 'secondary' }
+> = {
+  connected: { label: 'Live', variant: 'success' },
+  connecting: { label: 'Connecting', variant: 'warning' },
+  reconnecting: { label: 'Reconnecting', variant: 'warning' },
+  disconnected: { label: 'Offline', variant: 'destructive' },
+};
+
+interface EventStatusBadgeProps {
+  /** Additional CSS class names. */
+  className?: string;
+  /** Show the polling indicator when falling back to polling. */
+  showPolling?: boolean;
+}
+
+/**
+ * EventStatusBadge renders a colour-coded badge reflecting the
+ * chain event WebSocket connection status.
+ */
+export function EventStatusBadge({ className, showPolling = true }: EventStatusBadgeProps) {
+  const connectionStatus = useChainEventStore((s) => s.connectionStatus);
+  const isConnected = useChainEventStore(selectIsConnected);
+  const isPolling = useChainEventStore((s) => s.isPolling);
+
+  const config = STATUS_CONFIG[connectionStatus];
+
+  return (
+    <Badge
+      variant={isPolling && !isConnected ? 'warning' : config.variant}
+      size="sm"
+      dot
+      className={cn('gap-1', className)}
+    >
+      {isPolling && !isConnected && showPolling ? 'Polling' : config.label}
+    </Badge>
+  );
+}

--- a/portal/src/components/shared/index.ts
+++ b/portal/src/components/shared/index.ts
@@ -1,1 +1,2 @@
 export { ThemeToggle } from './ThemeToggle';
+export { EventStatusBadge } from './EventStatusBadge';

--- a/portal/src/hooks/index.ts
+++ b/portal/src/hooks/index.ts
@@ -22,3 +22,6 @@ export { useWalletAutoConnect } from './useWalletAutoConnect';
 export type { WalletAutoConnectConfig, UseWalletAutoConnectResult } from './useWalletAutoConnect';
 
 export { usePriceConversion } from './usePriceConversion';
+
+export { useChainEvents } from './useChainEvents';
+export type { UseChainEventsOptions } from './useChainEvents';

--- a/portal/src/hooks/useChainEvents.ts
+++ b/portal/src/hooks/useChainEvents.ts
@@ -1,0 +1,231 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * React hook for subscribing to chain events with automatic toast
+ * notifications and polling fallback when WebSocket is unavailable.
+ */
+
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+import { env } from '@/config/env';
+import { useChainEventStore, selectIsConnected } from '@/stores/chainEventStore';
+import { toast } from '@/hooks/use-toast';
+import { CHAIN_EVENT_LABELS } from '@/types/chain-events';
+import type { ChainEvent, ChainEventConfig, ChainEventType } from '@/types/chain-events';
+
+export interface UseChainEventsOptions {
+  /** Whether to connect automatically. Default true. */
+  enabled?: boolean;
+  /** Override the default WS URL from env. */
+  wsUrl?: string;
+  /** Event types to subscribe to. Default all. */
+  subscriptions?: ChainEventType[];
+  /** Show toast notifications for incoming events. Default true. */
+  showToasts?: boolean;
+  /** Callback invoked for every incoming event. */
+  onEvent?: (event: ChainEvent) => void;
+  /** Polling interval in ms when falling back to polling. Default 10000. */
+  pollingIntervalMs?: number;
+}
+
+const TOAST_VARIANT_MAP: Record<ChainEventType, 'default' | 'success' | 'info' | 'warning'> = {
+  'order.created': 'info',
+  'bid.created': 'info',
+  'allocation.status_changed': 'default',
+  'settlement.executed': 'success',
+  'hpc_job.status_changed': 'default',
+};
+
+/**
+ * useChainEvents connects to the CometBFT WebSocket for real-time chain
+ * events. Falls back to polling the REST API when WebSocket fails.
+ */
+export function useChainEvents(options: UseChainEventsOptions = {}) {
+  const {
+    enabled = true,
+    wsUrl,
+    subscriptions,
+    showToasts = true,
+    onEvent,
+    pollingIntervalMs = 10_000,
+  } = options;
+
+  const connect = useChainEventStore((s) => s.connect);
+  const disconnect = useChainEventStore((s) => s.disconnect);
+  const connectionStatus = useChainEventStore((s) => s.connectionStatus);
+  const events = useChainEventStore((s) => s.events);
+  const isConnected = useChainEventStore(selectIsConnected);
+  const isPolling = useChainEventStore((s) => s.isPolling);
+  const enablePolling = useChainEventStore((s) => s.enablePolling);
+  const disablePolling = useChainEventStore((s) => s.disablePolling);
+  const addEvent = useChainEventStore((s) => s.addEvent);
+  const error = useChainEventStore((s) => s.error);
+
+  // Track latest onEvent ref to avoid re-subscriptions.
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  // Track seen event IDs for dedup in polling.
+  const seenIdsRef = useRef(new Set<string>());
+
+  // Toast + callback handler for incoming events.
+  const handleEvent = useCallback(
+    (event: ChainEvent) => {
+      if (showToasts) {
+        const label = CHAIN_EVENT_LABELS[event.type] ?? event.type;
+        const variant = TOAST_VARIANT_MAP[event.type] ?? 'default';
+        toast({
+          title: label,
+          description: `Block ${event.blockHeight}`,
+          variant,
+        });
+      }
+      onEventRef.current?.(event);
+    },
+    [showToasts]
+  );
+
+  // Subscribe to store events and invoke handler.
+  const prevLenRef = useRef(0);
+  useEffect(() => {
+    if (events.length > prevLenRef.current) {
+      const newEvents = events.slice(0, events.length - prevLenRef.current);
+      for (const evt of newEvents) {
+        handleEvent(evt);
+      }
+    }
+    prevLenRef.current = events.length;
+  }, [events, handleEvent]);
+
+  // Connect/disconnect lifecycle.
+  useEffect(() => {
+    if (!enabled) return;
+
+    const config: Partial<ChainEventConfig> = {
+      wsUrl: wsUrl ?? env.chainWs + '/websocket',
+    };
+    if (subscriptions) {
+      config.subscriptions = subscriptions;
+    }
+
+    connect(config);
+
+    return () => {
+      disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, wsUrl]);
+
+  // Polling fallback: activate after WebSocket stays disconnected.
+  const failTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!enabled) return;
+
+    if (connectionStatus === 'disconnected' && !isPolling) {
+      // Wait 5s before enabling polling to allow reconnect attempts.
+      failTimerRef.current = setTimeout(() => {
+        enablePolling();
+      }, 5000);
+    } else if (connectionStatus === 'connected' && isPolling) {
+      disablePolling();
+    }
+
+    return () => {
+      if (failTimerRef.current) {
+        clearTimeout(failTimerRef.current);
+        failTimerRef.current = null;
+      }
+    };
+  }, [connectionStatus, enabled, isPolling, enablePolling, disablePolling]);
+
+  // Polling interval.
+  useEffect(() => {
+    if (!isPolling || !enabled) return;
+
+    const poll = () => {
+      void (async () => {
+        try {
+          const res = await fetch(
+            `${env.chainRest}/cosmos/tx/v1beta1/txs?events=tx.height>0&order_by=ORDER_BY_DESC&pagination.limit=5`
+          );
+          if (!res.ok) return;
+          const data = (await res.json()) as PollingResponse;
+
+          const txResponses = data.tx_responses ?? [];
+          for (const tx of txResponses) {
+            const id = `poll-${tx.txhash}`;
+            if (seenIdsRef.current.has(id)) continue;
+            seenIdsRef.current.add(id);
+
+            // Cap the dedup set.
+            if (seenIdsRef.current.size > 500) {
+              const arr = Array.from(seenIdsRef.current);
+              seenIdsRef.current = new Set(arr.slice(arr.length - 250));
+            }
+
+            for (const evt of tx.events ?? []) {
+              const type = mapRawEventType(evt.type);
+              if (!type) continue;
+              const attrs: Record<string, string> = {};
+              for (const attr of evt.attributes ?? []) {
+                attrs[attr.key] = attr.value;
+              }
+              addEvent({
+                id: `${id}-${evt.type}`,
+                type,
+                blockHeight: parseInt(tx.height ?? '0', 10),
+                timestamp: new Date(tx.timestamp),
+                txHash: tx.txhash ?? '',
+                attributes: attrs,
+              });
+            }
+          }
+        } catch {
+          // Polling errors are non-fatal.
+        }
+      })();
+    };
+
+    const interval = setInterval(poll, pollingIntervalMs);
+
+    return () => clearInterval(interval);
+  }, [isPolling, enabled, pollingIntervalMs, addEvent]);
+
+  return {
+    connectionStatus,
+    isConnected,
+    isPolling,
+    events,
+    error,
+  };
+}
+
+/** Shape of the Cosmos SDK tx search REST response (minimal). */
+interface PollingTxEvent {
+  type: string;
+  attributes: Array<{ key: string; value: string }>;
+}
+
+interface PollingTxResponse {
+  txhash: string;
+  height: string;
+  timestamp: string;
+  events: PollingTxEvent[];
+}
+
+interface PollingResponse {
+  tx_responses?: PollingTxResponse[];
+}
+
+function mapRawEventType(raw: string): ChainEventType | null {
+  const map: Record<string, ChainEventType> = {
+    create_order: 'order.created',
+    create_bid: 'bid.created',
+    update_allocation_status: 'allocation.status_changed',
+    execute_settlement: 'settlement.executed',
+    update_hpc_job_status: 'hpc_job.status_changed',
+  };
+  return map[raw] ?? null;
+}

--- a/portal/src/lib/chain-events.ts
+++ b/portal/src/lib/chain-events.ts
@@ -1,0 +1,245 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * WebSocket client for CometBFT real-time chain event subscriptions.
+ * Handles connection lifecycle, reconnection with exponential backoff,
+ * and event parsing from the CometBFT JSON-RPC WebSocket API.
+ */
+
+import type {
+  ChainEvent,
+  ChainEventConfig,
+  ChainEventType,
+  ConnectionStatus,
+} from '@/types/chain-events';
+import { DEFAULT_CHAIN_EVENT_CONFIG } from '@/types/chain-events';
+
+type EventHandler = (event: ChainEvent) => void;
+type StatusHandler = (status: ConnectionStatus) => void;
+
+/** Maps chain event types to CometBFT event query strings. */
+const EVENT_QUERIES: Record<ChainEventType, string> = {
+  'order.created': "message.action='CreateOrder'",
+  'bid.created': "message.action='CreateBid'",
+  'allocation.status_changed': "message.action='UpdateAllocationStatus'",
+  'settlement.executed': "message.action='ExecuteSettlement'",
+  'hpc_job.status_changed': "message.action='UpdateHPCJobStatus'",
+};
+
+/** Counter for JSON-RPC request IDs. */
+let rpcIdCounter = 0;
+
+/**
+ * ChainEventClient manages a WebSocket connection to a CometBFT node,
+ * subscribes to relevant transaction events, and emits parsed ChainEvent
+ * objects to registered handlers.
+ */
+export class ChainEventClient {
+  private ws: WebSocket | null = null;
+  private config: ChainEventConfig;
+  private eventHandlers: EventHandler[] = [];
+  private statusHandlers: StatusHandler[] = [];
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private status: ConnectionStatus = 'disconnected';
+  private disposed = false;
+
+  constructor(config: Partial<ChainEventConfig> = {}) {
+    this.config = { ...DEFAULT_CHAIN_EVENT_CONFIG, ...config };
+  }
+
+  /** Register a handler for parsed chain events. Returns unsubscribe fn. */
+  onEvent(handler: EventHandler): () => void {
+    this.eventHandlers.push(handler);
+    return () => {
+      this.eventHandlers = this.eventHandlers.filter((h) => h !== handler);
+    };
+  }
+
+  /** Register a handler for connection status changes. Returns unsubscribe fn. */
+  onStatusChange(handler: StatusHandler): () => void {
+    this.statusHandlers.push(handler);
+    return () => {
+      this.statusHandlers = this.statusHandlers.filter((h) => h !== handler);
+    };
+  }
+
+  /** Current connection status. */
+  getStatus(): ConnectionStatus {
+    return this.status;
+  }
+
+  /** Open the WebSocket connection and subscribe to events. */
+  connect(): void {
+    if (this.disposed) return;
+    if (this.ws?.readyState === WebSocket.OPEN || this.ws?.readyState === WebSocket.CONNECTING) {
+      return;
+    }
+
+    this.setStatus('connecting');
+
+    try {
+      this.ws = new WebSocket(this.config.wsUrl);
+    } catch {
+      this.setStatus('disconnected');
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.ws.onopen = () => {
+      this.reconnectAttempts = 0;
+      this.setStatus('connected');
+      this.subscribeAll();
+    };
+
+    this.ws.onmessage = (msg) => {
+      this.handleMessage(msg.data);
+    };
+
+    this.ws.onclose = () => {
+      this.setStatus('disconnected');
+      if (!this.disposed) {
+        this.scheduleReconnect();
+      }
+    };
+
+    this.ws.onerror = () => {
+      // onclose will fire after onerror — reconnect handled there.
+    };
+  }
+
+  /** Close the connection and clean up. */
+  disconnect(): void {
+    this.disposed = true;
+    this.clearReconnectTimer();
+    if (this.ws) {
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      this.ws.onmessage = null;
+      this.ws.onopen = null;
+      this.ws.close();
+      this.ws = null;
+    }
+    this.setStatus('disconnected');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  private setStatus(status: ConnectionStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    for (const handler of this.statusHandlers) {
+      handler(status);
+    }
+  }
+
+  private subscribeAll(): void {
+    const topics =
+      this.config.subscriptions.length > 0
+        ? this.config.subscriptions
+        : (Object.keys(EVENT_QUERIES) as ChainEventType[]);
+
+    for (const topic of topics) {
+      const query = EVENT_QUERIES[topic];
+      if (query && this.ws?.readyState === WebSocket.OPEN) {
+        this.ws.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'subscribe',
+            params: { query: `tm.event='Tx' AND ${query}` },
+            id: ++rpcIdCounter,
+          })
+        );
+      }
+    }
+  }
+
+  private handleMessage(raw: string): void {
+    try {
+      const data = JSON.parse(raw);
+      // Subscription confirmations have result: {} — skip them.
+      if (!data.result?.data?.value?.TxResult) return;
+
+      const txResult = data.result.data.value.TxResult;
+      const txHash: string = data.result.events?.['tx.hash']?.[0] ?? '';
+      const height: number = parseInt(txResult.height ?? '0', 10);
+
+      const events = txResult.result?.events ?? [];
+      for (const evt of events) {
+        const parsed = this.parseEvent(evt, txHash, height);
+        if (parsed) {
+          for (const handler of this.eventHandlers) {
+            handler(parsed);
+          }
+        }
+      }
+    } catch {
+      // Malformed messages are silently ignored.
+    }
+  }
+
+  private parseEvent(
+    evt: { type?: string; attributes?: Array<{ key: string; value: string }> },
+    txHash: string,
+    blockHeight: number
+  ): ChainEvent | null {
+    const rawType = evt.type ?? '';
+    const eventType = this.matchEventType(rawType);
+    if (!eventType) return null;
+
+    const attrs: Record<string, string> = {};
+    for (const attr of evt.attributes ?? []) {
+      attrs[attr.key] = attr.value;
+    }
+
+    const idx = Object.keys(attrs).length;
+    return {
+      id: `${txHash}-${rawType}-${idx}`,
+      type: eventType,
+      blockHeight,
+      timestamp: new Date(),
+      txHash,
+      attributes: attrs,
+    };
+  }
+
+  private matchEventType(rawType: string): ChainEventType | null {
+    const typeMap: Record<string, ChainEventType> = {
+      create_order: 'order.created',
+      create_bid: 'bid.created',
+      update_allocation_status: 'allocation.status_changed',
+      execute_settlement: 'settlement.executed',
+      update_hpc_job_status: 'hpc_job.status_changed',
+    };
+    return typeMap[rawType] ?? null;
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.config.autoReconnect) return;
+    if (this.reconnectAttempts >= this.config.maxReconnectAttempts) return;
+
+    this.clearReconnectTimer();
+    this.setStatus('reconnecting');
+
+    const delay = Math.min(
+      this.config.reconnectDelayMs * Math.pow(2, this.reconnectAttempts),
+      this.config.maxReconnectDelayMs
+    );
+    this.reconnectAttempts++;
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, delay);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+}

--- a/portal/src/providers/AppProviders.tsx
+++ b/portal/src/providers/AppProviders.tsx
@@ -11,6 +11,7 @@ import { PortalProvider } from '@/lib/portal-adapter';
 import { portalConfig, chainConfig, walletConfig } from '@/config';
 import { Toaster } from '@/components/ui/Toaster';
 import { CosmosKitProvider } from './CosmosKitProvider';
+import { ChainEventProvider } from './ChainEventProvider';
 
 interface AppProvidersProps {
   children: ReactNode;
@@ -27,7 +28,7 @@ export function AppProviders({ children }: AppProvidersProps) {
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
       <CosmosKitProvider>
         <PortalProvider config={portalConfig} chainConfig={chainConfig} walletConfig={walletConfig}>
-          {children}
+          <ChainEventProvider>{children}</ChainEventProvider>
           <Toaster />
         </PortalProvider>
       </CosmosKitProvider>

--- a/portal/src/providers/ChainEventProvider.tsx
+++ b/portal/src/providers/ChainEventProvider.tsx
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Provider component that initialises the chain event WebSocket
+ * connection when mounted and cleans up on unmount.
+ */
+
+'use client';
+
+import type { ReactNode } from 'react';
+import { useChainEvents } from '@/hooks/useChainEvents';
+import type { ChainEventType } from '@/types/chain-events';
+
+interface ChainEventProviderProps {
+  children: ReactNode;
+  /** Disable the WebSocket connection (e.g. for testing). */
+  disabled?: boolean;
+  /** Override WebSocket URL. */
+  wsUrl?: string;
+  /** Event types to subscribe to. Default all. */
+  subscriptions?: ChainEventType[];
+}
+
+/**
+ * ChainEventProvider wraps the app to establish a single chain-event
+ * WebSocket connection. Place inside AppProviders.
+ */
+export function ChainEventProvider({
+  children,
+  disabled = false,
+  wsUrl,
+  subscriptions,
+}: ChainEventProviderProps) {
+  useChainEvents({
+    enabled: !disabled,
+    wsUrl,
+    subscriptions,
+  });
+
+  return <>{children}</>;
+}

--- a/portal/src/providers/index.ts
+++ b/portal/src/providers/index.ts
@@ -6,3 +6,4 @@
 export { AppProviders } from './AppProviders';
 export { CosmosKitProvider, useCosmosKitWallets } from './CosmosKitProvider';
 export type { CosmosKitWallet } from './CosmosKitProvider';
+export { ChainEventProvider } from './ChainEventProvider';

--- a/portal/src/stores/chainEventStore.ts
+++ b/portal/src/stores/chainEventStore.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Zustand store for chain event state: connection status, recent events,
+ * and actions to connect/disconnect the WebSocket client.
+ */
+
+import { create } from 'zustand';
+import type { ChainEvent, ChainEventConfig, ConnectionStatus } from '@/types/chain-events';
+import { ChainEventClient } from '@/lib/chain-events';
+
+const MAX_EVENTS = 100;
+
+// =============================================================================
+// Store Interface
+// =============================================================================
+
+export interface ChainEventState {
+  /** Current WebSocket connection status. */
+  connectionStatus: ConnectionStatus;
+  /** Recent chain events (newest first), capped at MAX_EVENTS. */
+  events: ChainEvent[];
+  /** Whether polling fallback is active. */
+  isPolling: boolean;
+  /** Error message from last connection attempt. */
+  error: string | null;
+}
+
+export interface ChainEventActions {
+  /** Connect the WebSocket client. */
+  connect: (config?: Partial<ChainEventConfig>) => void;
+  /** Disconnect the WebSocket client. */
+  disconnect: () => void;
+  /** Add a chain event (used by client or polling). */
+  addEvent: (event: ChainEvent) => void;
+  /** Clear all stored events. */
+  clearEvents: () => void;
+  /** Enable polling fallback mode. */
+  enablePolling: () => void;
+  /** Disable polling fallback mode. */
+  disablePolling: () => void;
+  /** Clear the error state. */
+  clearError: () => void;
+}
+
+export type ChainEventStore = ChainEventState & ChainEventActions;
+
+// =============================================================================
+// Client singleton (lives outside the store to avoid serialization issues)
+// =============================================================================
+
+let clientInstance: ChainEventClient | null = null;
+
+/** Retrieve the active ChainEventClient (for testing/external use). */
+export function getChainEventClient(): ChainEventClient | null {
+  return clientInstance;
+}
+
+// =============================================================================
+// Store
+// =============================================================================
+
+const initialState: ChainEventState = {
+  connectionStatus: 'disconnected',
+  events: [],
+  isPolling: false,
+  error: null,
+};
+
+export const useChainEventStore = create<ChainEventStore>()((set, get) => ({
+  ...initialState,
+
+  connect: (config) => {
+    // Disconnect existing client first.
+    const { disconnect } = get();
+    if (clientInstance) {
+      disconnect();
+    }
+
+    const client = new ChainEventClient(config);
+    clientInstance = client;
+
+    client.onStatusChange((status) => {
+      set({ connectionStatus: status });
+      if (status === 'disconnected' && get().connectionStatus !== 'disconnected') {
+        set({ error: 'WebSocket disconnected' });
+      }
+    });
+
+    client.onEvent((event) => {
+      get().addEvent(event);
+    });
+
+    try {
+      client.connect();
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : 'Connection failed' });
+    }
+  },
+
+  disconnect: () => {
+    if (clientInstance) {
+      clientInstance.disconnect();
+      clientInstance = null;
+    }
+    set({ connectionStatus: 'disconnected' });
+  },
+
+  addEvent: (event) => {
+    set((state) => ({
+      events: [event, ...state.events].slice(0, MAX_EVENTS),
+    }));
+  },
+
+  clearEvents: () => {
+    set({ events: [] });
+  },
+
+  enablePolling: () => {
+    set({ isPolling: true });
+  },
+
+  disablePolling: () => {
+    set({ isPolling: false });
+  },
+
+  clearError: () => {
+    set({ error: null });
+  },
+}));
+
+// =============================================================================
+// Selectors
+// =============================================================================
+
+export const selectIsConnected = (state: ChainEventStore) => state.connectionStatus === 'connected';
+
+export const selectRecentEvents = (limit: number) => (state: ChainEventStore) =>
+  state.events.slice(0, limit);
+
+export const selectEventsByType = (type: ChainEvent['type']) => (state: ChainEventStore) =>
+  state.events.filter((e) => e.type === type);

--- a/portal/src/stores/index.ts
+++ b/portal/src/stores/index.ts
@@ -75,3 +75,13 @@ export {
   type DashboardConfigState,
   type DashboardConfigActions,
 } from './dashboardConfigStore';
+export {
+  useChainEventStore,
+  selectIsConnected,
+  selectRecentEvents,
+  selectEventsByType,
+  getChainEventClient,
+  type ChainEventStore,
+  type ChainEventState,
+  type ChainEventActions,
+} from './chainEventStore';

--- a/portal/src/types/chain-events.ts
+++ b/portal/src/types/chain-events.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ *
+ * Types for real-time chain event subscriptions via CometBFT WebSocket.
+ */
+
+/** Chain event topic identifiers matching on-chain event types. */
+export type ChainEventType =
+  | 'order.created'
+  | 'bid.created'
+  | 'allocation.status_changed'
+  | 'settlement.executed'
+  | 'hpc_job.status_changed';
+
+/** WebSocket connection states. */
+export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'reconnecting';
+
+/** A parsed chain event received from the CometBFT WebSocket. */
+export interface ChainEvent {
+  /** Unique event identifier (tx hash + event index). */
+  id: string;
+  /** The event topic. */
+  type: ChainEventType;
+  /** Block height at which the event occurred. */
+  blockHeight: number;
+  /** Timestamp from the block header. */
+  timestamp: Date;
+  /** Transaction hash that emitted the event. */
+  txHash: string;
+  /** Key-value attributes from the event. */
+  attributes: Record<string, string>;
+}
+
+/** Configuration for the chain event WebSocket client. */
+export interface ChainEventConfig {
+  /** WebSocket endpoint (e.g. wss://ws.virtengine.com/websocket). */
+  wsUrl: string;
+  /** Event types to subscribe to. Empty means all known types. */
+  subscriptions: ChainEventType[];
+  /** Whether to auto-reconnect on disconnect. Default true. */
+  autoReconnect: boolean;
+  /** Base reconnect delay in ms. Exponential backoff applied. Default 1000. */
+  reconnectDelayMs: number;
+  /** Maximum reconnect delay in ms. Default 30000. */
+  maxReconnectDelayMs: number;
+  /** Maximum number of reconnect attempts before giving up. Default 10. */
+  maxReconnectAttempts: number;
+}
+
+/** Human-readable labels for event types, used in toast notifications. */
+export const CHAIN_EVENT_LABELS: Record<ChainEventType, string> = {
+  'order.created': 'New Order',
+  'bid.created': 'New Bid',
+  'allocation.status_changed': 'Allocation Updated',
+  'settlement.executed': 'Settlement Executed',
+  'hpc_job.status_changed': 'HPC Job Updated',
+};
+
+/** Default config values for the chain event client. */
+export const DEFAULT_CHAIN_EVENT_CONFIG: ChainEventConfig = {
+  wsUrl: 'wss://ws.virtengine.com/websocket',
+  subscriptions: [
+    'order.created',
+    'bid.created',
+    'allocation.status_changed',
+    'settlement.executed',
+    'hpc_job.status_changed',
+  ],
+  autoReconnect: true,
+  reconnectDelayMs: 1000,
+  maxReconnectDelayMs: 30000,
+  maxReconnectAttempts: 10,
+};

--- a/portal/tests/unit/stores/chainEventStore.test.ts
+++ b/portal/tests/unit/stores/chainEventStore.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useChainEventStore,
+  selectIsConnected,
+  selectRecentEvents,
+  selectEventsByType,
+} from '@/stores/chainEventStore';
+import type { ChainEvent } from '@/types/chain-events';
+
+function makeEvent(overrides: Partial<ChainEvent> = {}): ChainEvent {
+  return {
+    id: `evt-${Math.random().toString(36).slice(2)}`,
+    type: 'order.created',
+    blockHeight: 100,
+    timestamp: new Date(),
+    txHash: 'hash123',
+    attributes: {},
+    ...overrides,
+  };
+}
+
+describe('chainEventStore', () => {
+  beforeEach(() => {
+    // Reset store to initial state.
+    useChainEventStore.setState({
+      connectionStatus: 'disconnected',
+      events: [],
+      isPolling: false,
+      error: null,
+    });
+  });
+
+  it('addEvent prepends events newest-first', () => {
+    const store = useChainEventStore.getState();
+    const evt1 = makeEvent({ id: 'evt-1', blockHeight: 10 });
+    const evt2 = makeEvent({ id: 'evt-2', blockHeight: 20 });
+
+    store.addEvent(evt1);
+    store.addEvent(evt2);
+
+    const { events } = useChainEventStore.getState();
+    expect(events.length).toBe(2);
+    expect(events[0]!.id).toBe('evt-2');
+    expect(events[1]!.id).toBe('evt-1');
+  });
+
+  it('caps events at 100', () => {
+    const store = useChainEventStore.getState();
+    for (let i = 0; i < 110; i++) {
+      store.addEvent(makeEvent({ id: `evt-${i}` }));
+    }
+    expect(useChainEventStore.getState().events.length).toBe(100);
+  });
+
+  it('clearEvents empties the event list', () => {
+    const store = useChainEventStore.getState();
+    store.addEvent(makeEvent());
+    store.clearEvents();
+    expect(useChainEventStore.getState().events.length).toBe(0);
+  });
+
+  it('enablePolling / disablePolling toggle isPolling', () => {
+    const store = useChainEventStore.getState();
+    expect(store.isPolling).toBe(false);
+    store.enablePolling();
+    expect(useChainEventStore.getState().isPolling).toBe(true);
+    useChainEventStore.getState().disablePolling();
+    expect(useChainEventStore.getState().isPolling).toBe(false);
+  });
+
+  it('clearError resets error to null', () => {
+    useChainEventStore.setState({ error: 'test error' });
+    useChainEventStore.getState().clearError();
+    expect(useChainEventStore.getState().error).toBeNull();
+  });
+
+  // Selectors
+  it('selectIsConnected returns true only when connected', () => {
+    useChainEventStore.setState({ connectionStatus: 'disconnected' });
+    expect(selectIsConnected(useChainEventStore.getState())).toBe(false);
+
+    useChainEventStore.setState({ connectionStatus: 'connected' });
+    expect(selectIsConnected(useChainEventStore.getState())).toBe(true);
+  });
+
+  it('selectRecentEvents returns limited events', () => {
+    const store = useChainEventStore.getState();
+    for (let i = 0; i < 10; i++) {
+      store.addEvent(makeEvent({ id: `evt-${i}` }));
+    }
+    const selector = selectRecentEvents(3);
+    const result = selector(useChainEventStore.getState());
+    expect(result.length).toBe(3);
+  });
+
+  it('selectEventsByType filters correctly', () => {
+    const store = useChainEventStore.getState();
+    store.addEvent(makeEvent({ id: 'a', type: 'order.created' }));
+    store.addEvent(makeEvent({ id: 'b', type: 'bid.created' }));
+    store.addEvent(makeEvent({ id: 'c', type: 'order.created' }));
+
+    const selector = selectEventsByType('order.created');
+    const result = selector(useChainEventStore.getState());
+    expect(result.length).toBe(2);
+    expect(result.every((e) => e.type === 'order.created')).toBe(true);
+  });
+});

--- a/portal/tests/unit/stores/chainEvents.test.ts
+++ b/portal/tests/unit/stores/chainEvents.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ChainEventClient } from '@/lib/chain-events';
+import type { ChainEvent, ConnectionStatus } from '@/types/chain-events';
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+
+  sent: string[] = [];
+
+  constructor(_url: string) {
+    // Auto-open after a tick.
+    setTimeout(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.onopen?.();
+    }, 0);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+let lastMockWs: MockWebSocket | null = null;
+
+beforeEach(() => {
+  lastMockWs = null;
+  vi.stubGlobal(
+    'WebSocket',
+    class extends MockWebSocket {
+      constructor(url: string) {
+        super(url);
+        lastMockWs = this;
+      }
+    }
+  );
+  (globalThis as Record<string, unknown>).WebSocket = (
+    globalThis as Record<string, unknown>
+  ).WebSocket;
+  // Set the static constants on the stub
+  (globalThis.WebSocket as unknown as typeof MockWebSocket).OPEN = MockWebSocket.OPEN;
+  (globalThis.WebSocket as unknown as typeof MockWebSocket).CONNECTING = MockWebSocket.CONNECTING;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChainEventClient', () => {
+  it('connects and sets status to connected', async () => {
+    const statuses: ConnectionStatus[] = [];
+    const client = new ChainEventClient({ autoReconnect: false });
+    client.onStatusChange((s) => statuses.push(s));
+
+    client.connect();
+    expect(statuses).toContain('connecting');
+
+    // Wait for mock WS to open.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(statuses).toContain('connected');
+    expect(client.getStatus()).toBe('connected');
+
+    client.disconnect();
+  });
+
+  it('sends subscribe messages for each configured event type', async () => {
+    const client = new ChainEventClient({
+      subscriptions: ['order.created', 'bid.created'],
+      autoReconnect: false,
+    });
+    client.connect();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(lastMockWs).not.toBeNull();
+    expect(lastMockWs!.sent.length).toBe(2);
+
+    const msg0 = JSON.parse(lastMockWs!.sent[0]!);
+    expect(msg0.method).toBe('subscribe');
+    expect(msg0.params.query).toContain('CreateOrder');
+
+    const msg1 = JSON.parse(lastMockWs!.sent[1]!);
+    expect(msg1.params.query).toContain('CreateBid');
+
+    client.disconnect();
+  });
+
+  it('parses incoming events and notifies handlers', async () => {
+    const received: ChainEvent[] = [];
+    const client = new ChainEventClient({ autoReconnect: false });
+    client.onEvent((e) => received.push(e));
+    client.connect();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const msg = JSON.stringify({
+      result: {
+        events: { 'tx.hash': ['ABC123'] },
+        data: {
+          value: {
+            TxResult: {
+              height: '42',
+              result: {
+                events: [
+                  {
+                    type: 'create_order',
+                    attributes: [{ key: 'order_id', value: '1001' }],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    lastMockWs!.onmessage?.({ data: msg });
+
+    expect(received.length).toBe(1);
+    expect(received[0]!.type).toBe('order.created');
+    expect(received[0]!.blockHeight).toBe(42);
+    expect(received[0]!.attributes['order_id']).toBe('1001');
+
+    client.disconnect();
+  });
+
+  it('ignores malformed messages', async () => {
+    const received: ChainEvent[] = [];
+    const client = new ChainEventClient({ autoReconnect: false });
+    client.onEvent((e) => received.push(e));
+    client.connect();
+    await new Promise((r) => setTimeout(r, 10));
+
+    lastMockWs!.onmessage?.({ data: 'not json' });
+    lastMockWs!.onmessage?.({ data: '{"result":{}}' });
+
+    expect(received.length).toBe(0);
+    client.disconnect();
+  });
+
+  it('reconnects with exponential backoff', async () => {
+    vi.useFakeTimers();
+
+    const statuses: ConnectionStatus[] = [];
+    const client = new ChainEventClient({
+      autoReconnect: true,
+      reconnectDelayMs: 100,
+      maxReconnectAttempts: 3,
+    });
+    client.onStatusChange((s) => statuses.push(s));
+
+    client.connect();
+    await vi.advanceTimersByTimeAsync(10); // open
+    expect(client.getStatus()).toBe('connected');
+
+    // Simulate close — scheduleReconnect runs synchronously, setting reconnecting.
+    lastMockWs!.close();
+    expect(client.getStatus()).toBe('reconnecting');
+
+    // First reconnect after 100ms.
+    await vi.advanceTimersByTimeAsync(110);
+    expect(statuses).toContain('reconnecting');
+
+    client.disconnect();
+  });
+
+  it('disconnect cleans up and prevents reconnection', async () => {
+    const client = new ChainEventClient({ autoReconnect: true });
+    client.connect();
+    await new Promise((r) => setTimeout(r, 10));
+
+    client.disconnect();
+    expect(client.getStatus()).toBe('disconnected');
+
+    // No reconnect should happen.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(client.getStatus()).toBe('disconnected');
+  });
+
+  it('onEvent returns an unsubscribe function', async () => {
+    const received: ChainEvent[] = [];
+    const client = new ChainEventClient({ autoReconnect: false });
+    const unsub = client.onEvent((e) => received.push(e));
+
+    client.connect();
+    await new Promise((r) => setTimeout(r, 10));
+
+    unsub();
+
+    const msg = JSON.stringify({
+      result: {
+        events: { 'tx.hash': ['XYZ'] },
+        data: {
+          value: {
+            TxResult: {
+              height: '1',
+              result: {
+                events: [{ type: 'create_order', attributes: [] }],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    lastMockWs!.onmessage?.({ data: msg });
+    expect(received.length).toBe(0);
+
+    client.disconnect();
+  });
+});


### PR DESCRIPTION
## Summary

Implements real-time chain event subscriptions via CometBFT WebSocket with automatic polling fallback, toast notifications, and a live connection status badge.

## Task Reference
- Vibe-Kanban: 23L - Real-time chain event subscriptions

## Changes

### New Files
- `portal/src/types/chain-events.ts` — Chain event types, connection status, config types, event labels
- `portal/src/lib/chain-events.ts` — WebSocket client with exponential backoff reconnection
- `portal/src/stores/chainEventStore.ts` — Zustand store for connection state and event history (max 100)
- `portal/src/hooks/useChainEvents.ts` — React hook with toast notifications and REST polling fallback
- `portal/src/providers/ChainEventProvider.tsx` — Provider component wired into AppProviders
- `portal/src/components/shared/EventStatusBadge.tsx` — Live status badge (Live/Connecting/Polling/Offline)
- `portal/tests/unit/stores/chainEvents.test.ts` — WebSocket client unit tests (7 tests)
- `portal/tests/unit/stores/chainEventStore.test.ts` — Store unit tests (8 tests)

### Modified Files
- `portal/src/providers/AppProviders.tsx` — Added ChainEventProvider
- `portal/src/hooks/index.ts` — Export useChainEvents
- `portal/src/stores/index.ts` — Export chainEventStore
- `portal/src/providers/index.ts` — Export ChainEventProvider
- `portal/src/components/shared/index.ts` — Export EventStatusBadge

## Acceptance Criteria
- [x] WebSocket connection to chain (CometBFT JSON-RPC WebSocket)
- [x] Event subscription for relevant topics (order, bid, allocation, settlement, HPC job)
- [x] Toast notification system (integrated with existing Radix toast)
- [x] Live status badge updates (EventStatusBadge component)
- [x] Reconnection handling (exponential backoff, max 10 attempts)
- [x] Fallback to polling if WS fails (REST API polling after 5s disconnect)

## Testing
- Unit tests: 265 passed, 0 failed (19 test files)
- Type-check: clean (0 errors)
- ESLint: clean (0 warnings, 0 errors)
- Pre-push hooks: all 5 checks passed