### PR TITLE
test(hpc): stabilize template browser test

### DIFF
--- a/portal/tests/unit/hpc/components.test.tsx
+++ b/portal/tests/unit/hpc/components.test.tsx
@@ -209,9 +209,11 @@ describe('TemplateBrowser', () => {
 
   it('renders category filters', async () => {
     render(<TemplateBrowser />);
-    expect(screen.getByText('All')).toBeInTheDocument();
-    expect(screen.getByText('Machine Learning')).toBeInTheDocument();
-    expect(screen.getByText('Scientific Computing')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('All')).toBeInTheDocument();
+      expect(screen.getByText('Machine Learning')).toBeInTheDocument();
+      expect(screen.getByText('Scientific Computing')).toBeInTheDocument();
+    });
   });
 
   it('filters templates by category', async () => {


### PR DESCRIPTION
## Summary
- wrap TemplateBrowser category filter assertions in waitFor to avoid act warnings

## Testing
- pnpm -C portal lint
- pnpm -C portal type-check
- pnpm -C portal test
- pnpm -C portal build