### PR TITLE
feat(support): Jira ticketing backend

### DIFF
--- a/pkg/jira/adf.go
+++ b/pkg/jira/adf.go
@@ -1,0 +1,111 @@
+// Package jira provides Jira Service Desk integration for VirtEngine.
+//
+// This file implements Atlassian Document Format (ADF) helpers for Jira API v3.
+package jira
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ADFDocument represents an Atlassian Document Format document.
+type ADFDocument struct {
+	Type    string    `json:"type"`
+	Version int       `json:"version"`
+	Content []ADFNode `json:"content,omitempty"`
+}
+
+// ADFNode represents a node in an ADF document.
+type ADFNode struct {
+	Type    string    `json:"type"`
+	Text    string    `json:"text,omitempty"`
+	Content []ADFNode `json:"content,omitempty"`
+}
+
+// NewADFDocument builds a basic ADF document from plain text.
+func NewADFDocument(text string) *ADFDocument {
+	doc := &ADFDocument{
+		Type:    "doc",
+		Version: 1,
+	}
+	if text == "" {
+		return doc
+	}
+
+	lines := strings.Split(text, "\n")
+	for _, line := range lines {
+		para := ADFNode{Type: "paragraph"}
+		if line != "" {
+			para.Content = []ADFNode{{Type: "text", Text: line}}
+		}
+		doc.Content = append(doc.Content, para)
+	}
+
+	return doc
+}
+
+// PlainText returns a best-effort plain text representation of the document.
+func (d *ADFDocument) PlainText() string {
+	if d == nil {
+		return ""
+	}
+	if len(d.Content) == 0 {
+		return ""
+	}
+
+	lines := make([]string, 0, len(d.Content))
+	for _, node := range d.Content {
+		lines = append(lines, nodePlainText(node))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func nodePlainText(node ADFNode) string {
+	if node.Type == "text" {
+		return node.Text
+	}
+	if node.Type == "hardBreak" {
+		return "\n"
+	}
+	if len(node.Content) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	for _, child := range node.Content {
+		sb.WriteString(nodePlainText(child))
+	}
+	return sb.String()
+}
+
+// UnmarshalJSON supports both Jira ADF objects and legacy string bodies.
+func (d *ADFDocument) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if data[0] == 34 {
+		var text string
+		if err := json.Unmarshal(data, &text); err != nil {
+			return err
+		}
+		*d = *NewADFDocument(text)
+		return nil
+	}
+
+	var alias struct {
+		Type    string    `json:"type"`
+		Version int       `json:"version"`
+		Content []ADFNode `json:"content,omitempty"`
+	}
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*d = ADFDocument(alias)
+	if d.Type == "" {
+		d.Type = "doc"
+	}
+	if d.Version == 0 {
+		d.Version = 1
+	}
+	return nil
+}

--- a/pkg/jira/comment.go
+++ b/pkg/jira/comment.go
@@ -1,0 +1,46 @@
+package jira
+
+// PlainText returns a best-effort plain text representation of the comment body.
+func (c *Comment) PlainText() string {
+	if c == nil || c.Body == nil {
+		return ""
+	}
+	return c.Body.PlainText()
+}
+
+// IsInternal returns true when the comment is marked as internal.
+func (c *Comment) IsInternal() bool {
+	if c == nil {
+		return false
+	}
+	for _, prop := range c.Properties {
+		if prop.Key != "sd.public.comment" {
+			continue
+		}
+		switch value := prop.Value.(type) {
+		case map[string]interface{}:
+			if internal, ok := value["internal"].(bool); ok {
+				return internal
+			}
+		case map[string]bool:
+			if internal, ok := value["internal"]; ok {
+				return internal
+			}
+		}
+	}
+	return false
+}
+
+// NewCommentRequest builds a Jira comment request with optional internal flag.
+func NewCommentRequest(body string, internal bool) *AddCommentRequest {
+	req := &AddCommentRequest{
+		Body: NewADFDocument(body),
+	}
+	if internal {
+		req.Properties = []CommentProperty{{
+			Key:   "sd.public.comment",
+			Value: map[string]bool{"internal": true},
+		}}
+	}
+	return req
+}

--- a/pkg/jira/types.go
+++ b/pkg/jira/types.go
@@ -98,7 +98,7 @@ type IssueFields struct {
 	Summary string `json:"summary"`
 
 	// Description is the issue description
-	Description string `json:"description,omitempty"`
+	Description *ADFDocument `json:"description,omitempty"`
 
 	// IssueType is the type of issue
 	IssueType IssueTypeField `json:"issuetype"`
@@ -193,12 +193,20 @@ type Component struct {
 
 // Comment represents a Jira comment
 type Comment struct {
-	ID      string `json:"id,omitempty"`
-	Self    string `json:"self,omitempty"`
-	Author  *User  `json:"author,omitempty"`
-	Body    string `json:"body"`
-	Created string `json:"created,omitempty"`
-	Updated string `json:"updated,omitempty"`
+	ID      string       `json:"id,omitempty"`
+	Self    string       `json:"self,omitempty"`
+	Author  *User        `json:"author,omitempty"`
+	Body    *ADFDocument `json:"body"`
+	Created string       `json:"created,omitempty"`
+	Updated string       `json:"updated,omitempty"`
+	// Properties contain comment metadata (e.g. internal notes flag).
+	Properties []CommentProperty `json:"properties,omitempty"`
+}
+
+// CommentProperty represents a Jira comment property.
+type CommentProperty struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
 }
 
 // CommentResponse represents a paginated comment response
@@ -239,7 +247,7 @@ type CreateIssueRequest struct {
 type CreateIssueFields struct {
 	Project     Project        `json:"project"`
 	Summary     string         `json:"summary"`
-	Description string         `json:"description,omitempty"`
+	Description *ADFDocument   `json:"description,omitempty"`
 	IssueType   IssueTypeField `json:"issuetype"`
 	Priority    *PriorityField `json:"priority,omitempty"`
 	Assignee    *User          `json:"assignee,omitempty"`
@@ -281,7 +289,28 @@ type TransitionID struct {
 
 // AddCommentRequest represents a request to add a comment
 type AddCommentRequest struct {
-	Body string `json:"body"`
+	Body       *ADFDocument      `json:"body"`
+	Properties []CommentProperty `json:"properties,omitempty"`
+}
+
+// Attachment represents a Jira attachment.
+type Attachment struct {
+	ID        string `json:"id,omitempty"`
+	Self      string `json:"self,omitempty"`
+	Filename  string `json:"filename,omitempty"`
+	Author    *User  `json:"author,omitempty"`
+	Created   string `json:"created,omitempty"`
+	Size      int64  `json:"size,omitempty"`
+	MimeType  string `json:"mimeType,omitempty"`
+	Content   string `json:"content,omitempty"`
+	Thumbnail string `json:"thumbnail,omitempty"`
+}
+
+// AttachmentUploadRequest represents a request to upload an attachment.
+type AttachmentUploadRequest struct {
+	Filename    string
+	ContentType string
+	Data        []byte
 }
 
 // CreateIssueResponse represents the response from creating an issue

--- a/pkg/servicedesk/callbacks.go
+++ b/pkg/servicedesk/callbacks.go
@@ -303,8 +303,9 @@ func (s *CallbackServer) registerJiraHandlers() {
 				ExternalID:      issueKey,
 				OnChainTicketID: ticketID,
 				Changes: map[string]interface{}{
-					"comment_id":   comment.ID,
-					"comment_body": comment.Body, // Note: should be encrypted before storing
+					"comment_id":       comment.ID,
+					"comment_body":     comment.PlainText(), // Note: should be encrypted before storing
+					"comment_internal": comment.IsInternal(),
 				},
 				Timestamp: time.Now(),
 				Nonce:     fmt.Sprintf("jira-comment-%s-%d", comment.ID, time.Now().UnixNano()),


### PR DESCRIPTION
## Summary
- add ADF handling and internal note support for Jira comments
- add Jira attachment upload/download support and API versioning
- allow Jira auth via bearer tokens and propagate internal comment flags

## Testing
- go test ./pkg/jira/... ./pkg/servicedesk/...
- go build ./...