### PR TITLE
feat(encryption): wire vault role resolver

### DIFF
--- a/pkg/provider_daemon/portal_chain_query.go
+++ b/pkg/provider_daemon/portal_chain_query.go
@@ -37,6 +37,9 @@ type ChainQuery interface {
 	GetDeploymentMetricsHistory(ctx context.Context, deploymentID string, start, end time.Time, interval time.Duration) (*MetricsSeriesResponse, error)
 	GetDeploymentEvents(ctx context.Context, deploymentID string, limit int, cursor string) ([]DeploymentEvent, string, error)
 	GetAggregatedMetrics(ctx context.Context, start, end time.Time, interval time.Duration) (*MetricsSeriesResponse, error)
+
+	// Roles.
+	HasRole(ctx context.Context, address, role string) (bool, error)
 }
 
 // NoopChainQuery is a default implementation that returns empty results.
@@ -135,4 +138,9 @@ func (NoopChainQuery) GetDeploymentEvents(_ context.Context, _ string, _ int, _ 
 // GetAggregatedMetrics returns empty series.
 func (NoopChainQuery) GetAggregatedMetrics(_ context.Context, _ time.Time, _ time.Time, _ time.Duration) (*MetricsSeriesResponse, error) {
 	return &MetricsSeriesResponse{Series: []MetricsPoint{}}, nil
+}
+
+// HasRole returns false in noop implementation.
+func (NoopChainQuery) HasRole(_ context.Context, _ string, _ string) (bool, error) {
+	return false, nil
 }

--- a/pkg/provider_daemon/vault_access.go
+++ b/pkg/provider_daemon/vault_access.go
@@ -47,3 +47,18 @@ func (c ChainOrgResolver) MemberRole(ctx context.Context, orgID, address string)
 
 var _ data_vault.OrgResolver = ChainOrgResolver{}
 var _ data_vault.OrgRoleResolver = ChainOrgResolver{}
+
+// ChainRoleResolver resolves chain roles using the portal chain query.
+type ChainRoleResolver struct {
+	ChainQuery ChainQuery
+}
+
+// HasRole checks if the address has the specified chain role.
+func (c ChainRoleResolver) HasRole(ctx context.Context, address, role string) (bool, error) {
+	if c.ChainQuery == nil || address == "" || role == "" {
+		return false, nil
+	}
+	return c.ChainQuery.HasRole(ctx, address, role)
+}
+
+var _ data_vault.RoleResolver = ChainRoleResolver{}

--- a/pkg/provider_daemon/vault_role_resolver.go
+++ b/pkg/provider_daemon/vault_role_resolver.go
@@ -1,0 +1,38 @@
+package provider_daemon
+
+import (
+	"context"
+
+	"github.com/virtengine/virtengine/pkg/data_vault"
+	rolesv1 "github.com/virtengine/virtengine/sdk/go/node/roles/v1"
+)
+
+// GRPCRoleResolver resolves roles via the chain gRPC roles query service.
+type GRPCRoleResolver struct {
+	client rolesv1.QueryClient
+}
+
+// NewGRPCRoleResolver returns a role resolver backed by the roles query client.
+func NewGRPCRoleResolver(client rolesv1.QueryClient) *GRPCRoleResolver {
+	if client == nil {
+		return nil
+	}
+	return &GRPCRoleResolver{client: client}
+}
+
+// HasRole checks if the address has the specified role on chain.
+func (r *GRPCRoleResolver) HasRole(ctx context.Context, address, role string) (bool, error) {
+	if r == nil || r.client == nil || address == "" || role == "" {
+		return false, nil
+	}
+	resp, err := r.client.HasRole(ctx, &rolesv1.QueryHasRoleRequest{
+		Address: address,
+		Role:    role,
+	})
+	if err != nil {
+		return false, err
+	}
+	return resp.GetHasRole(), nil
+}
+
+var _ data_vault.RoleResolver = (*GRPCRoleResolver)(nil)


### PR DESCRIPTION
## Summary
- add chain role resolver wiring for vault access control
- allow vault access policy to enforce global roles when resolver is configured
- expose chain role query through provider daemon chain query

## Testing
- go test ./pkg/data_vault/...
- go test ./pkg/provider_daemon/...
- go vet ./pkg/provider_daemon/... ./cmd/provider-daemon
- golangci-lint run --new-from-rev=HEAD~1
- go build ./cmd/provider-daemon