### PR TITLE
feat(observability): distributed tracing instrumentation

### DIFF
--- a/cmd/inference-sidecar/main.go
+++ b/cmd/inference-sidecar/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/virtengine/virtengine/pkg/inference"
 	inferencepb "github.com/virtengine/virtengine/pkg/inference/proto"
+	"github.com/virtengine/virtengine/pkg/observability"
 )
 
 // Version info (set at build time)
@@ -115,6 +116,7 @@ func run() int {
 	grpcServer := grpc.NewServer(
 		grpc.MaxRecvMsgSize(16*1024*1024), // 16MB max message size
 		grpc.MaxSendMsgSize(16*1024*1024),
+		grpc.StatsHandler(observability.GRPCServerStatsHandler()),
 	)
 
 	// Register services

--- a/deploy/monitoring/tempo/tempo.yaml
+++ b/deploy/monitoring/tempo/tempo.yaml
@@ -38,7 +38,7 @@ ingester:
 # Compactor configuration
 compactor:
   compaction:
-    block_retention: 72h  # Keep traces for 3 days
+    block_retention: 720h  # Keep traces for 30 days
 
 # Storage configuration
 storage:

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,13 @@ require (
 	github.com/stripe/stripe-go/v80 v80.2.1
 	github.com/virtengine/virtengine/sdk/go v0.0.0-00010101000000-000000000000
 	github.com/waldur/go-client v0.0.0-20260128112756-c3ba4e676796
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0
+	go.opentelemetry.io/otel v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0
+	go.opentelemetry.io/otel/sdk v1.38.0
+	go.opentelemetry.io/otel/trace v1.38.0
 	go.step.sm/crypto v0.76.0
 	golang.org/x/crypto v0.47.0
 	golang.org/x/mod v0.31.0
@@ -153,6 +160,7 @@ require (
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
@@ -219,6 +227,7 @@ require (
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/goware/urlx v0.3.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter v1.7.9 // indirect
@@ -317,13 +326,9 @@ require (
 	go.etcd.io/bbolt v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 // indirect
-	go.opentelemetry.io/otel v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.38.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
-	go.opentelemetry.io/otel/trace v1.38.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.uber.org/mock v0.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1364,6 +1364,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
@@ -1805,6 +1807,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 h1:8Tjv8EJ+pM1xP8mK6egEbD1OgnVTyacbefKhmbLhIhU=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2/go.mod h1:pkJQ2tZHJ0aFOVEEot6oZmaVEZcRme73eIFmhiVuRWs=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
@@ -2356,6 +2360,10 @@ go.opentelemetry.io/otel v1.19.0/go.mod h1:i0QyjOq3UPoTzff0PJB2N66fb4S0+rSbSB15/
 go.opentelemetry.io/otel v1.21.0/go.mod h1:QZzNPQPm1zLX4gZK4cMi+71eaorMSGT3A4znnUvNNEo=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
 go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 h1:GqRJVj7UmLjCVyVJ3ZFLdPRmhDUp2zFmQe3RHIOsw24=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0/go.mod h1:ri3aaHSmCTVYu2AWv44YMauwAQc0aqI9gHKIcSbI1pU=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0 h1:lwI4Dc5leUqENgGuQImwLo4WnuXFPetmPpkLi2IrX54=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0/go.mod h1:Kz/oCE7z5wuyhPxsXDuaPteSWqjSBD5YaSdbxZYGbGk=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.36.0 h1:rixTyDGXFxRy1xzhKrotaHy3/KXdPhlWARrCgK+eqUY=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.36.0/go.mod h1:dowW6UsM9MKbJq5JTz2AMVp3/5iW5I/TStsk8S+CfHw=
 go.opentelemetry.io/otel/metric v1.19.0/go.mod h1:L5rUsV9kM1IxCj1MmSdS+JQAcVm319EUrDVLrt7jqt8=
@@ -2376,6 +2384,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
+go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
+go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
 go.step.sm/crypto v0.76.0 h1:K23BSaeoiY7Y5dvvijTeYC9EduDBetNwQYMBwMhi1aA=
 go.step.sm/crypto v0.76.0/go.mod h1:PXYJdKkK8s+GHLwLguFaLxHNAFsFL3tL1vSBrYfey5k=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/pkg/observability/otel_tracer.go
+++ b/pkg/observability/otel_tracer.go
@@ -1,0 +1,262 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const defaultTraceEndpoint = "localhost:4317"
+
+type otelTracer struct {
+	tracer     trace.Tracer
+	propagator propagation.TextMapPropagator
+	provider   *sdktrace.TracerProvider
+}
+
+type otelSpanWrapper struct {
+	span trace.Span
+}
+
+func newOTelTracer(cfg Config) (*otelTracer, func(context.Context) error, error) {
+	endpoint := strings.TrimSpace(cfg.TracingEndpoint)
+	if endpoint == "" {
+		endpoint = defaultTraceEndpoint
+	}
+
+	clientOpts := []otlptracegrpc.Option{
+		otlptracegrpc.WithEndpoint(endpoint),
+	}
+	if cfg.TracingEndpoint == "" || !strings.HasPrefix(strings.ToLower(cfg.TracingEndpoint), "https://") {
+		clientOpts = append(clientOpts, otlptracegrpc.WithTLSCredentials(insecure.NewCredentials()))
+	}
+
+	exporter, err := otlptrace.New(
+		context.Background(),
+		otlptracegrpc.NewClient(clientOpts...),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("init otlp exporter: %w", err)
+	}
+
+	res, err := resource.New(
+		context.Background(),
+		resource.WithAttributes(
+			semconv.ServiceName(cfg.ServiceName),
+			semconv.ServiceVersion(cfg.ServiceVersion),
+			semconv.DeploymentEnvironment(cfg.Environment),
+		),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("init otel resource: %w", err)
+	}
+
+	sampleRate := cfg.TracingSampleRate
+	if sampleRate <= 0 || sampleRate > 1 {
+		sampleRate = DefaultConfig().TracingSampleRate
+	}
+	sampler := sdktrace.ParentBased(sdktrace.TraceIDRatioBased(sampleRate))
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sampler),
+	)
+
+	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		),
+	)
+
+	tracer := &otelTracer{
+		tracer:     provider.Tracer(cfg.ServiceName),
+		propagator: otel.GetTextMapPropagator(),
+		provider:   provider,
+	}
+
+	return tracer, provider.Shutdown, nil
+}
+
+func newOTelTracerFromTracingConfig(cfg TracingConfig) (*otelTracer, func(context.Context) error, error) {
+	obsCfg := Config{
+		ServiceName:       cfg.ServiceName,
+		ServiceVersion:    cfg.ServiceVersion,
+		Environment:       cfg.Environment,
+		TracingEnabled:    cfg.Enabled,
+		TracingEndpoint:   cfg.Endpoint,
+		TracingSampleRate: cfg.SampleRate,
+	}
+	return newOTelTracer(obsCfg)
+}
+
+func (t *otelTracer) withName(name string) *otelTracer {
+	if name == "" {
+		return t
+	}
+	return &otelTracer{
+		tracer:     t.provider.Tracer(name),
+		propagator: t.propagator,
+		provider:   t.provider,
+	}
+}
+
+func (t *otelTracer) Start(ctx context.Context, name string, opts ...SpanOption) (context.Context, Span) {
+	cfg := &spanConfig{
+		kind: SpanKindInternal,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	spanKind := trace.SpanKindInternal
+	switch cfg.kind {
+	case SpanKindServer:
+		spanKind = trace.SpanKindServer
+	case SpanKindClient:
+		spanKind = trace.SpanKindClient
+	case SpanKindProducer:
+		spanKind = trace.SpanKindProducer
+	case SpanKindConsumer:
+		spanKind = trace.SpanKindConsumer
+	}
+
+	attrs := make([]attribute.KeyValue, 0, len(cfg.attributes))
+	for _, attr := range cfg.attributes {
+		if kv, ok := fieldToAttribute(attr); ok {
+			attrs = append(attrs, kv)
+		}
+	}
+
+	ctx, span := t.tracer.Start(
+		ctx,
+		name,
+		trace.WithSpanKind(spanKind),
+		trace.WithAttributes(attrs...),
+	)
+
+	wrapped := &otelSpanWrapper{span: span}
+	ctx = context.WithValue(ctx, spanContextKey{}, wrapped)
+	return ctx, wrapped
+}
+
+func (t *otelTracer) Extract(ctx context.Context, carrier Carrier) context.Context {
+	ctx = t.propagator.Extract(ctx, carrierAdapter{carrier: carrier})
+	if span := trace.SpanFromContext(ctx); span != nil && span.SpanContext().IsValid() {
+		ctx = context.WithValue(ctx, spanContextKey{}, &otelSpanWrapper{span: span})
+	}
+	return ctx
+}
+
+func (t *otelTracer) Inject(ctx context.Context, carrier Carrier) error {
+	t.propagator.Inject(ctx, carrierAdapter{carrier: carrier})
+	return nil
+}
+
+func (s *otelSpanWrapper) End() {
+	s.span.End()
+}
+
+func (s *otelSpanWrapper) SetStatus(code StatusCode, description string) {
+	switch code {
+	case StatusError:
+		s.span.SetStatus(codes.Error, description)
+	case StatusOK:
+		s.span.SetStatus(codes.Ok, description)
+	default:
+		s.span.SetStatus(codes.Unset, description)
+	}
+}
+
+func (s *otelSpanWrapper) SetAttribute(key string, value interface{}) {
+	if kv, ok := fieldToAttribute(Field{Key: key, Value: value}); ok {
+		s.span.SetAttributes(kv)
+	}
+}
+
+func (s *otelSpanWrapper) RecordError(err error) {
+	if err == nil {
+		return
+	}
+	s.span.RecordError(err)
+	s.span.SetStatus(codes.Error, err.Error())
+}
+
+func (s *otelSpanWrapper) AddEvent(name string, attrs ...Field) {
+	otelAttrs := make([]attribute.KeyValue, 0, len(attrs))
+	for _, attr := range attrs {
+		if kv, ok := fieldToAttribute(attr); ok {
+			otelAttrs = append(otelAttrs, kv)
+		}
+	}
+	s.span.AddEvent(name, trace.WithAttributes(otelAttrs...))
+}
+
+func (s *otelSpanWrapper) SpanContext() SpanContext {
+	sc := s.span.SpanContext()
+	return SpanContext{
+		TraceID:    sc.TraceID().String(),
+		SpanID:     sc.SpanID().String(),
+		TraceFlags: byte(sc.TraceFlags()),
+	}
+}
+
+func fieldToAttribute(field Field) (attribute.KeyValue, bool) {
+	if field.Key == "" {
+		return attribute.KeyValue{}, false
+	}
+	switch v := field.Value.(type) {
+	case string:
+		return attribute.String(field.Key, v), true
+	case int:
+		return attribute.Int(field.Key, v), true
+	case int64:
+		return attribute.Int64(field.Key, v), true
+	case float64:
+		return attribute.Float64(field.Key, v), true
+	case bool:
+		return attribute.Bool(field.Key, v), true
+	case time.Duration:
+		return attribute.Int64(field.Key, int64(v)), true
+	case time.Time:
+		return attribute.String(field.Key, v.UTC().Format(time.RFC3339Nano)), true
+	default:
+		return attribute.String(field.Key, fmt.Sprintf("%v", field.Value)), true
+	}
+}
+
+type carrierAdapter struct {
+	carrier Carrier
+}
+
+func (c carrierAdapter) Get(key string) string {
+	return c.carrier.Get(key)
+}
+
+func (c carrierAdapter) Set(key, value string) {
+	c.carrier.Set(key, value)
+}
+
+func (c carrierAdapter) Keys() []string {
+	type keyer interface {
+		Keys() []string
+	}
+	if k, ok := c.carrier.(keyer); ok {
+		return k.Keys()
+	}
+	return nil
+}

--- a/pkg/observability/tracing_grpc.go
+++ b/pkg/observability/tracing_grpc.go
@@ -1,0 +1,16 @@
+package observability
+
+import (
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc/stats"
+)
+
+// GRPCServerStatsHandler returns a gRPC stats handler with OpenTelemetry tracing.
+func GRPCServerStatsHandler() stats.Handler {
+	return otelgrpc.NewServerHandler()
+}
+
+// GRPCClientStatsHandler returns a gRPC stats handler with OpenTelemetry tracing.
+func GRPCClientStatsHandler() stats.Handler {
+	return otelgrpc.NewClientHandler()
+}

--- a/pkg/observability/tracing_http.go
+++ b/pkg/observability/tracing_http.go
@@ -1,0 +1,25 @@
+package observability
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// HTTPTracingHandler wraps an HTTP handler with OpenTelemetry instrumentation.
+func HTTPTracingHandler(handler http.Handler, name string) http.Handler {
+	if handler == nil {
+		return nil
+	}
+	if name == "" {
+		name = "http.server"
+	}
+	return otelhttp.NewHandler(handler, name)
+}
+
+// TracedHTTPClient returns an HTTP client instrumented with OpenTelemetry.
+func TracedHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+	}
+}

--- a/pkg/provider_daemon/chain_client.go
+++ b/pkg/provider_daemon/chain_client.go
@@ -7,6 +7,7 @@ import (
 
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/virtengine/virtengine/pkg/observability"
 	hpcv1 "github.com/virtengine/virtengine/sdk/go/node/hpc/v1"
 	hpctypes "github.com/virtengine/virtengine/x/hpc/types"
 	"google.golang.org/grpc"
@@ -48,6 +49,7 @@ func newRPCChainClient(config RPCChainClientConfig) (*rpcChainClient, error) {
 		conn, err := grpc.NewClient(
 			config.GRPCEndpoint,
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithStatsHandler(observability.GRPCClientStatsHandler()),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to gRPC endpoint: %w", err)

--- a/pkg/provider_daemon/hpc_node_aggregator.go
+++ b/pkg/provider_daemon/hpc_node_aggregator.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/virtengine/virtengine/pkg/observability"
 	hpcv1 "github.com/virtengine/virtengine/sdk/go/node/hpc/v1"
 )
 
@@ -323,7 +324,7 @@ func (a *HPCNodeAggregator) Start(ctx context.Context) error {
 
 	a.server = &http.Server{
 		Addr:         a.config.ListenAddr,
-		Handler:      mux,
+		Handler:      observability.HTTPTracingHandler(mux, "provider.hpc_node_aggregator"),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}

--- a/pkg/provider_daemon/portal_api.go
+++ b/pkg/provider_daemon/portal_api.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/virtengine/virtengine/pkg/observability"
 )
 
 const (
@@ -101,7 +102,7 @@ func (s *PortalAPIServer) Start(ctx context.Context) error {
 
 	s.server = &http.Server{
 		Addr:              s.cfg.ListenAddr,
-		Handler:           router,
+		Handler:           observability.HTTPTracingHandler(router, "provider.portal_api"),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 

--- a/pkg/provider_daemon/status_callback.go
+++ b/pkg/provider_daemon/status_callback.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/virtengine/virtengine/pkg/observability"
 	"github.com/virtengine/virtengine/x/market/types/marketplace"
 )
 
@@ -261,7 +262,7 @@ func (s *OrderStatusWebhookServer) Start(ctx context.Context) error {
 
 	s.server = &http.Server{
 		Addr:         s.cfg.ListenAddr,
-		Handler:      mux,
+		Handler:      observability.HTTPTracingHandler(mux, "provider.order_status_webhook"),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  60 * time.Second,

--- a/pkg/provider_daemon/waldur_callbacks.go
+++ b/pkg/provider_daemon/waldur_callbacks.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/virtengine/virtengine/pkg/observability"
 	"github.com/virtengine/virtengine/pkg/waldur"
 	"github.com/virtengine/virtengine/x/market/types/marketplace"
 )
@@ -229,7 +230,7 @@ func (h *WaldurCallbackHandler) Start(ctx context.Context) error {
 
 	h.server = &http.Server{
 		Addr:         h.cfg.ListenAddr,
-		Handler:      mux,
+		Handler:      observability.HTTPTracingHandler(mux, "provider.waldur_callbacks"),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  60 * time.Second,

--- a/pkg/waldur/client.go
+++ b/pkg/waldur/client.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	client "github.com/waldur/go-client"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // Waldur-specific errors
@@ -195,7 +196,8 @@ func NewClient(cfg Config) (*Client, error) {
 
 	// Create HTTP client with timeout
 	httpClient := &http.Client{
-		Timeout: cfg.Timeout,
+		Timeout:   cfg.Timeout,
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
 	}
 
 	// Create Waldur API client


### PR DESCRIPTION
Implements distributed tracing across observability, provider daemon HTTP/gRPC, Waldur client, and updates Tempo retention.\n\n- Adds OTLP tracer provider wiring and helpers\n- Instruments provider daemon HTTP servers and gRPC clients\n- Adds tracing flags to provider-daemon CLI\n- Instruments inference-sidecar gRPC server\n- Updates Tempo retention to 30 days