### PR TITLE
feat(portal): add wallet-signed auth verification

### DIFF
--- a/cmd/provider-daemon/main.go
+++ b/cmd/provider-daemon/main.go
@@ -695,6 +695,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	portalCfg.ShellSessionTTL = viper.GetDuration(FlagPortalShellSessionTTL)
 	portalCfg.TokenTTL = viper.GetDuration(FlagPortalTokenTTL)
 	portalCfg.AuditLogger = portalAuditLogger
+	portalCfg.WalletAuthChainID = viper.GetString(FlagChainID)
 
 	portalAPI, err := provider_daemon.NewPortalAPIServer(portalCfg)
 	if err != nil {

--- a/lib/portal/src/auth/index.ts
+++ b/lib/portal/src/auth/index.ts
@@ -1,0 +1,6 @@
+export { signRequest } from "./wallet-sign";
+export type {
+  SignRequestOptions,
+  SignedRequestHeaders,
+  WalletRequestSigner,
+} from "./types";

--- a/lib/portal/src/auth/types.ts
+++ b/lib/portal/src/auth/types.ts
@@ -1,0 +1,33 @@
+import type {
+  AminoSignDoc,
+  AminoSignResponse,
+  WalletSignOptions,
+} from "../wallet/types";
+
+export interface WalletRequestSigner {
+  signAmino: (
+    signDoc: AminoSignDoc,
+    options?: WalletSignOptions,
+  ) => Promise<AminoSignResponse>;
+  signArbitrary?: (
+    data: string | Uint8Array,
+  ) => Promise<{ signature: string; pubKey: Uint8Array }>;
+}
+
+export interface SignedRequestHeaders {
+  "X-VE-Address": string;
+  "X-VE-Timestamp": string;
+  "X-VE-Nonce": string;
+  "X-VE-Signature": string;
+  "X-VE-PubKey": string;
+}
+
+export interface SignRequestOptions {
+  method: string;
+  path: string;
+  body?: unknown;
+  signer: WalletRequestSigner;
+  address: string;
+  chainId: string;
+  memo?: string;
+}

--- a/lib/portal/src/auth/wallet-sign.ts
+++ b/lib/portal/src/auth/wallet-sign.ts
@@ -1,36 +1,11 @@
 import type {
-  AminoSignDoc,
-  AminoSignResponse,
-  WalletSignOptions,
-} from "../wallet/types";
+  SignRequestOptions,
+  SignedRequestHeaders,
+  WalletRequestSigner,
+} from "./types";
+import type { AminoSignDoc } from "../wallet/types";
 
-export interface WalletRequestSigner {
-  signAmino: (
-    signDoc: AminoSignDoc,
-    options?: WalletSignOptions,
-  ) => Promise<AminoSignResponse>;
-  signArbitrary?: (
-    data: string | Uint8Array,
-  ) => Promise<{ signature: string; pubKey: Uint8Array }>;
-}
-
-export interface SignedRequestHeaders {
-  "X-VE-Address": string;
-  "X-VE-Timestamp": string;
-  "X-VE-Nonce": string;
-  "X-VE-Signature": string;
-  "X-VE-PubKey": string;
-}
-
-export interface SignRequestOptions {
-  method: string;
-  path: string;
-  body?: unknown;
-  signer: WalletRequestSigner;
-  address: string;
-  chainId: string;
-  memo?: string;
-}
+export type { SignRequestOptions, SignedRequestHeaders, WalletRequestSigner };
 
 interface RequestData {
   method: string;

--- a/pkg/provider_daemon/auth/auth_test.go
+++ b/pkg/provider_daemon/auth/auth_test.go
@@ -1,0 +1,169 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+type mockLeaseQuery struct {
+	lease *Lease
+	err   error
+	calls int
+}
+
+func (m *mockLeaseQuery) GetLease(_ context.Context, _ string) (*Lease, error) {
+	m.calls++
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.lease, nil
+}
+
+func TestVerifierVerifySuccess(t *testing.T) {
+	const chainID = "virtengine-1"
+	now := time.Now().UTC()
+	verifier := NewVerifier(VerifierConfig{
+		ChainID: chainID,
+		Clock:   func() time.Time { return now },
+	})
+
+	priv := secp256k1.GenPrivKey()
+	address := sdk.AccAddress(priv.PubKey().Address()).String()
+
+	body := []byte(`{"action":"restart","metadata":{"reason":"test","count":1}}`)
+	nonce := "nonce-123"
+
+	req := buildSignedRequest(t, priv, chainID, address, "POST", "/api/v1/deployments/lease1/actions", body, nonce, now)
+
+	signed, err := verifier.Verify(req)
+	require.NoError(t, err)
+	require.Equal(t, address, signed.Address)
+	require.Equal(t, nonce, signed.Nonce)
+	require.Equal(t, now.Truncate(time.Millisecond), signed.Timestamp)
+	require.NotEmpty(t, signed.Signature)
+	require.NotNil(t, signed.PubKey)
+
+	_, err = verifier.Verify(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nonce already used")
+}
+
+func TestVerifierTimestampValidation(t *testing.T) {
+	const chainID = "virtengine-1"
+	now := time.Now().UTC()
+	verifier := NewVerifier(VerifierConfig{
+		ChainID: chainID,
+		Clock:   func() time.Time { return now },
+	})
+
+	priv := secp256k1.GenPrivKey()
+	address := sdk.AccAddress(priv.PubKey().Address()).String()
+	body := []byte(`{"action":"restart"}`)
+
+	oldTimestamp := now.Add(-DefaultMaxTimestampAge - time.Minute)
+	req := buildSignedRequest(t, priv, chainID, address, "POST", "/api/v1/deployments/lease1/actions", body, "nonce-old", oldTimestamp)
+	_, err := verifier.Verify(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timestamp too old")
+}
+
+func TestVerifierLeaseOwnershipCache(t *testing.T) {
+	const chainID = "virtengine-1"
+	now := time.Unix(1_700_000_000, 0).UTC()
+	clock := now
+	leaseQuery := &mockLeaseQuery{
+		lease: &Lease{ID: "lease1", Owner: "owner1"},
+	}
+
+	verifier := NewVerifier(VerifierConfig{
+		ChainID:           chainID,
+		ChainQuerier:      leaseQuery,
+		OwnershipCacheTTL: 15 * time.Minute,
+		Clock:             func() time.Time { return clock },
+	})
+
+	err := verifier.VerifyLeaseOwnership(context.Background(), "owner1", "lease1")
+	require.NoError(t, err)
+	require.Equal(t, 1, leaseQuery.calls)
+
+	err = verifier.VerifyLeaseOwnership(context.Background(), "owner1", "lease1")
+	require.NoError(t, err)
+	require.Equal(t, 1, leaseQuery.calls)
+
+	err = verifier.VerifyLeaseOwnership(context.Background(), "other", "lease1")
+	require.Error(t, err)
+	require.Equal(t, 1, leaseQuery.calls)
+
+	clock = clock.Add(16 * time.Minute)
+	err = verifier.VerifyLeaseOwnership(context.Background(), "owner1", "lease1")
+	require.NoError(t, err)
+	require.Equal(t, 2, leaseQuery.calls)
+}
+
+func buildSignedRequest(
+	t *testing.T,
+	priv *secp256k1.PrivKey,
+	chainID string,
+	address string,
+	method string,
+	path string,
+	body []byte,
+	nonce string,
+	timestamp time.Time,
+) *http.Request {
+	t.Helper()
+
+	bodyHash := hashBodyForTest(body)
+
+	requestData := RequestData{
+		Method:    method,
+		Path:      path,
+		Timestamp: timestamp.UnixMilli(),
+		Nonce:     nonce,
+		BodyHash:  bodyHash,
+	}
+
+	dataToSign := serializeRequestData(requestData)
+	signDoc := buildSignDoc(chainID, address, base64.StdEncoding.EncodeToString([]byte(dataToSign)))
+	signBytes, err := canonicalJSON(signDoc)
+	require.NoError(t, err)
+
+	signature, err := priv.Sign([]byte(signBytes))
+	require.NoError(t, err)
+
+	pubKey := priv.PubKey().Bytes()
+
+	req := httptest.NewRequest(method, "http://example.com"+path, bytes.NewReader(body))
+	req.Header.Set(HeaderAddress, address)
+	req.Header.Set(HeaderTimestamp, strconv.FormatInt(timestamp.UnixMilli(), 10))
+	req.Header.Set(HeaderNonce, nonce)
+	req.Header.Set(HeaderSignature, base64.StdEncoding.EncodeToString(signature))
+	req.Header.Set(HeaderPubKey, base64.StdEncoding.EncodeToString(pubKey))
+	req.Header.Set("Content-Type", "application/json")
+
+	return req
+}
+
+func hashBodyForTest(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	if canonical, ok := canonicalizeJSON(body); ok {
+		sum := sha256.Sum256([]byte(canonical))
+		return hex.EncodeToString(sum[:])
+	}
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/provider_daemon/auth/chain_query.go
+++ b/pkg/provider_daemon/auth/chain_query.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrLeaseQueryUnavailable indicates lease data cannot be fetched.
+var ErrLeaseQueryUnavailable = errors.New("lease query unavailable")
+
+// ErrLeaseNotFound indicates lease does not exist.
+var ErrLeaseNotFound = errors.New("lease not found")
+
+// Lease contains ownership info used for authorization checks.
+type Lease struct {
+	ID    string
+	Owner string
+}
+
+// ChainQuerier retrieves lease ownership information.
+type ChainQuerier interface {
+	GetLease(ctx context.Context, leaseID string) (*Lease, error)
+}
+
+// NoopChainQuerier returns unavailable errors for lease queries.
+type NoopChainQuerier struct{}
+
+// GetLease returns ErrLeaseQueryUnavailable.
+func (NoopChainQuerier) GetLease(_ context.Context, _ string) (*Lease, error) {
+	return nil, ErrLeaseQueryUnavailable
+}

--- a/pkg/provider_daemon/auth/cosmos_verify.go
+++ b/pkg/provider_daemon/auth/cosmos_verify.go
@@ -1,0 +1,450 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+)
+
+const (
+	HeaderAddress   = "X-VE-Address"
+	HeaderTimestamp = "X-VE-Timestamp"
+	HeaderNonce     = "X-VE-Nonce"
+	HeaderSignature = "X-VE-Signature"
+	HeaderPubKey    = "X-VE-PubKey"
+
+	QueryAddress   = "ve_address"
+	QueryTimestamp = "ve_ts"
+	QueryNonce     = "ve_nonce"
+	QuerySignature = "ve_sig"
+	QueryPubKey    = "ve_pub"
+)
+
+const (
+	DefaultMaxTimestampAge   = 5 * time.Minute
+	DefaultFutureTimeDrift   = time.Minute
+	DefaultOwnershipCacheTTL = 15 * time.Minute
+)
+
+// SignedRequest contains parsed authentication data.
+type SignedRequest struct {
+	Address   string
+	Timestamp time.Time
+	Nonce     string
+	Signature []byte
+	PubKey    *secp256k1.PubKey
+	BodyHash  string
+}
+
+// RequestData is the canonical format of signed data.
+type RequestData struct {
+	Method    string `json:"method"`
+	Path      string `json:"path"`
+	Timestamp int64  `json:"timestamp"`
+	Nonce     string `json:"nonce"`
+	BodyHash  string `json:"body_hash"`
+}
+
+// VerifierConfig configures wallet signature verification.
+type VerifierConfig struct {
+	ChainID           string
+	NonceStore        NonceStore
+	ChainQuerier      ChainQuerier
+	MaxTimestampAge   time.Duration
+	FutureTimeDrift   time.Duration
+	OwnershipCacheTTL time.Duration
+	Clock             func() time.Time
+}
+
+// Verifier verifies wallet-signed requests and lease ownership.
+type Verifier struct {
+	chainID           string
+	nonceStore        NonceStore
+	chainQuery        ChainQuerier
+	maxTimestampAge   time.Duration
+	futureTimeDrift   time.Duration
+	ownershipCacheTTL time.Duration
+	clock             func() time.Time
+
+	cacheMu sync.RWMutex
+	cache   map[string]ownershipCacheEntry
+}
+
+type ownershipCacheEntry struct {
+	owner     string
+	expiresAt time.Time
+}
+
+// NewVerifier constructs a verifier with defaults.
+func NewVerifier(cfg VerifierConfig) *Verifier {
+	nonceStore := cfg.NonceStore
+	if nonceStore == nil {
+		nonceStore = NewInMemoryNonceStore()
+	}
+	chainQuery := cfg.ChainQuerier
+	if chainQuery == nil {
+		chainQuery = NoopChainQuerier{}
+	}
+	maxAge := cfg.MaxTimestampAge
+	if maxAge == 0 {
+		maxAge = DefaultMaxTimestampAge
+	}
+	futureDrift := cfg.FutureTimeDrift
+	if futureDrift == 0 {
+		futureDrift = DefaultFutureTimeDrift
+	}
+	ownershipTTL := cfg.OwnershipCacheTTL
+	if ownershipTTL == 0 {
+		ownershipTTL = DefaultOwnershipCacheTTL
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+
+	return &Verifier{
+		chainID:           cfg.ChainID,
+		nonceStore:        nonceStore,
+		chainQuery:        chainQuery,
+		maxTimestampAge:   maxAge,
+		futureTimeDrift:   futureDrift,
+		ownershipCacheTTL: ownershipTTL,
+		clock:             clock,
+		cache:             make(map[string]ownershipCacheEntry),
+	}
+}
+
+// HasWalletAuth checks if a request contains wallet auth headers or query params.
+func HasWalletAuth(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	return readAuthValue(r, HeaderAddress, QueryAddress) != ""
+}
+
+// Verify verifies the signature and returns the signer address.
+func (v *Verifier) Verify(r *http.Request) (*SignedRequest, error) {
+	if v == nil {
+		return nil, errors.New("wallet verifier not configured")
+	}
+	if v.chainID == "" {
+		return nil, errors.New("wallet auth chain id is required")
+	}
+
+	address := readAuthValue(r, HeaderAddress, QueryAddress)
+	timestampStr := readAuthValue(r, HeaderTimestamp, QueryTimestamp)
+	nonce := readAuthValue(r, HeaderNonce, QueryNonce)
+	signatureB64 := readAuthValue(r, HeaderSignature, QuerySignature)
+	pubKeyB64 := readAuthValue(r, HeaderPubKey, QueryPubKey)
+
+	if address == "" || timestampStr == "" || nonce == "" || signatureB64 == "" || pubKeyB64 == "" {
+		return nil, errors.New("missing wallet authentication headers")
+	}
+
+	timestampMs, err := strconv.ParseInt(timestampStr, 10, 64)
+	if err != nil {
+		return nil, errors.New("invalid timestamp")
+	}
+	timestamp := time.UnixMilli(timestampMs).UTC()
+
+	now := v.clock()
+	if now.Sub(timestamp) > v.maxTimestampAge {
+		return nil, errors.New("request timestamp too old")
+	}
+	if timestamp.After(now.Add(v.futureTimeDrift)) {
+		return nil, errors.New("request timestamp in future")
+	}
+
+	nonceKey := fmt.Sprintf("%s:%s", address, nonce)
+	if v.nonceStore.HasSeen(nonceKey) {
+		return nil, errors.New("nonce already used")
+	}
+
+	signature, err := base64.StdEncoding.DecodeString(signatureB64)
+	if err != nil {
+		return nil, errors.New("invalid signature encoding")
+	}
+
+	pubKeyBytes, err := base64.StdEncoding.DecodeString(pubKeyB64)
+	if err != nil {
+		return nil, errors.New("invalid public key encoding")
+	}
+	pubKey := &secp256k1.PubKey{Key: pubKeyBytes}
+
+	_, addrBytes, err := bech32.DecodeAndConvert(address)
+	if err != nil {
+		return nil, errors.New("invalid address")
+	}
+	if !bytes.Equal(addrBytes, pubKey.Address()) {
+		return nil, errors.New("address does not match public key")
+	}
+
+	bodyHash, err := hashRequestBody(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to hash body: %w", err)
+	}
+
+	requestData := RequestData{
+		Method:    strings.ToUpper(r.Method),
+		Path:      r.URL.Path,
+		Timestamp: timestampMs,
+		Nonce:     nonce,
+		BodyHash:  bodyHash,
+	}
+
+	dataToSign := serializeRequestData(requestData)
+	signDoc := buildSignDoc(v.chainID, address, base64.StdEncoding.EncodeToString([]byte(dataToSign)))
+	signBytes, err := canonicalJSON(signDoc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize sign doc: %w", err)
+	}
+
+	if !pubKey.VerifySignature([]byte(signBytes), signature) {
+		return nil, errors.New("signature verification failed")
+	}
+
+	v.nonceStore.MarkSeen(nonceKey, timestamp.Add(v.maxTimestampAge))
+
+	return &SignedRequest{
+		Address:   address,
+		Timestamp: timestamp,
+		Nonce:     nonce,
+		Signature: signature,
+		PubKey:    pubKey,
+		BodyHash:  bodyHash,
+	}, nil
+}
+
+// VerifyLeaseOwnership checks if the address owns the lease.
+func (v *Verifier) VerifyLeaseOwnership(ctx context.Context, address, leaseID string) error {
+	if v == nil {
+		return errors.New("wallet verifier not configured")
+	}
+	if leaseID == "" {
+		return errors.New("lease id required")
+	}
+	if address == "" {
+		return errors.New("signer address required")
+	}
+
+	if owner, ok := v.cachedOwner(leaseID); ok {
+		if owner != address {
+			return errors.New("address does not own this lease")
+		}
+		return nil
+	}
+
+	lease, err := v.chainQuery.GetLease(ctx, leaseID)
+	if err != nil {
+		return err
+	}
+	if lease == nil || lease.Owner == "" {
+		return ErrLeaseNotFound
+	}
+	v.storeOwner(leaseID, lease.Owner)
+	if lease.Owner != address {
+		return errors.New("address does not own this lease")
+	}
+	return nil
+}
+
+func (v *Verifier) cachedOwner(leaseID string) (string, bool) {
+	v.cacheMu.RLock()
+	entry, ok := v.cache[leaseID]
+	v.cacheMu.RUnlock()
+	if !ok {
+		return "", false
+	}
+	if v.clock().After(entry.expiresAt) {
+		return "", false
+	}
+	return entry.owner, true
+}
+
+func (v *Verifier) storeOwner(leaseID, owner string) {
+	v.cacheMu.Lock()
+	v.cache[leaseID] = ownershipCacheEntry{
+		owner:     owner,
+		expiresAt: v.clock().Add(v.ownershipCacheTTL),
+	}
+	v.cacheMu.Unlock()
+}
+
+func readAuthValue(r *http.Request, headerKey, queryKey string) string {
+	if r == nil {
+		return ""
+	}
+	if headerKey != "" {
+		if val := strings.TrimSpace(r.Header.Get(headerKey)); val != "" {
+			return val
+		}
+	}
+	if queryKey != "" {
+		if val := strings.TrimSpace(r.URL.Query().Get(queryKey)); val != "" {
+			return val
+		}
+	}
+	return ""
+}
+
+func serializeRequestData(data RequestData) string {
+	return fmt.Sprintf(
+		"{\"method\":\"%s\",\"path\":\"%s\",\"timestamp\":%d,\"nonce\":\"%s\",\"body_hash\":\"%s\"}",
+		data.Method,
+		data.Path,
+		data.Timestamp,
+		data.Nonce,
+		data.BodyHash,
+	)
+}
+
+func buildSignDoc(chainID, address, dataBase64 string) map[string]any {
+	return map[string]any{
+		"chain_id":       chainID,
+		"account_number": "0",
+		"sequence":       "0",
+		"fee": map[string]any{
+			"gas":    "0",
+			"amount": []any{},
+		},
+		"msgs": []any{
+			map[string]any{
+				"type": "sign/MsgSignData",
+				"value": map[string]any{
+					"signer": address,
+					"data":   dataBase64,
+				},
+			},
+		},
+		"memo": "",
+	}
+}
+
+func hashRequestBody(r *http.Request) (string, error) {
+	if r == nil || r.Body == nil {
+		return "", nil
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", err
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	if len(body) == 0 {
+		return "", nil
+	}
+
+	canonical, ok := canonicalizeJSON(body)
+	if ok {
+		sum := sha256.Sum256([]byte(canonical))
+		return hex.EncodeToString(sum[:]), nil
+	}
+
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func canonicalizeJSON(body []byte) (string, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+
+	var payload any
+	if err := decoder.Decode(&payload); err != nil {
+		return "", false
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return "", false
+	}
+	canonical, err := canonicalJSON(payload)
+	if err != nil {
+		return "", false
+	}
+	return canonical, true
+}
+
+func canonicalJSON(value any) (string, error) {
+	switch typed := value.(type) {
+	case nil:
+		return "null", nil
+	case string:
+		return marshalPrimitive(typed)
+	case bool:
+		return marshalPrimitive(typed)
+	case json.Number:
+		return typed.String(), nil
+	case float64, float32, int, int64, int32, int16, int8, uint, uint64, uint32, uint16, uint8:
+		return marshalPrimitive(typed)
+	case []any:
+		var buf bytes.Buffer
+		buf.WriteByte('[')
+		for i, item := range typed {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			encoded, err := canonicalJSON(item)
+			if err != nil {
+				return "", err
+			}
+			buf.WriteString(encoded)
+		}
+		buf.WriteByte(']')
+		return buf.String(), nil
+	case map[string]any:
+		return canonicalMap(typed)
+	default:
+		return marshalPrimitive(typed)
+	}
+}
+
+func canonicalMap(value map[string]any) (string, error) {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, key := range keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		encodedKey, err := marshalPrimitive(key)
+		if err != nil {
+			return "", err
+		}
+		buf.WriteString(encodedKey)
+		buf.WriteByte(':')
+		encodedValue, err := canonicalJSON(value[key])
+		if err != nil {
+			return "", err
+		}
+		buf.WriteString(encodedValue)
+	}
+	buf.WriteByte('}')
+	return buf.String(), nil
+}
+
+func marshalPrimitive(value any) (string, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}

--- a/pkg/provider_daemon/auth/middleware.go
+++ b/pkg/provider_daemon/auth/middleware.go
@@ -1,0 +1,36 @@
+package auth
+
+import "context"
+
+// AuthKind identifies the authentication mechanism used.
+type AuthKind string
+
+const (
+	AuthKindWallet   AuthKind = "wallet"
+	AuthKindHMAC     AuthKind = "hmac"
+	AuthKindInsecure AuthKind = "insecure"
+)
+
+type contextKey string
+
+const contextKeyAuth contextKey = "ve_auth"
+
+// AuthContext is attached to requests after authentication.
+type AuthContext struct {
+	Address string
+	Kind    AuthKind
+}
+
+// WithAuth stores authentication info on the context.
+func WithAuth(ctx context.Context, auth AuthContext) context.Context {
+	return context.WithValue(ctx, contextKeyAuth, auth)
+}
+
+// FromContext retrieves authentication info from context.
+func FromContext(ctx context.Context) AuthContext {
+	val := ctx.Value(contextKeyAuth)
+	if auth, ok := val.(AuthContext); ok {
+		return auth
+	}
+	return AuthContext{}
+}

--- a/pkg/provider_daemon/auth/nonce_store.go
+++ b/pkg/provider_daemon/auth/nonce_store.go
@@ -1,0 +1,76 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+// NonceStore tracks seen nonces to prevent replay attacks.
+type NonceStore interface {
+	HasSeen(key string) bool
+	MarkSeen(key string, expiry time.Time)
+}
+
+// InMemoryNonceStore stores nonces in memory with periodic cleanup.
+type InMemoryNonceStore struct {
+	mu     sync.RWMutex
+	nonces map[string]time.Time
+	stopCh chan struct{}
+}
+
+// NewInMemoryNonceStore creates a nonce store with background cleanup.
+func NewInMemoryNonceStore() *InMemoryNonceStore {
+	store := &InMemoryNonceStore{
+		nonces: make(map[string]time.Time),
+		stopCh: make(chan struct{}),
+	}
+	go store.cleanup()
+	return store
+}
+
+// HasSeen returns true if the nonce key is already recorded.
+func (s *InMemoryNonceStore) HasSeen(key string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	expiry, ok := s.nonces[key]
+	if !ok {
+		return false
+	}
+	if time.Now().After(expiry) {
+		return false
+	}
+	return true
+}
+
+// MarkSeen records a nonce key until expiry.
+func (s *InMemoryNonceStore) MarkSeen(key string, expiry time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nonces[key] = expiry
+}
+
+// Stop stops background cleanup.
+func (s *InMemoryNonceStore) Stop() {
+	close(s.stopCh)
+}
+
+func (s *InMemoryNonceStore) cleanup() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			now := time.Now()
+			s.mu.Lock()
+			for key, expiry := range s.nonces {
+				if now.After(expiry) {
+					delete(s.nonces, key)
+				}
+			}
+			s.mu.Unlock()
+		case <-s.stopCh:
+			return
+		}
+	}
+}

--- a/pkg/provider_daemon/portal_api.go
+++ b/pkg/provider_daemon/portal_api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/virtengine/virtengine/pkg/observability"
+	portalauth "github.com/virtengine/virtengine/pkg/provider_daemon/auth"
 )
 
 const (
@@ -30,22 +31,28 @@ const (
 )
 
 type PortalAPIServerConfig struct {
-	ListenAddr           string
-	AuthSecret           string
-	AllowInsecure        bool
-	RequireVEID          bool
-	MinVEIDScore         int
-	ShellSessionTTL      time.Duration
-	TokenTTL             time.Duration
-	AuditLogger          *AuditLogger
-	LogStore             *DeploymentLogStore
-	ChainQuery           ChainQuery
-	ProviderInfo         ProviderInfo
-	ProviderPricing      ProviderPricing
-	ProviderCapacity     ProviderCapacity
-	ProviderAttributes   ProviderAttributes
-	ProviderInfoProvider ProviderInfoProvider
-	RateLimit            RateLimitConfig
+	ListenAddr            string
+	AuthSecret            string
+	AllowInsecure         bool
+	RequireVEID           bool
+	MinVEIDScore          int
+	ShellSessionTTL       time.Duration
+	TokenTTL              time.Duration
+	AuditLogger           *AuditLogger
+	LogStore              *DeploymentLogStore
+	ChainQuery            ChainQuery
+	WalletAuthChainID     string
+	WalletAuthNonceStore  portalauth.NonceStore
+	WalletAuthChainQuery  portalauth.ChainQuerier
+	WalletAuthMaxAge      time.Duration
+	WalletAuthFutureDrift time.Duration
+	WalletAuthCacheTTL    time.Duration
+	ProviderInfo          ProviderInfo
+	ProviderPricing       ProviderPricing
+	ProviderCapacity      ProviderCapacity
+	ProviderAttributes    ProviderAttributes
+	ProviderInfoProvider  ProviderInfoProvider
+	RateLimit             RateLimitConfig
 }
 
 func DefaultPortalAPIServerConfig() PortalAPIServerConfig {
@@ -71,6 +78,7 @@ type PortalAPIServer struct {
 	chainQuery    ChainQuery
 	providerInfo  ProviderInfoProvider
 	rateLimiter   *PortalRateLimiter
+	authVerifier  *portalauth.Verifier
 }
 
 func NewPortalAPIServer(cfg PortalAPIServerConfig) (*PortalAPIServer, error) {
@@ -96,6 +104,12 @@ func NewPortalAPIServer(cfg PortalAPIServerConfig) (*PortalAPIServer, error) {
 	if cfg.ChainQuery == nil {
 		cfg.ChainQuery = NoopChainQuery{}
 	}
+	if cfg.WalletAuthNonceStore == nil {
+		cfg.WalletAuthNonceStore = portalauth.NewInMemoryNonceStore()
+	}
+	if cfg.WalletAuthChainQuery == nil {
+		cfg.WalletAuthChainQuery = portalauth.NoopChainQuerier{}
+	}
 
 	srv := &PortalAPIServer{
 		cfg:           cfg,
@@ -105,6 +119,14 @@ func NewPortalAPIServer(cfg PortalAPIServerConfig) (*PortalAPIServer, error) {
 			CheckOrigin: func(r *http.Request) bool { return true },
 		},
 		chainQuery: cfg.ChainQuery,
+		authVerifier: portalauth.NewVerifier(portalauth.VerifierConfig{
+			ChainID:           cfg.WalletAuthChainID,
+			NonceStore:        cfg.WalletAuthNonceStore,
+			ChainQuerier:      cfg.WalletAuthChainQuery,
+			MaxTimestampAge:   cfg.WalletAuthMaxAge,
+			FutureTimeDrift:   cfg.WalletAuthFutureDrift,
+			OwnershipCacheTTL: cfg.WalletAuthCacheTTL,
+		}),
 	}
 
 	if cfg.ProviderInfoProvider != nil {
@@ -150,32 +172,32 @@ func (s *PortalAPIServer) setupRoutes(router *mux.Router) {
 	api.HandleFunc("/deployments/{deploymentId}/shell/session", s.handleShellSession).Methods(http.MethodPost)
 	api.HandleFunc("/deployments/{deploymentId}/shell", s.handleShell).Methods(http.MethodGet)
 
-	api.Handle("/organizations", s.authMiddleware()(http.HandlerFunc(s.handleListOrganizations))).Methods(http.MethodGet)
-	api.Handle("/organizations/{orgId}", s.authMiddleware()(http.HandlerFunc(s.handleGetOrganization))).Methods(http.MethodGet)
-	api.Handle("/organizations/{orgId}/members", s.authMiddleware()(http.HandlerFunc(s.handleOrganizationMembers))).Methods(http.MethodGet)
-	api.Handle("/organizations/{orgId}/invite", s.authMiddleware()(http.HandlerFunc(s.handleInviteOrganizationMember))).Methods(http.MethodPost)
-	api.Handle("/organizations/{orgId}/members/{address}", s.authMiddleware()(http.HandlerFunc(s.handleRemoveOrganizationMember))).Methods(http.MethodDelete)
+	api.Handle("/organizations", s.authMiddleware(true)(http.HandlerFunc(s.handleListOrganizations))).Methods(http.MethodGet)
+	api.Handle("/organizations/{orgId}", s.authMiddleware(true)(http.HandlerFunc(s.handleGetOrganization))).Methods(http.MethodGet)
+	api.Handle("/organizations/{orgId}/members", s.authMiddleware(true)(http.HandlerFunc(s.handleOrganizationMembers))).Methods(http.MethodGet)
+	api.Handle("/organizations/{orgId}/invite", s.authMiddleware(true)(http.HandlerFunc(s.handleInviteOrganizationMember))).Methods(http.MethodPost)
+	api.Handle("/organizations/{orgId}/members/{address}", s.authMiddleware(true)(http.HandlerFunc(s.handleRemoveOrganizationMember))).Methods(http.MethodDelete)
 
-	api.Handle("/tickets", s.authMiddleware()(http.HandlerFunc(s.handleListTickets))).Methods(http.MethodGet)
-	api.Handle("/tickets", s.authMiddleware()(http.HandlerFunc(s.handleCreateTicket))).Methods(http.MethodPost)
-	api.Handle("/tickets/{ticketId}", s.authMiddleware()(http.HandlerFunc(s.handleGetTicket))).Methods(http.MethodGet)
-	api.Handle("/tickets/{ticketId}/comments", s.authMiddleware()(http.HandlerFunc(s.handleAddTicketComment))).Methods(http.MethodPost)
-	api.Handle("/tickets/{ticketId}", s.authMiddleware()(http.HandlerFunc(s.handleUpdateTicket))).Methods(http.MethodPatch)
+	api.Handle("/tickets", s.authMiddleware(true)(http.HandlerFunc(s.handleListTickets))).Methods(http.MethodGet)
+	api.Handle("/tickets", s.authMiddleware(true)(http.HandlerFunc(s.handleCreateTicket))).Methods(http.MethodPost)
+	api.Handle("/tickets/{ticketId}", s.authMiddleware(true)(http.HandlerFunc(s.handleGetTicket))).Methods(http.MethodGet)
+	api.Handle("/tickets/{ticketId}/comments", s.authMiddleware(true)(http.HandlerFunc(s.handleAddTicketComment))).Methods(http.MethodPost)
+	api.Handle("/tickets/{ticketId}", s.authMiddleware(true)(http.HandlerFunc(s.handleUpdateTicket))).Methods(http.MethodPatch)
 
-	api.Handle("/invoices", s.authMiddleware()(http.HandlerFunc(s.handleListInvoices))).Methods(http.MethodGet)
-	api.Handle("/invoices/{invoiceId}", s.authMiddleware()(http.HandlerFunc(s.handleGetInvoice))).Methods(http.MethodGet)
-	api.Handle("/usage", s.authMiddleware()(http.HandlerFunc(s.handleGetUsage))).Methods(http.MethodGet)
-	api.Handle("/usage/history", s.authMiddleware()(http.HandlerFunc(s.handleGetUsageHistory))).Methods(http.MethodGet)
+	api.Handle("/invoices", s.authMiddleware(true)(http.HandlerFunc(s.handleListInvoices))).Methods(http.MethodGet)
+	api.Handle("/invoices/{invoiceId}", s.authMiddleware(true)(http.HandlerFunc(s.handleGetInvoice))).Methods(http.MethodGet)
+	api.Handle("/usage", s.authMiddleware(true)(http.HandlerFunc(s.handleGetUsage))).Methods(http.MethodGet)
+	api.Handle("/usage/history", s.authMiddleware(true)(http.HandlerFunc(s.handleGetUsageHistory))).Methods(http.MethodGet)
 
-	api.Handle("/deployments/{deploymentId}/metrics", s.authMiddleware()(http.HandlerFunc(s.handleDeploymentMetrics))).Methods(http.MethodGet)
-	api.Handle("/deployments/{deploymentId}/metrics/history", s.authMiddleware()(http.HandlerFunc(s.handleDeploymentMetricsHistory))).Methods(http.MethodGet)
-	api.Handle("/deployments/{deploymentId}/events", s.authMiddleware()(http.HandlerFunc(s.handleDeploymentEvents))).Methods(http.MethodGet)
-	api.Handle("/metrics/aggregate", s.authMiddleware()(http.HandlerFunc(s.handleAggregatedMetrics))).Methods(http.MethodGet)
+	api.Handle("/deployments/{deploymentId}/metrics", s.authMiddleware(true)(s.leaseOwnerMiddleware()(http.HandlerFunc(s.handleDeploymentMetrics)))).Methods(http.MethodGet)
+	api.Handle("/deployments/{deploymentId}/metrics/history", s.authMiddleware(true)(s.leaseOwnerMiddleware()(http.HandlerFunc(s.handleDeploymentMetricsHistory)))).Methods(http.MethodGet)
+	api.Handle("/deployments/{deploymentId}/events", s.authMiddleware(true)(s.leaseOwnerMiddleware()(http.HandlerFunc(s.handleDeploymentEvents)))).Methods(http.MethodGet)
+	api.Handle("/metrics/aggregate", s.authMiddleware(true)(http.HandlerFunc(s.handleAggregatedMetrics))).Methods(http.MethodGet)
 
-	api.HandleFunc("/provider/info", s.handleProviderInfo).Methods(http.MethodGet)
-	api.HandleFunc("/provider/pricing", s.handleProviderPricing).Methods(http.MethodGet)
-	api.HandleFunc("/provider/capacity", s.handleProviderCapacity).Methods(http.MethodGet)
-	api.HandleFunc("/provider/attributes", s.handleProviderAttributes).Methods(http.MethodGet)
+	api.Handle("/provider/info", s.authMiddleware(false)(http.HandlerFunc(s.handleProviderInfo))).Methods(http.MethodGet)
+	api.Handle("/provider/pricing", s.authMiddleware(false)(http.HandlerFunc(s.handleProviderPricing))).Methods(http.MethodGet)
+	api.Handle("/provider/capacity", s.authMiddleware(false)(http.HandlerFunc(s.handleProviderCapacity))).Methods(http.MethodGet)
+	api.Handle("/provider/attributes", s.authMiddleware(false)(http.HandlerFunc(s.handleProviderAttributes))).Methods(http.MethodGet)
 }
 
 func (s *PortalAPIServer) Shutdown(ctx context.Context) error {
@@ -193,15 +215,20 @@ func (s *PortalAPIServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
 func (s *PortalAPIServer) handleLogs(w http.ResponseWriter, r *http.Request) {
 	deploymentID := deploymentIDFromVars(r)
 
-	principal, authErr := s.authenticateRequest(r)
+	authCtx, authErr := s.authenticateRequest(r)
 	if authErr != nil {
-		s.auditDenied(principal, deploymentID, "logs", authErr)
+		s.auditDenied(authCtx.Address, deploymentID, "logs", authErr)
 		http.Error(w, authErr.Error(), http.StatusUnauthorized)
+		return
+	}
+	if err := s.verifyLeaseOwnership(r.Context(), authCtx, deploymentID); err != nil {
+		s.auditDenied(authCtx.Address, deploymentID, "logs", err)
+		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
 
 	if websocket.IsWebSocketUpgrade(r) {
-		s.handleLogStreamWS(w, r, deploymentID, principal)
+		s.handleLogStreamWS(w, r, deploymentID, authCtx.Address)
 		return
 	}
 
@@ -287,16 +314,21 @@ func (s *PortalAPIServer) handleLogStreamWS(w http.ResponseWriter, r *http.Reque
 
 func (s *PortalAPIServer) handleShellSession(w http.ResponseWriter, r *http.Request) {
 	deploymentID := deploymentIDFromVars(r)
-	principal, authErr := s.authenticateRequest(r)
+	authCtx, authErr := s.authenticateRequest(r)
 	if authErr != nil {
-		s.auditDenied(principal, deploymentID, "shell_session", authErr)
+		s.auditDenied(authCtx.Address, deploymentID, "shell_session", authErr)
 		http.Error(w, authErr.Error(), http.StatusUnauthorized)
+		return
+	}
+	if err := s.verifyLeaseOwnership(r.Context(), authCtx, deploymentID); err != nil {
+		s.auditDenied(authCtx.Address, deploymentID, "shell_session", err)
+		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
 
 	if s.cfg.RequireVEID {
 		if err := s.verifyVEID(r); err != nil {
-			s.auditDenied(principal, deploymentID, "shell_session", err)
+			s.auditDenied(authCtx.Address, deploymentID, "shell_session", err)
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
@@ -307,7 +339,7 @@ func (s *PortalAPIServer) handleShellSession(w http.ResponseWriter, r *http.Requ
 	}
 	_ = json.NewDecoder(r.Body).Decode(&req)
 
-	session, err := s.shellSessions.Issue(deploymentID, principal, req.Container, s.cfg.ShellSessionTTL)
+	session, err := s.shellSessions.Issue(deploymentID, authCtx.Address, req.Container, s.cfg.ShellSessionTTL)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -317,7 +349,7 @@ func (s *PortalAPIServer) handleShellSession(w http.ResponseWriter, r *http.Requ
 		Type:        AuditEventShellSessionCreated,
 		Operation:   "shell_session",
 		Success:     true,
-		PrincipalID: principal,
+		PrincipalID: authCtx.Address,
 		Details: map[string]interface{}{
 			"deployment_id": deploymentID,
 			"container":     req.Container,
@@ -341,16 +373,21 @@ func (s *PortalAPIServer) handleShellSession(w http.ResponseWriter, r *http.Requ
 
 func (s *PortalAPIServer) handleShell(w http.ResponseWriter, r *http.Request) {
 	deploymentID := deploymentIDFromVars(r)
-	principal, authErr := s.authenticateRequest(r)
+	authCtx, authErr := s.authenticateRequest(r)
 	if authErr != nil {
-		s.auditDenied(principal, deploymentID, "shell", authErr)
+		s.auditDenied(authCtx.Address, deploymentID, "shell", authErr)
 		http.Error(w, authErr.Error(), http.StatusUnauthorized)
+		return
+	}
+	if err := s.verifyLeaseOwnership(r.Context(), authCtx, deploymentID); err != nil {
+		s.auditDenied(authCtx.Address, deploymentID, "shell", err)
+		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
 
 	if s.cfg.RequireVEID {
 		if err := s.verifyVEID(r); err != nil {
-			s.auditDenied(principal, deploymentID, "shell", err)
+			s.auditDenied(authCtx.Address, deploymentID, "shell", err)
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
@@ -358,7 +395,7 @@ func (s *PortalAPIServer) handleShell(w http.ResponseWriter, r *http.Request) {
 
 	sessionToken := r.URL.Query().Get("token")
 	if sessionToken == "" && !s.cfg.AllowInsecure {
-		s.auditDenied(principal, deploymentID, "shell", errors.New("missing session token"))
+		s.auditDenied(authCtx.Address, deploymentID, "shell", errors.New("missing session token"))
 		http.Error(w, "missing session token", http.StatusUnauthorized)
 		return
 	}
@@ -366,9 +403,9 @@ func (s *PortalAPIServer) handleShell(w http.ResponseWriter, r *http.Request) {
 	var session *ShellSession
 	if sessionToken != "" {
 		var err error
-		session, err = s.shellSessions.Validate(sessionToken, deploymentID, principal)
+		session, err = s.shellSessions.Validate(sessionToken, deploymentID, authCtx.Address)
 		if err != nil {
-			s.auditDenied(principal, deploymentID, "shell", err)
+			s.auditDenied(authCtx.Address, deploymentID, "shell", err)
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
@@ -384,7 +421,7 @@ func (s *PortalAPIServer) handleShell(w http.ResponseWriter, r *http.Request) {
 		Type:        AuditEventShellSessionStarted,
 		Operation:   "shell",
 		Success:     true,
-		PrincipalID: principal,
+		PrincipalID: authCtx.Address,
 		Details: map[string]interface{}{
 			"deployment_id": deploymentID,
 			"container":     r.URL.Query().Get("container"),
@@ -403,7 +440,7 @@ func (s *PortalAPIServer) handleShell(w http.ResponseWriter, r *http.Request) {
 			Type:        AuditEventShellSessionEnded,
 			Operation:   "shell",
 			Success:     true,
-			PrincipalID: principal,
+			PrincipalID: authCtx.Address,
 			Details: map[string]interface{}{
 				"deployment_id": deploymentID,
 			},
@@ -459,9 +496,20 @@ func (s *PortalAPIServer) handleShell(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *PortalAPIServer) authenticateRequest(r *http.Request) (string, error) {
-	if s.cfg.AllowInsecure || s.cfg.AuthSecret == "" {
-		return "dev", nil
+func (s *PortalAPIServer) authenticateRequest(r *http.Request) (portalauth.AuthContext, error) {
+	if portalauth.HasWalletAuth(r) {
+		if s.authVerifier == nil {
+			return portalauth.AuthContext{}, errors.New("wallet auth not configured")
+		}
+		signed, err := s.authVerifier.Verify(r)
+		if err != nil {
+			return portalauth.AuthContext{}, err
+		}
+		return portalauth.AuthContext{Address: signed.Address, Kind: portalauth.AuthKindWallet}, nil
+	}
+
+	if s.cfg.AllowInsecure && s.cfg.AuthSecret == "" {
+		return portalauth.AuthContext{Address: "dev", Kind: portalauth.AuthKindInsecure}, nil
 	}
 
 	signature := r.Header.Get("X-VE-Signature")
@@ -478,17 +526,24 @@ func (s *PortalAPIServer) authenticateRequest(r *http.Request) (string, error) {
 	}
 
 	if signature == "" || timestamp == "" || principal == "" {
-		return principal, errors.New("missing signed request headers")
+		if s.cfg.AllowInsecure {
+			return portalauth.AuthContext{Address: "dev", Kind: portalauth.AuthKindInsecure}, nil
+		}
+		return portalauth.AuthContext{}, errors.New("missing signed request headers")
 	}
 
 	ts, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
-		return principal, errors.New("invalid timestamp")
+		return portalauth.AuthContext{}, errors.New("invalid timestamp")
 	}
 
 	now := time.Now().Unix()
 	if ts < now-300 || ts > now+300 {
-		return principal, errors.New("request timestamp out of range")
+		return portalauth.AuthContext{}, errors.New("request timestamp out of range")
+	}
+
+	if s.cfg.AuthSecret == "" {
+		return portalauth.AuthContext{}, errors.New("hmac secret not configured")
 	}
 
 	payload := fmt.Sprintf("%s\n%s\n%s\n%s\n%s",
@@ -500,25 +555,68 @@ func (s *PortalAPIServer) authenticateRequest(r *http.Request) (string, error) {
 	)
 	expected := computeHMAC(payload, s.cfg.AuthSecret)
 	if !strings.EqualFold(expected, signature) {
-		return principal, errors.New("invalid signature")
+		return portalauth.AuthContext{}, errors.New("invalid signature")
 	}
 
-	return principal, nil
+	return portalauth.AuthContext{Address: principal, Kind: portalauth.AuthKindHMAC}, nil
 }
 
-func (s *PortalAPIServer) authMiddleware() func(http.Handler) http.Handler {
+func (s *PortalAPIServer) authMiddleware(required bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			principal, err := s.authenticateRequest(r)
+			if !required && !portalauth.HasWalletAuth(r) && r.Header.Get("X-VE-Principal") == "" && r.URL.Query().Get("principal") == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			authCtx, err := s.authenticateRequest(r)
 			if err != nil {
 				writeJSONError(w, http.StatusUnauthorized, err.Error())
 				return
 			}
 
-			ctx := withPrincipal(r.Context(), principal)
+			ctx := withAuth(r.Context(), authCtx)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+func (s *PortalAPIServer) leaseOwnerMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authCtx := authFromContext(r.Context())
+			if authCtx.Address == "" {
+				writeJSONError(w, http.StatusUnauthorized, "authentication required")
+				return
+			}
+
+			leaseID := deploymentIDFromVars(r)
+			if leaseID == "" {
+				writeJSONError(w, http.StatusBadRequest, "deployment id required")
+				return
+			}
+
+			if err := s.verifyLeaseOwnership(r.Context(), authCtx, leaseID); err != nil {
+				writeJSONError(w, http.StatusForbidden, err.Error())
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func (s *PortalAPIServer) verifyLeaseOwnership(ctx context.Context, authCtx portalauth.AuthContext, leaseID string) error {
+	if authCtx.Kind == portalauth.AuthKindInsecure {
+		return nil
+	}
+	if authCtx.Address == "" {
+		return errors.New("authentication required")
+	}
+	if s.authVerifier == nil {
+		return errors.New("lease ownership verification unavailable")
+	}
+	return s.authVerifier.VerifyLeaseOwnership(ctx, authCtx.Address, leaseID)
 }
 
 func (s *PortalAPIServer) verifyVEID(r *http.Request) error {

--- a/pkg/provider_daemon/portal_middleware.go
+++ b/pkg/provider_daemon/portal_middleware.go
@@ -10,12 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
-)
 
-type contextKey string
-
-const (
-	contextKeyPrincipal contextKey = "portal_principal"
+	portalauth "github.com/virtengine/virtengine/pkg/provider_daemon/auth"
 )
 
 // RateLimitConfig configures per-user rate limiting.
@@ -113,18 +109,18 @@ func clientIP(remoteAddr string) string {
 }
 
 func principalFromContext(ctx context.Context) string {
-	val := ctx.Value(contextKeyPrincipal)
-	if str, ok := val.(string); ok {
-		return str
-	}
-	return ""
+	return portalauth.FromContext(ctx).Address
 }
 
-func withPrincipal(ctx context.Context, principal string) context.Context {
-	if principal == "" {
+func authFromContext(ctx context.Context) portalauth.AuthContext {
+	return portalauth.FromContext(ctx)
+}
+
+func withAuth(ctx context.Context, auth portalauth.AuthContext) context.Context {
+	if auth.Address == "" {
 		return ctx
 	}
-	return context.WithValue(ctx, contextKeyPrincipal, principal)
+	return portalauth.WithAuth(ctx, auth)
 }
 
 func parseLimit(r *http.Request, fallback, max int) int {


### PR DESCRIPTION
## Summary
- add wallet-signed request verification middleware with nonce replay protection and lease ownership checks
- wire wallet auth into portal API routes and context handling
- add portal auth types/exports and provider daemon auth tests

## Testing
- go vet ./pkg/provider_daemon/... ./cmd/provider-daemon
- go test ./pkg/provider_daemon/auth -count=1
- go test ./pkg/provider_daemon -run TestDoesNotExist -count=1
- go build ./cmd/...
- pnpm -C portal lint
- pnpm -C portal type-check
- pnpm -C portal test
- pnpm -C lib/portal test
- pnpm -C portal build
