### PR TITLE
feat(cli): add claude primary agent adapter

### DIFF
--- a/scripts/codex-monitor/.env.example
+++ b/scripts/codex-monitor/.env.example
@@ -107,6 +107,19 @@ OPENAI_API_KEY=
 # Set to 1 to disable all Codex/AI features (analysis, autofix, shell)
 # CODEX_SDK_DISABLED=0
 
+# Primary agent adapter: codex-sdk | claude-sdk
+# PRIMARY_AGENT=codex-sdk
+# Set to 1 to disable the primary agent adapter
+# PRIMARY_AGENT_DISABLED=0
+
+# ─── Claude Agent SDK (Claude Code) ─────────────────────────────────────────
+# Set to 1 to disable Claude SDK features
+# CLAUDE_SDK_DISABLED=0
+# CLAUDE_MODEL=claude-opus-4-6
+# CLAUDE_PERMISSION_MODE=bypassPermissions
+# CLAUDE_MAX_TURNS=0
+# CLAUDE_ALLOWED_TOOLS=Read,Write,Edit,Grep,Glob,Bash,WebSearch,Task,Skill
+
 # ─── Task Planner ────────────────────────────────────────────────────────────
 # Auto-trigger task planner when backlog-per-slot drops below threshold
 TASK_PLANNER_PER_CAPITA_THRESHOLD=1

--- a/scripts/codex-monitor/README.md
+++ b/scripts/codex-monitor/README.md
@@ -529,6 +529,8 @@ codex-monitor/
 ├── monitor.mjs                  # Main supervisor (log analysis, PR flow)
 ├── telegram-bot.mjs             # Interactive Telegram chatbot
 ├── codex-shell.mjs              # Persistent Codex SDK session
+├── claude-shell.mjs             # Persistent Claude Agent SDK session
+├── primary-agent.mjs            # Primary agent adapter (Codex or Claude)
 ├── autofix.mjs                  # Error loop detection + auto-fix
 ├── maintenance.mjs              # Singleton lock, process cleanup
 ├── setup.mjs                    # Interactive setup wizard

--- a/scripts/codex-monitor/claude-shell.mjs
+++ b/scripts/codex-monitor/claude-shell.mjs
@@ -1,0 +1,618 @@
+/**
+ * claude-shell.mjs - Persistent Claude agent adapter for codex-monitor.
+ *
+ * Uses the Claude Agent SDK (@anthropic-ai/claude-agent-sdk) to run a
+ * long-lived session with steering support via streaming input mode.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(new URL(".", import.meta.url)));
+
+// ── Configuration ───────────────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS = 60 * 60 * 1000; // 60 min for agentic tasks
+const STATE_FILE = resolve(__dirname, "logs", "claude-shell-state.json");
+const REPO_ROOT = resolve(__dirname, "..", "..");
+
+// ── State ───────────────────────────────────────────────────────────────────
+
+let queryFn = null;
+let activeQuery = null;
+let activeQueue = null;
+let activeTurn = false;
+let activeSessionId = null;
+let turnCount = 0;
+
+// Track tool use IDs for mapping tool results to start events.
+const toolUseById = new Map();
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function timestamp() {
+  return new Date().toISOString();
+}
+
+function normalizeList(value) {
+  if (!value) return null;
+  if (Array.isArray(value)) return value.map(String).map((v) => v.trim());
+  return String(value)
+    .split(",")
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+function getToolName(block) {
+  return block?.name || block?.tool_name || block?.toolName || "";
+}
+
+function getToolUseId(block) {
+  return block?.tool_use_id || block?.toolUseId || block?.id || null;
+}
+
+function extractTextBlocks(content) {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b) => b?.type === "text" && typeof b.text === "string")
+    .map((b) => b.text)
+    .join("");
+}
+
+function extractResultText(block) {
+  if (!block) return "";
+  if (typeof block.content === "string") return block.content;
+  if (Array.isArray(block.content)) {
+    return block.content
+      .map((c) => (typeof c === "string" ? c : c?.text || ""))
+      .join("");
+  }
+  return "";
+}
+
+function formatEvent(event) {
+  if (!event) return null;
+  if (event.type === "item.started" && event.item?.type === "command_execution") {
+    return `⚡ Running: \`${event.item.command}\``;
+  }
+  if (event.type === "item.completed" && event.item?.type === "command_execution") {
+    const status = event.item.exit_code === 0 ? "✅" : "❌";
+    return `${status} Command done: \`${event.item.command}\``;
+  }
+  if (event.type === "item.started" && event.item?.type === "mcp_tool_call") {
+    return `🔌 MCP [${event.item.server}/${event.item.tool}]`;
+  }
+  if (event.type === "item.completed" && event.item?.type === "mcp_tool_call") {
+    const status = event.item.status === "completed" ? "✅" : "❌";
+    return `${status} MCP [${event.item.server}/${event.item.tool}]`;
+  }
+  if (event.type === "item.started" && event.item?.type === "web_search") {
+    return `🔍 Searching: ${event.item.query || ""}`;
+  }
+  if (event.type === "item.updated" && event.item?.type === "reasoning") {
+    return event.item.text ? `💭 ${event.item.text.slice(0, 300)}` : null;
+  }
+  return null;
+}
+
+function makeUserMessage(text) {
+  return {
+    type: "user",
+    session_id: activeSessionId || "",
+    message: {
+      role: "user",
+      content: [{ type: "text", text }],
+    },
+    parent_tool_use_id: null,
+  };
+}
+
+function createMessageQueue() {
+  const queue = [];
+  let resolver = null;
+  let closed = false;
+
+  async function* iterator() {
+    while (true) {
+      if (queue.length > 0) {
+        yield queue.shift();
+        continue;
+      }
+      if (closed) return;
+      await new Promise((resolve) => {
+        resolver = resolve;
+      });
+      resolver = null;
+    }
+  }
+
+  function push(message) {
+    if (closed) return false;
+    queue.push(message);
+    if (resolver) {
+      resolver();
+      resolver = null;
+    }
+    return true;
+  }
+
+  function close() {
+    closed = true;
+    if (resolver) {
+      resolver();
+      resolver = null;
+    }
+  }
+
+  function size() {
+    return queue.length;
+  }
+
+  return { iterator, push, close, size };
+}
+
+function buildOptions() {
+  const options = {
+    cwd: REPO_ROOT,
+    settingSources: ["user", "project"],
+    permissionMode: process.env.CLAUDE_PERMISSION_MODE || "bypassPermissions",
+  };
+
+  const model =
+    process.env.CLAUDE_MODEL ||
+    process.env.CLAUDE_CODE_MODEL ||
+    process.env.ANTHROPIC_MODEL ||
+    "";
+  if (model) options.model = model;
+
+  const maxTurns = Number(process.env.CLAUDE_MAX_TURNS || "0");
+  if (Number.isFinite(maxTurns) && maxTurns > 0) {
+    options.maxTurns = maxTurns;
+  }
+
+  const includePartial = process.env.CLAUDE_INCLUDE_PARTIAL === "1";
+  if (includePartial) {
+    options.includePartialMessages = true;
+  }
+
+  const allowedTools = normalizeList(process.env.CLAUDE_ALLOWED_TOOLS);
+  if (allowedTools && allowedTools.length > 0) {
+    options.allowedTools = allowedTools;
+  }
+
+  return options;
+}
+
+function buildCommandForTool(name, input) {
+  const toolName = String(name || "");
+  if (toolName === "Bash") {
+    return input?.command || input?.cmd || input?.script || "(bash)";
+  }
+  if (toolName === "Read") {
+    const path = input?.path || input?.file_path || input?.file || "";
+    return path ? `cat ${path}` : "cat";
+  }
+  if (toolName === "Grep") {
+    const pattern = input?.pattern || input?.query || "";
+    const path = input?.path || input?.file_path || "";
+    if (pattern && path) return `rg \"${pattern}\" ${path}`;
+    if (pattern) return `rg \"${pattern}\"`;
+    return "rg";
+  }
+  if (toolName === "Glob") {
+    const pattern = input?.pattern || input?.path || "";
+    return pattern ? `ls ${pattern}` : "ls";
+  }
+  if (toolName === "WebSearch") {
+    return input?.query || "";
+  }
+  if (toolName.startsWith("mcp__")) {
+    return toolName;
+  }
+  return toolName || "tool";
+}
+
+function parseMcpName(name) {
+  if (!name.startsWith("mcp__")) return null;
+  const parts = name.split("__").filter(Boolean);
+  if (parts.length < 3) return null;
+  return { server: parts[1], tool: parts.slice(2).join("__") };
+}
+
+function buildToolStartEvent(toolName, input) {
+  if (!toolName) return null;
+  if (toolName === "WebSearch") {
+    return {
+      type: "item.started",
+      item: { type: "web_search", query: input?.query || "" },
+    };
+  }
+  if (toolName.startsWith("mcp__")) {
+    const parsed = parseMcpName(toolName);
+    if (!parsed) return null;
+    return {
+      type: "item.started",
+      item: { type: "mcp_tool_call", server: parsed.server, tool: parsed.tool },
+    };
+  }
+
+  const command = buildCommandForTool(toolName, input);
+  if (!command) return null;
+  return {
+    type: "item.started",
+    item: { type: "command_execution", command },
+  };
+}
+
+function buildToolResultEvent(toolName, toolInput, resultBlock) {
+  if (!toolName) return null;
+  const isError = !!resultBlock?.is_error;
+
+  if (toolName.startsWith("mcp__")) {
+    const parsed = parseMcpName(toolName);
+    if (!parsed) return null;
+    return {
+      type: "item.completed",
+      item: {
+        type: "mcp_tool_call",
+        server: parsed.server,
+        tool: parsed.tool,
+        status: isError ? "failed" : "completed",
+      },
+    };
+  }
+
+  if (toolName === "Write" || toolName === "Edit") {
+    const path =
+      toolInput?.path ||
+      toolInput?.file_path ||
+      toolInput?.file ||
+      toolInput?.filename ||
+      "";
+    if (!path) return null;
+    return {
+      type: "item.completed",
+      item: {
+        type: "file_change",
+        changes: [
+          {
+            path,
+            kind: toolName === "Write" ? "add" : "update",
+            additions: 0,
+            deletions: 0,
+          },
+        ],
+      },
+    };
+  }
+
+  const command = buildCommandForTool(toolName, toolInput);
+  if (!command) return null;
+  return {
+    type: "item.completed",
+    item: {
+      type: "command_execution",
+      command,
+      exit_code: isError ? 1 : 0,
+      aggregated_output: extractResultText(resultBlock),
+    },
+  };
+}
+
+// ── SDK Loading ─────────────────────────────────────────────────────────────
+
+async function loadClaudeSdk() {
+  if (queryFn) return queryFn;
+  try {
+    const mod = await import("@anthropic-ai/claude-agent-sdk");
+    queryFn = mod.query;
+    if (!queryFn) {
+      throw new Error("query() not found in Claude SDK");
+    }
+    console.log("[claude-shell] SDK loaded successfully");
+    return queryFn;
+  } catch (err) {
+    console.error(`[claude-shell] failed to load SDK: ${err.message}`);
+    return null;
+  }
+}
+
+// ── State Persistence ───────────────────────────────────────────────────────
+
+async function loadState() {
+  try {
+    const raw = await readFile(STATE_FILE, "utf8");
+    const data = JSON.parse(raw);
+    activeSessionId = data.sessionId || null;
+    turnCount = data.turnCount || 0;
+    console.log(
+      `[claude-shell] loaded state: sessionId=${activeSessionId}, turns=${turnCount}`,
+    );
+  } catch {
+    activeSessionId = null;
+    turnCount = 0;
+  }
+}
+
+async function saveState() {
+  try {
+    await mkdir(resolve(__dirname, "logs"), { recursive: true });
+    await writeFile(
+      STATE_FILE,
+      JSON.stringify(
+        {
+          sessionId: activeSessionId,
+          turnCount,
+          updatedAt: timestamp(),
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+  } catch (err) {
+    console.warn(`[claude-shell] failed to save state: ${err.message}`);
+  }
+}
+
+function buildPrompt(userMessage, statusData) {
+  if (!statusData) {
+    return `# YOUR TASK — EXECUTE NOW\n\n${userMessage}\n\n---\nDo NOT respond with \"Ready\" or ask what to do. EXECUTE this task. Read files, run commands, produce detailed output.`;
+  }
+  const statusSnippet = JSON.stringify(statusData, null, 2).slice(0, 2000);
+  return `[Orchestrator Status]\n\`\`\`json\n${statusSnippet}\n\`\`\`\n\n# YOUR TASK — EXECUTE NOW\n\n${userMessage}\n\n---\nDo NOT respond with \"Ready\" or ask what to do. EXECUTE this task. Read files, run commands, produce detailed output.`;
+}
+
+// ── Main Execution ─────────────────────────────────────────────────────────
+
+/**
+ * Send a message to the Claude agent and stream events back.
+ *
+ * @param {string} userMessage
+ * @param {object} options
+ * @param {function} options.onEvent
+ * @param {object} options.statusData
+ * @param {number} options.timeoutMs
+ * @param {boolean} options.sendRawEvents
+ * @param {AbortController} options.abortController
+ * @returns {Promise<{finalResponse: string, items: Array, usage: object|null}>}
+ */
+export async function execClaudePrompt(userMessage, options = {}) {
+  const {
+    onEvent = null,
+    statusData = null,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    sendRawEvents = false,
+    abortController = null,
+  } = options;
+
+  if (activeTurn) {
+    return {
+      finalResponse: "⏳ Agent is still executing a previous task. Please wait.",
+      items: [],
+      usage: null,
+    };
+  }
+
+  const query = await loadClaudeSdk();
+  if (!query) {
+    return {
+      finalResponse: "❌ Claude SDK not available.",
+      items: [],
+      usage: null,
+    };
+  }
+
+  activeTurn = true;
+  toolUseById.clear();
+
+  const controller = abortController || new AbortController();
+  let abortReason = null;
+  const onAbort = () => {
+    abortReason = controller.signal.reason || "aborted";
+    try {
+      if (activeQuery?.interrupt) {
+        void activeQuery.interrupt();
+      }
+    } catch {
+      /* best effort */
+    }
+    if (activeQueue) {
+      activeQueue.close();
+    }
+  };
+  controller.signal.addEventListener("abort", onAbort, { once: true });
+
+  const timer = setTimeout(() => {
+    try {
+      controller.abort("timeout");
+    } catch {
+      /* noop */
+    }
+  }, timeoutMs);
+
+  let finalResponse = "";
+  const allItems = [];
+
+  try {
+    const queue = createMessageQueue();
+    activeQueue = queue;
+    queue.push(makeUserMessage(buildPrompt(userMessage, statusData)));
+
+    const optionsPayload = buildOptions();
+    if (activeSessionId) {
+      optionsPayload.resume = activeSessionId;
+    }
+
+    activeQuery = query({
+      prompt: queue.iterator(),
+      options: optionsPayload,
+    });
+
+    for await (const message of activeQuery) {
+      const sessionId = message?.session_id || message?.sessionId;
+      if (sessionId && sessionId !== activeSessionId) {
+        activeSessionId = sessionId;
+        await saveState();
+      }
+
+      const contentBlocks = message?.message?.content || message?.content || [];
+
+      if (message?.type === "assistant" && Array.isArray(contentBlocks)) {
+        const text = extractTextBlocks(contentBlocks);
+        if (text) {
+          finalResponse += text + "\n";
+        }
+
+        for (const block of contentBlocks) {
+          if (!block) continue;
+
+          if (block.type === "thinking" && block.text) {
+            const event = {
+              type: "item.updated",
+              item: { type: "reasoning", text: block.text },
+            };
+            if (onEvent) {
+              const formatted = formatEvent(event);
+              if (formatted || sendRawEvents) {
+                await onEvent(formatted, event);
+              }
+            }
+            continue;
+          }
+
+          if (block.type === "tool_use") {
+            const toolName = getToolName(block);
+            const toolId = getToolUseId(block);
+            if (toolId) {
+              toolUseById.set(toolId, { name: toolName, input: block.input });
+            }
+            const event = buildToolStartEvent(toolName, block.input);
+            if (event && onEvent) {
+              const formatted = formatEvent(event);
+              if (formatted || sendRawEvents) {
+                await onEvent(formatted, event);
+              }
+            }
+            continue;
+          }
+
+          if (block.type === "tool_result") {
+            const toolId = block.tool_use_id || block.toolUseId;
+            const toolData = toolUseById.get(toolId) || {};
+            const event = buildToolResultEvent(
+              toolData.name,
+              toolData.input,
+              block,
+            );
+            if (event) {
+              allItems.push(event.item);
+              if (onEvent) {
+                const formatted = formatEvent(event);
+                if (formatted || sendRawEvents) {
+                  await onEvent(formatted, event);
+                }
+              }
+            }
+            continue;
+          }
+        }
+      }
+
+      if (message?.type === "result" && message?.result) {
+        if (!finalResponse) {
+          finalResponse = message.result;
+        }
+      }
+    }
+
+    clearTimeout(timer);
+    turnCount += 1;
+    await saveState();
+
+    return {
+      finalResponse:
+        finalResponse.trim() || "(Agent completed with no text output)",
+      items: allItems,
+      usage: null,
+    };
+  } catch (err) {
+    clearTimeout(timer);
+    if (controller.signal.aborted) {
+      const reason = abortReason || controller.signal.reason;
+      const msg =
+        reason === "user_stop"
+          ? "🛑 Agent stopped by user."
+          : `⏱️ Agent timed out after ${timeoutMs / 1000}s`;
+      return { finalResponse: msg, items: [], usage: null };
+    }
+    const message = err?.message || String(err || "unknown error");
+    return { finalResponse: `❌ Claude agent failed: ${message}`, items: [], usage: null };
+  } finally {
+    if (activeQueue) activeQueue.close();
+    activeQueue = null;
+    activeQuery = null;
+    activeTurn = false;
+  }
+}
+
+/**
+ * Try to steer an in-flight agent without stopping the run.
+ */
+export async function steerClaudePrompt(message) {
+  if (!activeTurn || !activeQueue) {
+    return { ok: false, reason: "no_active_session" };
+  }
+  const ok = activeQueue.push(makeUserMessage(message));
+  if (ok) {
+    return { ok: true, mode: "enqueue" };
+  }
+  return { ok: false, reason: "queue_closed" };
+}
+
+/**
+ * Check if a turn is currently in flight.
+ */
+export function isClaudeBusy() {
+  return !!activeTurn;
+}
+
+/**
+ * Get session info for display.
+ */
+export function getSessionInfo() {
+  return {
+    sessionId: activeSessionId,
+    turnCount,
+    isActive: !!activeQuery,
+    isBusy: !!activeTurn,
+  };
+}
+
+/**
+ * Reset the session — starts a fresh conversation.
+ */
+export async function resetClaudeSession() {
+  activeQuery = null;
+  activeQueue = null;
+  activeSessionId = null;
+  turnCount = 0;
+  activeTurn = false;
+  await saveState();
+  console.log("[claude-shell] session reset");
+}
+
+// ── Initialization ──────────────────────────────────────────────────────────
+
+export async function initClaudeShell() {
+  await loadState();
+  const loaded = await loadClaudeSdk();
+  if (loaded) {
+    console.log("[claude-shell] initialised with Claude SDK");
+  } else {
+    console.warn(
+      "[claude-shell] initialised WITHOUT Claude SDK — agent will not work",
+    );
+  }
+}

--- a/scripts/codex-monitor/codex-monitor.config.json
+++ b/scripts/codex-monitor/codex-monitor.config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./codex-monitor.schema.json",
   "projectName": "virtengine",
+  "primaryAgent": "codex-sdk",
   "executors": [
     {
       "name": "copilot-claude",

--- a/scripts/codex-monitor/codex-monitor.schema.json
+++ b/scripts/codex-monitor/codex-monitor.schema.json
@@ -18,6 +18,10 @@
     "echoLogs": { "type": "boolean" },
     "autoFixEnabled": { "type": "boolean" },
     "codexEnabled": { "type": "boolean" },
+    "primaryAgent": {
+      "type": "string",
+      "enum": ["codex-sdk", "claude-sdk"]
+    },
     "vkSpawnEnabled": { "type": "boolean" },
     "plannerMode": {
       "type": "string",

--- a/scripts/codex-monitor/package-lock.json
+++ b/scripts/codex-monitor/package-lock.json
@@ -1,18 +1,337 @@
 {
-  "name": "codex-monitor",
-  "version": "0.1.0",
+  "name": "@virtengine/codex-monitor",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "codex-monitor",
-      "version": "0.1.0",
+      "name": "@virtengine/codex-monitor",
+      "version": "0.5.2",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32"
+      ],
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.2.37",
         "@openai/codex-sdk": "0.99.0-alpha.6",
         "vibe-kanban": "0.1.6"
       },
+      "bin": {
+        "codex-monitor": "cli.mjs",
+        "codex-monitor-chat-id": "get-telegram-chat-id.mjs",
+        "codex-monitor-setup": "setup.mjs",
+        "vibe-kanban": "vibe-kanban-wrapper.mjs"
+      },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.37.tgz",
+      "integrity": "sha512-0TCAUuGXiWYV2JK+j2SiakGzPA7aoR5DNRxZ0EA571loGIqN3FRfiO1kipeBpEc+cRQ03a/4Kt5YAjMx0KBW+A==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.5",
+        "@img/sharp-darwin-x64": "^0.33.5",
+        "@img/sharp-linux-arm": "^0.33.5",
+        "@img/sharp-linux-arm64": "^0.33.5",
+        "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
+        "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@openai/codex-sdk": {
@@ -42,6 +361,16 @@
       },
       "bin": {
         "vibe-kanban": "bin/cli.js"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/scripts/codex-monitor/package.json
+++ b/scripts/codex-monitor/package.json
@@ -40,6 +40,8 @@
     "./setup": "./setup.mjs",
     "./autofix": "./autofix.mjs",
     "./codex-shell": "./codex-shell.mjs",
+    "./claude-shell": "./claude-shell.mjs",
+    "./primary-agent": "./primary-agent.mjs",
     "./maintenance": "./maintenance.mjs",
     "./telegram-bot": "./telegram-bot.mjs",
     "./workspace-registry": "./workspace-registry.mjs"
@@ -63,6 +65,8 @@
     "monitor.mjs",
     "autofix.mjs",
     "codex-shell.mjs",
+    "claude-shell.mjs",
+    "primary-agent.mjs",
     "maintenance.mjs",
     "telegram-bot.mjs",
     "get-telegram-chat-id.mjs",
@@ -77,6 +81,7 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.2.37",
     "@openai/codex-sdk": "0.99.0-alpha.6",
     "vibe-kanban": "0.1.6"
   },

--- a/scripts/codex-monitor/postinstall.mjs
+++ b/scripts/codex-monitor/postinstall.mjs
@@ -143,6 +143,7 @@ function main() {
   // npm-installed tools (bundled with this package)
   console.log(`  ✅ vibe-kanban (bundled)`);
   console.log(`  ✅ @openai/codex-sdk (bundled)`);
+  console.log(`  ✅ @anthropic-ai/claude-agent-sdk (bundled)`);
 
   // Summary
   console.log("");

--- a/scripts/codex-monitor/primary-agent.mjs
+++ b/scripts/codex-monitor/primary-agent.mjs
@@ -1,0 +1,106 @@
+/**
+ * primary-agent.mjs - Unified adapter for Codex or Claude primary agents.
+ */
+
+import {
+  execCodexPrompt,
+  steerCodexPrompt,
+  isCodexBusy,
+  getThreadInfo,
+  resetThread,
+  initCodexShell,
+} from "./codex-shell.mjs";
+import {
+  execClaudePrompt,
+  steerClaudePrompt,
+  isClaudeBusy,
+  getSessionInfo,
+  resetClaudeSession,
+  initClaudeShell,
+} from "./claude-shell.mjs";
+
+const ADAPTERS = {
+  "codex-sdk": {
+    name: "codex-sdk",
+    exec: execCodexPrompt,
+    steer: steerCodexPrompt,
+    isBusy: isCodexBusy,
+    getInfo: () => {
+      const info = getThreadInfo();
+      return { ...info, sessionId: info.threadId };
+    },
+    reset: resetThread,
+    init: initCodexShell,
+  },
+  "claude-sdk": {
+    name: "claude-sdk",
+    exec: execClaudePrompt,
+    steer: steerClaudePrompt,
+    isBusy: isClaudeBusy,
+    getInfo: () => getSessionInfo(),
+    reset: resetClaudeSession,
+    init: initClaudeShell,
+  },
+};
+
+let activeAdapter = ADAPTERS["codex-sdk"];
+
+function normalizePrimaryAgent(value) {
+  const raw = String(value || "").trim().toLowerCase();
+  if (!raw) return "codex-sdk";
+  if (["codex", "codex-sdk"].includes(raw)) return "codex-sdk";
+  if (["claude", "claude-sdk", "claude_code", "claude-code"].includes(raw))
+    return "claude-sdk";
+  return raw;
+}
+
+export function setPrimaryAgent(name) {
+  const normalized = normalizePrimaryAgent(name);
+  activeAdapter = ADAPTERS[normalized] || ADAPTERS["codex-sdk"];
+  return activeAdapter.name;
+}
+
+export function getPrimaryAgentName() {
+  return activeAdapter?.name || "codex-sdk";
+}
+
+export async function initPrimaryAgent(name) {
+  if (name) {
+    setPrimaryAgent(name);
+  } else if (process.env.PRIMARY_AGENT) {
+    setPrimaryAgent(process.env.PRIMARY_AGENT);
+  }
+  if (activeAdapter?.init) {
+    await activeAdapter.init();
+  }
+}
+
+export async function execPrimaryPrompt(...args) {
+  return activeAdapter.exec(...args);
+}
+
+export async function steerPrimaryPrompt(...args) {
+  return activeAdapter.steer(...args);
+}
+
+export function isPrimaryBusy() {
+  return activeAdapter.isBusy();
+}
+
+export function getPrimaryAgentInfo() {
+  const info = activeAdapter.getInfo ? activeAdapter.getInfo() : {};
+  return {
+    adapter: activeAdapter.name,
+    sessionId: info.sessionId || info.threadId || null,
+    threadId: info.threadId || null,
+    turnCount: info.turnCount || 0,
+    isActive: !!info.isActive,
+    isBusy: !!info.isBusy,
+  };
+}
+
+export async function resetPrimaryAgent() {
+  if (activeAdapter.reset) {
+    await activeAdapter.reset();
+  }
+}


### PR DESCRIPTION
## Summary
- add Claude Agent SDK primary agent adapter with steering support
- route codex-monitor primary agent through a unified adapter + config flag
- update env/schema/docs and add SDK dependency

## Testing
- pwsh scripts/agent-preflight.ps1
- npm -C scripts/codex-monitor install --package-lock-only
- pre-push hooks (portal lint/type-check/tests/build)