### PR TITLE
fix(ci): upgrade to Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/codex-monitor-publish.yaml
+++ b/.github/workflows/codex-monitor-publish.yaml
@@ -22,7 +22,7 @@
 name: "Codex Monitor: Publish"
 
 env:
-    NODE_VERSION: "20"
+    NODE_VERSION: "24"
 
 on:
     push:
@@ -131,7 +131,8 @@ jobs:
               if: ${{ !inputs.dry-run }}
               working-directory: scripts/codex-monitor
               run: npm publish --access public --provenance
-              # No NODE_AUTH_TOKEN needed — OIDC handles auth via trusted publishing
+              # No NODE_AUTH_TOKEN needed — npm v11.5.1+ handles OIDC auth natively
+              # --provenance is optional with trusted publishing but kept for backward compat
 
             - name: Publish (dry run)
               if: ${{ inputs.dry-run }}


### PR DESCRIPTION
npm OIDC trusted publishing requires npm CLI v11.5.1+ which ships with Node.js 24. Node 20 (npm v10) only supports Sigstore provenance signing, not OIDC authentication, causing 'Access token expired' 404 errors on publish.

## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- One sentence: why is this change needed? -->

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [ ] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [ ] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
