### PR TITLE
feat(observability): production metrics dashboards

### DIFF
--- a/deploy/monitoring/alertmanager/alertmanager.yaml
+++ b/deploy/monitoring/alertmanager/alertmanager.yaml
@@ -147,6 +147,14 @@ receivers:
     # pagerduty_configs:
     #   - service_key: '{{ PAGERDUTY_SERVICE_KEY }}'
     #     severity: critical
+    # Uncomment for Opsgenie integration
+    # opsgenie_configs:
+    #   - api_key: '{{ OPSGENIE_API_KEY }}'
+    #     api_url: 'https://api.opsgenie.com/'
+    #     responders:
+    #       - name: 'virtengine-oncall'
+    #         type: team
+    #     send_resolved: true
     # Uncomment for Slack integration
     # slack_configs:
     #   - channel: '#alerts-critical'

--- a/deploy/monitoring/grafana/dashboards/business-metrics.json
+++ b/deploy/monitoring/grafana/dashboards/business-metrics.json
@@ -1,0 +1,134 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Business KPIs and revenue metrics",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["virtengine"],
+      "targetBlank": false,
+      "title": "VirtEngine Dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "targets": [
+        { "expr": "count(increase(virtengine_user_transactions_total[1d]) > 0)", "legendFormat": "DAU", "refId": "A" }
+      ],
+      "title": "Daily Active Users",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "id": 2,
+      "targets": [
+        { "expr": "sum by (tier) (virtengine_veid_verified_total)", "legendFormat": "Tier {{tier}}", "refId": "A" }
+      ],
+      "title": "VEID Verifications by Tier",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" },
+      "targets": [
+        { "expr": "increase(virtengine_veid_verified_total[24h])", "refId": "A" }
+      ],
+      "title": "New Verifications (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 4,
+      "targets": [
+        { "expr": "sum(increase(virtengine_market_orders_created[1d]))", "legendFormat": "Orders Created", "refId": "A" },
+        { "expr": "sum(increase(virtengine_market_orders_matched[1d]))", "legendFormat": "Orders Matched", "refId": "B" }
+      ],
+      "title": "Order Volume",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD", "decimals": 2 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" },
+      "targets": [
+        { "expr": "sum(virtengine_escrow_balance_total)", "legendFormat": "TVL", "refId": "A" }
+      ],
+      "title": "Total Value Locked",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 6,
+      "targets": [
+        { "expr": "sum(increase(virtengine_escrow_settlements_total[1d]))", "legendFormat": "Daily Settlements", "refId": "A" }
+      ],
+      "title": "Revenue (Settlements)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["virtengine", "business"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Business Metrics",
+  "uid": "business-metrics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/monitoring/grafana/dashboards/infrastructure-overview.json
+++ b/deploy/monitoring/grafana/dashboards/infrastructure-overview.json
@@ -1,0 +1,182 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Infrastructure and Kubernetes overview",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["virtengine"],
+      "targetBlank": false,
+      "title": "VirtEngine Dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" },
+      "targets": [
+        { "expr": "count(kube_node_status_condition{condition=\"Ready\",status=\"true\"})", "refId": "A" }
+      ],
+      "title": "Ready Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "(1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m]))) * 100",
+          "legendFormat": "Cluster CPU",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "(1 - avg(node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100",
+          "legendFormat": "Cluster Memory",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "targets": [
+        { "expr": "sum(kube_pod_status_phase{phase=\"Running\"})", "refId": "A" }
+      ],
+      "title": "Running Pods",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 4 },
+      "id": 5,
+      "targets": [
+        { "expr": "sum by (phase) (kube_pod_status_phase)", "legendFormat": "{{phase}}", "refId": "A" }
+      ],
+      "title": "Pods by Phase",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 4 },
+      "id": 6,
+      "targets": [
+        { "expr": "sum(rate(kube_pod_container_status_restarts_total[5m]))", "legendFormat": "Restarts/s", "refId": "A" }
+      ],
+      "title": "Pod Restarts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 4 },
+      "id": 7,
+      "targets": [
+        { "expr": "sum(rate(node_network_receive_bytes_total[5m]))", "legendFormat": "RX", "refId": "A" },
+        { "expr": "sum(rate(node_network_transmit_bytes_total[5m]))", "legendFormat": "TX", "refId": "B" }
+      ],
+      "title": "Network I/O",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(apiserver_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "API Server P95",
+          "refId": "A"
+        }
+      ],
+      "title": "Control Plane Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "id": 9,
+      "targets": [
+        {
+          "expr": "(1 - (sum(node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\"}) / sum(node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\"}))) * 100",
+          "legendFormat": "Disk Used",
+          "refId": "A"
+        }
+      ],
+      "title": "Storage Utilization",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["virtengine", "infrastructure"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Infrastructure Overview",
+  "uid": "infrastructure-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/monitoring/grafana/dashboards/market-module.json
+++ b/deploy/monitoring/grafana/dashboards/market-module.json
@@ -1,0 +1,141 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Market module metrics",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["virtengine"],
+      "targetBlank": false,
+      "title": "VirtEngine Dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "targets": [
+        { "expr": "rate(virtengine_market_orders_created_total[5m])", "legendFormat": "Orders Created", "refId": "A" },
+        { "expr": "rate(virtengine_market_orders_matched_total[5m])", "legendFormat": "Orders Matched", "refId": "B" }
+      ],
+      "title": "Order Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true },
+      "targets": [
+        {
+          "expr": "rate(virtengine_market_orders_matched_total[5m]) / rate(virtengine_market_orders_created_total[5m]) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Order Matching Success Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" },
+      "targets": [
+        { "expr": "sum(virtengine_market_leases_active)", "legendFormat": "Active Leases", "refId": "A" }
+      ],
+      "title": "Active Leases",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "rate(virtengine_market_bids_won_total[5m]) / rate(virtengine_market_bids_total[5m]) * 100",
+          "legendFormat": "Bid Success",
+          "refId": "A"
+        }
+      ],
+      "title": "Bid Success Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 5,
+      "targets": [
+        { "expr": "sum(rate(virtengine_market_order_value_total[5m]))", "legendFormat": "Order Value", "refId": "A" }
+      ],
+      "title": "Order Value (USD)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 6,
+      "targets": [
+        { "expr": "sum(increase(virtengine_escrow_settlements_total[1d]))", "legendFormat": "Settlements", "refId": "A" }
+      ],
+      "title": "Settlement Volume",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["virtengine", "market"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Market Module",
+  "uid": "market-module",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/monitoring/grafana/dashboards/ml-inference.json
+++ b/deploy/monitoring/grafana/dashboards/ml-inference.json
@@ -1,0 +1,149 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "ML inference service metrics",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["virtengine"],
+      "targetBlank": false,
+      "title": "VirtEngine Dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "targets": [
+        { "expr": "rate(virtengine_ml_inference_requests_total[5m])", "legendFormat": "Requests", "refId": "A" }
+      ],
+      "title": "Inference Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(virtengine_ml_inference_seconds_bucket[5m]))",
+          "legendFormat": "P95",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, rate(virtengine_ml_inference_seconds_bucket[5m]))",
+          "legendFormat": "Median",
+          "refId": "B"
+        }
+      ],
+      "title": "Inference Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true },
+      "targets": [
+        {
+          "expr": "rate(virtengine_ml_inference_errors_total[5m]) / rate(virtengine_ml_inference_requests_total[5m]) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Inference Error Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
+      "id": 4,
+      "targets": [
+        { "expr": "rate(virtengine_ml_inference_timeout_total[5m])", "legendFormat": "Timeouts", "refId": "A" }
+      ],
+      "title": "Inference Timeouts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" },
+      "targets": [
+        { "expr": "virtengine_ml_inference_queue_depth", "refId": "A" }
+      ],
+      "title": "Queue Depth",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(virtengine_ml_model_load_seconds_bucket[5m]))",
+          "legendFormat": "P95",
+          "refId": "A"
+        }
+      ],
+      "title": "Model Load Latency",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["virtengine", "ml"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ML Inference",
+  "uid": "ml-inference",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/monitoring/grafana/dashboards/provider-daemon.json
+++ b/deploy/monitoring/grafana/dashboards/provider-daemon.json
@@ -1,0 +1,145 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Provider daemon production metrics",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["virtengine"],
+      "targetBlank": false,
+      "title": "VirtEngine Dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" },
+      "targets": [
+        { "expr": "sum(virtengine_provider_status{status=\"active\"})", "refId": "A" }
+      ],
+      "title": "Active Providers",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": { "orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true },
+      "targets": [
+        {
+          "expr": "sum(rate(virtengine_provider_bids_won[1h])) / sum(rate(virtengine_provider_bids_total[1h])) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Bid Success Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "targets": [
+        { "expr": "sum by (state) (virtengine_provider_workloads)", "legendFormat": "{{state}}", "refId": "A" }
+      ],
+      "title": "Workload Status",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": { "unit": "percentunit", "max": 1, "min": 0 },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 4,
+      "targets": [
+        { "expr": "avg(virtengine_provider_cpu_utilization)", "legendFormat": "Average", "refId": "A" },
+        { "expr": "max(virtengine_provider_cpu_utilization)", "legendFormat": "Peak", "refId": "B" }
+      ],
+      "title": "Resource Utilization - CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 5,
+      "targets": [
+        { "expr": "avg(virtengine_provider_memory_utilization)", "legendFormat": "Average", "refId": "A" }
+      ],
+      "title": "Resource Utilization - Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "sum(increase(virtengine_provider_lease_operation_seconds_bucket[5m])) by (le, operation)",
+          "format": "heatmap",
+          "legendFormat": "{{operation}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lease Operations Latency",
+      "type": "heatmap"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["virtengine", "provider"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Provider Daemon",
+  "uid": "provider-daemon",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/monitoring/grafana/dashboards/veid-module.json
+++ b/deploy/monitoring/grafana/dashboards/veid-module.json
@@ -1,0 +1,151 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "VEID module operational metrics",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["virtengine"],
+      "targetBlank": false,
+      "title": "VirtEngine Dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "targets": [
+        { "expr": "rate(virtengine_veid_submissions_total[5m])", "legendFormat": "Submissions", "refId": "A" },
+        { "expr": "rate(virtengine_veid_verifications_total[5m])", "legendFormat": "Verifications", "refId": "B" }
+      ],
+      "title": "VEID Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "percent", "min": 0, "max": 100 }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true },
+      "targets": [
+        {
+          "expr": "rate(virtengine_veid_verifications_total[5m]) / rate(virtengine_veid_submissions_total[5m]) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Verification Success Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" },
+      "targets": [
+        { "expr": "virtengine_veid_pending_verifications", "refId": "A" }
+      ],
+      "title": "Pending Verifications",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(virtengine_veid_verification_seconds_bucket[5m]))",
+          "legendFormat": "P95",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, rate(virtengine_veid_verification_seconds_bucket[5m]))",
+          "legendFormat": "Median",
+          "refId": "B"
+        }
+      ],
+      "title": "Verification Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "sum by (status) (increase(virtengine_veid_verifications_total[1h]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Verification Outcomes (1h)",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "id": 6,
+      "targets": [
+        { "expr": "avg(virtengine_veid_score)", "legendFormat": "Average Score", "refId": "A" },
+        { "expr": "quantile_over_time(0.9, virtengine_veid_score[1h])", "legendFormat": "P90 Score", "refId": "B" }
+      ],
+      "title": "VEID Scoring",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["virtengine", "veid"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "VEID Module",
+  "uid": "veid-module",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/monitoring/grafana/dashboards/virtengine-overview.json
+++ b/deploy/monitoring/grafana/dashboards/virtengine-overview.json
@@ -1,0 +1,239 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "VirtEngine production overview dashboard",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["virtengine"],
+      "targetBlank": false,
+      "title": "VirtEngine Dashboards",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" },
+      "targets": [
+        { "expr": "cometbft_consensus_height", "legendFormat": "Block Height", "refId": "A" }
+      ],
+      "title": "Network Status",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 20 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "auto" },
+      "targets": [
+        { "expr": "max(virtengine_chain_block_height - virtengine_state_sync_height)", "legendFormat": "Lag (blocks)", "refId": "A" }
+      ],
+      "title": "Sync Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "green", "value": 80 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": { "orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true },
+      "targets": [
+        {
+          "expr": "cometbft_consensus_validators_power / cometbft_consensus_total_voting_power * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Validators",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" },
+      "targets": [
+        { "expr": "cometbft_p2p_peers", "legendFormat": "Peers", "refId": "A" }
+      ],
+      "title": "Peer Count",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 20 },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 5,
+      "targets": [
+        { "expr": "rate(cometbft_consensus_total_txs[5m])", "legendFormat": "TPS", "refId": "A" }
+      ],
+      "title": "Transaction Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, rate(cometbft_consensus_block_interval_seconds_bucket[5m]))",
+          "legendFormat": "P99",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, rate(cometbft_consensus_block_interval_seconds_bucket[5m]))",
+          "legendFormat": "Median",
+          "refId": "B"
+        }
+      ],
+      "title": "Block Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 12 },
+      "id": 7,
+      "targets": [
+        { "expr": "rate(virtengine_veid_submissions_total[1h])", "legendFormat": "Submissions/hr", "refId": "A" },
+        { "expr": "rate(virtengine_veid_verifications_total[1h])", "legendFormat": "Verifications/hr", "refId": "B" }
+      ],
+      "title": "VEID Activity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 12 },
+      "id": 8,
+      "targets": [
+        { "expr": "sum(virtengine_market_orders_active)", "legendFormat": "Active Orders", "refId": "A" },
+        { "expr": "sum(virtengine_market_leases_active)", "legendFormat": "Active Leases", "refId": "B" }
+      ],
+      "title": "Market Orders",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 12 },
+      "id": 9,
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "auto" },
+      "targets": [
+        { "expr": "sum(virtengine_escrow_balance_total)", "legendFormat": "Total Escrow", "refId": "A" }
+      ],
+      "title": "Escrow Balance",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["virtengine", "overview"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "VirtEngine Overview",
+  "uid": "virtengine-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/monitoring/prometheus/rules/virtengine_alerts.yaml
+++ b/deploy/monitoring/prometheus/rules/virtengine_alerts.yaml
@@ -1,0 +1,139 @@
+# VirtEngine Production Alert Rules
+# MONITOR-31J: Critical, warning, and business alerts
+
+groups:
+  - name: virtengine.critical
+    interval: 30s
+    rules:
+      - alert: ConsensusStalled
+        expr: increase(cometbft_consensus_height[5m]) == 0
+        for: 5m
+        labels:
+          severity: critical
+          tier: tier0
+          service: virtengine-node
+        annotations:
+          summary: "Consensus has stalled - no new blocks in 5 minutes"
+          description: "No new blocks have been produced in the last 5 minutes. Consensus may be stalled."
+          runbook_url: "https://docs.virtengine.io/runbooks/consensus-stalled"
+          dashboard_url: "http://grafana:3000/d/virtengine-overview"
+
+      - alert: ValidatorDown
+        expr: count(cometbft_consensus_validator_ready == 1) < (count(cometbft_consensus_validator_ready) * 0.67)
+        for: 2m
+        labels:
+          severity: critical
+          tier: tier0
+          service: virtengine-node
+        annotations:
+          summary: "More than 1/3 of validators are down"
+          description: "Validator readiness has dropped below 67% of total voting power."
+          runbook_url: "https://docs.virtengine.io/runbooks/validator-down"
+          dashboard_url: "http://grafana:3000/d/chain-health"
+
+      - alert: EscrowBalanceLow
+        expr: virtengine_escrow_balance_total < 1000000000
+        for: 10m
+        labels:
+          severity: critical
+          tier: tier1
+          service: escrow
+        annotations:
+          summary: "Escrow balance critically low"
+          description: "Escrow balance is below 1000 tokens (minor units)."
+          runbook_url: "https://docs.virtengine.io/runbooks/escrow-balance-low"
+          dashboard_url: "http://grafana:3000/d/business-metrics"
+
+  - name: virtengine.warning
+    interval: 1m
+    rules:
+      - alert: HighTransactionLatency
+        expr: histogram_quantile(0.99, rate(virtengine_tx_latency_seconds_bucket[5m])) > 5
+        for: 10m
+        labels:
+          severity: warning
+          tier: tier0
+          service: virtengine-node
+        annotations:
+          summary: "P99 transaction latency exceeds 5 seconds"
+          description: "Transaction latency P99 has exceeded 5 seconds for 10 minutes."
+          runbook_url: "https://docs.virtengine.io/runbooks/high-transaction-latency"
+          dashboard_url: "http://grafana:3000/d/virtengine-overview"
+
+      - alert: VEIDVerificationQueue
+        expr: virtengine_veid_pending_verifications > 100
+        for: 15m
+        labels:
+          severity: warning
+          tier: tier1
+          service: veid
+        annotations:
+          summary: "VEID verification queue backlog"
+          description: "Pending VEID verifications exceed 100 for 15 minutes."
+          runbook_url: "https://docs.virtengine.io/runbooks/veid-queue-backlog"
+          dashboard_url: "http://grafana:3000/d/veid-module"
+
+      - alert: ProviderHighFailureRate
+        expr: rate(virtengine_provider_workload_failures[1h]) / rate(virtengine_provider_workload_starts[1h]) > 0.1
+        for: 15m
+        labels:
+          severity: warning
+          tier: tier1
+          service: provider-daemon
+        annotations:
+          summary: "Provider experiencing high workload failure rate (>10%)"
+          description: "Provider workload failure rate has exceeded 10% for 15 minutes."
+          runbook_url: "https://docs.virtengine.io/runbooks/provider-failure-rate"
+          dashboard_url: "http://grafana:3000/d/provider-daemon"
+
+      - alert: MLInferenceTimeout
+        expr: rate(virtengine_ml_inference_timeout_total[5m]) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+          tier: tier1
+          service: ml-inference
+        annotations:
+          summary: "ML inference timeouts detected"
+          description: "ML inference timeout rate is above 0.01/sec."
+          runbook_url: "https://docs.virtengine.io/runbooks/ml-inference-timeout"
+          dashboard_url: "http://grafana:3000/d/ml-inference"
+
+  - name: virtengine.business
+    interval: 5m
+    rules:
+      - alert: SLOVEIDResponseTime
+        expr: |
+          (
+            sum(rate(virtengine_veid_submission_seconds_bucket{le="10"}[1h]))
+            / sum(rate(virtengine_veid_submission_seconds_count[1h]))
+          ) < 0.99
+        for: 1h
+        labels:
+          severity: warning
+          slo: veid_response_time
+          service: veid
+          alert_type: slo
+        annotations:
+          summary: "VEID response time SLO at risk (<99% within 10s)"
+          description: "Less than 99% of VEID submissions complete within 10 seconds."
+          runbook_url: "https://docs.virtengine.io/runbooks/veid-slo-response-time"
+          dashboard_url: "http://grafana:3000/d/veid-module"
+
+      - alert: SLOOrderMatchingSuccess
+        expr: |
+          (
+            sum(rate(virtengine_market_orders_matched[24h]))
+            / sum(rate(virtengine_market_orders_created[24h]))
+          ) < 0.95
+        for: 2h
+        labels:
+          severity: warning
+          slo: order_matching
+          service: market
+          alert_type: slo
+        annotations:
+          summary: "Order matching success rate below 95%"
+          description: "Order matching success rate has fallen below 95% for 2 hours."
+          runbook_url: "https://docs.virtengine.io/runbooks/order-matching-slo"
+          dashboard_url: "http://grafana:3000/d/market-module"


### PR DESCRIPTION
## Summary\n- add Grafana dashboards for infra, app, business, and ML metrics\n- add Prometheus alert rules for critical, warning, and SLO signals\n- document Opsgenie integration placeholder in Alertmanager\n\n## Testing\n- python JSON/YAML validation\n- go build ./...\n