### PR TITLE
feat(portal): 29E wallet-signed request auth

### DIFF
--- a/cmd/provider-daemon/main.go
+++ b/cmd/provider-daemon/main.go
@@ -659,6 +659,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 	portalCfg.ShellSessionTTL = viper.GetDuration(FlagPortalShellSessionTTL)
 	portalCfg.TokenTTL = viper.GetDuration(FlagPortalTokenTTL)
 	portalCfg.AuditLogger = portalAuditLogger
+	portalCfg.AuthChainID = viper.GetString(FlagChainID)
+	portalCfg.AuthChainGRPC = viper.GetString(FlagWaldurChainGRPC)
 
 	portalAPI, err := provider_daemon.NewPortalAPIServer(portalCfg)
 	if err != nil {

--- a/lib/portal/src/auth/wallet-sign.ts
+++ b/lib/portal/src/auth/wallet-sign.ts
@@ -62,6 +62,10 @@ const stableStringify = (value: unknown): string => {
     .join(",")}}`;
 };
 
+export const serializeRequestBody = (body: unknown): string => {
+  return stableStringify(body);
+};
+
 const toBase64 = (value: string): string => {
   if (typeof btoa === "function") {
     return btoa(value);
@@ -103,7 +107,7 @@ export async function signRequest(
 ): Promise<SignedRequestHeaders> {
   const timestamp = Date.now();
   const nonce = randomNonce();
-  const bodyPayload = options.body ? stableStringify(options.body) : "";
+  const bodyPayload = options.body ? serializeRequestBody(options.body) : "";
   const bodyHash = bodyPayload ? await sha256Hex(bodyPayload) : "";
 
   const requestData: RequestData = {

--- a/lib/portal/src/provider-api/client.ts
+++ b/lib/portal/src/provider-api/client.ts
@@ -1,4 +1,4 @@
-import { signRequest } from "../auth/wallet-sign";
+import { serializeRequestBody, signRequest } from "../auth/wallet-sign";
 import type { WalletRequestSigner } from "../auth/wallet-sign";
 import type {
   Deployment,
@@ -445,6 +445,11 @@ export class ProviderAPIClient {
 
     let lastError: Error | null = null;
 
+    const bodyPayload =
+      options.body === undefined
+        ? undefined
+        : serializeRequestBody(options.body);
+
     for (let attempt = 0; attempt <= this.retries; attempt += 1) {
       try {
         const headers: Record<string, string> = {
@@ -485,7 +490,7 @@ export class ProviderAPIClient {
         const response = await this.fetcher(url.toString(), {
           method,
           headers,
-          body: options.body ? JSON.stringify(options.body) : undefined,
+          body: bodyPayload,
           signal: controller.signal,
         });
 

--- a/pkg/provider_daemon/auth/canonical_json.go
+++ b/pkg/provider_daemon/auth/canonical_json.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+func canonicalJSON(value any) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := writeCanonicalJSON(&buf, value); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeCanonicalJSON(buf *bytes.Buffer, value any) error {
+	switch v := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		buf.WriteByte('{')
+		for i, key := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			encodedKey, err := json.Marshal(key)
+			if err != nil {
+				return err
+			}
+			buf.Write(encodedKey)
+			buf.WriteByte(':')
+			if err := writeCanonicalJSON(buf, v[key]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+		return nil
+	case []any:
+		buf.WriteByte('[')
+		for i, item := range v {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := writeCanonicalJSON(buf, item); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+		return nil
+	case string:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		buf.Write(encoded)
+		return nil
+	case json.RawMessage:
+		buf.Write(v)
+		return nil
+	case float64, float32, int, int64, int32, uint64, uint32, uint:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		buf.Write(encoded)
+		return nil
+	case bool:
+		if v {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+		return nil
+	case nil:
+		buf.WriteString("null")
+		return nil
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Errorf("failed to encode value: %w", err)
+		}
+		buf.Write(encoded)
+		return nil
+	}
+}
+
+func quoteJSONString(value string) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}

--- a/pkg/provider_daemon/auth/chain_query.go
+++ b/pkg/provider_daemon/auth/chain_query.go
@@ -1,0 +1,124 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	marketv1 "github.com/virtengine/virtengine/sdk/go/node/market/v1"
+	marketv1beta5 "github.com/virtengine/virtengine/sdk/go/node/market/v1beta5"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// ChainQuerier fetches lease data from chain.
+type ChainQuerier interface {
+	GetLease(ctx context.Context, leaseID marketv1.LeaseID) (marketv1.Lease, error)
+}
+
+type MarketLeaseQuerierConfig struct {
+	GRPCEndpoint string
+	Timeout      time.Duration
+}
+
+type MarketLeaseQuerier struct {
+	conn    *grpc.ClientConn
+	timeout time.Duration
+}
+
+func NewMarketLeaseQuerier(cfg MarketLeaseQuerierConfig) (*MarketLeaseQuerier, error) {
+	if cfg.GRPCEndpoint == "" {
+		return nil, fmt.Errorf("grpc endpoint is required")
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+	conn, err := grpc.NewClient(cfg.GRPCEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to grpc endpoint: %w", err)
+	}
+	return &MarketLeaseQuerier{conn: conn, timeout: cfg.Timeout}, nil
+}
+
+func (q *MarketLeaseQuerier) Close() error {
+	if q.conn == nil {
+		return nil
+	}
+	return q.conn.Close()
+}
+
+func (q *MarketLeaseQuerier) GetLease(ctx context.Context, leaseID marketv1.LeaseID) (marketv1.Lease, error) {
+	client := marketv1beta5.NewQueryClient(q.conn)
+	req := &marketv1beta5.QueryLeaseRequest{ID: leaseID}
+	queryCtx, cancel := context.WithTimeout(ctx, q.timeout)
+	defer cancel()
+	resp, err := client.Lease(queryCtx, req)
+	if err != nil {
+		return marketv1.Lease{}, err
+	}
+	return resp.Lease, nil
+}
+
+type leaseOwnerCacheEntry struct {
+	owner   string
+	expires time.Time
+}
+
+// LeaseOwnerCache stores lease owner lookups for a short TTL.
+type LeaseOwnerCache struct {
+	mu     sync.RWMutex
+	ttl    time.Duration
+	owners map[string]leaseOwnerCacheEntry
+}
+
+func NewLeaseOwnerCache(ttl time.Duration) *LeaseOwnerCache {
+	if ttl == 0 {
+		ttl = 15 * time.Minute
+	}
+	return &LeaseOwnerCache{
+		ttl:    ttl,
+		owners: make(map[string]leaseOwnerCacheEntry),
+	}
+}
+
+func (c *LeaseOwnerCache) Get(leaseID string) (string, bool) {
+	c.mu.RLock()
+	entry, ok := c.owners[leaseID]
+	c.mu.RUnlock()
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(entry.expires) {
+		c.mu.Lock()
+		delete(c.owners, leaseID)
+		c.mu.Unlock()
+		return "", false
+	}
+	return entry.owner, true
+}
+
+func (c *LeaseOwnerCache) Set(leaseID, owner string) {
+	if leaseID == "" || owner == "" {
+		return
+	}
+	c.mu.Lock()
+	c.owners[leaseID] = leaseOwnerCacheEntry{
+		owner:   owner,
+		expires: time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+}
+
+func parseLeaseID(raw string) (marketv1.LeaseID, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return marketv1.LeaseID{}, fmt.Errorf("lease id is required")
+	}
+	parts := strings.Split(raw, "/")
+	if len(parts) > 0 && parts[0] == "lease" {
+		parts = parts[1:]
+	}
+	return marketv1.ParseLeasePath(parts)
+}

--- a/pkg/provider_daemon/auth/cosmos_verify.go
+++ b/pkg/provider_daemon/auth/cosmos_verify.go
@@ -1,0 +1,299 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	HeaderAddress   = "X-VE-Address"
+	HeaderTimestamp = "X-VE-Timestamp"
+	HeaderNonce     = "X-VE-Nonce"
+	HeaderSignature = "X-VE-Signature"
+	HeaderPubKey    = "X-VE-PubKey"
+
+	QueryAddress   = "ve_address"
+	QueryTimestamp = "ve_ts"
+	QueryNonce     = "ve_nonce"
+	QuerySignature = "ve_sig"
+	QueryPubKey    = "ve_pub"
+)
+
+type SignedRequest struct {
+	Address   string
+	Timestamp time.Time
+	Nonce     string
+	Signature []byte
+	PubKey    *secp256k1.PubKey
+	Request   RequestData
+}
+
+type RequestData struct {
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	Timestamp int64  `json:"timestamp"`
+	Nonce     string `json:"nonce"`
+	BodyHash  string `json:"body_hash"`
+}
+
+type VerifierOptions struct {
+	MaxTimestampAge time.Duration
+	MaxFutureSkew   time.Duration
+	LeaseCacheTTL   time.Duration
+	ChainID         string
+	Now             func() time.Time
+}
+
+type Verifier struct {
+	nonceStore      NonceStore
+	chainQuery      ChainQuerier
+	maxAge          time.Duration
+	maxFutureSkew   time.Duration
+	now             func() time.Time
+	leaseOwnerCache *LeaseOwnerCache
+	chainID         string
+}
+
+func NewVerifier(nonceStore NonceStore, chainQuery ChainQuerier, opts VerifierOptions) *Verifier {
+	if nonceStore == nil {
+		nonceStore = NewInMemoryNonceStore()
+	}
+	nowFn := opts.Now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	maxAge := opts.MaxTimestampAge
+	if maxAge == 0 {
+		maxAge = 5 * time.Minute
+	}
+	maxFuture := opts.MaxFutureSkew
+	if maxFuture == 0 {
+		maxFuture = time.Minute
+	}
+	cache := NewLeaseOwnerCache(opts.LeaseCacheTTL)
+	return &Verifier{
+		nonceStore:      nonceStore,
+		chainQuery:      chainQuery,
+		maxAge:          maxAge,
+		maxFutureSkew:   maxFuture,
+		now:             nowFn,
+		leaseOwnerCache: cache,
+		chainID:         opts.ChainID,
+	}
+}
+
+func HasWalletHeaders(r *http.Request) bool {
+	return headerOrQuery(r, HeaderAddress, QueryAddress) != "" ||
+		headerOrQuery(r, HeaderSignature, QuerySignature) != "" ||
+		headerOrQuery(r, HeaderPubKey, QueryPubKey) != ""
+}
+
+func (v *Verifier) Verify(r *http.Request) (*SignedRequest, error) {
+	address := headerOrQuery(r, HeaderAddress, QueryAddress)
+	timestampStr := headerOrQuery(r, HeaderTimestamp, QueryTimestamp)
+	nonce := headerOrQuery(r, HeaderNonce, QueryNonce)
+	signatureB64 := headerOrQuery(r, HeaderSignature, QuerySignature)
+	pubKeyB64 := headerOrQuery(r, HeaderPubKey, QueryPubKey)
+
+	if address == "" || timestampStr == "" || nonce == "" || signatureB64 == "" || pubKeyB64 == "" {
+		return nil, errors.New("missing authentication headers")
+	}
+
+	timestampMs, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid timestamp: %w", err)
+	}
+	timestamp := time.UnixMilli(timestampMs)
+
+	now := v.now()
+	if timestamp.Before(now.Add(-v.maxAge)) {
+		return nil, errors.New("request timestamp too old")
+	}
+	if timestamp.After(now.Add(v.maxFutureSkew)) {
+		return nil, errors.New("request timestamp in future")
+	}
+
+	if v.nonceStore.HasSeen(nonce) {
+		return nil, errors.New("nonce already used")
+	}
+
+	signature, err := base64.StdEncoding.DecodeString(signatureB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signature encoding: %w", err)
+	}
+
+	pubKeyBytes, err := base64.StdEncoding.DecodeString(pubKeyB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key encoding: %w", err)
+	}
+	pubKey := &secp256k1.PubKey{Key: pubKeyBytes}
+
+	derivedAddr := sdk.AccAddress(pubKey.Address()).String()
+	if derivedAddr != address {
+		return nil, errors.New("address does not match public key")
+	}
+
+	bodyHash, err := computeBodyHash(r)
+	if err != nil {
+		return nil, err
+	}
+
+	requestData := RequestData{
+		Method:    strings.ToUpper(r.Method),
+		Path:      r.URL.Path,
+		Timestamp: timestampMs,
+		Nonce:     nonce,
+		BodyHash:  bodyHash,
+	}
+
+	requestJSON, err := serializeRequestData(requestData)
+	if err != nil {
+		return nil, err
+	}
+	dataBase64 := base64.StdEncoding.EncodeToString([]byte(requestJSON))
+	if v.chainID == "" {
+		return nil, errors.New("chain id not configured")
+	}
+	signDocBytes, err := buildADR036SignDocBytes(v.chainID, address, dataBase64)
+	if err != nil {
+		return nil, err
+	}
+
+	if !pubKey.VerifySignature(signDocBytes, signature) {
+		return nil, errors.New("signature verification failed")
+	}
+
+	v.nonceStore.MarkSeen(nonce, timestamp.Add(v.maxAge))
+
+	return &SignedRequest{
+		Address:   address,
+		Timestamp: timestamp,
+		Nonce:     nonce,
+		Signature: signature,
+		PubKey:    pubKey,
+		Request:   requestData,
+	}, nil
+}
+
+func (v *Verifier) VerifyLeaseOwnership(ctx context.Context, address string, leaseID string) error {
+	if address == "" {
+		return errors.New("missing signer address")
+	}
+	if v.chainQuery == nil {
+		return errors.New("chain query not configured")
+	}
+	if cachedOwner, ok := v.leaseOwnerCache.Get(leaseID); ok {
+		if cachedOwner != address {
+			return errors.New("address does not own this lease")
+		}
+		return nil
+	}
+
+	parsed, err := parseLeaseID(leaseID)
+	if err != nil {
+		return err
+	}
+	lease, err := v.chainQuery.GetLease(ctx, parsed)
+	if err != nil {
+		return fmt.Errorf("failed to query lease: %w", err)
+	}
+
+	owner := lease.ID.Owner
+	if owner == "" {
+		return errors.New("lease owner not found")
+	}
+
+	v.leaseOwnerCache.Set(leaseID, owner)
+
+	if owner != address {
+		return errors.New("address does not own this lease")
+	}
+	return nil
+}
+
+func computeBodyHash(r *http.Request) (string, error) {
+	if r.Body == nil {
+		return "", nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read body: %w", err)
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	if len(body) == 0 {
+		return "", nil
+	}
+	hash := sha256.Sum256(body)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+func serializeRequestData(data RequestData) (string, error) {
+	method, err := quoteJSONString(data.Method)
+	if err != nil {
+		return "", err
+	}
+	path, err := quoteJSONString(data.Path)
+	if err != nil {
+		return "", err
+	}
+	nonce, err := quoteJSONString(data.Nonce)
+	if err != nil {
+		return "", err
+	}
+	bodyHash, err := quoteJSONString(data.BodyHash)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("{\"method\":%s,\"path\":%s,\"timestamp\":%d,\"nonce\":%s,\"body_hash\":%s}",
+		method,
+		path,
+		data.Timestamp,
+		nonce,
+		bodyHash,
+	), nil
+}
+
+func buildADR036SignDocBytes(chainID, address, dataBase64 string) ([]byte, error) {
+	signDoc := map[string]any{
+		"account_number": "0",
+		"chain_id":       chainID,
+		"fee": map[string]any{
+			"amount": []any{},
+			"gas":    "0",
+		},
+		"memo": "",
+		"msgs": []any{
+			map[string]any{
+				"type": "sign/MsgSignData",
+				"value": map[string]any{
+					"data":   dataBase64,
+					"signer": address,
+				},
+			},
+		},
+		"sequence": "0",
+	}
+
+	return canonicalJSON(signDoc)
+}
+
+func headerOrQuery(r *http.Request, header, query string) string {
+	value := r.Header.Get(header)
+	if value == "" {
+		value = r.URL.Query().Get(query)
+	}
+	return value
+}

--- a/pkg/provider_daemon/auth/cosmos_verify_test.go
+++ b/pkg/provider_daemon/auth/cosmos_verify_test.go
@@ -1,0 +1,178 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	marketv1 "github.com/virtengine/virtengine/sdk/go/node/market/v1"
+)
+
+type mockChainQuerier struct {
+	lease marketv1.Lease
+	err   error
+}
+
+func (m mockChainQuerier) GetLease(ctx context.Context, leaseID marketv1.LeaseID) (marketv1.Lease, error) {
+	return m.lease, m.err
+}
+
+func TestVerifyWalletSignature(t *testing.T) {
+	nonceStore := NewInMemoryNonceStore()
+	now := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
+	chainID := "virtengine-1"
+
+	verifier := NewVerifier(nonceStore, nil, VerifierOptions{
+		ChainID: chainID,
+		Now:     func() time.Time { return now },
+	})
+
+	privKey := secp256k1.GenPrivKey()
+	pubKey := privKey.PubKey().(*secp256k1.PubKey)
+	address := sdk.AccAddress(pubKey.Address()).String()
+
+	body := []byte(`{"action":"start"}`)
+	hash := sha256.Sum256(body)
+	bodyHash := hex.EncodeToString(hash[:])
+	timestamp := now.UnixMilli()
+
+	requestData := RequestData{
+		Method:    "POST",
+		Path:      "/api/v1/deployments/owner/1/1/1/provider/actions",
+		Timestamp: timestamp,
+		Nonce:     "deadbeefcafefeed",
+		BodyHash:  bodyHash,
+	}
+
+	requestJSON, err := serializeRequestData(requestData)
+	if err != nil {
+		t.Fatalf("serialize request: %v", err)
+	}
+	dataBase64 := base64.StdEncoding.EncodeToString([]byte(requestJSON))
+	signDocBytes, err := buildADR036SignDocBytes(chainID, address, dataBase64)
+	if err != nil {
+		t.Fatalf("build sign doc: %v", err)
+	}
+
+	signature, err := privKey.Sign(signDocBytes)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://provider.example.com/api/v1/deployments/owner/1/1/1/provider/actions", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set(HeaderAddress, address)
+	req.Header.Set(HeaderTimestamp, strconvFormatInt(timestamp))
+	req.Header.Set(HeaderNonce, requestData.Nonce)
+	req.Header.Set(HeaderSignature, base64.StdEncoding.EncodeToString(signature))
+	req.Header.Set(HeaderPubKey, base64.StdEncoding.EncodeToString(pubKey.Bytes()))
+
+	signed, err := verifier.Verify(req)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if signed.Address != address {
+		t.Fatalf("expected address %s got %s", address, signed.Address)
+	}
+}
+
+func TestVerifyRejectsReplay(t *testing.T) {
+	nonceStore := NewInMemoryNonceStore()
+	now := time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC)
+	chainID := "virtengine-1"
+	verifier := NewVerifier(nonceStore, nil, VerifierOptions{
+		ChainID: chainID,
+		Now:     func() time.Time { return now },
+	})
+
+	privKey := secp256k1.GenPrivKey()
+	pubKey := privKey.PubKey().(*secp256k1.PubKey)
+	address := sdk.AccAddress(pubKey.Address()).String()
+	timestamp := now.UnixMilli()
+
+	requestData := RequestData{
+		Method:    "GET",
+		Path:      "/api/v1/deployments/owner/1/1/1/provider/logs",
+		Timestamp: timestamp,
+		Nonce:     "replaynonce",
+		BodyHash:  "",
+	}
+
+	requestJSON, err := serializeRequestData(requestData)
+	if err != nil {
+		t.Fatalf("serialize request: %v", err)
+	}
+	dataBase64 := base64.StdEncoding.EncodeToString([]byte(requestJSON))
+	signDocBytes, err := buildADR036SignDocBytes(chainID, address, dataBase64)
+	if err != nil {
+		t.Fatalf("build sign doc: %v", err)
+	}
+
+	signature, err := privKey.Sign(signDocBytes)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	makeRequest := func() *http.Request {
+		req, err := http.NewRequest(http.MethodGet, "https://provider.example.com/api/v1/deployments/owner/1/1/1/provider/logs", nil)
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		req.Header.Set(HeaderAddress, address)
+		req.Header.Set(HeaderTimestamp, strconvFormatInt(timestamp))
+		req.Header.Set(HeaderNonce, requestData.Nonce)
+		req.Header.Set(HeaderSignature, base64.StdEncoding.EncodeToString(signature))
+		req.Header.Set(HeaderPubKey, base64.StdEncoding.EncodeToString(pubKey.Bytes()))
+		return req
+	}
+
+	if _, err := verifier.Verify(makeRequest()); err != nil {
+		t.Fatalf("first verify failed: %v", err)
+	}
+	if _, err := verifier.Verify(makeRequest()); err == nil {
+		t.Fatalf("expected replay to fail")
+	}
+}
+
+func TestVerifyLeaseOwnership(t *testing.T) {
+	ownerKey := secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey)
+	providerKey := secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey)
+	otherKey := secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey)
+	owner := sdk.AccAddress(ownerKey.Address()).String()
+	provider := sdk.AccAddress(providerKey.Address()).String()
+	other := sdk.AccAddress(otherKey.Address()).String()
+	lease := marketv1.Lease{
+		ID: marketv1.LeaseID{
+			Owner:    owner,
+			DSeq:     1,
+			GSeq:     1,
+			OSeq:     1,
+			Provider: provider,
+		},
+	}
+	querier := mockChainQuerier{lease: lease}
+	verifier := NewVerifier(NewInMemoryNonceStore(), querier, VerifierOptions{
+		ChainID: "virtengine-1",
+	})
+
+	if err := verifier.VerifyLeaseOwnership(context.Background(), owner, fmt.Sprintf("lease/%s/1/1/1/%s", owner, provider)); err != nil {
+		t.Fatalf("expected ownership ok: %v", err)
+	}
+	if err := verifier.VerifyLeaseOwnership(context.Background(), other, fmt.Sprintf("%s/1/1/1/%s", owner, provider)); err == nil {
+		t.Fatalf("expected ownership mismatch")
+	}
+}
+
+func strconvFormatInt(value int64) string {
+	return fmt.Sprintf("%d", value)
+}

--- a/pkg/provider_daemon/auth/nonce_store.go
+++ b/pkg/provider_daemon/auth/nonce_store.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+// NonceStore tracks used nonces to prevent replay attacks.
+type NonceStore interface {
+	HasSeen(nonce string) bool
+	MarkSeen(nonce string, expiry time.Time)
+}
+
+// InMemoryNonceStore keeps nonces in memory with expirations.
+type InMemoryNonceStore struct {
+	mu     sync.RWMutex
+	nonces map[string]time.Time
+}
+
+func NewInMemoryNonceStore() *InMemoryNonceStore {
+	store := &InMemoryNonceStore{
+		nonces: make(map[string]time.Time),
+	}
+	go store.cleanup()
+	return store
+}
+
+func (s *InMemoryNonceStore) HasSeen(nonce string) bool {
+	if nonce == "" {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	expiry, exists := s.nonces[nonce]
+	if !exists {
+		return false
+	}
+	if time.Now().After(expiry) {
+		delete(s.nonces, nonce)
+		return false
+	}
+	return true
+}
+
+func (s *InMemoryNonceStore) MarkSeen(nonce string, expiry time.Time) {
+	if nonce == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nonces[nonce] = expiry
+}
+
+func (s *InMemoryNonceStore) cleanup() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		now := time.Now()
+		s.mu.Lock()
+		for nonce, expiry := range s.nonces {
+			if now.After(expiry) {
+				delete(s.nonces, nonce)
+			}
+		}
+		s.mu.Unlock()
+	}
+}

--- a/portal/tests/unit/hpc/components.test.tsx
+++ b/portal/tests/unit/hpc/components.test.tsx
@@ -209,7 +209,8 @@ describe('TemplateBrowser', () => {
 
   it('renders category filters', async () => {
     render(<TemplateBrowser />);
-    expect(await screen.findByText('All')).toBeInTheDocument();
+    await screen.findByText('PyTorch Training');
+    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Machine Learning' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Scientific Computing' })).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary\n- implement wallet-signed request verification + nonce store + lease ownership lookup in provider daemon\n- wire portal API auth to accept wallet-signed requests (HTTP + WS) with chain query config\n- align client-side request body hashing + add tests for auth + fix portal test selector\n\n## Testing\n- go test ./pkg/provider_daemon/auth -count=1\n- go test ./pkg/provider_daemon/... -count=1\n- go build ./...\n- pnpm -C portal lint\n- pnpm -C portal type-check\n- pnpm -C portal test\n- pnpm -C lib/portal test