### PR TITLE
feat(veid): add biometric hardware and device attestation

### DIFF
--- a/docs/veid/biometric-hardware-attestation.md
+++ b/docs/veid/biometric-hardware-attestation.md
@@ -1,0 +1,52 @@
+# VEID Biometric Hardware + Device Attestation
+
+This document describes biometric hardware capture and device integrity attestation support in VEID.
+It complements the VEID Flow Specification and the Biometric Data Addendum.
+
+## Supported Devices
+
+### Android
+- **Play Integrity API** (primary): device integrity + strong integrity verdicts
+- **SafetyNet Attestation** (fallback for legacy devices)
+- Supported sensors: fingerprint (optical/capacitive/ultrasonic), iris (if OEM hardware supports)
+
+### iOS
+- **App Attest** (primary)
+- **DeviceCheck** (fallback for legacy devices)
+- Supported sensors: Touch ID / Face ID / Iris (where available)
+
+## Enrollment Flow (End-to-End)
+
+1. **Consent**: user accepts biometric data notice and privacy terms.
+2. **Document capture**: front/back with OCR extraction.
+3. **Selfie + liveness**: active liveness challenges and anti-spoofing checks.
+4. **Biometric hardware capture**: fingerprint/iris template capture via platform-secure APIs.
+5. **Device attestation**: Play Integrity / App Attest token issued and verified.
+6. **Encrypted payload**: biometric templates + attestation payloads encrypted into the vault.
+7. **On-chain scope creation**: new scopes are created referencing encrypted vault payloads.
+8. **Verification**: verification service checks attestation and stores signed results on-chain.
+
+## On-Chain Scopes
+
+New scope types are used for biometric hardware and device attestation payloads:
+- `biometric_hardware`
+- `device_attestation`
+
+The encrypted payload stored in the identity scope references the vault (32A). The
+verification attestation references the scope IDs for auditability.
+
+## Privacy Considerations
+
+- **Data minimization**: store only templates + integrity metadata required for verification.
+- **Encryption**: all biometric templates and attestation payloads are encrypted using the
+  VEID envelope and stored in the vault.
+- **Consent**: biometric capture requires explicit consent (see `BIOMETRIC_DATA_ADDENDUM.md`).
+- **Retention**: attestation payloads follow VEID lifecycle policies (expiration + revocation).
+- **Auditability**: attestation failures are recorded on-chain for review and dispute handling.
+
+## Fallback Behavior
+
+- If the platform does not support attestation APIs, the capture flow continues with a
+  `device_attestation` scope marked as unsupported.
+- Verification pipelines should enforce **attestation-required** policies for high-risk actions
+  (e.g., validator onboarding) and allow fallback for low-risk flows.

--- a/mobile/veid-capture-app/App.tsx
+++ b/mobile/veid-capture-app/App.tsx
@@ -5,6 +5,7 @@ import { ConsentScreen } from "./src/screens/ConsentScreen";
 import { DocumentCaptureScreen } from "./src/screens/DocumentCaptureScreen";
 import { SelfieCaptureScreen } from "./src/screens/SelfieCaptureScreen";
 import { LivenessScreen } from "./src/screens/LivenessScreen";
+import { BiometricCaptureScreen } from "./src/screens/BiometricCaptureScreen";
 import { ReviewScreen } from "./src/screens/ReviewScreen";
 import { UploadScreen } from "./src/screens/UploadScreen";
 import { CompleteScreen } from "./src/screens/CompleteScreen";
@@ -20,9 +21,11 @@ function CaptureRouter() {
     case "document_back":
       return <DocumentCaptureScreen side="back" stepIndex={1} />;
     case "selfie":
-      return <SelfieCaptureScreen />;
+      return <SelfieCaptureScreen stepIndex={2} />;
     case "liveness":
-      return <LivenessScreen />;
+      return <LivenessScreen stepIndex={3} />;
+    case "biometric":
+      return <BiometricCaptureScreen />;
     case "review":
       return <ReviewScreen />;
     case "upload":

--- a/mobile/veid-capture-app/README.md
+++ b/mobile/veid-capture-app/README.md
@@ -9,13 +9,16 @@ and aligns with AU2024203136A1 requirements for document + biometric verificatio
 - Document capture (front/back)
 - Selfie capture with face detection guidance
 - Active liveness challenges (blink, head turn, smile)
+- Biometric hardware capture (fingerprint / iris) with liveness + anti-spoofing signals
 - Document OCR extraction + field parsing
 - Secure payload packaging hooks (encryption + signing adapters)
+- Device integrity attestation hooks (Play Integrity / App Attest)
 
 ## Requirements Mapping (AU2024203136A1)
 
 - Document capture: multi-side capture with guided framing
 - Biometric capture: selfie + liveness challenge-response
+- Biometric hardware attestation: fingerprint/iris sensor verification
 - Quality checks: face confidence + liveness gating
 - OCR: extracted fields from document image
 - Secure transport: encryption + device attestation hooks
@@ -33,5 +36,5 @@ npm test
 
 - Native ML modules are pluggable. The default adapters fall back to mock services
   when native modules are not present.
-- Encryption and device attestation are implemented as stubs with clear extension points
-  for the production mobile SDK.
+- Encryption, biometric hardware capture, and device attestation are implemented as stubs
+  with clear extension points for the production mobile SDK.

--- a/mobile/veid-capture-app/src/components/ProgressStepper.tsx
+++ b/mobile/veid-capture-app/src/components/ProgressStepper.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 
-const steps = ["Consent", "Document", "Selfie", "Liveness", "Review", "Upload"];
+const steps = ["Consent", "Document", "Selfie", "Liveness", "Biometric", "Review", "Upload"];
 
 export function ProgressStepper({ activeIndex }: { activeIndex: number }) {
   return (

--- a/mobile/veid-capture-app/src/core/biometric/index.ts
+++ b/mobile/veid-capture-app/src/core/biometric/index.ts
@@ -1,0 +1,38 @@
+import type { BiometricCapture, BiometricModality } from "../captureModels";
+import { MockBiometricProvider, type BiometricProviderAdapter } from "./provider";
+
+export function captureBiometric(
+  modality: BiometricModality,
+  provider: BiometricProviderAdapter = new MockBiometricProvider()
+): BiometricCapture {
+  if (!provider.isSupported(modality)) {
+    return {
+      modality,
+      templateFormat: "unknown",
+      template: "",
+      capturedAt: Date.now(),
+      liveness: {
+        passed: false,
+        score: 0,
+        method: "software",
+        detectedSignals: []
+      },
+      antiSpoofing: {
+        passed: false,
+        score: 0,
+        signals: []
+      },
+      deviceInfo: {
+        manufacturer: "unknown",
+        model: "unknown",
+        sensorType: "unknown",
+        securityLevel: "unknown",
+        firmwareVersion: "unknown"
+      },
+      supported: false,
+      failureReason: "biometric_not_supported"
+    };
+  }
+
+  return provider.capture(modality);
+}

--- a/mobile/veid-capture-app/src/core/biometric/provider.ts
+++ b/mobile/veid-capture-app/src/core/biometric/provider.ts
@@ -1,0 +1,45 @@
+import type { BiometricCapture, BiometricModality } from "../captureModels";
+import { hashString } from "../../utils/hash";
+
+export interface BiometricProviderAdapter {
+  isSupported(modality: BiometricModality): boolean;
+  capture(modality: BiometricModality): BiometricCapture;
+}
+
+export class MockBiometricProvider implements BiometricProviderAdapter {
+  isSupported(_modality: BiometricModality): boolean {
+    return true;
+  }
+
+  capture(modality: BiometricModality): BiometricCapture {
+    const timestamp = Date.now();
+    const templateSeed = `${modality}:${timestamp}`;
+    const template = hashString(templateSeed);
+
+    return {
+      modality,
+      templateFormat: modality === "fingerprint" ? "iso_19794_2" : "iso_19794_6",
+      template,
+      capturedAt: timestamp,
+      liveness: {
+        passed: true,
+        score: 94,
+        method: "combined",
+        detectedSignals: ["pulse_detection", "texture_analysis"]
+      },
+      antiSpoofing: {
+        passed: true,
+        score: 91,
+        signals: ["anti_replay", "surface_reflection"]
+      },
+      deviceInfo: {
+        manufacturer: "Mock Biometrics",
+        model: modality === "fingerprint" ? "Fingerprint X1" : "Iris Vision Pro",
+        sensorType: modality === "fingerprint" ? "ultrasonic" : "iris",
+        securityLevel: "hardware_backed",
+        firmwareVersion: "2.4.1"
+      },
+      supported: true
+    };
+  }
+}

--- a/mobile/veid-capture-app/src/core/captureModels.ts
+++ b/mobile/veid-capture-app/src/core/captureModels.ts
@@ -42,6 +42,43 @@ export interface LivenessResult {
   failureReason?: string;
 }
 
+export type BiometricModality = "fingerprint" | "iris";
+export type BiometricSensorType = "optical" | "capacitive" | "ultrasonic" | "iris" | "unknown";
+export type BiometricSecurityLevel = "unknown" | "basic" | "strong" | "hardware_backed";
+
+export interface BiometricLivenessResult {
+  passed: boolean;
+  score: number;
+  method: "hardware" | "software" | "combined";
+  detectedSignals: string[];
+}
+
+export interface BiometricAntiSpoofingResult {
+  passed: boolean;
+  score: number;
+  signals: string[];
+}
+
+export interface BiometricDeviceInfo {
+  manufacturer: string;
+  model: string;
+  sensorType: BiometricSensorType;
+  securityLevel: BiometricSecurityLevel;
+  firmwareVersion: string;
+}
+
+export interface BiometricCapture {
+  modality: BiometricModality;
+  templateFormat: "iso_19794_2" | "iso_19794_6" | "vendor" | "unknown";
+  template: string;
+  capturedAt: number;
+  liveness: BiometricLivenessResult;
+  antiSpoofing: BiometricAntiSpoofingResult;
+  deviceInfo: BiometricDeviceInfo;
+  supported: boolean;
+  failureReason?: string;
+}
+
 export interface OcrField {
   key: string;
   value: string;
@@ -53,11 +90,30 @@ export interface OcrResult {
   fields: OcrField[];
 }
 
+export type DevicePlatform = "android" | "ios" | "unknown";
+export type DeviceAttestationProvider =
+  | "android_play_integrity"
+  | "android_safetynet"
+  | "ios_devicecheck"
+  | "ios_app_attest"
+  | "mock";
+export type DeviceIntegrityLevel = "unknown" | "basic" | "strong" | "hardware_backed" | "unsupported";
+
 export interface DeviceAttestation {
   deviceId: string;
   deviceModel: string;
   osVersion: string;
   appVersion: string;
+  appId: string;
+  platform: DevicePlatform;
+  provider: DeviceAttestationProvider;
+  integrityLevel: DeviceIntegrityLevel;
+  integrityScore: number;
+  supported: boolean;
+  failureReason?: string;
+  nonce: string;
+  verdicts: Record<string, boolean>;
+  attestationPayload: string;
   attestedAt: number;
   attestationSignature: string;
 }
@@ -70,6 +126,7 @@ export interface CaptureSession {
   documentBack?: DocumentCapture;
   selfie?: SelfieCapture;
   liveness?: LivenessResult;
+  biometric?: BiometricCapture;
   ocr?: OcrResult;
   deviceAttestation?: DeviceAttestation;
 }

--- a/mobile/veid-capture-app/src/core/deviceAttestation.ts
+++ b/mobile/veid-capture-app/src/core/deviceAttestation.ts
@@ -1,13 +1,92 @@
-import type { DeviceAttestation } from "./captureModels";
+import type {
+  DeviceAttestation,
+  DeviceAttestationProvider,
+  DeviceIntegrityLevel,
+  DevicePlatform
+} from "./captureModels";
 import { createId } from "../utils/id";
 
-export function createDeviceAttestation(appVersion: string): DeviceAttestation {
+export interface DeviceAttestationProviderAdapter {
+  getPlatform(): DevicePlatform;
+  getProvider(): DeviceAttestationProvider;
+  supportsAttestation(): boolean;
+  attest(request: DeviceAttestationRequest): DeviceAttestationResponse;
+}
+
+export interface DeviceAttestationRequest {
+  appId: string;
+  appVersion: string;
+  nonce: string;
+}
+
+export interface DeviceAttestationResponse {
+  supported: boolean;
+  integrityLevel: DeviceIntegrityLevel;
+  integrityScore: number;
+  deviceModel: string;
+  osVersion: string;
+  attestationPayload: string;
+  attestationSignature: string;
+  verdicts: Record<string, boolean>;
+  failureReason?: string;
+}
+
+export class MockDeviceAttestationProvider implements DeviceAttestationProviderAdapter {
+  getPlatform(): DevicePlatform {
+    return "android";
+  }
+
+  getProvider(): DeviceAttestationProvider {
+    return "mock";
+  }
+
+  supportsAttestation(): boolean {
+    return true;
+  }
+
+  attest(request: DeviceAttestationRequest): DeviceAttestationResponse {
+    return {
+      supported: true,
+      integrityLevel: "strong",
+      integrityScore: 92,
+      deviceModel: "Mock Device",
+      osVersion: "Android 16",
+      attestationPayload: `mock:${request.appId}:${request.nonce}`,
+      attestationSignature: "mock_signature",
+      verdicts: {
+        basic_integrity: true,
+        strong_integrity: true,
+        hardware_backed: true
+      }
+    };
+  }
+}
+
+export function createDeviceAttestation(
+  appVersion: string,
+  appId = "com.virtengine.veid",
+  provider: DeviceAttestationProviderAdapter = new MockDeviceAttestationProvider()
+): DeviceAttestation {
+  const nonce = createId("nonce");
+  const response = provider.attest({ appId, appVersion, nonce });
+  const supported = provider.supportsAttestation() && response.supported;
+
   return {
     deviceId: createId("device"),
-    deviceModel: "unknown",
-    osVersion: "unknown",
+    deviceModel: response.deviceModel,
+    osVersion: response.osVersion,
     appVersion,
+    appId,
+    platform: provider.getPlatform(),
+    provider: provider.getProvider(),
+    integrityLevel: supported ? response.integrityLevel : "unsupported",
+    integrityScore: supported ? response.integrityScore : 50,
+    supported,
+    failureReason: supported ? undefined : response.failureReason ?? "unsupported_device",
+    nonce,
+    verdicts: response.verdicts,
+    attestationPayload: response.attestationPayload,
     attestedAt: Date.now(),
-    attestationSignature: "attestation_pending"
+    attestationSignature: response.attestationSignature
   };
 }

--- a/mobile/veid-capture-app/src/screens/BiometricCaptureScreen.tsx
+++ b/mobile/veid-capture-app/src/screens/BiometricCaptureScreen.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { CaptureFooter } from "../components/CaptureFooter";
+import { CaptureHeader } from "../components/CaptureHeader";
+import { captureBiometric } from "../core/biometric";
+import type { BiometricCapture, BiometricModality } from "../core/captureModels";
+import { useCaptureStore } from "../state/captureStore";
+
+export function BiometricCaptureScreen() {
+  const { state, dispatch } = useCaptureStore();
+  const [modality, setModality] = useState<BiometricModality>("fingerprint");
+  const [capture, setCapture] = useState<BiometricCapture | undefined>(state.session.biometric);
+
+  const handleCapture = () => {
+    const result = captureBiometric(modality);
+    dispatch({ type: "set_biometric", payload: result });
+    setCapture(result);
+  };
+
+  return (
+    <View style={styles.container}>
+      <CaptureHeader
+        title="Biometric Hardware"
+        stepIndex={4}
+        subtitle="Capture fingerprint or iris using the secure sensor."
+      />
+      <View style={styles.selectorRow}>
+        {(["fingerprint", "iris"] as BiometricModality[]).map((option) => (
+          <Pressable
+            key={option}
+            style={[styles.selector, modality === option ? styles.selectorActive : null]}
+            onPress={() => setModality(option)}
+          >
+            <Text style={[styles.selectorText, modality === option ? styles.selectorTextActive : null]}>
+              {option === "fingerprint" ? "Fingerprint" : "Iris"}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>Sensor Status</Text>
+        <Text style={styles.cardLine}>
+          Capture: {capture ? (capture.supported ? "Ready" : "Unsupported") : "Pending"}
+        </Text>
+        {capture ? (
+          <>
+            <Text style={styles.cardLine}>Liveness: {capture.liveness.passed ? "Passed" : "Failed"}</Text>
+            <Text style={styles.cardLine}>Anti-spoof: {capture.antiSpoofing.passed ? "Passed" : "Failed"}</Text>
+            <Text style={styles.cardLine}>Security: {capture.deviceInfo.securityLevel}</Text>
+          </>
+        ) : null}
+        <Pressable style={styles.captureButton} onPress={handleCapture}>
+          <Text style={styles.captureText}>Capture {modality === "fingerprint" ? "Fingerprint" : "Iris"}</Text>
+        </Pressable>
+      </View>
+      <CaptureFooter
+        primaryLabel="Continue"
+        onPrimary={() => dispatch({ type: "next" })}
+        secondaryLabel="Back"
+        onSecondary={() => dispatch({ type: "prev" })}
+        disabled={!capture}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#f9fafb"
+  },
+  selectorRow: {
+    flexDirection: "row",
+    paddingHorizontal: 20,
+    marginTop: 12,
+    gap: 12
+  },
+  selector: {
+    flex: 1,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    paddingVertical: 10,
+    alignItems: "center"
+  },
+  selectorActive: {
+    backgroundColor: "#111827",
+    borderColor: "#111827"
+  },
+  selectorText: {
+    color: "#111827",
+    fontWeight: "600"
+  },
+  selectorTextActive: {
+    color: "#ffffff"
+  },
+  card: {
+    marginTop: 20,
+    marginHorizontal: 20,
+    padding: 16,
+    backgroundColor: "#ffffff",
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "#e5e7eb"
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#111827"
+  },
+  cardLine: {
+    marginTop: 6,
+    fontSize: 13,
+    color: "#4b5563"
+  },
+  captureButton: {
+    marginTop: 14,
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: "#111827",
+    alignItems: "center"
+  },
+  captureText: {
+    color: "#ffffff",
+    fontWeight: "600"
+  }
+});

--- a/mobile/veid-capture-app/src/screens/LivenessScreen.tsx
+++ b/mobile/veid-capture-app/src/screens/LivenessScreen.tsx
@@ -7,7 +7,7 @@ import { useCaptureStore } from "../state/captureStore";
 import { LivenessEngine, createDefaultChallenges, DEFAULT_LIVENESS_CONFIG } from "../core/liveness/engine";
 import type { FaceSignal, LivenessUpdate } from "../core/liveness/types";
 
-export function LivenessScreen() {
+export function LivenessScreen({ stepIndex = 3 }: { stepIndex?: number }) {
   const { dispatch } = useCaptureStore();
   const challenges = useMemo(() => createDefaultChallenges(), []);
   const engineRef = useRef(new LivenessEngine(challenges, DEFAULT_LIVENESS_CONFIG));
@@ -83,7 +83,7 @@ export function LivenessScreen() {
     <View style={styles.container}>
       <CaptureHeader
         title="Liveness Check"
-        stepIndex={3}
+        stepIndex={stepIndex}
         subtitle="Complete the active liveness challenge prompts."
       />
       {update ? (

--- a/mobile/veid-capture-app/src/screens/ReviewScreen.tsx
+++ b/mobile/veid-capture-app/src/screens/ReviewScreen.tsx
@@ -8,6 +8,16 @@ import { useCaptureStore } from "../state/captureStore";
 export function ReviewScreen() {
   const { state, dispatch } = useCaptureStore();
   const [loading, setLoading] = useState(false);
+  const biometricStatus = state.session.biometric
+    ? state.session.biometric.supported
+      ? "Captured"
+      : "Unsupported"
+    : "Pending";
+  const attestationStatus = state.session.deviceAttestation
+    ? state.session.deviceAttestation.supported
+      ? "Verified"
+      : "Unsupported"
+    : "Pending";
 
   useEffect(() => {
     const runOcr = async () => {
@@ -27,8 +37,8 @@ export function ReviewScreen() {
     <View style={styles.container}>
       <CaptureHeader
         title="Review Capture"
-        stepIndex={4}
-        subtitle="Confirm your document details and liveness status."
+        stepIndex={5}
+        subtitle="Confirm your document, biometric, and liveness status."
       />
       <ScrollView style={styles.content}>
         <Text style={styles.sectionTitle}>Captured Assets</Text>
@@ -36,6 +46,8 @@ export function ReviewScreen() {
         <Text style={styles.line}>Document back: {state.session.documentBack ? "Ready" : "Missing"}</Text>
         <Text style={styles.line}>Selfie: {state.session.selfie ? "Ready" : "Missing"}</Text>
         <Text style={styles.line}>Liveness: {state.session.liveness?.passed ? "Passed" : "Pending"}</Text>
+        <Text style={styles.line}>Biometric hardware: {biometricStatus}</Text>
+        <Text style={styles.line}>Device attestation: {attestationStatus}</Text>
 
         <Text style={styles.sectionTitle}>OCR Fields</Text>
         {loading ? <ActivityIndicator /> : null}

--- a/mobile/veid-capture-app/src/screens/SelfieCaptureScreen.tsx
+++ b/mobile/veid-capture-app/src/screens/SelfieCaptureScreen.tsx
@@ -5,7 +5,7 @@ import { CaptureFooter } from "../components/CaptureFooter";
 import { CaptureHeader } from "../components/CaptureHeader";
 import { useCaptureStore } from "../state/captureStore";
 
-export function SelfieCaptureScreen() {
+export function SelfieCaptureScreen({ stepIndex = 2 }: { stepIndex?: number }) {
   const { dispatch } = useCaptureStore();
   const [hasCapture, setHasCapture] = useState(false);
 
@@ -13,7 +13,7 @@ export function SelfieCaptureScreen() {
     <View style={styles.container}>
       <CaptureHeader
         title="Selfie Capture"
-        stepIndex={2}
+        stepIndex={stepIndex}
         subtitle="Ensure your face is centered and well-lit."
       />
       <Text style={styles.guidance}>Remove glasses and keep a neutral expression.</Text>

--- a/mobile/veid-capture-app/src/screens/UploadScreen.tsx
+++ b/mobile/veid-capture-app/src/screens/UploadScreen.tsx
@@ -29,8 +29,8 @@ export function UploadScreen() {
     <View style={styles.container}>
       <CaptureHeader
         title="Secure Upload"
-        stepIndex={5}
-        subtitle="Encrypt and transmit your capture package."
+        stepIndex={6}
+        subtitle="Encrypt and transmit your capture package with attestation."
       />
       <View style={styles.content}>
         {status === "uploading" ? <ActivityIndicator /> : null}

--- a/mobile/veid-capture-app/src/state/captureStore.tsx
+++ b/mobile/veid-capture-app/src/state/captureStore.tsx
@@ -1,5 +1,12 @@
 import React, { createContext, useContext, useReducer } from "react";
-import type { CaptureSession, DocumentCapture, LivenessResult, OcrResult, SelfieCapture } from "../core/captureModels";
+import type {
+  BiometricCapture,
+  CaptureSession,
+  DocumentCapture,
+  LivenessResult,
+  OcrResult,
+  SelfieCapture
+} from "../core/captureModels";
 import { initializeCaptureSession } from "../core/captureSession";
 
 export type CaptureStep =
@@ -8,6 +15,7 @@ export type CaptureStep =
   | "document_back"
   | "selfie"
   | "liveness"
+  | "biometric"
   | "review"
   | "upload"
   | "complete";
@@ -23,6 +31,7 @@ type CaptureAction =
   | { type: "set_document"; payload: DocumentCapture }
   | { type: "set_selfie"; payload: SelfieCapture }
   | { type: "set_liveness"; payload: LivenessResult }
+  | { type: "set_biometric"; payload: BiometricCapture }
   | { type: "set_ocr"; payload: OcrResult }
   | { type: "next" }
   | { type: "prev" };
@@ -33,6 +42,7 @@ const steps: CaptureStep[] = [
   "document_back",
   "selfie",
   "liveness",
+  "biometric",
   "review",
   "upload",
   "complete"
@@ -67,6 +77,11 @@ function reducer(state: CaptureState, action: CaptureAction): CaptureState {
       return {
         ...state,
         session: { ...state.session, liveness: action.payload }
+      };
+    case "set_biometric":
+      return {
+        ...state,
+        session: { ...state.session, biometric: action.payload }
       };
     case "set_ocr":
       return {

--- a/mobile/veid-capture-app/src/test/biometricCapture.test.ts
+++ b/mobile/veid-capture-app/src/test/biometricCapture.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { captureBiometric } from "../core/biometric";
+
+describe("captureBiometric", () => {
+  it("captures a fingerprint with liveness and anti-spoofing", () => {
+    const result = captureBiometric("fingerprint");
+    expect(result.supported).toBe(true);
+    expect(result.liveness.passed).toBe(true);
+    expect(result.antiSpoofing.passed).toBe(true);
+    expect(result.template.length).toBeGreaterThan(0);
+  });
+});

--- a/mobile/veid-capture-app/src/test/deviceAttestation.test.ts
+++ b/mobile/veid-capture-app/src/test/deviceAttestation.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { createDeviceAttestation } from "../core/deviceAttestation";
+
+describe("createDeviceAttestation", () => {
+  it("returns a supported mock attestation", () => {
+    const attestation = createDeviceAttestation("1.0.0");
+    expect(attestation.supported).toBe(true);
+    expect(attestation.provider).toBe("mock");
+    expect(attestation.integrityLevel).toBe("strong");
+    expect(attestation.nonce.length).toBeGreaterThan(0);
+  });
+});

--- a/pkg/verification/device/mock_provider.go
+++ b/pkg/verification/device/mock_provider.go
@@ -1,0 +1,70 @@
+package device
+
+import (
+	"context"
+	"time"
+
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// MockVerifier is a mock attestation verifier for tests and CI.
+type MockVerifier struct {
+	ShouldFail     bool
+	IntegrityScore uint32
+	IntegrityLevel veidtypes.DeviceIntegrityLevel
+	HardwareBacked bool
+	FailureReason  string
+}
+
+// Verify returns a deterministic mock result.
+func (m MockVerifier) Verify(_ context.Context, req AttestationRequest) (AttestationResult, error) {
+	if m.ShouldFail {
+		return AttestationResult{
+			Status:         AttestationStatusFailed,
+			Verified:       false,
+			IntegrityLevel: veidtypes.DeviceIntegrityUnknown,
+			IntegrityScore: 0,
+			FailureReason:  m.failureReason(),
+			AttestedAt:     time.Now().UTC(),
+			Provider:       req.Provider,
+			Platform:       req.Platform,
+			DeviceModel:    req.DeviceModel,
+			OSVersion:      req.OSVersion,
+			AppVersion:     req.AppVersion,
+			AppID:          req.AppID,
+			Nonce:          req.Nonce,
+		}, nil
+	}
+
+	score := m.IntegrityScore
+	if score == 0 {
+		score = 8500
+	}
+	level := m.IntegrityLevel
+	if level == "" {
+		level = veidtypes.DeviceIntegrityStrong
+	}
+
+	return AttestationResult{
+		Status:         AttestationStatusVerified,
+		Verified:       true,
+		IntegrityLevel: level,
+		IntegrityScore: score,
+		HardwareBacked: m.HardwareBacked,
+		AttestedAt:     time.Now().UTC(),
+		Provider:       req.Provider,
+		Platform:       req.Platform,
+		DeviceModel:    req.DeviceModel,
+		OSVersion:      req.OSVersion,
+		AppVersion:     req.AppVersion,
+		AppID:          req.AppID,
+		Nonce:          req.Nonce,
+	}, nil
+}
+
+func (m MockVerifier) failureReason() string {
+	if m.FailureReason != "" {
+		return m.FailureReason
+	}
+	return "mock_attestation_failed"
+}

--- a/pkg/verification/device/service.go
+++ b/pkg/verification/device/service.go
@@ -1,0 +1,81 @@
+package device
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// Service verifies device attestations using configured providers.
+type Service struct {
+	providers map[veidtypes.DeviceAttestationProvider]AttestationVerifier
+}
+
+// NewService creates a new device attestation service.
+func NewService(providers map[veidtypes.DeviceAttestationProvider]AttestationVerifier) *Service {
+	return &Service{providers: providers}
+}
+
+// VerifyAttestation verifies device attestation and returns the verification result.
+func (s *Service) VerifyAttestation(ctx context.Context, req AttestationRequest) (AttestationResult, error) {
+	provider := req.Provider
+	if provider == "" {
+		provider = defaultProviderForPlatform(req.Platform)
+	}
+
+	verifier, ok := s.providers[provider]
+	if !ok {
+		if req.RequireAttestation {
+			return AttestationResult{}, errors.New("device attestation provider not configured")
+		}
+		return unsupportedResult(req, provider, "provider_not_configured"), nil
+	}
+
+	result, err := verifier.Verify(ctx, req)
+	if err != nil {
+		if req.AllowFallback && !req.RequireAttestation {
+			return unsupportedResult(req, provider, err.Error()), nil
+		}
+		return AttestationResult{}, err
+	}
+
+	if result.AttestedAt.IsZero() {
+		result.AttestedAt = time.Now().UTC()
+	}
+	if result.Nonce == "" {
+		result.Nonce = req.Nonce
+	}
+
+	return result, nil
+}
+
+func defaultProviderForPlatform(platform veidtypes.DevicePlatform) veidtypes.DeviceAttestationProvider {
+	switch platform {
+	case veidtypes.DevicePlatformAndroid:
+		return veidtypes.DeviceAttestationProviderPlayIntegrity
+	case veidtypes.DevicePlatformIOS:
+		return veidtypes.DeviceAttestationProviderAppAttest
+	default:
+		return ""
+	}
+}
+
+func unsupportedResult(req AttestationRequest, provider veidtypes.DeviceAttestationProvider, reason string) AttestationResult {
+	return AttestationResult{
+		Status:         AttestationStatusUnsupported,
+		Verified:       false,
+		IntegrityLevel: veidtypes.DeviceIntegrityUnsupported,
+		IntegrityScore: 5000,
+		FailureReason:  reason,
+		AttestedAt:     time.Now().UTC(),
+		Provider:       provider,
+		Platform:       req.Platform,
+		DeviceModel:    req.DeviceModel,
+		OSVersion:      req.OSVersion,
+		AppVersion:     req.AppVersion,
+		AppID:          req.AppID,
+		Nonce:          req.Nonce,
+	}
+}

--- a/pkg/verification/device/service_test.go
+++ b/pkg/verification/device/service_test.go
@@ -1,0 +1,61 @@
+package device
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+func TestServiceVerifyAttestation(t *testing.T) {
+	service := NewService(map[veidtypes.DeviceAttestationProvider]AttestationVerifier{
+		veidtypes.DeviceAttestationProviderPlayIntegrity: MockVerifier{},
+	})
+
+	req := AttestationRequest{
+		AccountAddress:     "virt1device",
+		Platform:           veidtypes.DevicePlatformAndroid,
+		Provider:           veidtypes.DeviceAttestationProviderPlayIntegrity,
+		AppID:              "com.virtengine.veid",
+		AppVersion:         "1.0.0",
+		DeviceModel:        "Pixel",
+		OSVersion:          "Android 16",
+		Nonce:              "nonce",
+		RequestedAt:        time.Now().UTC(),
+		RequireAttestation: true,
+	}
+
+	result, err := service.VerifyAttestation(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, result.Verified)
+	require.Equal(t, AttestationStatusVerified, result.Status)
+
+	record := BuildDeviceAttestationRecord(result, "vault://device/attestation", []byte("hash"))
+	require.NoError(t, record.Validate())
+}
+
+func TestServiceVerifyAttestationFallback(t *testing.T) {
+	service := NewService(map[veidtypes.DeviceAttestationProvider]AttestationVerifier{})
+
+	req := AttestationRequest{
+		AccountAddress:     "virt1device",
+		Platform:           veidtypes.DevicePlatformIOS,
+		Provider:           veidtypes.DeviceAttestationProviderAppAttest,
+		AppID:              "com.virtengine.veid",
+		AppVersion:         "1.0.0",
+		DeviceModel:        "iPhone",
+		OSVersion:          "iOS 19",
+		Nonce:              "nonce",
+		RequestedAt:        time.Now().UTC(),
+		AllowFallback:      true,
+		RequireAttestation: false,
+	}
+
+	result, err := service.VerifyAttestation(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, AttestationStatusUnsupported, result.Status)
+	require.False(t, result.Verified)
+}

--- a/pkg/verification/device/types.go
+++ b/pkg/verification/device/types.go
@@ -1,0 +1,82 @@
+package device
+
+import (
+	"context"
+	"time"
+
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// AttestationStatus represents the device attestation verification state.
+type AttestationStatus string
+
+const (
+	AttestationStatusVerified    AttestationStatus = "verified"
+	AttestationStatusFailed      AttestationStatus = "failed"
+	AttestationStatusUnsupported AttestationStatus = "unsupported"
+)
+
+// AttestationRequest contains the data required to verify device attestation.
+type AttestationRequest struct {
+	AccountAddress string                              `json:"account_address"`
+	Platform       veidtypes.DevicePlatform            `json:"platform"`
+	Provider       veidtypes.DeviceAttestationProvider `json:"provider"`
+	AppID          string                              `json:"app_id"`
+	AppVersion     string                              `json:"app_version"`
+	DeviceModel    string                              `json:"device_model"`
+	OSVersion      string                              `json:"os_version"`
+	Nonce          string                              `json:"nonce"`
+	Attestation    []byte                              `json:"attestation"`
+	RequestedAt    time.Time                           `json:"requested_at"`
+
+	RequireAttestation bool `json:"require_attestation"`
+	AllowFallback      bool `json:"allow_fallback"`
+}
+
+// AttestationResult contains the verification outcome and scoring signals.
+type AttestationResult struct {
+	Status         AttestationStatus                   `json:"status"`
+	Verified       bool                                `json:"verified"`
+	IntegrityLevel veidtypes.DeviceIntegrityLevel      `json:"integrity_level"`
+	IntegrityScore uint32                              `json:"integrity_score"`
+	FailureReason  string                              `json:"failure_reason,omitempty"`
+	AttestedAt     time.Time                           `json:"attested_at"`
+	HardwareBacked bool                                `json:"hardware_backed"`
+	Provider       veidtypes.DeviceAttestationProvider `json:"provider"`
+	Platform       veidtypes.DevicePlatform            `json:"platform"`
+	DeviceModel    string                              `json:"device_model"`
+	OSVersion      string                              `json:"os_version"`
+	AppVersion     string                              `json:"app_version"`
+	AppID          string                              `json:"app_id"`
+	Nonce          string                              `json:"nonce"`
+	RawAttestation []byte                              `json:"raw_attestation,omitempty"`
+	Metadata       map[string]string                   `json:"metadata,omitempty"`
+}
+
+// AttestationVerifier verifies a device attestation document.
+type AttestationVerifier interface {
+	Verify(ctx context.Context, req AttestationRequest) (AttestationResult, error)
+}
+
+// BuildDeviceAttestationRecord converts a verification result to an on-chain record.
+func BuildDeviceAttestationRecord(result AttestationResult, vaultRef string, payloadHash []byte) veidtypes.DeviceAttestationRecord {
+	return veidtypes.DeviceAttestationRecord{
+		AttestationID:  result.AttestedAt.Format("20060102T150405Z") + ":" + result.DeviceModel,
+		Platform:       result.Platform,
+		Provider:       result.Provider,
+		Nonce:          result.Nonce,
+		AttestedAt:     result.AttestedAt,
+		IntegrityLevel: result.IntegrityLevel,
+		DeviceModel:    result.DeviceModel,
+		OSVersion:      result.OSVersion,
+		AppVersion:     result.AppVersion,
+		AppID:          result.AppID,
+		HardwareBacked: result.HardwareBacked,
+		Supported:      result.Status != AttestationStatusUnsupported,
+		Verified:       result.Verified,
+		FailureReason:  result.FailureReason,
+		PayloadHash:    payloadHash,
+		VaultRef:       vaultRef,
+		Metadata:       result.Metadata,
+	}
+}

--- a/sdk/go/node/veid/v1/types.pb.go
+++ b/sdk/go/node/veid/v1/types.pb.go
@@ -50,32 +50,40 @@ const (
 	ScopeTypeDomainVerify ScopeType = 8
 	// SCOPE_TYPE_AD_SSO represents Active Directory SSO verification
 	ScopeTypeADSSO ScopeType = 9
+	// SCOPE_TYPE_BIOMETRIC_HARDWARE represents biometric hardware attestation payloads
+	ScopeTypeBiometricHardware ScopeType = 10
+	// SCOPE_TYPE_DEVICE_ATTESTATION represents device integrity attestation payloads
+	ScopeTypeDeviceAttestation ScopeType = 11
 )
 
 var ScopeType_name = map[int32]string{
-	0: "SCOPE_TYPE_UNSPECIFIED",
-	1: "SCOPE_TYPE_ID_DOCUMENT",
-	2: "SCOPE_TYPE_SELFIE",
-	3: "SCOPE_TYPE_FACE_VIDEO",
-	4: "SCOPE_TYPE_BIOMETRIC",
-	5: "SCOPE_TYPE_SSO_METADATA",
-	6: "SCOPE_TYPE_EMAIL_PROOF",
-	7: "SCOPE_TYPE_SMS_PROOF",
-	8: "SCOPE_TYPE_DOMAIN_VERIFY",
-	9: "SCOPE_TYPE_AD_SSO",
+	0:  "SCOPE_TYPE_UNSPECIFIED",
+	1:  "SCOPE_TYPE_ID_DOCUMENT",
+	2:  "SCOPE_TYPE_SELFIE",
+	3:  "SCOPE_TYPE_FACE_VIDEO",
+	4:  "SCOPE_TYPE_BIOMETRIC",
+	5:  "SCOPE_TYPE_SSO_METADATA",
+	6:  "SCOPE_TYPE_EMAIL_PROOF",
+	7:  "SCOPE_TYPE_SMS_PROOF",
+	8:  "SCOPE_TYPE_DOMAIN_VERIFY",
+	9:  "SCOPE_TYPE_AD_SSO",
+	10: "SCOPE_TYPE_BIOMETRIC_HARDWARE",
+	11: "SCOPE_TYPE_DEVICE_ATTESTATION",
 }
 
 var ScopeType_value = map[string]int32{
-	"SCOPE_TYPE_UNSPECIFIED":   0,
-	"SCOPE_TYPE_ID_DOCUMENT":   1,
-	"SCOPE_TYPE_SELFIE":        2,
-	"SCOPE_TYPE_FACE_VIDEO":    3,
-	"SCOPE_TYPE_BIOMETRIC":     4,
-	"SCOPE_TYPE_SSO_METADATA":  5,
-	"SCOPE_TYPE_EMAIL_PROOF":   6,
-	"SCOPE_TYPE_SMS_PROOF":     7,
-	"SCOPE_TYPE_DOMAIN_VERIFY": 8,
-	"SCOPE_TYPE_AD_SSO":        9,
+	"SCOPE_TYPE_UNSPECIFIED":        0,
+	"SCOPE_TYPE_ID_DOCUMENT":        1,
+	"SCOPE_TYPE_SELFIE":             2,
+	"SCOPE_TYPE_FACE_VIDEO":         3,
+	"SCOPE_TYPE_BIOMETRIC":          4,
+	"SCOPE_TYPE_SSO_METADATA":       5,
+	"SCOPE_TYPE_EMAIL_PROOF":        6,
+	"SCOPE_TYPE_SMS_PROOF":          7,
+	"SCOPE_TYPE_DOMAIN_VERIFY":      8,
+	"SCOPE_TYPE_AD_SSO":             9,
+	"SCOPE_TYPE_BIOMETRIC_HARDWARE": 10,
+	"SCOPE_TYPE_DEVICE_ATTESTATION": 11,
 }
 
 func (x ScopeType) String() string {

--- a/sdk/proto/node/virtengine/veid/v1/types.proto
+++ b/sdk/proto/node/virtengine/veid/v1/types.proto
@@ -40,6 +40,12 @@ enum ScopeType {
   
   // SCOPE_TYPE_AD_SSO represents Active Directory SSO verification
   SCOPE_TYPE_AD_SSO = 9 [(gogoproto.enumvalue_customname) = "ScopeTypeADSSO"];
+
+  // SCOPE_TYPE_BIOMETRIC_HARDWARE represents biometric hardware attestation payloads
+  SCOPE_TYPE_BIOMETRIC_HARDWARE = 10 [(gogoproto.enumvalue_customname) = "ScopeTypeBiometricHardware"];
+
+  // SCOPE_TYPE_DEVICE_ATTESTATION represents device integrity attestation payloads
+  SCOPE_TYPE_DEVICE_ATTESTATION = 11 [(gogoproto.enumvalue_customname) = "ScopeTypeDeviceAttestation"];
 }
 
 // VerificationStatus represents the verification state of an identity scope

--- a/sdk/ts/src/generated/protos/virtengine/veid/v1/types.ts
+++ b/sdk/ts/src/generated/protos/virtengine/veid/v1/types.ts
@@ -32,6 +32,10 @@ export enum ScopeType {
   SCOPE_TYPE_DOMAIN_VERIFY = 8,
   /** SCOPE_TYPE_AD_SSO - SCOPE_TYPE_AD_SSO represents Active Directory SSO verification */
   SCOPE_TYPE_AD_SSO = 9,
+  /** SCOPE_TYPE_BIOMETRIC_HARDWARE - SCOPE_TYPE_BIOMETRIC_HARDWARE represents biometric hardware attestation payloads */
+  SCOPE_TYPE_BIOMETRIC_HARDWARE = 10,
+  /** SCOPE_TYPE_DEVICE_ATTESTATION - SCOPE_TYPE_DEVICE_ATTESTATION represents device integrity attestation payloads */
+  SCOPE_TYPE_DEVICE_ATTESTATION = 11,
   UNRECOGNIZED = -1,
 }
 
@@ -67,6 +71,12 @@ export function scopeTypeFromJSON(object: any): ScopeType {
     case 9:
     case "SCOPE_TYPE_AD_SSO":
       return ScopeType.SCOPE_TYPE_AD_SSO;
+    case 10:
+    case "SCOPE_TYPE_BIOMETRIC_HARDWARE":
+      return ScopeType.SCOPE_TYPE_BIOMETRIC_HARDWARE;
+    case 11:
+    case "SCOPE_TYPE_DEVICE_ATTESTATION":
+      return ScopeType.SCOPE_TYPE_DEVICE_ATTESTATION;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -96,6 +106,10 @@ export function scopeTypeToJSON(object: ScopeType): string {
       return "SCOPE_TYPE_DOMAIN_VERIFY";
     case ScopeType.SCOPE_TYPE_AD_SSO:
       return "SCOPE_TYPE_AD_SSO";
+    case ScopeType.SCOPE_TYPE_BIOMETRIC_HARDWARE:
+      return "SCOPE_TYPE_BIOMETRIC_HARDWARE";
+    case ScopeType.SCOPE_TYPE_DEVICE_ATTESTATION:
+      return "SCOPE_TYPE_DEVICE_ATTESTATION";
     case ScopeType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";

--- a/x/veid/keeper/composite_scoring_test.go
+++ b/x/veid/keeper/composite_scoring_test.go
@@ -492,12 +492,14 @@ func (s *CompositeScoringTestSuite) createInputsWithAllMax() types.CompositeScor
 			SuccessfulVerificationRate: 10000,
 		},
 		RiskIndicators: types.RiskIndicatorsInput{
-			Present:                true,
-			FraudPatternScore:      10000,
-			DeviceFingerprintScore: 10000,
-			IPReputationScore:      10000,
-			VelocityCheckPassed:    true,
-			GeoConsistencyScore:    10000,
+			Present:                 true,
+			FraudPatternScore:       10000,
+			DeviceFingerprintScore:  10000,
+			DeviceIntegrityScore:    10000,
+			IPReputationScore:       10000,
+			VelocityCheckPassed:     true,
+			DeviceAttestationPassed: true,
+			GeoConsistencyScore:     10000,
 		},
 	}
 }
@@ -542,12 +544,14 @@ func (s *CompositeScoringTestSuite) createInputsWithAllMin() types.CompositeScor
 			SuccessfulVerificationRate: 0,
 		},
 		RiskIndicators: types.RiskIndicatorsInput{
-			Present:                true,
-			FraudPatternScore:      0,
-			DeviceFingerprintScore: 0,
-			IPReputationScore:      0,
-			VelocityCheckPassed:    false,
-			GeoConsistencyScore:    0,
+			Present:                 true,
+			FraudPatternScore:       0,
+			DeviceFingerprintScore:  0,
+			DeviceIntegrityScore:    0,
+			IPReputationScore:       0,
+			VelocityCheckPassed:     false,
+			DeviceAttestationPassed: false,
+			GeoConsistencyScore:     0,
 		},
 	}
 }
@@ -644,9 +648,11 @@ func (s *CompositeScoringTestSuite) createInputsForScore(targetScore uint32) typ
 			AccountAgeScore:        score,
 		},
 		RiskIndicators: types.RiskIndicatorsInput{
-			Present:             true,
-			FraudPatternScore:   score,
-			VelocityCheckPassed: true,
+			Present:                 true,
+			FraudPatternScore:       score,
+			DeviceIntegrityScore:    score,
+			VelocityCheckPassed:     true,
+			DeviceAttestationPassed: true,
 		},
 	}
 }
@@ -721,9 +727,11 @@ func TestCompositeScoreComputation(t *testing.T) {
 
 	t.Run("risk indicators compute score", func(t *testing.T) {
 		input := types.RiskIndicatorsInput{
-			Present:             true,
-			FraudPatternScore:   10000, // No fraud
-			VelocityCheckPassed: true,
+			Present:                 true,
+			FraudPatternScore:       10000, // No fraud
+			DeviceIntegrityScore:    9000,
+			VelocityCheckPassed:     true,
+			DeviceAttestationPassed: true,
 		}
 
 		score := input.ComputeScore()

--- a/x/veid/keeper/keeper_test.go
+++ b/x/veid/keeper/keeper_test.go
@@ -495,6 +495,8 @@ func TestScopeTypeValidation(t *testing.T) {
 	require.True(t, types.IsValidScopeType(types.ScopeTypeSelfie))
 	require.True(t, types.IsValidScopeType(types.ScopeTypeFaceVideo))
 	require.True(t, types.IsValidScopeType(types.ScopeTypeBiometric))
+	require.True(t, types.IsValidScopeType(types.ScopeTypeBiometricHardware))
+	require.True(t, types.IsValidScopeType(types.ScopeTypeDeviceAttestation))
 	require.True(t, types.IsValidScopeType(types.ScopeTypeSSOMetadata))
 	require.True(t, types.IsValidScopeType(types.ScopeTypeEmailProof))
 	require.True(t, types.IsValidScopeType(types.ScopeTypeSMSProof))

--- a/x/veid/types/attestation.go
+++ b/x/veid/types/attestation.go
@@ -66,6 +66,12 @@ const (
 	// AttestationTypeBiometricVerification for biometric verification
 	AttestationTypeBiometricVerification AttestationType = "biometric_verification"
 
+	// AttestationTypeBiometricHardware for biometric hardware attestation
+	AttestationTypeBiometricHardware AttestationType = "biometric_hardware_attestation"
+
+	// AttestationTypeDeviceIntegrity for device integrity attestation
+	AttestationTypeDeviceIntegrity AttestationType = "device_integrity_attestation"
+
 	// AttestationTypeCompositeIdentity for combined identity attestations
 	AttestationTypeCompositeIdentity AttestationType = "composite_identity"
 )
@@ -81,6 +87,8 @@ func AllAttestationTypes() []AttestationType {
 		AttestationTypeDomainVerification,
 		AttestationTypeSSOVerification,
 		AttestationTypeBiometricVerification,
+		AttestationTypeBiometricHardware,
+		AttestationTypeDeviceIntegrity,
 		AttestationTypeCompositeIdentity,
 	}
 }
@@ -114,6 +122,10 @@ func ScopeTypeFromAttestationType(t AttestationType) ScopeType {
 		return ScopeTypeSSOMetadata
 	case AttestationTypeBiometricVerification:
 		return ScopeTypeBiometric
+	case AttestationTypeBiometricHardware:
+		return ScopeTypeBiometricHardware
+	case AttestationTypeDeviceIntegrity:
+		return ScopeTypeDeviceAttestation
 	case AttestationTypeCompositeIdentity:
 		return ScopeTypeIDDocument // Default to ID document for composite
 	default:

--- a/x/veid/types/attestation_test.go
+++ b/x/veid/types/attestation_test.go
@@ -293,6 +293,8 @@ func TestVerificationAttestation_ToScopeType(t *testing.T) {
 		{AttestationTypeDomainVerification, ScopeTypeDomainVerify},
 		{AttestationTypeSSOVerification, ScopeTypeSSOMetadata},
 		{AttestationTypeBiometricVerification, ScopeTypeBiometric},
+		{AttestationTypeBiometricHardware, ScopeTypeBiometricHardware},
+		{AttestationTypeDeviceIntegrity, ScopeTypeDeviceAttestation},
 	}
 
 	for _, tc := range tests {

--- a/x/veid/types/biometric_hardware_attestation.go
+++ b/x/veid/types/biometric_hardware_attestation.go
@@ -1,0 +1,110 @@
+package types
+
+import "time"
+
+// BiometricModality identifies biometric modality.
+type BiometricModality string
+
+const (
+	BiometricModalityFingerprint BiometricModality = "fingerprint"
+	BiometricModalityIris        BiometricModality = "iris"
+)
+
+// BiometricSensorType identifies the sensor technology.
+type BiometricSensorType string
+
+const (
+	BiometricSensorOptical     BiometricSensorType = "optical"
+	BiometricSensorCapacitive  BiometricSensorType = "capacitive"
+	BiometricSensorUltrasonic  BiometricSensorType = "ultrasonic"
+	BiometricSensorIris        BiometricSensorType = "iris"
+	BiometricSensorUnspecified BiometricSensorType = "unspecified"
+)
+
+// BiometricSecurityLevel describes the security tier for the sensor.
+type BiometricSecurityLevel string
+
+const (
+	BiometricSecurityUnknown        BiometricSecurityLevel = "unknown"
+	BiometricSecurityBasic          BiometricSecurityLevel = "basic"
+	BiometricSecurityStrong         BiometricSecurityLevel = "strong"
+	BiometricSecurityHardwareBacked BiometricSecurityLevel = "hardware_backed"
+)
+
+// BiometricHardwareAttestation represents a biometric hardware attestation record.
+type BiometricHardwareAttestation struct {
+	AttestationID string                 `json:"attestation_id"`
+	Modality      BiometricModality      `json:"modality"`
+	SensorType    BiometricSensorType    `json:"sensor_type"`
+	SecurityLevel BiometricSecurityLevel `json:"security_level"`
+	AttestedAt    time.Time              `json:"attested_at"`
+
+	LivenessScore   uint32 `json:"liveness_score"`
+	AntiSpoofScore  uint32 `json:"anti_spoof_score"`
+	HardwareModel   string `json:"hardware_model"`
+	FirmwareVersion string `json:"firmware_version"`
+
+	PayloadHash []byte            `json:"payload_hash,omitempty"`
+	VaultRef    string            `json:"vault_ref,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// Validate validates the biometric hardware attestation.
+func (b BiometricHardwareAttestation) Validate() error {
+	if b.AttestationID == "" {
+		return ErrInvalidScope.Wrap("biometric hardware attestation ID is required")
+	}
+	if !IsValidBiometricModality(b.Modality) {
+		return ErrInvalidScope.Wrap("invalid biometric modality")
+	}
+	if !IsValidBiometricSensorType(b.SensorType) {
+		return ErrInvalidScope.Wrap("invalid biometric sensor type")
+	}
+	if !IsValidBiometricSecurityLevel(b.SecurityLevel) {
+		return ErrInvalidScope.Wrap("invalid biometric security level")
+	}
+	if b.AttestedAt.IsZero() {
+		return ErrInvalidScope.Wrap("attested_at is required")
+	}
+	if b.HardwareModel == "" {
+		return ErrInvalidScope.Wrap("hardware_model is required")
+	}
+	if b.FirmwareVersion == "" {
+		return ErrInvalidScope.Wrap("firmware_version is required")
+	}
+	return nil
+}
+
+// IsValidBiometricModality checks if modality is supported.
+func IsValidBiometricModality(modality BiometricModality) bool {
+	switch modality {
+	case BiometricModalityFingerprint, BiometricModalityIris:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsValidBiometricSensorType checks if sensor type is supported.
+func IsValidBiometricSensorType(sensor BiometricSensorType) bool {
+	switch sensor {
+	case BiometricSensorOptical,
+		BiometricSensorCapacitive,
+		BiometricSensorUltrasonic,
+		BiometricSensorIris,
+		BiometricSensorUnspecified:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsValidBiometricSecurityLevel checks if security level is supported.
+func IsValidBiometricSecurityLevel(level BiometricSecurityLevel) bool {
+	switch level {
+	case BiometricSecurityUnknown, BiometricSecurityBasic, BiometricSecurityStrong, BiometricSecurityHardwareBacked:
+		return true
+	default:
+		return false
+	}
+}

--- a/x/veid/types/composite_scoring_test.go
+++ b/x/veid/types/composite_scoring_test.go
@@ -262,14 +262,18 @@ func TestRiskIndicatorsInputComputeScore(t *testing.T) {
 
 	t.Run("velocity check failure penalizes", func(t *testing.T) {
 		passing := RiskIndicatorsInput{
-			Present:             true,
-			FraudPatternScore:   8000,
-			VelocityCheckPassed: true,
+			Present:                 true,
+			FraudPatternScore:       8000,
+			DeviceIntegrityScore:    8000,
+			VelocityCheckPassed:     true,
+			DeviceAttestationPassed: true,
 		}
 		failing := RiskIndicatorsInput{
-			Present:             true,
-			FraudPatternScore:   8000,
-			VelocityCheckPassed: false,
+			Present:                 true,
+			FraudPatternScore:       8000,
+			DeviceIntegrityScore:    8000,
+			VelocityCheckPassed:     false,
+			DeviceAttestationPassed: true,
 		}
 		require.Greater(t, passing.ComputeScore(), failing.ComputeScore())
 	})
@@ -492,12 +496,14 @@ func createMaxInputs() CompositeScoringInputs {
 			SuccessfulVerificationRate: 10000,
 		},
 		RiskIndicators: RiskIndicatorsInput{
-			Present:                true,
-			FraudPatternScore:      10000,
-			DeviceFingerprintScore: 10000,
-			IPReputationScore:      10000,
-			VelocityCheckPassed:    true,
-			GeoConsistencyScore:    10000,
+			Present:                 true,
+			FraudPatternScore:       10000,
+			DeviceFingerprintScore:  10000,
+			DeviceIntegrityScore:    10000,
+			IPReputationScore:       10000,
+			VelocityCheckPassed:     true,
+			DeviceAttestationPassed: true,
+			GeoConsistencyScore:     10000,
 		},
 	}
 }
@@ -545,12 +551,14 @@ func createMinInputs() CompositeScoringInputs {
 			SuccessfulVerificationRate: 0,
 		},
 		RiskIndicators: RiskIndicatorsInput{
-			Present:                true,
-			FraudPatternScore:      0,
-			DeviceFingerprintScore: 0,
-			IPReputationScore:      0,
-			VelocityCheckPassed:    false,
-			GeoConsistencyScore:    0,
+			Present:                 true,
+			FraudPatternScore:       0,
+			DeviceFingerprintScore:  0,
+			DeviceIntegrityScore:    0,
+			IPReputationScore:       0,
+			VelocityCheckPassed:     false,
+			DeviceAttestationPassed: false,
+			GeoConsistencyScore:     0,
 		},
 	}
 }

--- a/x/veid/types/device_attestation.go
+++ b/x/veid/types/device_attestation.go
@@ -1,0 +1,156 @@
+package types
+
+import (
+	"fmt"
+	"time"
+)
+
+// DevicePlatform identifies the mobile platform that generated the attestation.
+type DevicePlatform string
+
+const (
+	DevicePlatformAndroid DevicePlatform = "android"
+	DevicePlatformIOS     DevicePlatform = "ios"
+)
+
+// DeviceAttestationProvider identifies the attestation provider.
+type DeviceAttestationProvider string
+
+const (
+	DeviceAttestationProviderPlayIntegrity DeviceAttestationProvider = "android_play_integrity"
+	DeviceAttestationProviderSafetyNet     DeviceAttestationProvider = "android_safetynet"
+	DeviceAttestationProviderDeviceCheck   DeviceAttestationProvider = "ios_devicecheck"
+	DeviceAttestationProviderAppAttest     DeviceAttestationProvider = "ios_app_attest"
+)
+
+// DeviceIntegrityLevel represents the assessed integrity level of a device.
+type DeviceIntegrityLevel string
+
+const (
+	DeviceIntegrityUnknown        DeviceIntegrityLevel = "unknown"
+	DeviceIntegrityBasic          DeviceIntegrityLevel = "basic"
+	DeviceIntegrityStrong         DeviceIntegrityLevel = "strong"
+	DeviceIntegrityHardwareBacked DeviceIntegrityLevel = "hardware_backed"
+	DeviceIntegrityUnsupported    DeviceIntegrityLevel = "unsupported"
+)
+
+// DeviceAttestationRecord represents a device integrity attestation payload stored on-chain.
+// The encrypted payload (vault reference) is stored separately in the identity scope envelope.
+type DeviceAttestationRecord struct {
+	AttestationID string                    `json:"attestation_id"`
+	Platform      DevicePlatform            `json:"platform"`
+	Provider      DeviceAttestationProvider `json:"provider"`
+	Nonce         string                    `json:"nonce"`
+	AttestedAt    time.Time                 `json:"attested_at"`
+
+	IntegrityLevel DeviceIntegrityLevel `json:"integrity_level"`
+	DeviceModel    string               `json:"device_model"`
+	OSVersion      string               `json:"os_version"`
+	AppVersion     string               `json:"app_version"`
+	AppID          string               `json:"app_id"`
+	HardwareBacked bool                 `json:"hardware_backed"`
+
+	Supported     bool   `json:"supported"`
+	Verified      bool   `json:"verified"`
+	FailureReason string `json:"failure_reason,omitempty"`
+
+	PayloadHash []byte            `json:"payload_hash,omitempty"`
+	VaultRef    string            `json:"vault_ref,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// Validate validates the device attestation record.
+func (r DeviceAttestationRecord) Validate() error {
+	if r.AttestationID == "" {
+		return ErrInvalidScope.Wrap("device attestation ID is required")
+	}
+
+	if !r.Supported {
+		if r.FailureReason == "" {
+			return ErrInvalidScope.Wrap("unsupported device attestation requires failure reason")
+		}
+		return nil
+	}
+
+	if !IsValidDevicePlatform(r.Platform) {
+		return ErrInvalidScope.Wrapf("invalid device platform: %s", r.Platform)
+	}
+	if !IsValidDeviceAttestationProvider(r.Provider) {
+		return ErrInvalidScope.Wrapf("invalid device attestation provider: %s", r.Provider)
+	}
+	if r.Nonce == "" {
+		return ErrInvalidScope.Wrap("attestation nonce is required")
+	}
+	if r.AttestedAt.IsZero() {
+		return ErrInvalidScope.Wrap("attested_at is required")
+	}
+	if !IsValidDeviceIntegrityLevel(r.IntegrityLevel) {
+		return ErrInvalidScope.Wrapf("invalid device integrity level: %s", r.IntegrityLevel)
+	}
+	if r.DeviceModel == "" {
+		return ErrInvalidScope.Wrap("device_model is required")
+	}
+	if r.OSVersion == "" {
+		return ErrInvalidScope.Wrap("os_version is required")
+	}
+	if r.AppVersion == "" {
+		return ErrInvalidScope.Wrap("app_version is required")
+	}
+	if r.AppID == "" {
+		return ErrInvalidScope.Wrap("app_id is required")
+	}
+
+	return nil
+}
+
+// IsValidDevicePlatform checks if a platform is supported.
+func IsValidDevicePlatform(platform DevicePlatform) bool {
+	switch platform {
+	case DevicePlatformAndroid, DevicePlatformIOS:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsValidDeviceAttestationProvider checks if the attestation provider is supported.
+func IsValidDeviceAttestationProvider(provider DeviceAttestationProvider) bool {
+	switch provider {
+	case DeviceAttestationProviderPlayIntegrity,
+		DeviceAttestationProviderSafetyNet,
+		DeviceAttestationProviderDeviceCheck,
+		DeviceAttestationProviderAppAttest:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsValidDeviceIntegrityLevel checks if integrity level is supported.
+func IsValidDeviceIntegrityLevel(level DeviceIntegrityLevel) bool {
+	switch level {
+	case DeviceIntegrityUnknown,
+		DeviceIntegrityBasic,
+		DeviceIntegrityStrong,
+		DeviceIntegrityHardwareBacked,
+		DeviceIntegrityUnsupported:
+		return true
+	default:
+		return false
+	}
+}
+
+// DeviceAttestationFingerprint builds a short deterministic fingerprint for audit logs.
+func DeviceAttestationFingerprint(record DeviceAttestationRecord) string {
+	if record.AttestationID == "" || record.Nonce == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%s:%s", record.AttestationID, record.Platform, record.Nonce[:min(12, len(record.Nonce))])
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/x/veid/types/device_attestation_test.go
+++ b/x/veid/types/device_attestation_test.go
@@ -1,0 +1,59 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceAttestationRecordValidate(t *testing.T) {
+	valid := DeviceAttestationRecord{
+		AttestationID:  "attest-001",
+		Platform:       DevicePlatformAndroid,
+		Provider:       DeviceAttestationProviderPlayIntegrity,
+		Nonce:          "nonce-123",
+		AttestedAt:     time.Now().UTC(),
+		IntegrityLevel: DeviceIntegrityStrong,
+		DeviceModel:    "Pixel 9 Pro",
+		OSVersion:      "Android 16",
+		AppVersion:     "1.2.3",
+		AppID:          "com.virtengine.veid",
+		HardwareBacked: true,
+		Supported:      true,
+		Verified:       true,
+	}
+
+	require.NoError(t, valid.Validate())
+
+	invalidProvider := valid
+	invalidProvider.Provider = DeviceAttestationProvider("invalid")
+	require.Error(t, invalidProvider.Validate())
+
+	unsupported := DeviceAttestationRecord{
+		AttestationID: "attest-unsupported",
+		Supported:     false,
+		FailureReason: "unsupported_device",
+	}
+	require.NoError(t, unsupported.Validate())
+}
+
+func TestBiometricHardwareAttestationValidate(t *testing.T) {
+	valid := BiometricHardwareAttestation{
+		AttestationID:   "bio-attest-001",
+		Modality:        BiometricModalityFingerprint,
+		SensorType:      BiometricSensorUltrasonic,
+		SecurityLevel:   BiometricSecurityHardwareBacked,
+		AttestedAt:      time.Now().UTC(),
+		LivenessScore:   8200,
+		AntiSpoofScore:  9000,
+		HardwareModel:   "Ultrasonic X2",
+		FirmwareVersion: "5.4.1",
+	}
+
+	require.NoError(t, valid.Validate())
+
+	invalid := valid
+	invalid.Modality = BiometricModality("unknown")
+	require.Error(t, invalid.Validate())
+}

--- a/x/veid/types/proto_types.go
+++ b/x/veid/types/proto_types.go
@@ -22,16 +22,18 @@ type ScopeTypePB = veidv1.ScopeType
 
 // Proto enum constants for ScopeType
 const (
-	ScopeTypePBUnspecified  = veidv1.ScopeTypeUnspecified
-	ScopeTypePBIDDocument   = veidv1.ScopeTypeIDDocument
-	ScopeTypePBSelfie       = veidv1.ScopeTypeSelfie
-	ScopeTypePBFaceVideo    = veidv1.ScopeTypeFaceVideo
-	ScopeTypePBBiometric    = veidv1.ScopeTypeBiometric
-	ScopeTypePBSSOMetadata  = veidv1.ScopeTypeSSOMetadata
-	ScopeTypePBEmailProof   = veidv1.ScopeTypeEmailProof
-	ScopeTypePBSMSProof     = veidv1.ScopeTypeSMSProof
-	ScopeTypePBDomainVerify = veidv1.ScopeTypeDomainVerify
-	ScopeTypePBADSSO        = veidv1.ScopeTypeADSSO
+	ScopeTypePBUnspecified       = veidv1.ScopeTypeUnspecified
+	ScopeTypePBIDDocument        = veidv1.ScopeTypeIDDocument
+	ScopeTypePBSelfie            = veidv1.ScopeTypeSelfie
+	ScopeTypePBFaceVideo         = veidv1.ScopeTypeFaceVideo
+	ScopeTypePBBiometric         = veidv1.ScopeTypeBiometric
+	ScopeTypePBSSOMetadata       = veidv1.ScopeTypeSSOMetadata
+	ScopeTypePBEmailProof        = veidv1.ScopeTypeEmailProof
+	ScopeTypePBSMSProof          = veidv1.ScopeTypeSMSProof
+	ScopeTypePBDomainVerify      = veidv1.ScopeTypeDomainVerify
+	ScopeTypePBADSSO             = veidv1.ScopeTypeADSSO
+	ScopeTypePBBiometricHardware = veidv1.ScopeTypeBiometricHardware
+	ScopeTypePBDeviceAttestation = veidv1.ScopeTypeDeviceAttestation
 )
 
 // VerificationStatusPB is the protobuf-generated enum for verification status
@@ -190,6 +192,10 @@ func ScopeTypeToProto(st ScopeType) ScopeTypePB {
 		return ScopeTypePBFaceVideo
 	case ScopeTypeBiometric:
 		return ScopeTypePBBiometric
+	case ScopeTypeBiometricHardware:
+		return ScopeTypePBBiometricHardware
+	case ScopeTypeDeviceAttestation:
+		return ScopeTypePBDeviceAttestation
 	case ScopeTypeSSOMetadata:
 		return ScopeTypePBSSOMetadata
 	case ScopeTypeEmailProof:
@@ -216,6 +222,10 @@ func ScopeTypeFromProto(st ScopeTypePB) ScopeType {
 		return ScopeTypeFaceVideo
 	case ScopeTypePBBiometric:
 		return ScopeTypeBiometric
+	case ScopeTypePBBiometricHardware:
+		return ScopeTypeBiometricHardware
+	case ScopeTypePBDeviceAttestation:
+		return ScopeTypeDeviceAttestation
 	case ScopeTypePBSSOMetadata:
 		return ScopeTypeSSOMetadata
 	case ScopeTypePBEmailProof:

--- a/x/veid/types/scope.go
+++ b/x/veid/types/scope.go
@@ -24,6 +24,12 @@ const (
 	// ScopeTypeBiometric represents biometric data (fingerprint, voice, etc.)
 	ScopeTypeBiometric ScopeType = "biometric"
 
+	// ScopeTypeBiometricHardware represents biometric hardware attestation payloads
+	ScopeTypeBiometricHardware ScopeType = "biometric_hardware"
+
+	// ScopeTypeDeviceAttestation represents device integrity attestation payloads
+	ScopeTypeDeviceAttestation ScopeType = "device_attestation"
+
 	// ScopeTypeSSOMetadata represents SSO provider metadata pointers
 	ScopeTypeSSOMetadata ScopeType = "sso_metadata"
 
@@ -56,6 +62,8 @@ func AllScopeTypes() []ScopeType {
 		ScopeTypeSelfie,
 		ScopeTypeFaceVideo,
 		ScopeTypeBiometric,
+		ScopeTypeBiometricHardware,
+		ScopeTypeDeviceAttestation,
 		ScopeTypeSSOMetadata,
 		ScopeTypeEmailProof,
 		ScopeTypeSMSProof,
@@ -86,6 +94,10 @@ func ScopeTypeWeight(scopeType ScopeType) uint32 {
 		return 20 // Medium-high weight - face verification
 	case ScopeTypeBiometric:
 		return 20 // Medium-high weight - biometric data
+	case ScopeTypeBiometricHardware:
+		return 22 // Medium-high weight - biometric hardware attestation
+	case ScopeTypeDeviceAttestation:
+		return 12 // Medium weight - device integrity signal
 	case ScopeTypeDomainVerify:
 		return 15 // Medium weight - domain ownership
 	case ScopeTypeEmailProof:
@@ -117,6 +129,10 @@ func ScopeTypeDescription(scopeType ScopeType) string {
 		return "Video recording for liveness detection"
 	case ScopeTypeBiometric:
 		return "Biometric data (fingerprint, voice, etc.)"
+	case ScopeTypeBiometricHardware:
+		return "Biometric hardware attestation (fingerprint/iris sensor integrity)"
+	case ScopeTypeDeviceAttestation:
+		return "Device integrity attestation (Play Integrity / App Attest)"
 	case ScopeTypeSSOMetadata:
 		return "SSO provider metadata and verification pointers"
 	case ScopeTypeEmailProof:

--- a/x/veid/types/scope_test.go
+++ b/x/veid/types/scope_test.go
@@ -24,6 +24,8 @@ func TestIsValidScopeType(t *testing.T) {
 		{types.ScopeTypeSelfie, true},
 		{types.ScopeTypeFaceVideo, true},
 		{types.ScopeTypeBiometric, true},
+		{types.ScopeTypeBiometricHardware, true},
+		{types.ScopeTypeDeviceAttestation, true},
 		{types.ScopeTypeSSOMetadata, true},
 		{types.ScopeTypeEmailProof, true},
 		{types.ScopeTypeSMSProof, true},
@@ -42,13 +44,15 @@ func TestIsValidScopeType(t *testing.T) {
 
 func TestAllScopeTypes(t *testing.T) {
 	scopeTypes := types.AllScopeTypes()
-	assert.Len(t, scopeTypes, 9) // All 9 scope types
+	assert.Len(t, scopeTypes, 11) // All 11 scope types
 
 	// Verify all types are present
 	assert.Contains(t, scopeTypes, types.ScopeTypeIDDocument)
 	assert.Contains(t, scopeTypes, types.ScopeTypeSelfie)
 	assert.Contains(t, scopeTypes, types.ScopeTypeFaceVideo)
 	assert.Contains(t, scopeTypes, types.ScopeTypeBiometric)
+	assert.Contains(t, scopeTypes, types.ScopeTypeBiometricHardware)
+	assert.Contains(t, scopeTypes, types.ScopeTypeDeviceAttestation)
 	assert.Contains(t, scopeTypes, types.ScopeTypeSSOMetadata)
 	assert.Contains(t, scopeTypes, types.ScopeTypeEmailProof)
 	assert.Contains(t, scopeTypes, types.ScopeTypeSMSProof)
@@ -65,6 +69,8 @@ func TestScopeTypeWeight(t *testing.T) {
 		{types.ScopeTypeFaceVideo, 25},
 		{types.ScopeTypeSelfie, 20},
 		{types.ScopeTypeBiometric, 20},
+		{types.ScopeTypeBiometricHardware, 22},
+		{types.ScopeTypeDeviceAttestation, 12},
 		{types.ScopeTypeDomainVerify, 15},
 		{types.ScopeTypeADSSO, 12},
 		{types.ScopeTypeEmailProof, 10},
@@ -89,6 +95,8 @@ func TestScopeTypeDescription(t *testing.T) {
 		{types.ScopeTypeSelfie, "Selfie photo"},
 		{types.ScopeTypeFaceVideo, "liveness"},
 		{types.ScopeTypeBiometric, "Biometric"},
+		{types.ScopeTypeBiometricHardware, "hardware"},
+		{types.ScopeTypeDeviceAttestation, "Device integrity"},
 		{types.ScopeTypeSSOMetadata, "SSO provider"},
 		{types.ScopeTypeEmailProof, "Email"},
 		{types.ScopeTypeSMSProof, "Phone number"},


### PR DESCRIPTION
## Summary\n- add biometric hardware capture + device attestation support in mobile capture app\n- add new VEID scope and attestation types, plus device integrity scoring signals\n- add device attestation verification service + mocks and tests\n- add documentation for supported devices, flow, and privacy\n\n## Testing\n- go test ./x/veid/... -count=1\n- go test ./pkg/verification/device/... -count=1\n- go vet ./x/veid/...\n- go vet ./pkg/verification/device/...\n- golangci-lint run --new-from-rev=HEAD~1\n- go build ./...\n- npm -C mobile/veid-capture-app run typecheck\n- npm -C mobile/veid-capture-app test