### PR TITLE
feat(provider): add SLA monitoring alerts

### DIFF
--- a/deploy/monitoring/prometheus/rules/sla.yml
+++ b/deploy/monitoring/prometheus/rules/sla.yml
@@ -1,0 +1,43 @@
+groups:
+  - name: sla.alerts
+    rules:
+      - alert: SLAUptimeBreach
+        expr: |
+          (1 - (
+            sum(rate(virtengine_provider_workload_uptime_seconds[30d])) by (provider_id, lease_id)
+            / sum(rate(virtengine_provider_workload_expected_uptime_seconds[30d])) by (provider_id, lease_id)
+          )) * 100 > 0.1
+        for: 5m
+        labels:
+          severity: critical
+          sla_metric: uptime
+        annotations:
+          summary: "SLA Uptime breach for {{ $labels.lease_id }}"
+          description: "Uptime is {{ $value | printf \"%.2f\" }}% below SLA target"
+
+      - alert: SLALatencyBreach
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(virtengine_provider_request_latency_bucket[1h])) by (le, lease_id)
+          ) > 500
+        for: 5m
+        labels:
+          severity: critical
+          sla_metric: latency_p99
+        annotations:
+          summary: "SLA P99 Latency breach for {{ $labels.lease_id }}"
+          description: "P99 latency is {{ $value | printf \"%.0f\" }}ms, exceeds 500ms SLA"
+
+      - alert: SLAUptimeWarning
+        expr: |
+          (1 - (
+            sum(rate(virtengine_provider_workload_uptime_seconds[30d])) by (provider_id, lease_id)
+            / sum(rate(virtengine_provider_workload_expected_uptime_seconds[30d])) by (provider_id, lease_id)
+          )) * 100 > 0.05
+        for: 5m
+        labels:
+          severity: warning
+          sla_metric: uptime
+        annotations:
+          summary: "SLA Uptime approaching threshold for {{ $labels.lease_id }}"
+          description: "Uptime buffer is {{ $value | printf \"%.2f\" }}%"

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/rs/zerolog v1.34.0
 	github.com/russellhaering/goxmldsig v1.5.0
+	github.com/shopspring/decimal v1.4.0
 	github.com/sideshow/apns2 v0.25.0
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -2253,6 +2253,8 @@ github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6v
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shamaton/msgpack/v2 v2.2.3 h1:uDOHmxQySlvlUYfQwdjxyybAOzjlQsD1Vjy+4jmO9NM=
 github.com/shamaton/msgpack/v2 v2.2.3/go.mod h1:6khjYnkx73f7VQU7wjcFS9DFjs+59naVWJv1TB7qdOI=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sideshow/apns2 v0.25.0 h1:XOzanncO9MQxkb03T/2uU2KcdVjYiIf0TMLzec0FTW4=
 github.com/sideshow/apns2 v0.25.0/go.mod h1:7Fceu+sL0XscxrfLSkAoH6UtvKefq3Kq1n4W3ayQZqE=

--- a/pkg/notifications/types.go
+++ b/pkg/notifications/types.go
@@ -16,6 +16,8 @@ const (
 	NotificationTypeEscrowDeposit NotificationType = "escrow_deposit"
 	NotificationTypeSecurityAlert NotificationType = "security_alert"
 	NotificationTypeProviderAlert NotificationType = "provider_alert"
+	NotificationTypeSLABreach     NotificationType = "sla_breach"
+	NotificationTypeSLAWarning    NotificationType = "sla_warning"
 )
 
 // Channel defines delivery channels.

--- a/pkg/sla/alerter.go
+++ b/pkg/sla/alerter.go
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+package sla
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/virtengine/virtengine/pkg/notifications"
+)
+
+// AlertSeverity controls alert routing.
+type AlertSeverity string
+
+const (
+	AlertInfo     AlertSeverity = "info"
+	AlertWarning  AlertSeverity = "warning"
+	AlertCritical AlertSeverity = "critical"
+)
+
+// Alert represents a monitoring alert.
+type Alert struct {
+	Severity AlertSeverity
+	Title    string
+	Message  string
+	Labels   map[string]string
+}
+
+// CustomerNotification describes a customer notification payload.
+type CustomerNotification struct {
+	Type    string
+	Title   string
+	Message string
+	LeaseID string
+}
+
+// ProviderNotification describes a provider notification payload.
+type ProviderNotification struct {
+	Type    string
+	Title   string
+	Message string
+	LeaseID string
+	Metric  SLAMetricType
+}
+
+// Alerter dispatches alerts and user notifications.
+type Alerter interface {
+	SendAlert(ctx context.Context, alert Alert) error
+	NotifyCustomer(ctx context.Context, customerID string, notif CustomerNotification) error
+	NotifyProvider(ctx context.Context, providerID string, notif ProviderNotification) error
+}
+
+// PrometheusClient sends alerts to Alertmanager.
+type PrometheusClient interface {
+	SendAlert(ctx context.Context, alert PrometheusAlert) error
+}
+
+// PrometheusAlert is a minimal Alertmanager payload.
+type PrometheusAlert struct {
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+// PagerDutyClient pages on-call.
+type PagerDutyClient interface {
+	CreateIncident(ctx context.Context, incident PagerDutyIncident) error
+}
+
+// PagerDutyIncident represents a PagerDuty incident.
+type PagerDutyIncident struct {
+	Title    string
+	Body     string
+	Severity string
+	Service  string
+}
+
+var errNotificationsUnavailable = errors.New("notification service unavailable")
+
+// AlerterImpl wires Alertmanager, PagerDuty, and notifications.
+type AlerterImpl struct {
+	prometheus    PrometheusClient
+	pagerduty     PagerDutyClient
+	notifications notifications.Service
+}
+
+// NewAlerter creates an alerter implementation.
+func NewAlerter(prometheus PrometheusClient, pagerduty PagerDutyClient, notifService notifications.Service) *AlerterImpl {
+	return &AlerterImpl{
+		prometheus:    prometheus,
+		pagerduty:     pagerduty,
+		notifications: notifService,
+	}
+}
+
+// SendAlert dispatches a monitoring alert.
+func (a *AlerterImpl) SendAlert(ctx context.Context, alert Alert) error {
+	if a == nil {
+		return nil
+	}
+
+	if a.prometheus != nil {
+		if err := a.prometheus.SendAlert(ctx, PrometheusAlert{
+			Labels: map[string]string{
+				"alertname": alert.Title,
+				"severity":  string(alert.Severity),
+			},
+			Annotations: map[string]string{
+				"summary":     alert.Title,
+				"description": alert.Message,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+
+	if alert.Severity == AlertCritical && a.pagerduty != nil {
+		return a.pagerduty.CreateIncident(ctx, PagerDutyIncident{
+			Title:    alert.Title,
+			Body:     alert.Message,
+			Severity: "critical",
+			Service:  "virtengine-sla",
+		})
+	}
+
+	return nil
+}
+
+// NotifyCustomer sends notifications to customers.
+func (a *AlerterImpl) NotifyCustomer(ctx context.Context, customerID string, notif CustomerNotification) error {
+	if a == nil {
+		return nil
+	}
+	if a.notifications == nil {
+		return errNotificationsUnavailable
+	}
+
+	notifType := notifications.NotificationTypeSLABreach
+	if notif.Type == "sla_warning" {
+		notifType = notifications.NotificationTypeSLAWarning
+	}
+
+	return a.notifications.Send(ctx, notifications.Notification{
+		UserAddress: customerID,
+		Type:        notifType,
+		Title:       notif.Title,
+		Body:        notif.Message,
+		Data: map[string]string{
+			"lease_id": notif.LeaseID,
+		},
+		Channels: []notifications.Channel{notifications.ChannelPush, notifications.ChannelEmail, notifications.ChannelInApp},
+	})
+}
+
+// NotifyProvider sends provider alerts.
+func (a *AlerterImpl) NotifyProvider(ctx context.Context, providerID string, notif ProviderNotification) error {
+	if a == nil {
+		return nil
+	}
+	if a.notifications == nil {
+		return errNotificationsUnavailable
+	}
+
+	data := map[string]string{
+		"lease_id": notif.LeaseID,
+		"metric":   string(notif.Metric),
+	}
+
+	return a.notifications.Send(ctx, notifications.Notification{
+		UserAddress: providerID,
+		Type:        notifications.NotificationTypeProviderAlert,
+		Title:       fmt.Sprintf("Provider Alert: %s", notif.Title),
+		Body:        notif.Message,
+		Data:        data,
+		Channels:    []notifications.Channel{notifications.ChannelPush, notifications.ChannelEmail, notifications.ChannelInApp},
+	})
+}

--- a/pkg/sla/credit.go
+++ b/pkg/sla/credit.go
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+package sla
+
+import (
+	"fmt"
+
+	"github.com/shopspring/decimal"
+)
+
+// CalculateCredit computes the credit percentage owed for a breach.
+func CalculateCredit(definition *SLADefinition, breach *BreachRecord) (decimal.Decimal, error) {
+	if definition == nil {
+		return decimal.Zero, fmt.Errorf("sla definition is nil")
+	}
+	if breach == nil {
+		return decimal.Zero, fmt.Errorf("breach is nil")
+	}
+
+	metric, ok := findMetric(definition.Metrics, breach.MetricType)
+	if !ok {
+		return decimal.Zero, fmt.Errorf("sla metric %s not found", breach.MetricType)
+	}
+
+	deviation, err := calculateDeviation(metric, breach.ActualValue)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	if deviation.LessThanOrEqual(decimal.Zero) {
+		return decimal.Zero, nil
+	}
+
+	credit := decimal.Zero
+	for _, bracket := range definition.CreditPolicy.Brackets {
+		if deviation.GreaterThanOrEqual(bracket.MinDeviation) {
+			if bracket.MaxDeviation.IsZero() || deviation.LessThanOrEqual(bracket.MaxDeviation) {
+				credit = bracket.CreditPercent
+				break
+			}
+		}
+	}
+
+	if !definition.CreditPolicy.MaxCredit.IsZero() && credit.GreaterThan(definition.CreditPolicy.MaxCredit) {
+		credit = definition.CreditPolicy.MaxCredit
+	}
+
+	return credit, nil
+}
+
+func calculateDeviation(metric SLAMetric, actual decimal.Decimal) (decimal.Decimal, error) {
+	switch metric.Comparison {
+	case ComparisonGTE:
+		if actual.GreaterThanOrEqual(metric.Target) {
+			return decimal.Zero, nil
+		}
+		return metric.Target.Sub(actual), nil
+	case ComparisonLTE:
+		if actual.LessThanOrEqual(metric.Target) {
+			return decimal.Zero, nil
+		}
+		return actual.Sub(metric.Target), nil
+	default:
+		return decimal.Zero, fmt.Errorf("unsupported comparison type: %s", metric.Comparison)
+	}
+}
+
+func findMetric(metrics []SLAMetric, metricType SLAMetricType) (SLAMetric, bool) {
+	for _, metric := range metrics {
+		if metric.Type == metricType {
+			return metric, true
+		}
+	}
+
+	return SLAMetric{}, false
+}

--- a/pkg/sla/credit_test.go
+++ b/pkg/sla/credit_test.go
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+package sla
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestCalculateCredit(t *testing.T) {
+	uptimeDefinition := &SLADefinition{
+		ProviderID: "provider-1",
+		Metrics: []SLAMetric{
+			{
+				Type:       MetricUptime,
+				Target:     decimal.NewFromFloat(99.9),
+				Comparison: ComparisonGTE,
+			},
+		},
+		CreditPolicy: CreditPolicy{
+			Brackets: []CreditBracket{
+				{
+					MinDeviation:  decimal.NewFromFloat(0.1),
+					MaxDeviation:  decimal.NewFromFloat(0.5),
+					CreditPercent: decimal.NewFromInt(10),
+				},
+				{
+					MinDeviation:  decimal.NewFromFloat(0.5),
+					MaxDeviation:  decimal.NewFromFloat(2.0),
+					CreditPercent: decimal.NewFromInt(20),
+				},
+			},
+			MaxCredit: decimal.NewFromInt(25),
+		},
+	}
+
+	latencyDefinition := &SLADefinition{
+		ProviderID: "provider-1",
+		Metrics: []SLAMetric{
+			{
+				Type:       MetricLatencyP99,
+				Target:     decimal.NewFromInt(500),
+				Comparison: ComparisonLTE,
+			},
+		},
+		CreditPolicy: CreditPolicy{
+			Brackets: []CreditBracket{
+				{
+					MinDeviation:  decimal.NewFromInt(10),
+					MaxDeviation:  decimal.NewFromInt(50),
+					CreditPercent: decimal.NewFromInt(10),
+				},
+			},
+		},
+	}
+
+	type testCase struct {
+		name       string
+		definition *SLADefinition
+		breach     *BreachRecord
+		want       decimal.Decimal
+	}
+
+	cases := []testCase{
+		{
+			name:       "uptime mild deviation",
+			definition: uptimeDefinition,
+			breach: &BreachRecord{
+				MetricType:  MetricUptime,
+				ActualValue: decimal.NewFromFloat(99.7),
+			},
+			want: decimal.NewFromInt(10),
+		},
+		{
+			name:       "uptime larger deviation",
+			definition: uptimeDefinition,
+			breach: &BreachRecord{
+				MetricType:  MetricUptime,
+				ActualValue: decimal.NewFromFloat(98.2),
+			},
+			want: decimal.NewFromInt(20),
+		},
+		{
+			name:       "latency deviation",
+			definition: latencyDefinition,
+			breach: &BreachRecord{
+				MetricType:  MetricLatencyP99,
+				ActualValue: decimal.NewFromInt(510),
+			},
+			want: decimal.NewFromInt(10),
+		},
+		{
+			name:       "no matching bracket",
+			definition: uptimeDefinition,
+			breach: &BreachRecord{
+				MetricType:  MetricUptime,
+				ActualValue: decimal.NewFromFloat(96.0),
+			},
+			want: decimal.Zero,
+		},
+	}
+
+	for _, tc := range cases {
+		credit, err := CalculateCredit(tc.definition, tc.breach)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+
+		if !credit.Equal(tc.want) {
+			t.Fatalf("%s: expected %s, got %s", tc.name, tc.want, credit)
+		}
+	}
+}

--- a/pkg/sla/monitor.go
+++ b/pkg/sla/monitor.go
@@ -1,0 +1,356 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+package sla
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// Monitor evaluates SLA metrics, detects breaches, and triggers alerts.
+type Monitor struct {
+	metricsCollector MetricsCollector
+	slaStore         SLAStore
+	alerter          Alerter
+	remediator       Remediator
+
+	mu            sync.RWMutex
+	currentStatus map[string]*SLAStatus
+
+	checkInterval time.Duration
+	warningBuffer decimal.Decimal
+	nowFn         func() time.Time
+}
+
+// MonitorOption configures the SLA monitor.
+type MonitorOption func(*Monitor)
+
+// WithCheckInterval sets the monitor interval.
+func WithCheckInterval(interval time.Duration) MonitorOption {
+	return func(m *Monitor) {
+		m.checkInterval = interval
+	}
+}
+
+// WithWarningBuffer sets the warning buffer percent (e.g. 0.05 for 5%).
+func WithWarningBuffer(buffer decimal.Decimal) MonitorOption {
+	return func(m *Monitor) {
+		m.warningBuffer = buffer
+	}
+}
+
+// WithNowFn sets a custom clock for testing.
+func WithNowFn(nowFn func() time.Time) MonitorOption {
+	return func(m *Monitor) {
+		m.nowFn = nowFn
+	}
+}
+
+// NewMonitor constructs a Monitor.
+func NewMonitor(
+	collector MetricsCollector,
+	store SLAStore,
+	alerter Alerter,
+	remediator Remediator,
+	opts ...MonitorOption,
+) *Monitor {
+	monitor := &Monitor{
+		metricsCollector: collector,
+		slaStore:         store,
+		alerter:          alerter,
+		remediator:       remediator,
+		currentStatus:    make(map[string]*SLAStatus),
+		checkInterval:    1 * time.Minute,
+		warningBuffer:    decimal.NewFromFloat(0.05),
+		nowFn:            time.Now,
+	}
+
+	for _, opt := range opts {
+		opt(monitor)
+	}
+
+	return monitor
+}
+
+// Start begins periodic SLA checks until the context is canceled.
+func (m *Monitor) Start(ctx context.Context) {
+	if m == nil {
+		return
+	}
+
+	ticker := time.NewTicker(m.checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.checkAllLeases(ctx)
+		}
+	}
+}
+
+func (m *Monitor) checkAllLeases(ctx context.Context) {
+	if m.slaStore == nil || m.metricsCollector == nil {
+		return
+	}
+
+	leases, err := m.slaStore.GetActiveLeases(ctx)
+	if err != nil {
+		return
+	}
+
+	for _, lease := range leases {
+		if ctx.Err() != nil {
+			return
+		}
+		m.checkLease(ctx, lease)
+	}
+}
+
+func (m *Monitor) checkLease(ctx context.Context, lease LeaseInfo) {
+	slaDef, err := m.slaStore.GetSLADefinition(ctx, lease.ProviderID)
+	if err != nil || slaDef == nil {
+		return
+	}
+
+	status := &SLAStatus{
+		LeaseID:       lease.ID,
+		ProviderID:    lease.ProviderID,
+		CustomerID:    lease.CustomerID,
+		SLADefinition: slaDef,
+		Metrics:       make(map[SLAMetricType]*MetricStatus),
+		OverallStatus: StatusHealthy,
+		LastChecked:   m.nowFn(),
+	}
+
+	for _, metric := range slaDef.Metrics {
+		currentValue, err := m.metricsCollector.GetMetric(ctx, lease.ID, metric.Type, metric.Window)
+		if err != nil {
+			continue
+		}
+
+		metricStatus := m.evaluateMetric(metric, currentValue)
+		status.Metrics[metric.Type] = metricStatus
+
+		if metricStatus.Status == StatusBreached {
+			status.OverallStatus = StatusBreached
+		} else if metricStatus.Status == StatusWarning && status.OverallStatus != StatusBreached {
+			status.OverallStatus = StatusWarning
+		}
+	}
+
+	m.mu.Lock()
+	oldStatus := m.currentStatus[lease.ID]
+	m.currentStatus[lease.ID] = status
+	m.mu.Unlock()
+
+	m.handleStatusChange(ctx, oldStatus, status)
+}
+
+func (m *Monitor) evaluateMetric(metric SLAMetric, currentValue decimal.Decimal) *MetricStatus {
+	status := &MetricStatus{
+		Type:         metric.Type,
+		CurrentValue: currentValue,
+		Target:       metric.Target,
+		LastUpdated:  m.nowFn(),
+	}
+
+	breached := false
+	warning := false
+
+	one := decimal.NewFromInt(1)
+
+	switch metric.Comparison {
+	case ComparisonGTE:
+		if currentValue.LessThan(metric.Target) {
+			breached = true
+		} else {
+			warningThreshold := metric.Target.Mul(one.Add(m.warningBuffer))
+			warning = currentValue.LessThan(warningThreshold)
+		}
+	case ComparisonLTE:
+		if currentValue.GreaterThan(metric.Target) {
+			breached = true
+		} else {
+			warningThreshold := metric.Target.Mul(one.Sub(m.warningBuffer))
+			warning = currentValue.GreaterThan(warningThreshold)
+		}
+	default:
+		breached = false
+		warning = false
+	}
+
+	if breached {
+		status.Status = StatusBreached
+	} else if warning {
+		status.Status = StatusWarning
+	} else {
+		status.Status = StatusHealthy
+	}
+
+	return status
+}
+
+func (m *Monitor) handleStatusChange(ctx context.Context, oldStatus, newStatus *SLAStatus) {
+	if newStatus == nil {
+		return
+	}
+
+	if oldStatus == nil {
+		return
+	}
+
+	for metricType, newMetric := range newStatus.Metrics {
+		oldMetric, exists := oldStatus.Metrics[metricType]
+
+		if newMetric.Status == StatusBreached && (!exists || oldMetric.Status != StatusBreached) {
+			m.handleBreach(ctx, newStatus, metricType, newMetric)
+			continue
+		}
+
+		if newMetric.Status == StatusWarning && (!exists || oldMetric.Status == StatusHealthy) {
+			m.handleWarning(ctx, newStatus, metricType, newMetric)
+			continue
+		}
+
+		if newMetric.Status == StatusHealthy && exists && oldMetric.Status == StatusBreached {
+			m.handleBreachResolved(ctx, newStatus, metricType)
+		}
+	}
+}
+
+func (m *Monitor) handleBreach(ctx context.Context, status *SLAStatus, metricType SLAMetricType, metric *MetricStatus) {
+	breach := &BreachRecord{
+		ID:          uuid.NewString(),
+		LeaseID:     status.LeaseID,
+		MetricType:  metricType,
+		TargetValue: metric.Target,
+		ActualValue: metric.CurrentValue,
+		StartedAt:   m.nowFn(),
+	}
+
+	status.ActiveBreach = breach
+
+	if m.slaStore != nil {
+		_ = m.slaStore.CreateBreach(ctx, breach)
+	}
+
+	if m.alerter != nil {
+		_ = m.alerter.SendAlert(ctx, Alert{
+			Severity: AlertCritical,
+			Title:    fmt.Sprintf("SLA Breach: %s for lease %s", metricType, status.LeaseID),
+			Message: fmt.Sprintf(
+				"SLA breach detected. Metric: %s, Target: %s, Current: %s",
+				metricType, metric.Target, metric.CurrentValue,
+			),
+			Labels: map[string]string{
+				"lease_id":    status.LeaseID,
+				"provider_id": status.ProviderID,
+				"customer_id": status.CustomerID,
+				"metric":      string(metricType),
+			},
+		})
+
+		_ = m.alerter.NotifyCustomer(ctx, status.CustomerID, CustomerNotification{
+			Type:    "sla_breach",
+			Title:   "SLA Breach Detected",
+			Message: "An SLA breach has been detected for your service. Credit compensation will be applied automatically.",
+			LeaseID: status.LeaseID,
+		})
+	}
+
+	if m.remediator != nil {
+		m.remediator.HandleBreach(ctx, breach)
+	}
+}
+
+func (m *Monitor) handleWarning(ctx context.Context, status *SLAStatus, metricType SLAMetricType, metric *MetricStatus) {
+	if m.alerter != nil {
+		_ = m.alerter.SendAlert(ctx, Alert{
+			Severity: AlertWarning,
+			Title:    fmt.Sprintf("SLA Warning: %s approaching threshold", metricType),
+			Message: fmt.Sprintf(
+				"SLA metric approaching breach threshold. Metric: %s, Target: %s, Current: %s",
+				metricType, metric.Target, metric.CurrentValue,
+			),
+			Labels: map[string]string{
+				"lease_id":    status.LeaseID,
+				"provider_id": status.ProviderID,
+				"metric":      string(metricType),
+			},
+		})
+
+		_ = m.alerter.NotifyProvider(ctx, status.ProviderID, ProviderNotification{
+			Type:    "sla_warning",
+			Title:   "SLA Warning",
+			Message: "SLA metrics are approaching the breach threshold. Please investigate.",
+			LeaseID: status.LeaseID,
+			Metric:  metricType,
+		})
+	}
+
+	if m.remediator != nil {
+		m.remediator.HandleWarning(ctx, status, metricType)
+	}
+}
+
+func (m *Monitor) handleBreachResolved(ctx context.Context, status *SLAStatus, metricType SLAMetricType) {
+	if m.slaStore == nil {
+		return
+	}
+
+	breach, err := m.slaStore.GetActiveBreach(ctx, status.LeaseID, metricType)
+	if err != nil || breach == nil {
+		return
+	}
+
+	now := m.nowFn()
+	breach.ResolvedAt = &now
+	breach.Duration = now.Sub(breach.StartedAt)
+
+	credit, err := CalculateCredit(status.SLADefinition, breach)
+	if err == nil {
+		breach.CreditAmount = credit
+	}
+
+	_ = m.slaStore.UpdateBreach(ctx, breach)
+
+	if m.alerter != nil {
+		_ = m.alerter.SendAlert(ctx, Alert{
+			Severity: AlertInfo,
+			Title:    fmt.Sprintf("SLA Breach Resolved: %s", metricType),
+			Message:  fmt.Sprintf("SLA breach resolved after %s. Credit: %s", breach.Duration, breach.CreditAmount),
+			Labels: map[string]string{
+				"lease_id": status.LeaseID,
+				"metric":   string(metricType),
+			},
+		})
+	}
+
+	if m.remediator != nil {
+		m.remediator.ApplyCredit(ctx, breach)
+	}
+}
+
+// GetStatus returns the latest SLA status for a lease.
+func (m *Monitor) GetStatus(leaseID string) (*SLAStatus, bool) {
+	if m == nil {
+		return nil, false
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	status, ok := m.currentStatus[leaseID]
+	return status, ok
+}

--- a/pkg/sla/monitor_test.go
+++ b/pkg/sla/monitor_test.go
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+package sla
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestEvaluateMetric(t *testing.T) {
+	monitor := NewMonitor(nil, nil, nil, nil, WithWarningBuffer(decimal.NewFromFloat(0.05)), WithNowFn(func() time.Time {
+		return time.Unix(0, 0)
+	}))
+
+	t.Run("gte", func(t *testing.T) {
+		metric := SLAMetric{
+			Type:       MetricUptime,
+			Target:     decimal.NewFromInt(100),
+			Comparison: ComparisonGTE,
+		}
+
+		cases := []struct {
+			name   string
+			value  decimal.Decimal
+			status HealthStatus
+		}{
+			{name: "healthy", value: decimal.NewFromInt(110), status: StatusHealthy},
+			{name: "warning", value: decimal.NewFromInt(102), status: StatusWarning},
+			{name: "breach", value: decimal.NewFromInt(99), status: StatusBreached},
+		}
+
+		for _, tc := range cases {
+			if got := monitor.evaluateMetric(metric, tc.value); got.Status != tc.status {
+				t.Fatalf("%s: expected %s, got %s", tc.name, tc.status, got.Status)
+			}
+		}
+	})
+
+	t.Run("lte", func(t *testing.T) {
+		metric := SLAMetric{
+			Type:       MetricLatencyP99,
+			Target:     decimal.NewFromInt(500),
+			Comparison: ComparisonLTE,
+		}
+
+		cases := []struct {
+			name   string
+			value  decimal.Decimal
+			status HealthStatus
+		}{
+			{name: "healthy", value: decimal.NewFromInt(470), status: StatusHealthy},
+			{name: "warning", value: decimal.NewFromInt(480), status: StatusWarning},
+			{name: "breach", value: decimal.NewFromInt(510), status: StatusBreached},
+		}
+
+		for _, tc := range cases {
+			if got := monitor.evaluateMetric(metric, tc.value); got.Status != tc.status {
+				t.Fatalf("%s: expected %s, got %s", tc.name, tc.status, got.Status)
+			}
+		}
+	})
+}

--- a/pkg/sla/remediator.go
+++ b/pkg/sla/remediator.go
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+package sla
+
+import "context"
+
+// Remediator handles SLA breach remediation.
+type Remediator interface {
+	HandleBreach(ctx context.Context, breach *BreachRecord)
+	HandleWarning(ctx context.Context, status *SLAStatus, metricType SLAMetricType)
+	ApplyCredit(ctx context.Context, breach *BreachRecord)
+}
+
+// NoopRemediator is a safe default implementation.
+type NoopRemediator struct{}
+
+// HandleBreach implements Remediator.
+func (r NoopRemediator) HandleBreach(_ context.Context, _ *BreachRecord) {}
+
+// HandleWarning implements Remediator.
+func (r NoopRemediator) HandleWarning(_ context.Context, _ *SLAStatus, _ SLAMetricType) {}
+
+// ApplyCredit implements Remediator.
+func (r NoopRemediator) ApplyCredit(_ context.Context, _ *BreachRecord) {}

--- a/pkg/sla/store/memory.go
+++ b/pkg/sla/store/memory.go
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/virtengine/virtengine/pkg/sla"
+)
+
+// MemoryStore provides an in-memory SLA store for development and tests.
+type MemoryStore struct {
+	mu          sync.RWMutex
+	leases      []sla.LeaseInfo
+	definitions map[string]*sla.SLADefinition
+	breaches    map[string]*sla.BreachRecord
+}
+
+// NewMemoryStore creates a new in-memory SLA store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		definitions: make(map[string]*sla.SLADefinition),
+		breaches:    make(map[string]*sla.BreachRecord),
+	}
+}
+
+// SetActiveLeases sets leases for monitoring.
+func (s *MemoryStore) SetActiveLeases(leases []sla.LeaseInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.leases = append([]sla.LeaseInfo{}, leases...)
+}
+
+// SetSLADefinition associates a provider with an SLA definition.
+func (s *MemoryStore) SetSLADefinition(providerID string, definition *sla.SLADefinition) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.definitions[providerID] = definition
+}
+
+// GetActiveLeases returns configured leases.
+func (s *MemoryStore) GetActiveLeases(_ context.Context) ([]sla.LeaseInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]sla.LeaseInfo{}, s.leases...), nil
+}
+
+// GetSLADefinition returns the provider SLA definition.
+func (s *MemoryStore) GetSLADefinition(_ context.Context, providerID string) (*sla.SLADefinition, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	def, ok := s.definitions[providerID]
+	if !ok {
+		return nil, fmt.Errorf("sla definition not found for provider %s", providerID)
+	}
+	return def, nil
+}
+
+// CreateBreach stores an active breach.
+func (s *MemoryStore) CreateBreach(_ context.Context, breach *sla.BreachRecord) error {
+	if breach == nil {
+		return fmt.Errorf("breach is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.breaches[breachKey(breach.LeaseID, breach.MetricType)] = breach
+	return nil
+}
+
+// UpdateBreach updates a breach record.
+func (s *MemoryStore) UpdateBreach(_ context.Context, breach *sla.BreachRecord) error {
+	if breach == nil {
+		return fmt.Errorf("breach is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.breaches[breachKey(breach.LeaseID, breach.MetricType)] = breach
+	return nil
+}
+
+// GetActiveBreach returns an unresolved breach for a lease/metric.
+func (s *MemoryStore) GetActiveBreach(_ context.Context, leaseID string, metricType sla.SLAMetricType) (*sla.BreachRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	breach, ok := s.breaches[breachKey(leaseID, metricType)]
+	if !ok {
+		return nil, nil
+	}
+	if breach.ResolvedAt != nil {
+		return nil, nil
+	}
+
+	return breach, nil
+}
+
+func breachKey(leaseID string, metricType sla.SLAMetricType) string {
+	return fmt.Sprintf("%s:%s", leaseID, metricType)
+}

--- a/pkg/sla/types.go
+++ b/pkg/sla/types.go
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) VirtEngine, Inc.
+ * SPDX-License-Identifier: BSL-1.1
+ */
+
+package sla
+
+import (
+	"context"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// SLAMetricType defines the supported SLA metrics.
+type SLAMetricType string
+
+const (
+	MetricUptime     SLAMetricType = "uptime"
+	MetricLatencyP50 SLAMetricType = "latency_p50"
+	MetricLatencyP99 SLAMetricType = "latency_p99"
+	MetricThroughput SLAMetricType = "throughput"
+	MetricErrorRate  SLAMetricType = "error_rate"
+)
+
+// SLATier defines standard SLA tiers.
+type SLATier string
+
+const (
+	TierBronze   SLATier = "bronze"
+	TierSilver   SLATier = "silver"
+	TierGold     SLATier = "gold"
+	TierPlatinum SLATier = "platinum"
+)
+
+// ComparisonType describes how SLA targets are evaluated.
+type ComparisonType string
+
+const (
+	ComparisonGTE ComparisonType = "gte" // >= (for uptime/throughput)
+	ComparisonLTE ComparisonType = "lte" // <= (for latency/error rate)
+)
+
+// SLADefinition describes the SLA commitment for a provider.
+type SLADefinition struct {
+	ID            string
+	ProviderID    string
+	Tier          SLATier
+	Metrics       []SLAMetric
+	EffectiveFrom time.Time
+	EffectiveTo   *time.Time
+
+	CreditPolicy CreditPolicy
+}
+
+// SLAMetric is a single SLA metric target and evaluation window.
+type SLAMetric struct {
+	Type       SLAMetricType
+	Target     decimal.Decimal
+	Window     time.Duration
+	Comparison ComparisonType
+}
+
+// CreditPolicy defines breach compensation rules.
+type CreditPolicy struct {
+	Brackets  []CreditBracket
+	MaxCredit decimal.Decimal // Maximum credit percentage
+}
+
+// CreditBracket assigns a credit percentage based on deviation.
+type CreditBracket struct {
+	MinDeviation  decimal.Decimal
+	MaxDeviation  decimal.Decimal
+	CreditPercent decimal.Decimal
+}
+
+// LeaseInfo identifies the lease under SLA monitoring.
+type LeaseInfo struct {
+	ID         string
+	ProviderID string
+	CustomerID string
+}
+
+// MetricDataPoint is a historical metric sample.
+type MetricDataPoint struct {
+	Timestamp time.Time
+	Value     decimal.Decimal
+}
+
+// SLAStatus captures the current SLA health state for a lease.
+type SLAStatus struct {
+	LeaseID       string
+	ProviderID    string
+	CustomerID    string
+	SLADefinition *SLADefinition
+
+	Metrics       map[SLAMetricType]*MetricStatus
+	OverallStatus HealthStatus
+
+	ActiveBreach  *BreachRecord
+	BreachHistory []BreachRecord
+
+	LastChecked time.Time
+}
+
+// MetricStatus captures status for a single metric.
+type MetricStatus struct {
+	Type         SLAMetricType
+	CurrentValue decimal.Decimal
+	Target       decimal.Decimal
+	Status       HealthStatus
+	LastUpdated  time.Time
+}
+
+// HealthStatus represents SLA health categories.
+type HealthStatus string
+
+const (
+	StatusHealthy  HealthStatus = "healthy"
+	StatusWarning  HealthStatus = "warning"
+	StatusBreached HealthStatus = "breached"
+)
+
+// BreachRecord tracks SLA breaches for a lease.
+type BreachRecord struct {
+	ID           string
+	LeaseID      string
+	MetricType   SLAMetricType
+	TargetValue  decimal.Decimal
+	ActualValue  decimal.Decimal
+	StartedAt    time.Time
+	ResolvedAt   *time.Time
+	Duration     time.Duration
+	CreditAmount decimal.Decimal
+}
+
+// MetricsCollector supplies aggregated metric values.
+type MetricsCollector interface {
+	GetMetric(ctx context.Context, leaseID string, metric SLAMetricType, window time.Duration) (decimal.Decimal, error)
+	GetHistoricalMetrics(ctx context.Context, leaseID string, metric SLAMetricType, start, end time.Time) ([]MetricDataPoint, error)
+}
+
+// SLAStore provides SLA definitions and breach persistence.
+type SLAStore interface {
+	GetActiveLeases(ctx context.Context) ([]LeaseInfo, error)
+	GetSLADefinition(ctx context.Context, providerID string) (*SLADefinition, error)
+	CreateBreach(ctx context.Context, breach *BreachRecord) error
+	UpdateBreach(ctx context.Context, breach *BreachRecord) error
+	GetActiveBreach(ctx context.Context, leaseID string, metricType SLAMetricType) (*BreachRecord, error)
+}
+
+// DefaultSLATiers provides baseline SLA tiers.
+var DefaultSLATiers = map[SLATier][]SLAMetric{
+	TierBronze: {
+		{Type: MetricUptime, Target: decimal.NewFromFloat(99.0), Window: 30 * 24 * time.Hour, Comparison: ComparisonGTE},
+		{Type: MetricLatencyP99, Target: decimal.NewFromInt(1000), Window: 24 * time.Hour, Comparison: ComparisonLTE},
+	},
+	TierSilver: {
+		{Type: MetricUptime, Target: decimal.NewFromFloat(99.5), Window: 30 * 24 * time.Hour, Comparison: ComparisonGTE},
+		{Type: MetricLatencyP99, Target: decimal.NewFromInt(500), Window: 24 * time.Hour, Comparison: ComparisonLTE},
+		{Type: MetricErrorRate, Target: decimal.NewFromFloat(1.0), Window: 24 * time.Hour, Comparison: ComparisonLTE},
+	},
+	TierGold: {
+		{Type: MetricUptime, Target: decimal.NewFromFloat(99.9), Window: 30 * 24 * time.Hour, Comparison: ComparisonGTE},
+		{Type: MetricLatencyP99, Target: decimal.NewFromInt(200), Window: 24 * time.Hour, Comparison: ComparisonLTE},
+		{Type: MetricErrorRate, Target: decimal.NewFromFloat(0.1), Window: 24 * time.Hour, Comparison: ComparisonLTE},
+	},
+	TierPlatinum: {
+		{Type: MetricUptime, Target: decimal.NewFromFloat(99.99), Window: 30 * 24 * time.Hour, Comparison: ComparisonGTE},
+		{Type: MetricLatencyP99, Target: decimal.NewFromInt(100), Window: 24 * time.Hour, Comparison: ComparisonLTE},
+		{Type: MetricErrorRate, Target: decimal.NewFromFloat(0.01), Window: 24 * time.Hour, Comparison: ComparisonLTE},
+	},
+}


### PR DESCRIPTION
## Summary
- add SLA monitoring core types, monitor, alerting, remediation scaffolding
- add in-memory SLA store and credit calculation tests
- add Prometheus SLA alert rules

## Testing
- go test ./pkg/sla/... -count=1
- go vet ./pkg/sla/...
- golangci-lint run --new-from-rev=HEAD~1
- go build ./cmd/...
- go build ./...
