### PR TITLE
feat(provider): add durable lifecycle command queue

### DIFF
--- a/_docs/provider-daemon-lifecycle-queue.md
+++ b/_docs/provider-daemon-lifecycle-queue.md
@@ -1,0 +1,47 @@
+# Provider Daemon Lifecycle Queue (VE-34E)
+
+This document describes the durable lifecycle command queue used by the provider daemon to execute lifecycle actions (start/stop/resize/terminate) safely across restarts.
+
+## Overview
+
+The lifecycle command queue persists action requests to disk (Badger-backed by default), retries transient failures with exponential backoff, and reconciles desired state drift with Waldur resource state.
+
+Key behaviors:
+
+- **Durable storage:** lifecycle commands are persisted in `data/lifecycle_queue` (configurable).
+- **Idempotent execution:** commands include an idempotency key derived from chain operation IDs to prevent duplicates.
+- **Retry policy:** exponential backoff with a configurable max retry count before dead-lettering.
+- **Reconciliation loop:** periodically checks desired allocation state vs. Waldur resource state and reissues safe commands when drift is detected.
+- **Crash recovery:** pending/executing commands are requeued after restart; stale executions are reissued.
+
+## Configuration flags
+
+All flags are exposed via `provider-daemon`:
+
+- `--waldur-lifecycle-queue-enabled` (default: true)
+- `--waldur-lifecycle-queue-backend` (default: badger)
+- `--waldur-lifecycle-queue-path` (default: data/lifecycle_queue)
+- `--waldur-lifecycle-queue-workers` (default: 2)
+- `--waldur-lifecycle-queue-max-retries` (default: 5)
+- `--waldur-lifecycle-queue-retry-backoff` (default: 10s)
+- `--waldur-lifecycle-queue-max-backoff` (default: 5m)
+- `--waldur-lifecycle-queue-poll-interval` (default: 2s)
+- `--waldur-lifecycle-queue-reconcile-interval` (default: 5m)
+- `--waldur-lifecycle-queue-reconcile-on-start` (default: true)
+- `--waldur-lifecycle-queue-stale-after` (default: 20m)
+
+## Metrics
+
+Prometheus metrics emitted by the queue:
+
+- `provider_daemon_lifecycle_queue_depth{status=...}` — queue depth by status
+- `provider_daemon_lifecycle_queue_retries_total{action=...}` — retry count by action
+- `provider_daemon_lifecycle_queue_commands_total{action=...,outcome=...}` — command outcomes
+- `provider_daemon_lifecycle_reconcile_runs_total{outcome=...}` — reconciliation cycles
+- `provider_daemon_lifecycle_reconcile_commands_total{action=...,outcome=...}` — reconcile outcomes
+
+## Operational notes
+
+- **Crash/restart safety:** Commands are stored before execution. On restart, pending or stale executing commands are requeued.
+- **Drift handling:** If Waldur state diverges from the desired allocation state, the reconciler issues safe lifecycle actions (e.g., start/resume/stop/terminate).
+- **Dead-lettering:** Commands exceeding max retries are marked dead-lettered and surfaced via metrics for operator inspection.

--- a/cmd/provider-daemon/main.go
+++ b/cmd/provider-daemon/main.go
@@ -185,6 +185,39 @@ const (
 	// FlagWaldurOfferingSyncMaxRetries is max retries before dead-letter
 	FlagWaldurOfferingSyncMaxRetries = "waldur-offering-sync-max-retries"
 
+	// FlagWaldurLifecycleQueueEnabled enables the lifecycle command queue
+	FlagWaldurLifecycleQueueEnabled = "waldur-lifecycle-queue-enabled"
+
+	// FlagWaldurLifecycleQueueBackend sets lifecycle queue storage backend
+	FlagWaldurLifecycleQueueBackend = "waldur-lifecycle-queue-backend"
+
+	// FlagWaldurLifecycleQueuePath sets lifecycle queue storage path
+	FlagWaldurLifecycleQueuePath = "waldur-lifecycle-queue-path"
+
+	// FlagWaldurLifecycleQueueWorkers sets lifecycle queue worker count
+	FlagWaldurLifecycleQueueWorkers = "waldur-lifecycle-queue-workers"
+
+	// FlagWaldurLifecycleQueueMaxRetries sets lifecycle queue max retries
+	FlagWaldurLifecycleQueueMaxRetries = "waldur-lifecycle-queue-max-retries"
+
+	// FlagWaldurLifecycleQueueRetryBackoff sets lifecycle queue retry backoff
+	FlagWaldurLifecycleQueueRetryBackoff = "waldur-lifecycle-queue-retry-backoff"
+
+	// FlagWaldurLifecycleQueueMaxBackoff sets lifecycle queue max backoff
+	FlagWaldurLifecycleQueueMaxBackoff = "waldur-lifecycle-queue-max-backoff"
+
+	// FlagWaldurLifecycleQueuePollInterval sets lifecycle queue poll interval
+	FlagWaldurLifecycleQueuePollInterval = "waldur-lifecycle-queue-poll-interval"
+
+	// FlagWaldurLifecycleQueueReconcileInterval sets lifecycle queue reconcile interval
+	FlagWaldurLifecycleQueueReconcileInterval = "waldur-lifecycle-queue-reconcile-interval"
+
+	// FlagWaldurLifecycleQueueReconcileOnStart toggles reconciliation on startup
+	FlagWaldurLifecycleQueueReconcileOnStart = "waldur-lifecycle-queue-reconcile-on-start"
+
+	// FlagWaldurLifecycleQueueStaleAfter sets stale executing command threshold
+	FlagWaldurLifecycleQueueStaleAfter = "waldur-lifecycle-queue-stale-after"
+
 	// Portal API flags
 	FlagPortalAuthSecret      = "portal-auth-secret" // #nosec G101 -- flag name, not a credential
 	FlagPortalAllowInsecure   = "portal-allow-insecure"
@@ -296,6 +329,17 @@ func init() {
 	rootCmd.PersistentFlags().String(FlagWaldurCategoryMap, "", "Path to JSON file mapping offering categories to Waldur category UUIDs")
 	rootCmd.PersistentFlags().Int64(FlagWaldurOfferingSyncInterval, 300, "Offering sync reconciliation interval in seconds")
 	rootCmd.PersistentFlags().Int(FlagWaldurOfferingSyncMaxRetries, 5, "Max sync retries before dead-lettering")
+	rootCmd.PersistentFlags().Bool(FlagWaldurLifecycleQueueEnabled, true, "Enable durable lifecycle command queue")
+	rootCmd.PersistentFlags().String(FlagWaldurLifecycleQueueBackend, "badger", "Lifecycle queue storage backend (badger)")
+	rootCmd.PersistentFlags().String(FlagWaldurLifecycleQueuePath, "data/lifecycle_queue", "Lifecycle queue storage path")
+	rootCmd.PersistentFlags().Int(FlagWaldurLifecycleQueueWorkers, 2, "Lifecycle queue worker count")
+	rootCmd.PersistentFlags().Int(FlagWaldurLifecycleQueueMaxRetries, 5, "Lifecycle queue max retries")
+	rootCmd.PersistentFlags().Duration(FlagWaldurLifecycleQueueRetryBackoff, 10*time.Second, "Lifecycle queue retry backoff")
+	rootCmd.PersistentFlags().Duration(FlagWaldurLifecycleQueueMaxBackoff, 5*time.Minute, "Lifecycle queue max backoff")
+	rootCmd.PersistentFlags().Duration(FlagWaldurLifecycleQueuePollInterval, 2*time.Second, "Lifecycle queue poll interval")
+	rootCmd.PersistentFlags().Duration(FlagWaldurLifecycleQueueReconcileInterval, 5*time.Minute, "Lifecycle queue reconcile interval")
+	rootCmd.PersistentFlags().Bool(FlagWaldurLifecycleQueueReconcileOnStart, true, "Run lifecycle reconciliation on startup")
+	rootCmd.PersistentFlags().Duration(FlagWaldurLifecycleQueueStaleAfter, 20*time.Minute, "Lifecycle queue stale command threshold")
 
 	// Portal API flags
 	rootCmd.PersistentFlags().String(FlagPortalAuthSecret, "", "Shared secret for portal signed requests")
@@ -379,6 +423,17 @@ func init() {
 	_ = viper.BindPFlag(FlagWaldurCategoryMap, rootCmd.PersistentFlags().Lookup(FlagWaldurCategoryMap))
 	_ = viper.BindPFlag(FlagWaldurOfferingSyncInterval, rootCmd.PersistentFlags().Lookup(FlagWaldurOfferingSyncInterval))
 	_ = viper.BindPFlag(FlagWaldurOfferingSyncMaxRetries, rootCmd.PersistentFlags().Lookup(FlagWaldurOfferingSyncMaxRetries))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueueEnabled, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueueEnabled))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueueBackend, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueueBackend))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueuePath, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueuePath))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueueWorkers, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueueWorkers))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueueMaxRetries, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueueMaxRetries))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueueRetryBackoff, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueueRetryBackoff))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueueMaxBackoff, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueueMaxBackoff))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueuePollInterval, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueuePollInterval))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueueReconcileInterval, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueueReconcileInterval))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueueReconcileOnStart, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueueReconcileOnStart))
+	_ = viper.BindPFlag(FlagWaldurLifecycleQueueStaleAfter, rootCmd.PersistentFlags().Lookup(FlagWaldurLifecycleQueueStaleAfter))
 
 	// Portal API flags
 	_ = viper.BindPFlag(FlagPortalAuthSecret, rootCmd.PersistentFlags().Lookup(FlagPortalAuthSecret))
@@ -853,6 +908,17 @@ func runStart(cmd *cobra.Command, args []string) error {
 		bridgeCfg.WaldurProjectUUID = viper.GetString(FlagWaldurProjectUUID)
 		bridgeCfg.WaldurOfferingMap = offeringMap
 		bridgeCfg.OrderCallbackURL = viper.GetString(FlagWaldurOrderCallbackURL)
+		bridgeCfg.LifecycleQueueEnabled = viper.GetBool(FlagWaldurLifecycleQueueEnabled)
+		bridgeCfg.LifecycleQueueBackend = viper.GetString(FlagWaldurLifecycleQueueBackend)
+		bridgeCfg.LifecycleQueuePath = viper.GetString(FlagWaldurLifecycleQueuePath)
+		bridgeCfg.LifecycleQueueWorkerCount = viper.GetInt(FlagWaldurLifecycleQueueWorkers)
+		bridgeCfg.LifecycleQueueMaxRetries = viper.GetInt(FlagWaldurLifecycleQueueMaxRetries)
+		bridgeCfg.LifecycleQueueRetryBackoff = viper.GetDuration(FlagWaldurLifecycleQueueRetryBackoff)
+		bridgeCfg.LifecycleQueueMaxBackoff = viper.GetDuration(FlagWaldurLifecycleQueueMaxBackoff)
+		bridgeCfg.LifecycleQueuePollInterval = viper.GetDuration(FlagWaldurLifecycleQueuePollInterval)
+		bridgeCfg.LifecycleQueueReconcileInterval = viper.GetDuration(FlagWaldurLifecycleQueueReconcileInterval)
+		bridgeCfg.LifecycleQueueReconcileOnStart = viper.GetBool(FlagWaldurLifecycleQueueReconcileOnStart)
+		bridgeCfg.LifecycleQueueStaleAfter = viper.GetDuration(FlagWaldurLifecycleQueueStaleAfter)
 
 		waldurBridge, err := provider_daemon.NewWaldurBridge(bridgeCfg, keyManager, callbackSink, usageReporter)
 		if err != nil {

--- a/pkg/provider_daemon/lifecycle_command_queue.go
+++ b/pkg/provider_daemon/lifecycle_command_queue.go
@@ -1,0 +1,693 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-34E: Durable lifecycle command queue for provider daemon operations.
+package provider_daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/virtengine/virtengine/pkg/waldur"
+	"github.com/virtengine/virtengine/x/market/types/marketplace"
+)
+
+// LifecycleCommandStatus represents the lifecycle command queue state.
+type LifecycleCommandStatus string
+
+const (
+	// LifecycleCommandStatusPending indicates command is ready to be processed.
+	LifecycleCommandStatusPending LifecycleCommandStatus = "pending"
+	// LifecycleCommandStatusExecuting indicates command is being executed.
+	LifecycleCommandStatusExecuting LifecycleCommandStatus = "executing"
+	// LifecycleCommandStatusSucceeded indicates command completed successfully.
+	LifecycleCommandStatusSucceeded LifecycleCommandStatus = "succeeded"
+	// LifecycleCommandStatusFailed indicates command failed permanently.
+	LifecycleCommandStatusFailed LifecycleCommandStatus = "failed"
+	// LifecycleCommandStatusDeadLettered indicates command exceeded max retries.
+	LifecycleCommandStatusDeadLettered LifecycleCommandStatus = "dead_lettered"
+)
+
+// LifecycleCommand represents a durable lifecycle action request.
+type LifecycleCommand struct {
+	ID             string                          `json:"id"`
+	IdempotencyKey string                          `json:"idempotency_key"`
+	AllocationID   string                          `json:"allocation_id"`
+	OrderID        string                          `json:"order_id,omitempty"`
+	OperationID    string                          `json:"operation_id,omitempty"`
+	Provider       string                          `json:"provider_address"`
+	ResourceUUID   string                          `json:"resource_uuid,omitempty"`
+	Action         marketplace.LifecycleActionType `json:"action"`
+	TargetState    marketplace.AllocationState     `json:"target_state"`
+	RequestedBy    string                          `json:"requested_by"`
+	Parameters     map[string]interface{}          `json:"parameters,omitempty"`
+	RollbackPolicy marketplace.RollbackPolicy      `json:"rollback_policy"`
+	Status         LifecycleCommandStatus          `json:"status"`
+	AttemptCount   int                             `json:"attempt_count"`
+	MaxAttempts    int                             `json:"max_attempts"`
+	LastAttemptAt  *time.Time                      `json:"last_attempt_at,omitempty"`
+	NextAttemptAt  *time.Time                      `json:"next_attempt_at,omitempty"`
+	CreatedAt      time.Time                       `json:"created_at"`
+	UpdatedAt      time.Time                       `json:"updated_at"`
+	CompletedAt    *time.Time                      `json:"completed_at,omitempty"`
+	LastError      string                          `json:"last_error,omitempty"`
+	WaldurOpID     string                          `json:"waldur_operation_id,omitempty"`
+	EventID        string                          `json:"event_id,omitempty"`
+	BlockHeight    int64                           `json:"block_height,omitempty"`
+	Sequence       uint64                          `json:"sequence,omitempty"`
+	EventTimestamp time.Time                       `json:"event_timestamp"`
+	Reconcile      bool                            `json:"reconcile"`
+}
+
+// LifecycleDesiredState tracks desired state for reconciliation.
+type LifecycleDesiredState struct {
+	AllocationID    string                          `json:"allocation_id"`
+	ResourceUUID    string                          `json:"resource_uuid,omitempty"`
+	DesiredState    marketplace.AllocationState     `json:"desired_state"`
+	LastAction      marketplace.LifecycleActionType `json:"last_action"`
+	LastCommandID   string                          `json:"last_command_id"`
+	LastObserved    marketplace.AllocationState     `json:"last_observed_state,omitempty"`
+	UpdatedAt       time.Time                       `json:"updated_at"`
+	LastReconciled  *time.Time                      `json:"last_reconciled_at,omitempty"`
+	LastObservation *time.Time                      `json:"last_observation_at,omitempty"`
+}
+
+// LifecycleCommandQueueConfig configures the durable command queue.
+type LifecycleCommandQueueConfig struct {
+	Enabled           bool
+	Backend           string
+	Path              string
+	InMemory          bool
+	WorkerCount       int
+	MaxRetries        int
+	RetryBackoff      time.Duration
+	MaxBackoff        time.Duration
+	PollInterval      time.Duration
+	ReconcileInterval time.Duration
+	ReconcileOnStart  bool
+	StaleAfter        time.Duration
+	ExecuteTimeout    time.Duration
+	CallbackOnSuccess bool
+	CallbackOnFailure bool
+}
+
+// DefaultLifecycleCommandQueueConfig returns defaults.
+func DefaultLifecycleCommandQueueConfig() LifecycleCommandQueueConfig {
+	return LifecycleCommandQueueConfig{
+		Enabled:           true,
+		Backend:           "badger",
+		Path:              "data/lifecycle_queue",
+		WorkerCount:       2,
+		MaxRetries:        5,
+		RetryBackoff:      10 * time.Second,
+		MaxBackoff:        5 * time.Minute,
+		PollInterval:      2 * time.Second,
+		ReconcileInterval: 5 * time.Minute,
+		ReconcileOnStart:  true,
+		StaleAfter:        20 * time.Minute,
+		ExecuteTimeout:    2 * time.Minute,
+		CallbackOnSuccess: true,
+		CallbackOnFailure: true,
+	}
+}
+
+// LifecycleCommandExecutionResult captures executor output.
+type LifecycleCommandExecutionResult struct {
+	WaldurOperationID string
+	ResourceState     string
+}
+
+// LifecycleCommandExecutor executes lifecycle commands against the backend.
+type LifecycleCommandExecutor interface {
+	Execute(ctx context.Context, cmd *LifecycleCommand) (*LifecycleCommandExecutionResult, error)
+	GetResourceState(ctx context.Context, resourceUUID string) (waldur.ResourceState, error)
+}
+
+// LifecycleCommandCallback publishes command completion callbacks.
+type LifecycleCommandCallback func(ctx context.Context, cmd *LifecycleCommand, err error) error
+
+// LifecycleResourceResolver resolves allocation IDs to resource UUIDs.
+type LifecycleResourceResolver func(ctx context.Context, allocationID string) (string, error)
+
+// LifecycleCommandStore persists lifecycle commands and desired state.
+type LifecycleCommandStore interface {
+	Enqueue(ctx context.Context, cmd *LifecycleCommand) (*LifecycleCommand, bool, error)
+	Get(ctx context.Context, id string) (*LifecycleCommand, error)
+	Update(ctx context.Context, cmd *LifecycleCommand) error
+	ClaimNextReady(ctx context.Context, now time.Time, workerID string) (*LifecycleCommand, error)
+	ListByStatus(ctx context.Context, statuses ...LifecycleCommandStatus) ([]*LifecycleCommand, error)
+	ListByAllocation(ctx context.Context, allocationID string, statuses ...LifecycleCommandStatus) ([]*LifecycleCommand, error)
+	ListDesiredStates(ctx context.Context) ([]*LifecycleDesiredState, error)
+	GetDesiredState(ctx context.Context, allocationID string) (*LifecycleDesiredState, error)
+	SetDesiredState(ctx context.Context, state *LifecycleDesiredState) error
+	Close() error
+}
+
+// LifecycleCommandQueue manages durable lifecycle command processing.
+type LifecycleCommandQueue struct {
+	cfg      LifecycleCommandQueueConfig
+	store    LifecycleCommandStore
+	executor LifecycleCommandExecutor
+	resolver LifecycleResourceResolver
+	callback LifecycleCommandCallback
+	metrics  *LifecycleQueueMetrics
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+// NewLifecycleCommandQueue creates a new command queue.
+func NewLifecycleCommandQueue(
+	cfg LifecycleCommandQueueConfig,
+	store LifecycleCommandStore,
+	executor LifecycleCommandExecutor,
+	resolver LifecycleResourceResolver,
+	callback LifecycleCommandCallback,
+	metrics *LifecycleQueueMetrics,
+) (*LifecycleCommandQueue, error) {
+	if store == nil {
+		return nil, errors.New("lifecycle command store is required")
+	}
+	if executor == nil {
+		return nil, errors.New("lifecycle command executor is required")
+	}
+	if metrics == nil {
+		metrics = NewLifecycleQueueMetrics()
+	}
+
+	if cfg.WorkerCount <= 0 {
+		cfg.WorkerCount = 1
+	}
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = 3
+	}
+	if cfg.RetryBackoff <= 0 {
+		cfg.RetryBackoff = 10 * time.Second
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = 5 * time.Minute
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 2 * time.Second
+	}
+	if cfg.ReconcileInterval <= 0 {
+		cfg.ReconcileInterval = 5 * time.Minute
+	}
+	if cfg.StaleAfter <= 0 {
+		cfg.StaleAfter = 20 * time.Minute
+	}
+	if cfg.ExecuteTimeout <= 0 {
+		cfg.ExecuteTimeout = 2 * time.Minute
+	}
+
+	return &LifecycleCommandQueue{
+		cfg:      cfg,
+		store:    store,
+		executor: executor,
+		resolver: resolver,
+		callback: callback,
+		metrics:  metrics,
+		stopCh:   make(chan struct{}),
+	}, nil
+}
+
+// Start begins worker and reconciliation loops.
+func (q *LifecycleCommandQueue) Start(ctx context.Context) error {
+	if !q.cfg.Enabled {
+		return nil
+	}
+
+	if err := q.refreshMetrics(ctx); err != nil {
+		log.Printf("[lifecycle-queue] metrics refresh failed: %v", err)
+	}
+
+	if q.cfg.ReconcileOnStart {
+		q.ReconcileOnce(ctx)
+	}
+
+	q.wg.Add(q.cfg.WorkerCount)
+	for i := 0; i < q.cfg.WorkerCount; i++ {
+		workerID := fmt.Sprintf("worker-%d", i+1)
+		go func(id string) {
+			defer q.wg.Done()
+			q.workerLoop(ctx, id)
+		}(workerID)
+	}
+
+	q.wg.Add(1)
+	go func() {
+		defer q.wg.Done()
+		q.reconcileLoop(ctx)
+	}()
+
+	return nil
+}
+
+// Stop stops all workers and closes the store.
+func (q *LifecycleCommandQueue) Stop() {
+	close(q.stopCh)
+	q.wg.Wait()
+	_ = q.store.Close()
+}
+
+// EnqueueFromEvent enqueues a lifecycle action requested event.
+func (q *LifecycleCommandQueue) EnqueueFromEvent(ctx context.Context, event marketplace.LifecycleActionRequestedEvent, resourceUUID string) (*LifecycleCommand, error) {
+	cmd := buildLifecycleCommandFromEvent(event, resourceUUID, q.cfg.MaxRetries)
+	stored, existing, err := q.store.Enqueue(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+	if existing {
+		return stored, nil
+	}
+
+	q.metrics.QueueDepth.WithLabelValues(string(LifecycleCommandStatusPending)).Inc()
+	q.metrics.CommandsTotal.WithLabelValues(string(cmd.Action), "enqueued").Inc()
+
+	desired := &LifecycleDesiredState{
+		AllocationID:  cmd.AllocationID,
+		ResourceUUID:  cmd.ResourceUUID,
+		DesiredState:  cmd.TargetState,
+		LastAction:    cmd.Action,
+		LastCommandID: cmd.ID,
+		UpdatedAt:     time.Now().UTC(),
+	}
+	if err := q.store.SetDesiredState(ctx, desired); err != nil {
+		log.Printf("[lifecycle-queue] failed to persist desired state for %s: %v", cmd.AllocationID, err)
+	}
+
+	return stored, nil
+}
+
+// ReconcileOnce runs reconciliation for stale commands and drift.
+func (q *LifecycleCommandQueue) ReconcileOnce(ctx context.Context) {
+	if !q.cfg.Enabled {
+		return
+	}
+	q.metrics.ReconcileRuns.WithLabelValues("started").Inc()
+
+	if err := q.requeueStaleExecuting(ctx); err != nil {
+		log.Printf("[lifecycle-queue] stale command reconcile failed: %v", err)
+		q.metrics.ReconcileRuns.WithLabelValues("error").Inc()
+		return
+	}
+
+	desiredStates, err := q.store.ListDesiredStates(ctx)
+	if err != nil {
+		log.Printf("[lifecycle-queue] desired state list failed: %v", err)
+		q.metrics.ReconcileRuns.WithLabelValues("error").Inc()
+		return
+	}
+
+	drifted := 0
+	for _, desired := range desiredStates {
+		if desired == nil || desired.AllocationID == "" {
+			continue
+		}
+		if err := q.reconcileDesiredState(ctx, desired); err != nil {
+			log.Printf("[lifecycle-queue] reconcile allocation %s failed: %v", desired.AllocationID, err)
+			q.metrics.ReconcileCommands.WithLabelValues("unknown", "error").Inc()
+			continue
+		}
+		if desired.LastObserved != desired.DesiredState {
+			drifted++
+		}
+	}
+
+	if drifted > 0 {
+		q.metrics.ReconcileRuns.WithLabelValues("drift_detected").Inc()
+	} else {
+		q.metrics.ReconcileRuns.WithLabelValues("matched").Inc()
+	}
+}
+
+func (q *LifecycleCommandQueue) reconcileLoop(ctx context.Context) {
+	ticker := time.NewTicker(q.cfg.ReconcileInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-q.stopCh:
+			return
+		case <-ticker.C:
+			q.ReconcileOnce(ctx)
+		}
+	}
+}
+
+func (q *LifecycleCommandQueue) workerLoop(ctx context.Context, workerID string) {
+	ticker := time.NewTicker(q.cfg.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-q.stopCh:
+			return
+		case <-ticker.C:
+			cmd, err := q.store.ClaimNextReady(ctx, time.Now().UTC(), workerID)
+			if err != nil {
+				log.Printf("[lifecycle-queue] claim failed: %v", err)
+				continue
+			}
+			if cmd == nil {
+				continue
+			}
+			q.metrics.QueueDepth.WithLabelValues(string(LifecycleCommandStatusPending)).Dec()
+			q.metrics.QueueDepth.WithLabelValues(string(LifecycleCommandStatusExecuting)).Inc()
+
+			q.executeCommand(ctx, cmd)
+
+			q.metrics.QueueDepth.WithLabelValues(string(LifecycleCommandStatusExecuting)).Dec()
+		}
+	}
+}
+
+func (q *LifecycleCommandQueue) executeCommand(ctx context.Context, cmd *LifecycleCommand) {
+	if cmd == nil {
+		return
+	}
+
+	if cmd.ResourceUUID == "" && q.resolver != nil {
+		resourceUUID, err := q.resolver(ctx, cmd.AllocationID)
+		if err != nil {
+			q.handleCommandFailure(ctx, cmd, err)
+			return
+		}
+		cmd.ResourceUUID = resourceUUID
+		_ = q.store.Update(ctx, cmd)
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, q.cfg.ExecuteTimeout)
+	defer cancel()
+
+	result, err := q.executor.Execute(execCtx, cmd)
+	if err != nil {
+		q.handleCommandFailure(ctx, cmd, err)
+		return
+	}
+
+	if result != nil {
+		cmd.WaldurOpID = result.WaldurOperationID
+	}
+
+	now := time.Now().UTC()
+	cmd.Status = LifecycleCommandStatusSucceeded
+	cmd.CompletedAt = &now
+	cmd.UpdatedAt = now
+	cmd.LastError = ""
+
+	if err := q.store.Update(ctx, cmd); err != nil {
+		log.Printf("[lifecycle-queue] update success failed: %v", err)
+	}
+
+	q.metrics.CommandsTotal.WithLabelValues(string(cmd.Action), "succeeded").Inc()
+	q.metrics.QueueDepth.WithLabelValues(string(LifecycleCommandStatusSucceeded)).Inc()
+
+	if q.callback != nil && q.cfg.CallbackOnSuccess {
+		if err := q.callback(ctx, cmd, nil); err != nil {
+			log.Printf("[lifecycle-queue] callback failed for %s: %v", cmd.ID, err)
+		}
+	}
+}
+
+func (q *LifecycleCommandQueue) handleCommandFailure(ctx context.Context, cmd *LifecycleCommand, err error) {
+	if cmd == nil {
+		return
+	}
+
+	now := time.Now().UTC()
+	cmd.LastError = err.Error()
+	cmd.UpdatedAt = now
+
+	if cmd.AttemptCount >= cmd.MaxAttempts {
+		cmd.Status = LifecycleCommandStatusDeadLettered
+		cmd.CompletedAt = &now
+		if err := q.store.Update(ctx, cmd); err != nil {
+			log.Printf("[lifecycle-queue] dead-letter update failed: %v", err)
+		}
+		q.metrics.CommandsTotal.WithLabelValues(string(cmd.Action), "dead_lettered").Inc()
+		q.metrics.QueueDepth.WithLabelValues(string(LifecycleCommandStatusDeadLettered)).Inc()
+		if q.callback != nil && q.cfg.CallbackOnFailure {
+			if cbErr := q.callback(ctx, cmd, err); cbErr != nil {
+				log.Printf("[lifecycle-queue] failure callback failed for %s: %v", cmd.ID, cbErr)
+			}
+		}
+		return
+	}
+
+	delay := retryDelay(cmd.AttemptCount, q.cfg.RetryBackoff, q.cfg.MaxBackoff)
+	nextAttempt := now.Add(delay)
+	cmd.Status = LifecycleCommandStatusPending
+	cmd.NextAttemptAt = &nextAttempt
+
+	if updateErr := q.store.Update(ctx, cmd); updateErr != nil {
+		log.Printf("[lifecycle-queue] retry update failed: %v", updateErr)
+	}
+
+	q.metrics.RetriesTotal.WithLabelValues(string(cmd.Action)).Inc()
+	q.metrics.QueueDepth.WithLabelValues(string(LifecycleCommandStatusPending)).Inc()
+}
+
+func (q *LifecycleCommandQueue) refreshMetrics(ctx context.Context) error {
+	commands, err := q.store.ListByStatus(ctx,
+		LifecycleCommandStatusPending,
+		LifecycleCommandStatusExecuting,
+		LifecycleCommandStatusSucceeded,
+		LifecycleCommandStatusFailed,
+		LifecycleCommandStatusDeadLettered,
+	)
+	if err != nil {
+		return err
+	}
+
+	counts := map[LifecycleCommandStatus]int{}
+	for _, cmd := range commands {
+		if cmd == nil {
+			continue
+		}
+		counts[cmd.Status]++
+	}
+
+	for _, status := range []LifecycleCommandStatus{
+		LifecycleCommandStatusPending,
+		LifecycleCommandStatusExecuting,
+		LifecycleCommandStatusSucceeded,
+		LifecycleCommandStatusFailed,
+		LifecycleCommandStatusDeadLettered,
+	} {
+		q.metrics.QueueDepth.WithLabelValues(string(status)).Set(0)
+	}
+
+	for status, count := range counts {
+		q.metrics.QueueDepth.WithLabelValues(string(status)).Set(float64(count))
+	}
+
+	return nil
+}
+
+func (q *LifecycleCommandQueue) requeueStaleExecuting(ctx context.Context) error {
+	commands, err := q.store.ListByStatus(ctx, LifecycleCommandStatusExecuting)
+	if err != nil {
+		return err
+	}
+
+	cutoff := time.Now().UTC().Add(-q.cfg.StaleAfter)
+	for _, cmd := range commands {
+		if cmd == nil || cmd.LastAttemptAt == nil {
+			continue
+		}
+		if cmd.LastAttemptAt.After(cutoff) {
+			continue
+		}
+		cmd.Status = LifecycleCommandStatusPending
+		now := time.Now().UTC()
+		cmd.NextAttemptAt = &now
+		cmd.UpdatedAt = now
+		if err := q.store.Update(ctx, cmd); err != nil {
+			log.Printf("[lifecycle-queue] failed to requeue stale command %s: %v", cmd.ID, err)
+			continue
+		}
+		q.metrics.RetriesTotal.WithLabelValues(string(cmd.Action)).Inc()
+		q.metrics.ReconcileCommands.WithLabelValues(string(cmd.Action), "stale_requeued").Inc()
+	}
+
+	return nil
+}
+
+func (q *LifecycleCommandQueue) reconcileDesiredState(ctx context.Context, desired *LifecycleDesiredState) error {
+	resourceUUID := desired.ResourceUUID
+	if resourceUUID == "" && q.resolver != nil {
+		resolved, err := q.resolver(ctx, desired.AllocationID)
+		if err != nil {
+			return err
+		}
+		resourceUUID = resolved
+		desired.ResourceUUID = resourceUUID
+	}
+
+	if resourceUUID == "" {
+		return fmt.Errorf("resource UUID unavailable for %s", desired.AllocationID)
+	}
+
+	state, err := q.executor.GetResourceState(ctx, resourceUUID)
+	if err != nil {
+		return err
+	}
+
+	observed := mapWaldurStateToAllocationState(string(state))
+	now := time.Now().UTC()
+	desired.LastObserved = observed
+	desired.LastObservation = &now
+	desired.LastReconciled = &now
+	if err := q.store.SetDesiredState(ctx, desired); err != nil {
+		log.Printf("[lifecycle-queue] desired state update failed for %s: %v", desired.AllocationID, err)
+	}
+
+	if observed == desired.DesiredState {
+		q.metrics.ReconcileCommands.WithLabelValues("none", "matched").Inc()
+		return nil
+	}
+
+	inFlight, err := q.store.ListByAllocation(ctx, desired.AllocationID, LifecycleCommandStatusPending, LifecycleCommandStatusExecuting)
+	if err != nil {
+		return err
+	}
+	if len(inFlight) > 0 {
+		q.metrics.ReconcileCommands.WithLabelValues("none", "in_flight").Inc()
+		return nil
+	}
+
+	action, ok := reconcileActionForDesired(desired.DesiredState, state)
+	if !ok {
+		q.metrics.ReconcileCommands.WithLabelValues("none", "unsupported").Inc()
+		return nil
+	}
+
+	cmd := &LifecycleCommand{
+		ID:             fmt.Sprintf("reconcile-%s-%d", desired.AllocationID, time.Now().UnixNano()),
+		IdempotencyKey: marketplace.GenerateIdempotencyKey(desired.AllocationID, action, time.Now().UTC()),
+		AllocationID:   desired.AllocationID,
+		Provider:       "reconciler",
+		ResourceUUID:   resourceUUID,
+		Action:         action,
+		TargetState:    desired.DesiredState,
+		RequestedBy:    "reconciler",
+		Parameters: map[string]interface{}{
+			"reconcile":      "true",
+			"expected_state": desired.DesiredState.String(),
+			"observed_state": observed.String(),
+		},
+		Status:         LifecycleCommandStatusPending,
+		AttemptCount:   0,
+		MaxAttempts:    q.cfg.MaxRetries,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		EventTimestamp: now,
+		Reconcile:      true,
+	}
+
+	_, _, err = q.store.Enqueue(ctx, cmd)
+	if err != nil {
+		q.metrics.ReconcileCommands.WithLabelValues(string(action), "enqueue_failed").Inc()
+		return err
+	}
+
+	q.metrics.QueueDepth.WithLabelValues(string(LifecycleCommandStatusPending)).Inc()
+	q.metrics.ReconcileCommands.WithLabelValues(string(action), "issued").Inc()
+	return nil
+}
+
+func retryDelay(attempt int, base, max time.Duration) time.Duration {
+	if attempt <= 0 {
+		return base
+	}
+	delay := base
+	for i := 1; i < attempt; i++ {
+		delay *= 2
+		if delay >= max {
+			return max
+		}
+	}
+	if delay > max {
+		return max
+	}
+	return delay
+}
+
+func buildLifecycleCommandFromEvent(event marketplace.LifecycleActionRequestedEvent, resourceUUID string, maxRetries int) *LifecycleCommand {
+	now := time.Now().UTC()
+	cmdID := event.OperationID
+	if cmdID == "" {
+		cmdID = event.EventID
+	}
+	if cmdID == "" {
+		cmdID = fmt.Sprintf("cmd-%s-%d", event.AllocationID, time.Now().UnixNano())
+	}
+
+	idempotencyKey := event.OperationID
+	if idempotencyKey == "" {
+		idempotencyKey = event.EventID
+	}
+	if idempotencyKey == "" {
+		idempotencyKey = marketplace.GenerateIdempotencyKey(event.AllocationID, event.Action, event.Timestamp)
+	}
+
+	if maxRetries <= 0 {
+		maxRetries = 3
+	}
+
+	return &LifecycleCommand{
+		ID:             cmdID,
+		IdempotencyKey: idempotencyKey,
+		AllocationID:   event.AllocationID,
+		OrderID:        event.OrderID,
+		OperationID:    event.OperationID,
+		Provider:       event.ProviderAddress,
+		ResourceUUID:   resourceUUID,
+		Action:         event.Action,
+		TargetState:    event.TargetState,
+		RequestedBy:    event.RequestedBy,
+		Parameters:     event.Parameters,
+		RollbackPolicy: event.RollbackPolicy,
+		Status:         LifecycleCommandStatusPending,
+		AttemptCount:   0,
+		MaxAttempts:    maxRetries,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		NextAttemptAt:  &now,
+		EventID:        event.EventID,
+		BlockHeight:    event.BlockHeight,
+		Sequence:       event.Sequence,
+		EventTimestamp: event.Timestamp,
+	}
+}
+
+func reconcileActionForDesired(desired marketplace.AllocationState, waldurState waldur.ResourceState) (marketplace.LifecycleActionType, bool) {
+	switch desired {
+	case marketplace.AllocationStateActive:
+		switch waldurState {
+		case waldur.ResourceStateStopped:
+			return marketplace.LifecycleActionStart, true
+		case waldur.ResourceStatePaused:
+			return marketplace.LifecycleActionResume, true
+		default:
+			return "", false
+		}
+	case marketplace.AllocationStateSuspended:
+		if waldurState == waldur.ResourceStateOK {
+			return marketplace.LifecycleActionStop, true
+		}
+	case marketplace.AllocationStateTerminating, marketplace.AllocationStateTerminated:
+		if waldurState != waldur.ResourceStateTerminated && waldurState != waldur.ResourceStateTerminating {
+			return marketplace.LifecycleActionTerminate, true
+		}
+	}
+	return "", false
+}

--- a/pkg/provider_daemon/lifecycle_command_queue_badger.go
+++ b/pkg/provider_daemon/lifecycle_command_queue_badger.go
@@ -1,0 +1,411 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-34E: Badger-backed lifecycle command queue storage.
+package provider_daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+const (
+	lifecycleQueueSchemaVersion      = 1
+	lifecycleQueueCmdPrefix          = "lifecyclequeue/cmd/"
+	lifecycleQueueIdempotencyPrefix  = "lifecyclequeue/idem/"
+	lifecycleQueueReadyPrefix        = "lifecyclequeue/ready/"
+	lifecycleQueueAllocationPrefix   = "lifecyclequeue/alloc/"
+	lifecycleQueueDesiredStatePrefix = "lifecyclequeue/desired/"
+	lifecycleQueueSchemaKey          = "lifecyclequeue/meta/schema_version"
+)
+
+// BadgerLifecycleCommandStore implements LifecycleCommandStore using Badger.
+type BadgerLifecycleCommandStore struct {
+	db *badger.DB
+}
+
+// OpenBadgerLifecycleCommandStore opens or creates the Badger-backed store.
+func OpenBadgerLifecycleCommandStore(path string, inMemory bool) (*BadgerLifecycleCommandStore, error) {
+	if path == "" {
+		path = "data/lifecycle_queue"
+	}
+
+	opts := badger.DefaultOptions(path).WithLogger(nil)
+	if inMemory {
+		opts = badger.DefaultOptions("").WithLogger(nil).WithInMemory(true)
+	} else {
+		opts = opts.WithValueDir(filepath.Join(path, "value"))
+	}
+
+	db, err := badger.Open(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	store := &BadgerLifecycleCommandStore{db: db}
+	if err := store.ensureSchema(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	return store, nil
+}
+
+func (s *BadgerLifecycleCommandStore) ensureSchema() error {
+	return s.db.Update(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(lifecycleQueueSchemaKey))
+		if err != nil {
+			if err == badger.ErrKeyNotFound {
+				return txn.Set([]byte(lifecycleQueueSchemaKey), []byte(fmt.Sprintf("%d", lifecycleQueueSchemaVersion)))
+			}
+			return err
+		}
+
+		return item.Value(func(val []byte) error {
+			version := strings.TrimSpace(string(val))
+			if version == fmt.Sprintf("%d", lifecycleQueueSchemaVersion) {
+				return nil
+			}
+			return fmt.Errorf("unsupported lifecycle queue schema version %s", version)
+		})
+	})
+}
+
+// Enqueue stores a new command, enforcing idempotency by IdempotencyKey.
+func (s *BadgerLifecycleCommandStore) Enqueue(ctx context.Context, cmd *LifecycleCommand) (*LifecycleCommand, bool, error) {
+	if cmd == nil {
+		return nil, false, fmt.Errorf("command is nil")
+	}
+
+	var stored *LifecycleCommand
+	existingFound := false
+	err := s.db.Update(func(txn *badger.Txn) error {
+		if cmd.IdempotencyKey != "" {
+			item, err := txn.Get(idempotencyKey(cmd.IdempotencyKey))
+			if err == nil {
+				return item.Value(func(val []byte) error {
+					existingID := string(val)
+					existing, err := readCommand(txn, existingID)
+					if err != nil {
+						return err
+					}
+					stored = existing
+					existingFound = true
+					return nil
+				})
+			}
+			if err != nil && err != badger.ErrKeyNotFound {
+				return err
+			}
+		}
+		if existingFound {
+			return nil
+		}
+
+		data, err := json.Marshal(cmd)
+		if err != nil {
+			return err
+		}
+		if err := txn.Set(cmdKey(cmd.ID), data); err != nil {
+			return err
+		}
+
+		if cmd.IdempotencyKey != "" {
+			if err := txn.Set(idempotencyKey(cmd.IdempotencyKey), []byte(cmd.ID)); err != nil {
+				return err
+			}
+		}
+
+		if err := txn.Set(allocationKey(cmd.AllocationID, cmd.ID), []byte(cmd.ID)); err != nil {
+			return err
+		}
+
+		if cmd.Status == LifecycleCommandStatusPending && cmd.NextAttemptAt != nil {
+			if err := txn.Set(readyKey(*cmd.NextAttemptAt, cmd.ID), []byte(cmd.ID)); err != nil {
+				return err
+			}
+		}
+
+		stored = cmd
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	if existingFound && stored != nil {
+		return stored, true, nil
+	}
+	return stored, false, nil
+}
+
+// Get loads a command by ID.
+func (s *BadgerLifecycleCommandStore) Get(ctx context.Context, id string) (*LifecycleCommand, error) {
+	var cmd *LifecycleCommand
+	err := s.db.View(func(txn *badger.Txn) error {
+		var err error
+		cmd, err = readCommand(txn, id)
+		return err
+	})
+	return cmd, err
+}
+
+// Update replaces a command and updates indexes.
+func (s *BadgerLifecycleCommandStore) Update(ctx context.Context, cmd *LifecycleCommand) error {
+	if cmd == nil {
+		return fmt.Errorf("command is nil")
+	}
+
+	return s.db.Update(func(txn *badger.Txn) error {
+		existing, err := readCommand(txn, cmd.ID)
+		if err != nil {
+			return err
+		}
+
+		if existing != nil && existing.NextAttemptAt != nil {
+			_ = txn.Delete(readyKey(*existing.NextAttemptAt, existing.ID))
+		}
+
+		data, err := json.Marshal(cmd)
+		if err != nil {
+			return err
+		}
+		if err := txn.Set(cmdKey(cmd.ID), data); err != nil {
+			return err
+		}
+
+		if cmd.Status == LifecycleCommandStatusPending && cmd.NextAttemptAt != nil {
+			if err := txn.Set(readyKey(*cmd.NextAttemptAt, cmd.ID), []byte(cmd.ID)); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// ClaimNextReady picks the next ready command and marks it executing.
+func (s *BadgerLifecycleCommandStore) ClaimNextReady(ctx context.Context, now time.Time, workerID string) (*LifecycleCommand, error) {
+	var claimed *LifecycleCommand
+	err := s.db.Update(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+
+		prefix := []byte(lifecycleQueueReadyPrefix)
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			key := item.KeyCopy(nil)
+			val, err := item.ValueCopy(nil)
+			if err != nil {
+				return err
+			}
+			cmdID := string(val)
+			cmd, err := readCommand(txn, cmdID)
+			if err != nil {
+				return err
+			}
+			if cmd == nil || cmd.NextAttemptAt == nil {
+				_ = txn.Delete(key)
+				continue
+			}
+			if cmd.NextAttemptAt.After(now) {
+				return nil
+			}
+
+			_ = txn.Delete(key)
+
+			cmd.Status = LifecycleCommandStatusExecuting
+			cmd.AttemptCount++
+			cmd.LastAttemptAt = &now
+			cmd.UpdatedAt = now
+
+			data, err := json.Marshal(cmd)
+			if err != nil {
+				return err
+			}
+			if err := txn.Set(cmdKey(cmd.ID), data); err != nil {
+				return err
+			}
+
+			claimed = cmd
+			return nil
+		}
+
+		return nil
+	})
+	return claimed, err
+}
+
+// ListByStatus returns commands with the provided statuses.
+func (s *BadgerLifecycleCommandStore) ListByStatus(ctx context.Context, statuses ...LifecycleCommandStatus) ([]*LifecycleCommand, error) {
+	allowed := map[LifecycleCommandStatus]bool{}
+	for _, status := range statuses {
+		allowed[status] = true
+	}
+
+	var commands []*LifecycleCommand
+	err := s.db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+
+		prefix := []byte(lifecycleQueueCmdPrefix)
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			var cmd LifecycleCommand
+			if err := item.Value(func(val []byte) error {
+				return json.Unmarshal(val, &cmd)
+			}); err != nil {
+				return err
+			}
+			if len(allowed) == 0 || allowed[cmd.Status] {
+				copyCmd := cmd
+				commands = append(commands, &copyCmd)
+			}
+		}
+		return nil
+	})
+	return commands, err
+}
+
+// ListByAllocation returns commands for a specific allocation.
+func (s *BadgerLifecycleCommandStore) ListByAllocation(ctx context.Context, allocationID string, statuses ...LifecycleCommandStatus) ([]*LifecycleCommand, error) {
+	if allocationID == "" {
+		return nil, fmt.Errorf("allocation ID is required")
+	}
+	allowed := map[LifecycleCommandStatus]bool{}
+	for _, status := range statuses {
+		allowed[status] = true
+	}
+
+	var commands []*LifecycleCommand
+	err := s.db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+
+		prefix := []byte(lifecycleQueueAllocationPrefix + allocationID + "/")
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			val, err := item.ValueCopy(nil)
+			if err != nil {
+				return err
+			}
+			cmdID := string(val)
+			cmd, err := readCommand(txn, cmdID)
+			if err != nil {
+				return err
+			}
+			if cmd == nil {
+				continue
+			}
+			if len(allowed) == 0 || allowed[cmd.Status] {
+				commands = append(commands, cmd)
+			}
+		}
+		return nil
+	})
+	return commands, err
+}
+
+// ListDesiredStates returns all desired state records.
+func (s *BadgerLifecycleCommandStore) ListDesiredStates(ctx context.Context) ([]*LifecycleDesiredState, error) {
+	var states []*LifecycleDesiredState
+	err := s.db.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.DefaultIteratorOptions)
+		defer it.Close()
+
+		prefix := []byte(lifecycleQueueDesiredStatePrefix)
+		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+			item := it.Item()
+			var state LifecycleDesiredState
+			if err := item.Value(func(val []byte) error {
+				return json.Unmarshal(val, &state)
+			}); err != nil {
+				return err
+			}
+			copyState := state
+			states = append(states, &copyState)
+		}
+		return nil
+	})
+	return states, err
+}
+
+// GetDesiredState fetches a desired state record for an allocation.
+func (s *BadgerLifecycleCommandStore) GetDesiredState(ctx context.Context, allocationID string) (*LifecycleDesiredState, error) {
+	var state *LifecycleDesiredState
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(desiredStateKey(allocationID))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(val []byte) error {
+			var decoded LifecycleDesiredState
+			if err := json.Unmarshal(val, &decoded); err != nil {
+				return err
+			}
+			state = &decoded
+			return nil
+		})
+	})
+	if err == badger.ErrKeyNotFound {
+		return nil, nil
+	}
+	return state, err
+}
+
+// SetDesiredState stores the desired state record.
+func (s *BadgerLifecycleCommandStore) SetDesiredState(ctx context.Context, state *LifecycleDesiredState) error {
+	if state == nil {
+		return fmt.Errorf("desired state is nil")
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return s.db.Update(func(txn *badger.Txn) error {
+		return txn.Set(desiredStateKey(state.AllocationID), data)
+	})
+}
+
+// Close closes the underlying Badger DB.
+func (s *BadgerLifecycleCommandStore) Close() error {
+	return s.db.Close()
+}
+
+func cmdKey(id string) []byte {
+	return []byte(lifecycleQueueCmdPrefix + id)
+}
+
+func idempotencyKey(id string) []byte {
+	return []byte(lifecycleQueueIdempotencyPrefix + id)
+}
+
+func readyKey(at time.Time, id string) []byte {
+	return []byte(fmt.Sprintf("%s%020d/%s", lifecycleQueueReadyPrefix, at.UnixNano(), id))
+}
+
+func allocationKey(allocationID, id string) []byte {
+	return []byte(lifecycleQueueAllocationPrefix + allocationID + "/" + id)
+}
+
+func desiredStateKey(allocationID string) []byte {
+	return []byte(lifecycleQueueDesiredStatePrefix + allocationID)
+}
+
+func readCommand(txn *badger.Txn, id string) (*LifecycleCommand, error) {
+	item, err := txn.Get(cmdKey(id))
+	if err != nil {
+		return nil, err
+	}
+	var cmd LifecycleCommand
+	if err := item.Value(func(val []byte) error {
+		return json.Unmarshal(val, &cmd)
+	}); err != nil {
+		return nil, err
+	}
+	return &cmd, nil
+}

--- a/pkg/provider_daemon/lifecycle_command_queue_executor.go
+++ b/pkg/provider_daemon/lifecycle_command_queue_executor.go
@@ -1,0 +1,161 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-34E: Lifecycle command executor for Waldur lifecycle APIs.
+package provider_daemon
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/virtengine/virtengine/pkg/waldur"
+	"github.com/virtengine/virtengine/x/market/types/marketplace"
+)
+
+// WaldurLifecycleCommandExecutor executes lifecycle commands using Waldur APIs.
+type WaldurLifecycleCommandExecutor struct {
+	lifecycle *waldur.LifecycleClient
+}
+
+// NewWaldurLifecycleCommandExecutor creates a new executor.
+func NewWaldurLifecycleCommandExecutor(lifecycle *waldur.LifecycleClient) *WaldurLifecycleCommandExecutor {
+	return &WaldurLifecycleCommandExecutor{lifecycle: lifecycle}
+}
+
+// Execute executes the lifecycle command.
+func (e *WaldurLifecycleCommandExecutor) Execute(ctx context.Context, cmd *LifecycleCommand) (*LifecycleCommandExecutionResult, error) {
+	if cmd == nil {
+		return nil, fmt.Errorf("command is nil")
+	}
+	if cmd.ResourceUUID == "" {
+		return nil, fmt.Errorf("resource UUID is required")
+	}
+	if e.lifecycle == nil {
+		return nil, fmt.Errorf("waldur lifecycle client is not configured")
+	}
+
+	params := make(map[string]interface{})
+	for k, v := range cmd.Parameters {
+		params[k] = v
+	}
+
+	req := waldur.LifecycleRequest{
+		ResourceUUID:   cmd.ResourceUUID,
+		IdempotencyKey: cmd.IdempotencyKey,
+		Parameters:     params,
+	}
+
+	var resp *waldur.LifecycleResponse
+	var err error
+
+	switch cmd.Action {
+	case marketplace.LifecycleActionStart:
+		resp, err = e.lifecycle.Start(ctx, req)
+	case marketplace.LifecycleActionStop:
+		resp, err = e.lifecycle.Stop(ctx, req)
+	case marketplace.LifecycleActionRestart:
+		resp, err = e.lifecycle.Restart(ctx, req)
+	case marketplace.LifecycleActionSuspend:
+		resp, err = e.lifecycle.Suspend(ctx, req)
+	case marketplace.LifecycleActionResume:
+		resp, err = e.lifecycle.Resume(ctx, req)
+	case marketplace.LifecycleActionTerminate:
+		resp, err = e.lifecycle.Terminate(ctx, req)
+	case marketplace.LifecycleActionResize:
+		resizeReq := waldur.ResizeRequest{LifecycleRequest: req}
+		applyResizeParams(&resizeReq, params)
+		resp, err = e.lifecycle.Resize(ctx, resizeReq)
+	case marketplace.LifecycleActionProvision:
+		return nil, fmt.Errorf("provision action is handled via allocation provisioning flow")
+	default:
+		return nil, fmt.Errorf("unsupported lifecycle action: %s", cmd.Action)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	result := &LifecycleCommandExecutionResult{}
+	if resp != nil {
+		result.WaldurOperationID = resp.OperationID
+		if result.WaldurOperationID == "" {
+			result.WaldurOperationID = resp.UUID
+		}
+		result.ResourceState = resp.ResourceState
+	}
+
+	return result, nil
+}
+
+// GetResourceState returns the resource state via Waldur API.
+func (e *WaldurLifecycleCommandExecutor) GetResourceState(ctx context.Context, resourceUUID string) (waldur.ResourceState, error) {
+	if e.lifecycle == nil {
+		return "", fmt.Errorf("waldur lifecycle client is not configured")
+	}
+	return e.lifecycle.GetResourceState(ctx, resourceUUID)
+}
+
+func applyResizeParams(req *waldur.ResizeRequest, params map[string]interface{}) {
+	if params == nil {
+		return
+	}
+	if cpu := intFromParam(params["cpu_cores"]); cpu > 0 {
+		req.CPUCores = &cpu
+	}
+	if mem := intFromParam(params["memory_mb"]); mem > 0 {
+		req.MemoryMB = &mem
+	}
+	if disk := intFromParam(params["disk_gb"]); disk > 0 {
+		req.DiskGB = &disk
+	}
+	if disk := intFromParam(params["storage_gb"]); disk > 0 && req.DiskGB == nil {
+		req.DiskGB = &disk
+	}
+	if flavor := stringFromParam(params["flavor"]); flavor != "" {
+		req.Flavor = flavor
+	}
+	if it := stringFromParam(params["instance_type"]); it != "" {
+		req.InstanceType = it
+	}
+}
+
+func intFromParam(value interface{}) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int32:
+		return int(v)
+	case int64:
+		if v > math.MaxInt || v < math.MinInt {
+			return 0
+		}
+		return int(v)
+	case uint32:
+		return int(v)
+	case uint64:
+		if v > uint64(math.MaxInt) {
+			return 0
+		}
+		return int(v)
+	case float64:
+		return int(v)
+	case string:
+		parsed, err := strconv.Atoi(v)
+		if err == nil {
+			return parsed
+		}
+	}
+	return 0
+}
+
+func stringFromParam(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return ""
+	}
+}

--- a/pkg/provider_daemon/lifecycle_command_queue_metrics.go
+++ b/pkg/provider_daemon/lifecycle_command_queue_metrics.go
@@ -1,0 +1,69 @@
+// Package provider_daemon implements provider-side services for VirtEngine.
+//
+// VE-34E: Prometheus metrics for lifecycle command queue.
+package provider_daemon
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// LifecycleQueueMetrics captures queue and reconciliation metrics.
+type LifecycleQueueMetrics struct {
+	QueueDepth        *prometheus.GaugeVec
+	RetriesTotal      *prometheus.CounterVec
+	CommandsTotal     *prometheus.CounterVec
+	ReconcileRuns     *prometheus.CounterVec
+	ReconcileCommands *prometheus.CounterVec
+}
+
+// NewLifecycleQueueMetrics registers lifecycle queue metrics.
+func NewLifecycleQueueMetrics() *LifecycleQueueMetrics {
+	return &LifecycleQueueMetrics{
+		QueueDepth: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "provider_daemon",
+				Subsystem: "lifecycle_queue",
+				Name:      "depth",
+				Help:      "Current number of lifecycle commands by status",
+			},
+			[]string{"status"},
+		),
+		RetriesTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "provider_daemon",
+				Subsystem: "lifecycle_queue",
+				Name:      "retries_total",
+				Help:      "Total number of lifecycle command retries",
+			},
+			[]string{"action"},
+		),
+		CommandsTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "provider_daemon",
+				Subsystem: "lifecycle_queue",
+				Name:      "commands_total",
+				Help:      "Total lifecycle commands by action and outcome",
+			},
+			[]string{"action", "outcome"},
+		),
+		ReconcileRuns: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "provider_daemon",
+				Subsystem: "lifecycle_reconcile",
+				Name:      "runs_total",
+				Help:      "Total reconciliation cycles by outcome",
+			},
+			[]string{"outcome"},
+		),
+		ReconcileCommands: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "provider_daemon",
+				Subsystem: "lifecycle_reconcile",
+				Name:      "commands_total",
+				Help:      "Total reconciled lifecycle commands by action and outcome",
+			},
+			[]string{"action", "outcome"},
+		),
+	}
+}

--- a/pkg/provider_daemon/lifecycle_command_queue_test.go
+++ b/pkg/provider_daemon/lifecycle_command_queue_test.go
@@ -1,0 +1,211 @@
+package provider_daemon
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/virtengine/virtengine/pkg/waldur"
+	"github.com/virtengine/virtengine/x/market/types/marketplace"
+)
+
+type fakeLifecycleExecutor struct {
+	execCount atomic.Int64
+	execErr   error
+	state     string
+}
+
+var (
+	lifecycleQueueMetricsOnce sync.Once
+	lifecycleQueueMetrics     *LifecycleQueueMetrics
+)
+
+func testLifecycleQueueMetrics() *LifecycleQueueMetrics {
+	lifecycleQueueMetricsOnce.Do(func() {
+		lifecycleQueueMetrics = NewLifecycleQueueMetrics()
+	})
+	return lifecycleQueueMetrics
+}
+
+func (f *fakeLifecycleExecutor) Execute(ctx context.Context, cmd *LifecycleCommand) (*LifecycleCommandExecutionResult, error) {
+	f.execCount.Add(1)
+	if f.execErr != nil {
+		return nil, f.execErr
+	}
+	return &LifecycleCommandExecutionResult{WaldurOperationID: "op-1", ResourceState: f.state}, nil
+}
+
+func (f *fakeLifecycleExecutor) GetResourceState(ctx context.Context, resourceUUID string) (waldur.ResourceState, error) {
+	return waldur.ResourceState(f.state), nil
+}
+
+func TestLifecycleCommandQueue_PersistsAcrossRestart(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := OpenBadgerLifecycleCommandStore(tmp, false)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	event := marketplace.NewLifecycleActionRequestedEventAt(
+		"alloc-1",
+		"order-1",
+		"provider-1",
+		marketplace.LifecycleActionStart,
+		"op-1",
+		"tester",
+		marketplace.AllocationStateActive,
+		map[string]interface{}{},
+		marketplace.RollbackPolicyManual,
+		1,
+		1,
+		time.Now(),
+	)
+
+	cfg := DefaultLifecycleCommandQueueConfig()
+	cfg.Path = tmp
+	cfg.WorkerCount = 1
+	cfg.PollInterval = 20 * time.Millisecond
+	cfg.ReconcileInterval = 200 * time.Millisecond
+	cfg.StaleAfter = 50 * time.Millisecond
+
+	executor := &fakeLifecycleExecutor{state: "OK"}
+	queue, err := NewLifecycleCommandQueue(cfg, store, executor, func(ctx context.Context, allocationID string) (string, error) {
+		return "resource-1", nil
+	}, nil, testLifecycleQueueMetrics())
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+
+	if _, err := queue.EnqueueFromEvent(context.Background(), *event, "resource-1"); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	queue.Stop()
+
+	store2, err := OpenBadgerLifecycleCommandStore(tmp, false)
+	if err != nil {
+		t.Fatalf("open store restart: %v", err)
+	}
+	queue2, err := NewLifecycleCommandQueue(cfg, store2, executor, func(ctx context.Context, allocationID string) (string, error) {
+		return "resource-1", nil
+	}, nil, testLifecycleQueueMetrics())
+	if err != nil {
+		t.Fatalf("create queue restart: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := queue2.Start(ctx); err != nil {
+		t.Fatalf("start queue: %v", err)
+	}
+
+	defer queue2.Stop()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		cmd, err := store2.Get(context.Background(), "op-1")
+		if err == nil && cmd != nil && cmd.Status == LifecycleCommandStatusSucceeded {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Fatalf("command not processed after restart")
+}
+
+func TestLifecycleCommandQueue_RequeueStaleExecuting(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := OpenBadgerLifecycleCommandStore(tmp, true)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	now := time.Now().UTC()
+	cmd := &LifecycleCommand{
+		ID:             "cmd-stale",
+		AllocationID:   "alloc-2",
+		Action:         marketplace.LifecycleActionStop,
+		TargetState:    marketplace.AllocationStateSuspended,
+		RequestedBy:    "tester",
+		Status:         LifecycleCommandStatusExecuting,
+		AttemptCount:   1,
+		MaxAttempts:    3,
+		LastAttemptAt:  ptrTime(now.Add(-2 * time.Hour)),
+		CreatedAt:      now.Add(-2 * time.Hour),
+		UpdatedAt:      now.Add(-2 * time.Hour),
+		EventTimestamp: now.Add(-2 * time.Hour),
+	}
+	if _, _, err := store.Enqueue(context.Background(), cmd); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if err := store.Update(context.Background(), cmd); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	cfg := DefaultLifecycleCommandQueueConfig()
+	cfg.StaleAfter = 30 * time.Minute
+
+	executor := &fakeLifecycleExecutor{state: "Stopped"}
+	queue, err := NewLifecycleCommandQueue(cfg, store, executor, nil, nil, testLifecycleQueueMetrics())
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+
+	queue.ReconcileOnce(context.Background())
+
+	updated, err := store.Get(context.Background(), "cmd-stale")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if updated.Status != LifecycleCommandStatusPending {
+		t.Fatalf("expected pending after requeue, got %s", updated.Status)
+	}
+	if updated.NextAttemptAt == nil {
+		t.Fatalf("expected next attempt timestamp")
+	}
+}
+
+func TestLifecycleCommandQueue_ReconcileDrift(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := OpenBadgerLifecycleCommandStore(tmp, true)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	desired := &LifecycleDesiredState{
+		AllocationID:  "alloc-3",
+		ResourceUUID:  "resource-3",
+		DesiredState:  marketplace.AllocationStateActive,
+		LastAction:    marketplace.LifecycleActionStart,
+		LastCommandID: "cmd-prev",
+		UpdatedAt:     time.Now().UTC(),
+	}
+	if err := store.SetDesiredState(context.Background(), desired); err != nil {
+		t.Fatalf("set desired: %v", err)
+	}
+
+	executor := &fakeLifecycleExecutor{state: "Stopped"}
+	queue, err := NewLifecycleCommandQueue(DefaultLifecycleCommandQueueConfig(), store, executor, nil, nil, testLifecycleQueueMetrics())
+	if err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+
+	queue.ReconcileOnce(context.Background())
+
+	cmds, err := store.ListByAllocation(context.Background(), "alloc-3", LifecycleCommandStatusPending)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(cmds) == 0 {
+		t.Fatalf("expected reconcile command to be enqueued")
+	}
+	if cmds[0].Action != marketplace.LifecycleActionStart {
+		t.Fatalf("expected start action, got %s", cmds[0].Action)
+	}
+}
+
+func ptrTime(t time.Time) *time.Time {
+	return &t
+}


### PR DESCRIPTION
## Summary
- add badger-backed durable lifecycle command queue with retries and reconciliation
- wire queue into Waldur bridge and expose lifecycle queue flags
- add metrics, docs, and crash/restart tests for lifecycle processing

## Testing
- go test ./pkg/provider_daemon/... -count=1
- go vet ./pkg/provider_daemon/... ./cmd/provider-daemon/...
- go build ./...
- GOLANGCI_LINT_CACHE=/tmp/golangci-lint- golangci-lint run --new-from-rev=HEAD~1
- scripts/agent-preflight.ps1