### PR TITLE
fix(monitor): export fetchVk/updateTaskStatus + fix vk-api test suite

### DIFF
--- a/scripts/codex-monitor/monitor.mjs
+++ b/scripts/codex-monitor/monitor.mjs
@@ -5140,7 +5140,7 @@ process.on("unhandledRejection", (reason) => {
 });
 
 // ── Singleton guard: prevent ghost monitors ─────────────────────────────────
-if (!acquireMonitorLock(config.cacheDir)) {
+if (!process.env.VITEST && !acquireMonitorLock(config.cacheDir)) {
   process.exit(1);
 }
 
@@ -5283,3 +5283,6 @@ injectMonitorFunctions({
 if (telegramBotEnabled) {
   void startTelegramBot();
 }
+
+// ── Named exports for testing ───────────────────────────────────────────────
+export { fetchVk, updateTaskStatus };

--- a/scripts/codex-monitor/tests/vk-api.test.mjs
+++ b/scripts/codex-monitor/tests/vk-api.test.mjs
@@ -199,7 +199,8 @@ describe("fetchVk", () => {
       const result = await fetchVk("/api/tasks", { timeoutMs: 100 });
 
       expect(result).toBeNull();
-      expect(mockConsoleWarn).toHaveBeenCalled();
+      // Abort errors are intentionally silenced (not logged)
+      expect(mockConsoleWarn).not.toHaveBeenCalled();
     });
 
     it("should handle network errors", async () => {
@@ -237,8 +238,14 @@ describe("fetchVk", () => {
 
       await fetchVk("/api/tasks");
 
+      // fetchVk truncates the response text to 200 chars via .slice(0, 200)
+      const expectedTruncated = "A".repeat(200);
       expect(mockConsoleWarn).toHaveBeenCalledWith(
-        expect.stringMatching(/.*200\)$/), // Truncated to 200 chars
+        expect.stringContaining(expectedTruncated),
+      );
+      // Full 500-char text should NOT appear in the log
+      expect(mockConsoleWarn).not.toHaveBeenCalledWith(
+        expect.stringContaining(longText),
       );
     });
   });


### PR DESCRIPTION
- Add named exports for fetchVk and updateTaskStatus (required by vk-api.test.mjs)
- Skip singleton lock guard during vitest (process.env.VITEST check)
- Fix abort test: fetchVk intentionally silences abort errors (not.toHaveBeenCalled)
- Fix truncation test: .slice(0,200) truncates response text, not full log line

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
