### PR TITLE
chore(portal): Docker and deployment configuration

### DIFF
--- a/_build/Dockerfile.portal
+++ b/_build/Dockerfile.portal
@@ -1,8 +1,8 @@
-FROM node:20-alpine
-
-WORKDIR /workspace
+FROM node:20-alpine AS base
 
 RUN corepack enable
+
+WORKDIR /workspace
 
 COPY pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY portal/package.json portal/package.json
@@ -17,6 +17,27 @@ COPY lib ./lib
 
 WORKDIR /workspace/portal
 
+# --- Development target (default) ---
+FROM base AS dev
 EXPOSE 3000
-
 CMD ["pnpm", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"]
+
+# --- Production build ---
+FROM base AS builder
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV DOCKER_BUILD=true
+RUN pnpm build
+
+FROM node:20-alpine AS production
+RUN corepack enable
+WORKDIR /workspace/portal
+
+COPY --from=builder /workspace/portal/.next/standalone /workspace
+COPY --from=builder /workspace/portal/.next/static /workspace/portal/.next/static
+COPY --from=builder /workspace/portal/public /workspace/portal/public
+
+ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+EXPOSE 3000
+CMD ["node", "portal/server.js"]

--- a/config/kong/kong.yaml
+++ b/config/kong/kong.yaml
@@ -181,6 +181,28 @@ services:
                 headers:
                   - x-gateway:virtengine
 
+  - name: ve-portal
+    url: http://portal:3000
+    tags:
+      - system:portal
+    routes:
+      - name: ve-portal
+        paths:
+          - /app
+        strip_path: true
+        tags:
+          - lifecycle:stable
+        plugins:
+          - name: rate-limiting
+            config:
+              minute: 600
+              policy: local
+          - name: response-transformer
+            config:
+              add:
+                headers:
+                  - x-gateway:virtengine
+
 consumers:
   - username: dev-portal
     keyauth_credentials:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -464,6 +464,7 @@ services:
     build:
       context: .
       dockerfile: _build/Dockerfile.portal
+      target: dev
     container_name: portal
     hostname: portal
     networks:
@@ -471,6 +472,10 @@ services:
         ipv4_address: 172.28.0.55
     ports:
       - "3000:3000" # Local Portal UI
+    volumes:
+      - ./portal/src:/workspace/portal/src
+      - ./portal/public:/workspace/portal/public
+      - ./lib:/workspace/lib
     environment:
       NODE_ENV: development
       NEXT_PUBLIC_CHAIN_ID: ${CHAIN_ID:-virtengine-localnet-1}
@@ -487,6 +492,12 @@ services:
       NEXT_PUBLIC_ENABLE_IDENTITY: ${NEXT_PUBLIC_ENABLE_IDENTITY:-true}
       NEXT_PUBLIC_DEV_MODE: ${NEXT_PUBLIC_DEV_MODE:-true}
       NEXT_PUBLIC_APP_URL: http://localhost:3000
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     depends_on:
       - virtengine-node
       - kong

--- a/portal/next.config.mjs
+++ b/portal/next.config.mjs
@@ -6,11 +6,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /** @type {import('next').NextConfig} */
 const isPages = process.env.GITHUB_PAGES === 'true';
 
+const isDocker = process.env.DOCKER_BUILD === 'true';
+
 const nextConfig = {
   reactStrictMode: true,
 
-  // Enable static export for GitHub Pages deployment
-  output: isPages ? 'export' : undefined,
+  // Enable static export for GitHub Pages, standalone for Docker
+  output: isPages ? 'export' : isDocker ? 'standalone' : undefined,
 
   // Use trailing slashes for better GitHub Pages compatibility
   trailingSlash: isPages,

--- a/portal/src/app/api/health/route.ts
+++ b/portal/src/app/api/health/route.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+
+export function GET() {
+  return NextResponse.json({ status: 'ok' }, { status: 200 });
+}


### PR DESCRIPTION
## Summary

Add Docker deployment configuration for the VE Portal including multi-stage Dockerfile, health check endpoint, Kong API gateway routing, and development hot-reload support.

## Changes

### New Files
- `portal/src/app/api/health/route.ts` — Health check endpoint returning `{ status: 'ok' }`

### Modified Files
- `_build/Dockerfile.portal` — Multi-stage build with dev and production targets
- `docker-compose.yaml` — Add healthcheck probe, volume mounts for hot-reload, and build target
- `config/kong/kong.yaml` — Add `ve-portal` service and `/app` route through API gateway
- `portal/next.config.mjs` — Add `DOCKER_BUILD` env var for standalone output mode

## Acceptance Criteria
- [x] Dockerfile for portal (multi-stage: dev + production)
- [x] docker-compose service definition (already existed, enhanced with healthcheck + volumes + target)
- [x] Kong route configuration (`/app` path with rate limiting)
- [x] Environment variable configuration (already existed in docker-compose + .env.example)
- [x] Health check endpoint (`/api/health`)
- [x] Development hot-reload mode (volume mounts + dev build target)

## Testing
- Pre-commit: Prettier + ESLint passed
- Pre-push: go vet, go build, golangci-lint, portal build — all passed
