### PR TITLE
feat(api): add wallet-signed request auth

### DIFF
--- a/cmd/provider-daemon/main.go
+++ b/cmd/provider-daemon/main.go
@@ -695,6 +695,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 	portalCfg.ShellSessionTTL = viper.GetDuration(FlagPortalShellSessionTTL)
 	portalCfg.TokenTTL = viper.GetDuration(FlagPortalTokenTTL)
 	portalCfg.AuditLogger = portalAuditLogger
+	portalCfg.ChainID = viper.GetString(FlagChainID)
+	portalCfg.ChainGRPC = viper.GetString(FlagWaldurChainGRPC)
 
 	portalAPI, err := provider_daemon.NewPortalAPIServer(portalCfg)
 	if err != nil {

--- a/lib/portal/__tests__/auth/wallet-sign.test.ts
+++ b/lib/portal/__tests__/auth/wallet-sign.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "crypto";
+import { signRequest } from "../../src/auth/wallet-sign";
+
+const fixedTimestamp = 1_700_000_000_000;
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+describe("signRequest", () => {
+  let randomSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(fixedTimestamp);
+    const getRandomValues = (arr: Uint8Array) => {
+      for (let i = 0; i < arr.length; i += 1) {
+        arr[i] = i;
+      }
+      return arr;
+    };
+    if (globalThis.crypto?.getRandomValues) {
+      randomSpy = vi
+        .spyOn(globalThis.crypto, "getRandomValues")
+        .mockImplementation(getRandomValues);
+    }
+  });
+
+  afterEach(() => {
+    randomSpy?.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it("builds ADR-036 sign doc and headers", async () => {
+    const signer = {
+      signAmino: vi.fn(async (signDoc) => ({
+        signed: signDoc,
+        signature: {
+          pub_key: { type: "tendermint/PubKeySecp256k1", value: "cHVi" },
+          signature: "c2ln",
+        },
+      })),
+    };
+
+    const body = { b: 2, a: 1 };
+    const headers = await signRequest({
+      method: "post",
+      path: "/api/v1/deployments/lease-1/logs",
+      body,
+      signer,
+      address: "cosmos1address",
+      chainId: "virtengine-test",
+    });
+
+    expect(signer.signAmino).toHaveBeenCalledTimes(1);
+    const [signDoc] = signer.signAmino.mock.calls[0];
+
+    const expectedBodyHash = sha256Hex('{"a":1,"b":2}');
+    const expectedNonce = "000102030405060708090a0b0c0d0e0f";
+    const expectedData = JSON.stringify({
+      method: "POST",
+      path: "/api/v1/deployments/lease-1/logs",
+      timestamp: fixedTimestamp,
+      nonce: expectedNonce,
+      body_hash: expectedBodyHash,
+    });
+
+    const signedData = Buffer.from(
+      signDoc.msgs[0].value.data,
+      "base64",
+    ).toString("utf-8");
+    expect(signedData).toBe(expectedData);
+    expect(signDoc.chain_id).toBe("virtengine-test");
+
+    expect(headers["X-VE-Address"]).toBe("cosmos1address");
+    expect(headers["X-VE-Timestamp"]).toBe(String(fixedTimestamp));
+    expect(headers["X-VE-Nonce"]).toBe(expectedNonce);
+    expect(headers["X-VE-Signature"]).toBe("c2ln");
+    expect(headers["X-VE-PubKey"]).toBe("cHVi");
+  });
+});

--- a/lib/portal/src/auth/wallet-sign.ts
+++ b/lib/portal/src/auth/wallet-sign.ts
@@ -43,7 +43,7 @@ interface RequestData {
 const textEncoder = new TextEncoder();
 
 const serializeRequestData = (data: RequestData): string => {
-  return `{"method":"${data.method}","path":"${data.path}","timestamp":${data.timestamp},"nonce":"${data.nonce}","body_hash":"${data.body_hash}"}`;
+  return JSON.stringify(data);
 };
 
 const stableStringify = (value: unknown): string => {

--- a/pkg/provider_daemon/auth/auth_test.go
+++ b/pkg/provider_daemon/auth/auth_test.go
@@ -1,0 +1,127 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	marketv1 "github.com/virtengine/virtengine/sdk/go/node/market/v1"
+)
+
+type stubLeaseQuerier struct {
+	owner string
+}
+
+func (s stubLeaseQuerier) LeaseOwner(_ context.Context, _ marketv1.LeaseID) (string, error) {
+	return s.owner, nil
+}
+
+func TestInMemoryNonceStore(t *testing.T) {
+	store := NewInMemoryNonceStore()
+	nonce := "nonce-1"
+	store.MarkSeen(nonce, time.Now().Add(time.Minute))
+	if !store.HasSeen(nonce) {
+		t.Fatalf("expected nonce to be seen")
+	}
+	store.MarkSeen("expired", time.Now().Add(-time.Minute))
+	if store.HasSeen("expired") {
+		t.Fatalf("expected expired nonce to be cleared")
+	}
+	store.Stop()
+}
+
+func TestVerifySignedRequest(t *testing.T) {
+	privKey := secp256k1.GenPrivKey()
+	address := sdk.AccAddress(privKey.PubKey().Address()).String()
+	chainID := "virtengine-test"
+
+	body := []byte(`{"b":2,"a":1}`)
+	sorted, err := sdk.SortJSON(body)
+	if err != nil {
+		t.Fatalf("failed to sort json: %v", err)
+	}
+	bodyHash := sha256.Sum256(sorted)
+	timestamp := time.Now().UTC()
+	timestampMs := timestamp.UnixMilli()
+
+	requestData := RequestData{
+		Method:    "POST",
+		Path:      "/api/v1/deployments/lease-1/logs",
+		Timestamp: timestampMs,
+		Nonce:     "nonce-abc",
+		BodyHash:  hex.EncodeToString(bodyHash[:]),
+	}
+
+	payload, err := marshalRequestData(requestData)
+	if err != nil {
+		t.Fatalf("failed to marshal request data: %v", err)
+	}
+	payloadB64 := base64.StdEncoding.EncodeToString(payload)
+
+	signBytes, err := buildSignDocBytes(chainID, address, payloadB64, "")
+	if err != nil {
+		t.Fatalf("failed to build sign doc: %v", err)
+	}
+
+	signature, err := privKey.Sign(signBytes)
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "https://provider.example.com/api/v1/deployments/lease-1/logs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(HeaderAddress, address)
+	req.Header.Set(HeaderTimestamp, strconv.FormatInt(timestampMs, 10))
+	req.Header.Set(HeaderNonce, requestData.Nonce)
+	req.Header.Set(HeaderSignature, base64.StdEncoding.EncodeToString(signature))
+	req.Header.Set(HeaderPubKey, base64.StdEncoding.EncodeToString(privKey.PubKey().Bytes()))
+
+	verifier := NewVerifier(VerifierConfig{
+		ChainID:         chainID,
+		NonceStore:      NewInMemoryNonceStore(),
+		MaxTimestampAge: time.Minute * 10,
+	})
+
+	signed, err := verifier.Verify(req)
+	if err != nil {
+		t.Fatalf("expected verification success, got %v", err)
+	}
+	if signed.Address != address {
+		t.Fatalf("expected address %s, got %s", address, signed.Address)
+	}
+
+	// replay should fail
+	reqReplay := httptest.NewRequest("POST", "https://provider.example.com/api/v1/deployments/lease-1/logs", bytes.NewReader(body))
+	reqReplay.Header = req.Header.Clone()
+	if _, err := verifier.Verify(reqReplay); err == nil {
+		t.Fatalf("expected replay to be rejected")
+	}
+}
+
+func TestVerifyLeaseOwnership(t *testing.T) {
+	ownerKey := secp256k1.GenPrivKey()
+	providerKey := secp256k1.GenPrivKey()
+	owner := sdk.AccAddress(ownerKey.PubKey().Address()).String()
+	provider := sdk.AccAddress(providerKey.PubKey().Address()).String()
+
+	verifier := NewVerifier(VerifierConfig{
+		ChainID:      "virtengine-test",
+		LeaseQuerier: stubLeaseQuerier{owner: owner},
+	})
+
+	leaseID := owner + "/1/1/1/" + provider
+	if err := verifier.VerifyLeaseOwnership(context.Background(), owner, leaseID); err != nil {
+		t.Fatalf("expected lease ownership to pass: %v", err)
+	}
+	if err := verifier.VerifyLeaseOwnership(context.Background(), "cosmos1other", leaseID); err == nil {
+		t.Fatalf("expected lease ownership to fail")
+	}
+}

--- a/pkg/provider_daemon/auth/chain_query.go
+++ b/pkg/provider_daemon/auth/chain_query.go
@@ -1,0 +1,164 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/virtengine/virtengine/pkg/observability"
+	marketv1 "github.com/virtengine/virtengine/sdk/go/node/market/v1"
+	marketv1beta5 "github.com/virtengine/virtengine/sdk/go/node/market/v1beta5"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const defaultLeaseCacheTTL = 15 * time.Minute
+
+// LeaseOwnerQuerier provides lease owner lookup.
+type LeaseOwnerQuerier interface {
+	LeaseOwner(ctx context.Context, leaseID marketv1.LeaseID) (string, error)
+}
+
+// LeaseOwnerCache caches lease owner lookups.
+type LeaseOwnerCache struct {
+	mu    sync.RWMutex
+	ttl   time.Duration
+	items map[string]leaseOwnerEntry
+}
+
+type leaseOwnerEntry struct {
+	owner     string
+	expiresAt time.Time
+}
+
+// NewLeaseOwnerCache creates a cache with TTL.
+func NewLeaseOwnerCache(ttl time.Duration) *LeaseOwnerCache {
+	if ttl <= 0 {
+		ttl = defaultLeaseCacheTTL
+	}
+	return &LeaseOwnerCache{
+		ttl:   ttl,
+		items: make(map[string]leaseOwnerEntry),
+	}
+}
+
+func (c *LeaseOwnerCache) Get(leaseID string) (string, bool) {
+	c.mu.RLock()
+	entry, ok := c.items[leaseID]
+	c.mu.RUnlock()
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(entry.expiresAt) {
+		c.mu.Lock()
+		delete(c.items, leaseID)
+		c.mu.Unlock()
+		return "", false
+	}
+	return entry.owner, true
+}
+
+func (c *LeaseOwnerCache) Set(leaseID, owner string) {
+	c.mu.Lock()
+	c.items[leaseID] = leaseOwnerEntry{
+		owner:     owner,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+}
+
+// CachedLeaseOwnerQuerier adds caching to a LeaseOwnerQuerier.
+type CachedLeaseOwnerQuerier struct {
+	base  LeaseOwnerQuerier
+	cache *LeaseOwnerCache
+}
+
+// NewCachedLeaseOwnerQuerier wraps a LeaseOwnerQuerier with cache.
+func NewCachedLeaseOwnerQuerier(base LeaseOwnerQuerier, cache *LeaseOwnerCache) *CachedLeaseOwnerQuerier {
+	if cache == nil {
+		cache = NewLeaseOwnerCache(defaultLeaseCacheTTL)
+	}
+	return &CachedLeaseOwnerQuerier{base: base, cache: cache}
+}
+
+// LeaseOwner returns cached lease owner if available.
+func (c *CachedLeaseOwnerQuerier) LeaseOwner(ctx context.Context, leaseID marketv1.LeaseID) (string, error) {
+	key := leaseID.String()
+	if owner, ok := c.cache.Get(key); ok {
+		return owner, nil
+	}
+	owner, err := c.base.LeaseOwner(ctx, leaseID)
+	if err != nil {
+		return "", err
+	}
+	c.cache.Set(key, owner)
+	return owner, nil
+}
+
+// MarketLeaseQuerier queries chain for lease ownership.
+type MarketLeaseQuerier struct {
+	conn    *grpc.ClientConn
+	client  marketv1beta5.QueryClient
+	timeout time.Duration
+}
+
+// NewMarketLeaseQuerier creates a lease querier using gRPC endpoint.
+func NewMarketLeaseQuerier(grpcEndpoint string, timeout time.Duration) (*MarketLeaseQuerier, error) {
+	if grpcEndpoint == "" {
+		return nil, errors.New("grpc endpoint is required")
+	}
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	conn, err := grpc.NewClient(
+		grpcEndpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithStatsHandler(observability.GRPCClientStatsHandler()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to gRPC endpoint: %w", err)
+	}
+
+	return &MarketLeaseQuerier{
+		conn:    conn,
+		client:  marketv1beta5.NewQueryClient(conn),
+		timeout: timeout,
+	}, nil
+}
+
+// LeaseOwner queries chain for lease owner.
+func (q *MarketLeaseQuerier) LeaseOwner(ctx context.Context, leaseID marketv1.LeaseID) (string, error) {
+	if q.client == nil {
+		return "", errors.New("chain query not configured")
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, q.timeout)
+	defer cancel()
+
+	resp, err := q.client.Lease(reqCtx, &marketv1beta5.QueryLeaseRequest{ID: leaseID})
+	if err != nil {
+		return "", err
+	}
+	return resp.Lease.ID.Owner, nil
+}
+
+// Close closes the gRPC connection.
+func (q *MarketLeaseQuerier) Close() error {
+	if q.conn != nil {
+		return q.conn.Close()
+	}
+	return nil
+}
+
+// ParseLeaseID parses a string lease identifier into a LeaseID.
+func ParseLeaseID(leaseID string) (marketv1.LeaseID, error) {
+	trimmed := strings.Trim(leaseID, "/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) >= 1 && (parts[0] == "lease" || parts[0] == "leases") {
+		parts = parts[1:]
+	}
+	return marketv1.ParseLeasePath(parts)
+}

--- a/pkg/provider_daemon/auth/cosmos_verify.go
+++ b/pkg/provider_daemon/auth/cosmos_verify.go
@@ -1,0 +1,310 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// VerifierConfig configures the request verifier.
+type VerifierConfig struct {
+	ChainID         string
+	NonceStore      NonceStore
+	LeaseQuerier    LeaseOwnerQuerier
+	MaxTimestampAge time.Duration
+	AllowedTimeSkew time.Duration
+}
+
+// Verifier verifies wallet-signed requests.
+type Verifier struct {
+	chainID         string
+	nonceStore      NonceStore
+	leaseQuerier    LeaseOwnerQuerier
+	maxTimestampAge time.Duration
+	allowedSkew     time.Duration
+}
+
+// NewVerifier creates a new verifier instance.
+func NewVerifier(cfg VerifierConfig) *Verifier {
+	maxAge := cfg.MaxTimestampAge
+	if maxAge <= 0 {
+		maxAge = MaxTimestampAge
+	}
+	allowedSkew := cfg.AllowedTimeSkew
+	if allowedSkew <= 0 {
+		allowedSkew = AllowedFutureSkew
+	}
+
+	return &Verifier{
+		chainID:         cfg.ChainID,
+		nonceStore:      cfg.NonceStore,
+		leaseQuerier:    cfg.LeaseQuerier,
+		maxTimestampAge: maxAge,
+		allowedSkew:     allowedSkew,
+	}
+}
+
+// HasSignature returns true if wallet auth headers/query are present.
+func HasSignature(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if r.Header.Get(HeaderAddress) != "" || r.URL.Query().Get(QueryAddress) != "" {
+		return true
+	}
+	if r.Header.Get(HeaderPubKey) != "" || r.URL.Query().Get(QueryPubKey) != "" {
+		return true
+	}
+	return false
+}
+
+// Verify validates a signed request and returns the parsed details.
+func (v *Verifier) Verify(r *http.Request) (*SignedRequest, error) {
+	if r == nil {
+		return nil, errors.New("request is nil")
+	}
+
+	address, timestampStr, nonce, signatureB64, pubKeyB64 := extractAuthFields(r)
+	if address == "" || timestampStr == "" || nonce == "" || signatureB64 == "" || pubKeyB64 == "" {
+		return nil, errors.New("missing authentication headers")
+	}
+
+	timestampVal, timestampTime, err := parseTimestamp(timestampStr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := v.validateTimestamp(timestampTime); err != nil {
+		return nil, err
+	}
+
+	if v.nonceStore != nil && v.nonceStore.HasSeen(nonce) {
+		return nil, errors.New("nonce already used")
+	}
+
+	signature, err := base64.StdEncoding.DecodeString(signatureB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signature encoding: %w", err)
+	}
+
+	pubKeyBytes, err := base64.StdEncoding.DecodeString(pubKeyB64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key encoding: %w", err)
+	}
+	pubKey := &secp256k1.PubKey{Key: pubKeyBytes}
+
+	addrBytes, err := sdk.AccAddressFromBech32(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address: %w", err)
+	}
+	if !bytes.Equal(addrBytes, pubKey.Address()) {
+		return nil, errors.New("address does not match public key")
+	}
+
+	bodyHash, err := readAndHashBody(r)
+	if err != nil {
+		return nil, err
+	}
+
+	requestData := RequestData{
+		Method:    strings.ToUpper(r.Method),
+		Path:      r.URL.Path,
+		Timestamp: timestampVal,
+		Nonce:     nonce,
+		BodyHash:  bodyHash,
+	}
+
+	payload, err := marshalRequestData(requestData)
+	if err != nil {
+		return nil, err
+	}
+	payloadB64 := base64.StdEncoding.EncodeToString(payload)
+
+	signBytes, err := buildSignDocBytes(v.chainID, address, payloadB64, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if !pubKey.VerifySignature(signBytes, signature) {
+		return nil, errors.New("signature verification failed")
+	}
+
+	if v.nonceStore != nil {
+		v.nonceStore.MarkSeen(nonce, timestampTime.Add(v.maxTimestampAge))
+	}
+
+	return &SignedRequest{
+		Address:   address,
+		Timestamp: timestampTime,
+		Nonce:     nonce,
+		Signature: signature,
+		PubKey:    pubKey,
+		BodyHash:  bodyHash,
+	}, nil
+}
+
+// VerifyLeaseOwnership checks if the address owns the lease.
+func (v *Verifier) VerifyLeaseOwnership(ctx context.Context, address string, leaseID string) error {
+	if v.leaseQuerier == nil {
+		return errors.New("lease ownership query not configured")
+	}
+	lease, err := ParseLeaseID(leaseID)
+	if err != nil {
+		return fmt.Errorf("invalid lease id: %w", err)
+	}
+	owner, err := v.leaseQuerier.LeaseOwner(ctx, lease)
+	if err != nil {
+		return fmt.Errorf("failed to query lease: %w", err)
+	}
+	if owner != address {
+		return errors.New("address does not own this lease")
+	}
+	return nil
+}
+
+func extractAuthFields(r *http.Request) (string, string, string, string, string) {
+	address := firstNonEmpty(r.Header.Get(HeaderAddress), r.URL.Query().Get(QueryAddress))
+	timestamp := firstNonEmpty(r.Header.Get(HeaderTimestamp), r.URL.Query().Get(QueryTimestamp))
+	nonce := firstNonEmpty(r.Header.Get(HeaderNonce), r.URL.Query().Get(QueryNonce))
+	signature := firstNonEmpty(r.Header.Get(HeaderSignature), r.URL.Query().Get(QuerySignature))
+	pubKey := firstNonEmpty(r.Header.Get(HeaderPubKey), r.URL.Query().Get(QueryPubKey))
+	return address, timestamp, nonce, signature, pubKey
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func parseTimestamp(raw string) (int64, time.Time, error) {
+	val, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, time.Time{}, fmt.Errorf("invalid timestamp: %w", err)
+	}
+	if val == 0 {
+		return 0, time.Time{}, errors.New("invalid timestamp")
+	}
+	if val < 1_000_000_000_000 {
+		// treat as seconds
+		return val, time.Unix(val, 0), nil
+	}
+	return val, time.UnixMilli(val), nil
+}
+
+func (v *Verifier) validateTimestamp(ts time.Time) error {
+	now := time.Now()
+	if now.Sub(ts) > v.maxTimestampAge {
+		return errors.New("request timestamp too old")
+	}
+	if ts.After(now.Add(v.allowedSkew)) {
+		return errors.New("request timestamp in future")
+	}
+	return nil
+}
+
+func readAndHashBody(r *http.Request) (string, error) {
+	if r.Body == nil {
+		return "", nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read body: %w", err)
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	if len(body) == 0 {
+		return "", nil
+	}
+
+	normalized := body
+	contentType := r.Header.Get("Content-Type")
+	if strings.Contains(contentType, "application/json") {
+		if sorted, err := sdk.SortJSON(body); err == nil {
+			normalized = sorted
+		}
+	}
+
+	hash := sha256.Sum256(normalized)
+	return hex.EncodeToString(hash[:]), nil
+}
+
+func marshalRequestData(data RequestData) ([]byte, error) {
+	return json.Marshal(data)
+}
+
+type aminoFee struct {
+	Gas    string      `json:"gas"`
+	Amount []aminoCoin `json:"amount"`
+}
+
+type aminoCoin struct {
+	Denom  string `json:"denom"`
+	Amount string `json:"amount"`
+}
+
+type aminoMsg struct {
+	Type  string      `json:"type"`
+	Value aminoMsgVal `json:"value"`
+}
+
+type aminoMsgVal struct {
+	Signer string `json:"signer"`
+	Data   string `json:"data"`
+}
+
+type aminoSignDoc struct {
+	ChainID       string     `json:"chain_id"`
+	AccountNumber string     `json:"account_number"`
+	Sequence      string     `json:"sequence"`
+	Fee           aminoFee   `json:"fee"`
+	Msgs          []aminoMsg `json:"msgs"`
+	Memo          string     `json:"memo"`
+}
+
+func buildSignDocBytes(chainID, signer, dataB64, memo string) ([]byte, error) {
+	if chainID == "" {
+		return nil, errors.New("chain id is required")
+	}
+
+	signDoc := aminoSignDoc{
+		ChainID:       chainID,
+		AccountNumber: "0",
+		Sequence:      "0",
+		Fee: aminoFee{
+			Gas:    "0",
+			Amount: []aminoCoin{},
+		},
+		Msgs: []aminoMsg{
+			{
+				Type: "sign/MsgSignData",
+				Value: aminoMsgVal{
+					Signer: signer,
+					Data:   dataB64,
+				},
+			},
+		},
+		Memo: memo,
+	}
+
+	payload, err := json.Marshal(signDoc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal sign doc: %w", err)
+	}
+	return sdk.SortJSON(payload)
+}

--- a/pkg/provider_daemon/auth/middleware.go
+++ b/pkg/provider_daemon/auth/middleware.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+)
+
+type contextKey string
+
+const addressContextKey contextKey = "ve.address"
+
+// WithAddress adds the verified address to context.
+func WithAddress(ctx context.Context, address string) context.Context {
+	return context.WithValue(ctx, addressContextKey, address)
+}
+
+// AddressFromContext retrieves the verified address from context.
+func AddressFromContext(ctx context.Context) (string, bool) {
+	value := ctx.Value(addressContextKey)
+	address, ok := value.(string)
+	return address, ok
+}
+
+// RequireWalletAuth enforces wallet signature verification.
+func RequireWalletAuth(verifier *Verifier, allowInsecure bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if verifier == nil {
+				http.Error(w, "wallet authentication not configured", http.StatusUnauthorized)
+				return
+			}
+			if !HasSignature(r) {
+				if allowInsecure {
+					ctx := WithAddress(r.Context(), "dev")
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+				http.Error(w, "authentication required", http.StatusUnauthorized)
+				return
+			}
+			signed, err := verifier.Verify(r)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusUnauthorized)
+				return
+			}
+			ctx := WithAddress(r.Context(), signed.Address)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// RequireLeaseOwner enforces lease ownership for the request.
+func RequireLeaseOwner(verifier *Verifier, leaseIDFunc func(*http.Request) string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if verifier == nil {
+				http.Error(w, "lease authorization not configured", http.StatusUnauthorized)
+				return
+			}
+			address, ok := AddressFromContext(r.Context())
+			if !ok || address == "" {
+				http.Error(w, "missing authenticated address", http.StatusUnauthorized)
+				return
+			}
+			leaseID := leaseIDFunc(r)
+			if leaseID == "" {
+				http.Error(w, "missing lease id", http.StatusBadRequest)
+				return
+			}
+			if err := verifier.VerifyLeaseOwnership(r.Context(), address, leaseID); err != nil {
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/provider_daemon/auth/nonce_store.go
+++ b/pkg/provider_daemon/auth/nonce_store.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+// NonceStore tracks recently seen nonces.
+type NonceStore interface {
+	HasSeen(nonce string) bool
+	MarkSeen(nonce string, expiry time.Time)
+}
+
+// InMemoryNonceStore tracks nonces in memory with expiry.
+type InMemoryNonceStore struct {
+	mu     sync.RWMutex
+	nonces map[string]time.Time
+	stopCh chan struct{}
+}
+
+// NewInMemoryNonceStore creates a nonce store with cleanup goroutine.
+func NewInMemoryNonceStore() *InMemoryNonceStore {
+	store := &InMemoryNonceStore{
+		nonces: make(map[string]time.Time),
+		stopCh: make(chan struct{}),
+	}
+	go store.cleanupLoop()
+	return store
+}
+
+// HasSeen returns true if the nonce exists and has not expired.
+func (s *InMemoryNonceStore) HasSeen(nonce string) bool {
+	s.mu.RLock()
+	expiry, exists := s.nonces[nonce]
+	s.mu.RUnlock()
+	if !exists {
+		return false
+	}
+	if time.Now().After(expiry) {
+		s.mu.Lock()
+		delete(s.nonces, nonce)
+		s.mu.Unlock()
+		return false
+	}
+	return true
+}
+
+// MarkSeen records the nonce with an expiry time.
+func (s *InMemoryNonceStore) MarkSeen(nonce string, expiry time.Time) {
+	s.mu.Lock()
+	s.nonces[nonce] = expiry
+	s.mu.Unlock()
+}
+
+// Stop stops the cleanup goroutine.
+func (s *InMemoryNonceStore) Stop() {
+	close(s.stopCh)
+}
+
+func (s *InMemoryNonceStore) cleanupLoop() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.cleanupExpired()
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+func (s *InMemoryNonceStore) cleanupExpired() {
+	now := time.Now()
+	s.mu.Lock()
+	for nonce, expiry := range s.nonces {
+		if now.After(expiry) {
+			delete(s.nonces, nonce)
+		}
+	}
+	s.mu.Unlock()
+}

--- a/pkg/provider_daemon/auth/types.go
+++ b/pkg/provider_daemon/auth/types.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+)
+
+const (
+	// MaxTimestampAge is the maximum age for signed requests.
+	MaxTimestampAge = 5 * time.Minute
+	// AllowedFutureSkew allows small client clock drift.
+	AllowedFutureSkew = 1 * time.Minute
+
+	HeaderAddress   = "X-VE-Address"
+	HeaderTimestamp = "X-VE-Timestamp"
+	HeaderNonce     = "X-VE-Nonce"
+	HeaderSignature = "X-VE-Signature"
+	HeaderPubKey    = "X-VE-PubKey"
+
+	QueryAddress   = "ve_address"
+	QueryTimestamp = "ve_ts"
+	QueryNonce     = "ve_nonce"
+	QuerySignature = "ve_sig"
+	QueryPubKey    = "ve_pub"
+)
+
+// SignedRequest contains parsed authentication details.
+type SignedRequest struct {
+	Address   string
+	Timestamp time.Time
+	Nonce     string
+	Signature []byte
+	PubKey    *secp256k1.PubKey
+	BodyHash  string
+}
+
+// RequestData is the canonical format for signed data.
+type RequestData struct {
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	Timestamp int64  `json:"timestamp"`
+	Nonce     string `json:"nonce"`
+	BodyHash  string `json:"body_hash"`
+}
+
+// AuthMethod represents the auth mechanism used.
+type AuthMethod string
+
+const (
+	AuthMethodWallet   AuthMethod = "wallet"
+	AuthMethodHMAC     AuthMethod = "hmac"
+	AuthMethodInsecure AuthMethod = "insecure"
+)
+
+// AuthResult represents an authenticated principal.
+type AuthResult struct {
+	Principal string
+	Method    AuthMethod
+}


### PR DESCRIPTION
## Summary
- add wallet signature verifier with nonce store and lease ownership checks
- wire portal API auth to wallet signatures with HMAC fallback and chain lookups
- add signer/verifier unit tests and wallet signRequest test

## Testing
- go test ./pkg/provider_daemon/auth -count=1
- go test ./pkg/provider_daemon -count=1
- go build ./...
- pnpm -C portal lint
- pnpm -C portal type-check
- pnpm -C portal test
- pnpm -C lib/portal test
- golangci-lint run --new-from-rev=HEAD~1
- go vet ./pkg/provider_daemon/...