### PR TITLE
fix(portal): show stats refresh time

### DIFF
--- a/scripts/codex-monitor/package-lock.json
+++ b/scripts/codex-monitor/package-lock.json
@@ -1876,6 +1876,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- show relative refresh time in the landing page network stats header
- keep stats metadata in sync with fetch timestamps

## Testing
- pnpm -C portal lint
- pnpm -C portal type-check
- pnpm -C lib/portal test
- pnpm -C portal test
- pnpm -C portal build