### PR TITLE
docs(provider): add AGENTS guides for core packages

### DIFF
--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,0 +1,60 @@
+# API Layer (api/openapi) — AGENTS Guide
+
+## Package Overview
+- Purpose: OpenAPI specifications for VirtEngine blockchain and provider portal APIs, used for client generation and documentation.
+- Use `api/openapi/virtengine-api.yaml` for chain-level queries and transactions; use `api/openapi/portal_api.yaml` for provider portal operations.
+- Key assets:
+  - `api/openapi/virtengine-api.yaml` entry point (`api/openapi/virtengine-api.yaml:1`).
+  - `api/openapi/portal_api.yaml` entry point (`api/openapi/portal_api.yaml:1`).
+
+## Architecture
+- `api/openapi/virtengine-api.yaml` — blockchain API specification, shared tags for modules, and server definitions (`api/openapi/virtengine-api.yaml:1`).
+- `api/openapi/portal_api.yaml` — provider portal REST API specification, with ADR-036 auth headers (`api/openapi/portal_api.yaml:10`).
+- Both specs define `servers`, `security`, `tags`, `paths`, and `components` blocks for downstream generators.
+
+## Core Concepts
+- Authentication:
+  - Chain API supports wallet signature auth and MFA for sensitive operations (`api/openapi/virtengine-api.yaml:11`).
+  - Portal API uses ADR-036 wallet signature headers or optional HMAC auth (`api/openapi/portal_api.yaml:10`).
+- Rate limits and tiers are documented in the chain spec (`api/openapi/virtengine-api.yaml:19`).
+- Tags organize module endpoints; examples include Provider, Market, VEID (`api/openapi/virtengine-api.yaml:47`).
+
+## Usage Examples
+
+### Query a VEID identity
+```bash
+curl https://api.virtengine.com/virtengine/veid/v1/identity/<bech32_address>
+```
+
+### Provider portal health check
+```bash
+curl https://provider.example.com:8443/api/v1/health
+```
+
+### Portal request with wallet headers (ADR-036)
+```
+X-VE-Address: <bech32>
+X-VE-Timestamp: <unix_ms>
+X-VE-Nonce: <random_hex>
+X-VE-Signature: <base64_sig>
+X-VE-PubKey: <base64_pubkey>
+```
+
+## Implementation Patterns
+- Add new endpoints in the appropriate spec file under `paths:` and assign a tag (`api/openapi/virtengine-api.yaml:85`, `api/openapi/portal_api.yaml:67`).
+- Update shared schemas under `components:` to avoid copy/paste drift.
+- Keep `servers` in sync with deployment environments (`api/openapi/virtengine-api.yaml:35`, `api/openapi/portal_api.yaml:37`).
+- Anti-patterns:
+  - Do not introduce new auth headers without documenting them in `security` and `description` blocks.
+  - Do not add paths without rate-limit metadata for chain endpoints.
+
+## API Reference
+- Chain API metadata: `openapi`, `info`, `servers`, `security`, `tags` (`api/openapi/virtengine-api.yaml:1`).
+- Portal API metadata: auth headers and server variables (`api/openapi/portal_api.yaml:8`).
+
+## Dependencies & Environment
+- Specs are documentation-only; no runtime dependencies.
+- Client generation depends on OpenAPI tooling of choice (e.g., `openapi-generator`).
+
+## Testing
+- Validate specs with your OpenAPI linter or generator before release.

--- a/scripts/codex-monitor/AGENTS.md
+++ b/scripts/codex-monitor/AGENTS.md
@@ -1,0 +1,94 @@
+# Codex Monitor Orchestrator (scripts/codex-monitor) — AGENTS Guide
+
+## Package Overview
+- Purpose: Node.js orchestrator supervisor that manages agent executors with failover, auto-restarts the orchestrator script, and integrates with Vibe-Kanban + Telegram for automation (`scripts/codex-monitor/package.json:2`).
+- Use this package to run multi-agent task orchestration locally or in CI; use chain modules (e.g., `x/provider`) for on-chain logic.
+- Key exports / public API surface:
+  - CLI entry: `codex-monitor` binary (`scripts/codex-monitor/package.json:55`, `scripts/codex-monitor/cli.mjs:1`).
+  - Core monitor runtime: `scripts/codex-monitor/monitor.mjs:1`.
+  - Config loader: `loadConfig` in `scripts/codex-monitor/config.mjs:716`.
+  - Public ESM exports listed in `scripts/codex-monitor/package.json:33`.
+
+## Architecture
+- Entry points:
+  - `scripts/codex-monitor/cli.mjs:1` — CLI routing, setup, update checks.
+  - `scripts/codex-monitor/monitor.mjs:1` — main supervisor loop, restarts, Telegram, Vibe-Kanban integration.
+  - `scripts/codex-monitor/config.mjs:3` — layered configuration resolution.
+- Supporting subsystems (imported into `monitor.mjs`):
+  - Fleet coordination: `scripts/codex-monitor/monitor.mjs:56`.
+  - Task complexity and scheduling: `scripts/codex-monitor/monitor.mjs:70`.
+  - Conflict resolution for dirty workspaces: `scripts/codex-monitor/monitor.mjs:79`.
+  - Telegram integrations: `scripts/codex-monitor/monitor.mjs:23`.
+
+```mermaid
+flowchart TD
+  CLI[cli.mjs] --> Monitor[monitor.mjs]
+  Monitor --> Orchestrator[ve-orchestrator.ps1]
+  Monitor --> VK[Vibe-Kanban API]
+  Monitor --> Telegram[telegram-bot.mjs]
+  Monitor --> Autofix[autofix.mjs]
+  Monitor --> Fleet[fleet-coordinator.mjs]
+```
+
+## Core Concepts
+- Config layering: CLI args, env vars, `.env`, config JSON, and defaults are merged in that order (`scripts/codex-monitor/config.mjs:3`, `scripts/codex-monitor/config.mjs:716`).
+- Orchestrator supervision: the CLI forks `monitor.mjs` so it can auto-restart on file changes and recover from exit code 75 (`scripts/codex-monitor/cli.mjs:190`).
+- Executor scheduling + failover: executor distribution and failover strategies are defined in config JSON or environment (`scripts/codex-monitor/cli.mjs:101`).
+- Observability: Telegram notifications, presence tracking, and batch summaries are configured via `.env` (`scripts/codex-monitor/.env.example:11`).
+
+## Usage Examples
+
+### Start with defaults
+```bash
+node scripts/codex-monitor/cli.mjs
+```
+
+### Run setup wizard
+```bash
+node scripts/codex-monitor/cli.mjs --setup
+```
+
+### Configure via environment
+```bash
+export TELEGRAM_BOT_TOKEN=...
+export TELEGRAM_CHAT_ID=...
+export VK_BASE_URL=http://127.0.0.1:54089
+node scripts/codex-monitor/cli.mjs --args "-MaxParallel 6"
+```
+
+### config.json executor override
+```json
+{
+  "executors": [
+    { "name": "copilot-claude", "executor": "COPILOT", "variant": "CLAUDE_OPUS_4_6", "weight": 50, "role": "primary" },
+    { "name": "codex-default", "executor": "CODEX", "variant": "DEFAULT", "weight": 50, "role": "backup" }
+  ],
+  "distribution": "weighted"
+}
+```
+
+## Implementation Patterns
+- Add new config fields by updating `scripts/codex-monitor/config.mjs:716`, the schema (`scripts/codex-monitor/codex-monitor.schema.json`), and `.env.example` if exposed.
+- Add new CLI flags in `scripts/codex-monitor/cli.mjs:35` and plumb them through `loadConfig`.
+- For new runtime behaviors, prefer non-blocking async operations in `monitor.mjs` and keep error handling centralized.
+- Tests live in `scripts/codex-monitor/tests/` and should mirror new behaviors or edge cases.
+- Anti-patterns:
+  - Do not block the main supervisor loop with long synchronous work.
+  - Do not mutate config after it is frozen by `loadConfig` (`scripts/codex-monitor/config.mjs:716`).
+
+## API Reference
+- CLI binary: `codex-monitor` (`scripts/codex-monitor/package.json:55`, `scripts/codex-monitor/cli.mjs:1`).
+- Main runtime entry: `monitor.mjs` (package export `"."`, `scripts/codex-monitor/package.json:33`).
+- Config loader: `loadConfig(argv?, options?)` (`scripts/codex-monitor/config.mjs:716`).
+- Exported modules: `./config`, `./autofix`, `./primary-agent`, `./fleet-coordinator`, `./task-complexity` (`scripts/codex-monitor/package.json:33`).
+
+## Dependencies & Environment
+- Runtime deps: `@openai/codex-sdk`, `@github/copilot-sdk`, `@anthropic-ai/claude-agent-sdk`, `vibe-kanban` (`scripts/codex-monitor/package.json:116`).
+- Node.js engine: `>=18` (`scripts/codex-monitor/package.json:125`).
+- Primary env vars are documented in `.env.example` (`scripts/codex-monitor/.env.example:11`).
+
+## Testing
+- Tests: `scripts/codex-monitor/tests/*.test.mjs`.
+- Commands:
+  - `npm test` (runs `vitest`, `scripts/codex-monitor/package.json:69`).
+  - `npm run syntax:check` (fast syntax validation, `scripts/codex-monitor/package.json:67`).

--- a/sdk/ts/AGENTS.md
+++ b/sdk/ts/AGENTS.md
@@ -1,0 +1,82 @@
+# Chain SDK (sdk/ts) — AGENTS Guide
+
+## Package Overview
+- Purpose: TypeScript SDK for VirtEngine chain APIs, gRPC clients, wallet helpers, and provider SDK access (`sdk/ts/package.json:2`).
+- Use this package for TypeScript/JS integrations; use Go modules under `x/` for on-chain logic.
+- Key exports / public API surface:
+  - Barrel exports from `sdk/ts/src/index.ts:1`.
+  - Chain SDK factories: `createChainNodeSDK`, `createChainNodeWebSDK` (`sdk/ts/src/sdk/index.ts:2`).
+  - Provider SDK factory: `createProviderSDK` (`sdk/ts/src/sdk/index.ts:4`).
+
+## Architecture
+- Entry points:
+  - `sdk/ts/src/index.ts:1` — public API barrel.
+  - `sdk/ts/src/sdk/index.ts:1` — SDK factory exports.
+- Directory layout:
+  - `sdk/ts/src/clients/` — generated gRPC/Connect clients.
+  - `sdk/ts/src/generated/` — generated proto clients and patches.
+  - `sdk/ts/src/sdk/` — SDK factories and transports.
+  - `sdk/ts/src/network/` and `sdk/ts/src/wallet/` — network helpers and signing.
+  - `sdk/ts/test/` — unit and functional tests.
+
+## Core Concepts
+- Query vs tx: `createChainNodeSDK` builds gRPC query transport and optional tx transport, falling back to a noop transport when a signer is missing (`sdk/ts/src/sdk/chain/createChainNodeSDK.ts:17`).
+- Web vs node: `createChainNodeWebSDK` targets gRPC-gateway endpoints for browser usage (`sdk/ts/src/sdk/chain/createChainNodeWebSDK.ts:15`).
+- Provider SDK: `createProviderSDK` constructs provider-service clients with optional mTLS and retry interceptors (`sdk/ts/src/sdk/provider/createProviderSDK.ts:12`).
+
+## Usage Examples
+
+### Node SDK (gRPC)
+```ts
+import { createChainNodeSDK } from "@virtengine/chain-sdk";
+
+const sdk = createChainNodeSDK({
+  query: { baseUrl: "https://grpc.testnet.virtengine.com" },
+});
+
+const identity = await sdk.virtengine.veid.v1.identity({ accountAddress: "..."} );
+```
+
+### Web SDK (gRPC-gateway)
+```ts
+import { createChainNodeWebSDK } from "@virtengine/chain-sdk";
+
+const sdk = createChainNodeWebSDK({
+  query: { baseUrl: "https://api.testnet.virtengine.com" },
+});
+```
+
+### Provider SDK (mTLS)
+```ts
+import { createProviderSDK } from "@virtengine/chain-sdk";
+
+const providerSDK = createProviderSDK({
+  baseUrl: "https://provider.example.com:8443",
+  authentication: { type: "mtls", cert: "<pem>", key: "<pem>" },
+});
+```
+
+## Implementation Patterns
+- Add new API surfaces by updating generators under `sdk/ts/src/generated/` and re-export via `sdk/ts/src/index.ts:1`.
+- New SDK factories should live under `sdk/ts/src/sdk/` and be exported from `sdk/ts/src/sdk/index.ts:1`.
+- Keep retry and transport options wired through to avoid breaking existing integrations (`sdk/ts/src/sdk/provider/createProviderSDK.ts:12`).
+- Anti-patterns:
+  - Do not hardcode endpoint URLs inside SDK factories; always accept them via options.
+  - Do not bypass generated patches when composing SDKs (`sdk/ts/src/sdk/chain/createChainNodeSDK.ts:36`).
+
+## API Reference
+- `createChainNodeSDK(options: ChainNodeSDKOptions)` (`sdk/ts/src/sdk/chain/createChainNodeSDK.ts:17`).
+- `createChainNodeWebSDK(options: ChainNodeWebSDKOptions)` (`sdk/ts/src/sdk/chain/createChainNodeWebSDK.ts:15`).
+- `createProviderSDK(options: ProviderSDKOptions)` (`sdk/ts/src/sdk/provider/createProviderSDK.ts:12`).
+- Public exports barrel: `sdk/ts/src/index.ts:1`.
+
+## Dependencies & Environment
+- Node engine: `>=22.14.0` (`sdk/ts/package.json:106`).
+- Key deps: `@connectrpc/*`, `@cosmjs/*`, `jsrsasign`, `long` (`sdk/ts/package.json:60`).
+- Build outputs live in `sdk/ts/dist` (package `files` list, `sdk/ts/package.json:34`).
+
+## Testing
+- Tests live in `sdk/ts/test/` (unit + functional).
+- Commands:
+  - `npm test` (runs Jest, `sdk/ts/package.json:41`).
+  - `npm run test:unit` and `npm run test:functional` for focused suites.

--- a/x/provider/AGENTS.md
+++ b/x/provider/AGENTS.md
@@ -1,0 +1,95 @@
+# Provider Module (x/provider) — AGENTS Guide
+
+## Package Overview
+- Purpose: chain module that owns provider registration, lifecycle management, domain verification, and provider public-key management.
+- Use this module when you need on-chain provider state or provider-facing governance logic; use the TypeScript SDK in `sdk/ts` for off-chain clients.
+- Key exports / public API surface:
+  - `AppModuleBasic` and `AppModule` for module wiring in the app (`x/provider/module.go:44`, `x/provider/module.go:49`).
+  - `keeper.IKeeper` for cross-module reads/writes (`x/provider/keeper/keeper.go:15`).
+  - `handler.NewMsgServerImpl` for MsgServer registration (`x/provider/handler/server.go:34`).
+  - Module constants and store prefixes in `sdk/go/node/provider/v1beta4/key.go:3`.
+
+## Architecture
+- Entry points:
+  - Module wiring and registration: `x/provider/module.go:44`.
+  - Keeper implementation: `x/provider/keeper/keeper.go:15`.
+  - MsgServer (tx handlers): `x/provider/handler/server.go:34`.
+  - Domain verification flow: `x/provider/keeper/domain_verification.go:47`.
+  - SDK types and keys: `sdk/go/node/provider/v1beta4/key.go:3` and `sdk/go/node/provider/v1beta4/types.go:11`.
+- Directory layout:
+  - `x/provider/keeper/` — store access, domain verification, public-key management.
+  - `x/provider/handler/` — gRPC MsgServer implementation and error mapping.
+  - `x/provider/query/` — query service wiring.
+  - `x/provider/types/daemon/` — provider-daemon transport models.
+  - `sdk/go/node/provider/v1beta4/` — protobuf-generated types, errors, and keys.
+
+## Core Concepts
+- Provider lifecycle: `CreateProvider`, `UpdateProvider`, `DeleteProvider` validate input, enforce constraints, emit typed events (`x/provider/handler/server.go:47`).
+- Domain verification uses DNS TXT records with `_virtengine-verification` prefix and token expiry; verification state is stored in-module and emits events (`x/provider/keeper/domain_verification.go:17`, `x/provider/keeper/domain_verification.go:81`).
+- Public-key management supports `ed25519`, `x25519`, and `secp256k1` key types (`sdk/go/node/provider/v1beta4/key.go:13`) and is exposed via `keeper.IKeeper` (`x/provider/keeper/keeper.go:26`).
+- Error handling uses Cosmos SDK error wrapping and module-registered errors for deterministic codes (`x/provider/handler/server.go:18`).
+
+## Usage Examples
+
+### Wiring the module in the app
+```go
+import (
+  provider "github.com/virtengine/virtengine/x/provider"
+  providerkeeper "github.com/virtengine/virtengine/x/provider/keeper"
+  providertypes "github.com/virtengine/virtengine/sdk/go/node/provider/v1beta4"
+)
+
+providerKeeper := providerkeeper.NewKeeper(appCodec, keys[providertypes.StoreKey])
+providerModule := provider.NewAppModule(
+  appCodec,
+  providerKeeper,
+  accountKeeper,
+  bankKeeper,
+  marketKeeper,
+  veidKeeper,
+  mfaKeeper,
+)
+moduleManager.RegisterModules(providerModule)
+```
+
+### Using the keeper for domain verification
+```go
+record, err := providerKeeper.GenerateDomainVerificationToken(ctx, providerAddr, "example.com")
+if err != nil {
+  return err
+}
+// DNS TXT record is expected at: _virtengine-verification.example.com
+err = providerKeeper.VerifyProviderDomain(ctx, providerAddr)
+```
+
+## Implementation Patterns
+- Add new provider messages by updating protobuf definitions in `sdk/go/node/provider/v1beta4/`, re-generating code, and extending MsgServer in `x/provider/handler/server.go:47`.
+- Keep state mutations inside the keeper; MsgServer should validate and delegate to keeper methods (`x/provider/keeper/keeper.go:70`).
+- Add new domain verification logic in `x/provider/keeper/domain_verification.go:47` and wire new events in `sdk/go/node/provider/v1beta4/event.pb.go`.
+- Tests live alongside keepers and handlers; mirror error scenarios and event emission in tests under `x/provider/keeper/*_test.go` and `x/provider/handler/handler_test.go`.
+- Anti-patterns:
+  - Do not bypass `ValidateBasic()` in MsgServer handlers (`x/provider/handler/server.go:50`).
+  - Do not write directly to KVStore outside the keeper (`x/provider/keeper/keeper.go:70`).
+
+## API Reference
+- `provider.NewAppModule(codec.Codec, keeper.IKeeper, govtypes.AccountKeeper, bankkeeper.Keeper, mkeeper.IKeeper, veidkeeper.IKeeper, mfakeeper.IKeeper) AppModule` (`x/provider/module.go:110`).
+- `keeper.NewKeeper(codec.BinaryCodec, storetypes.StoreKey) IKeeper` (`x/provider/keeper/keeper.go:48`).
+- `keeper.IKeeper` key methods:
+  - `Get`, `Create`, `Update`, `Delete` (`x/provider/keeper/keeper.go:18`).
+  - `SetProviderPublicKey`, `RotateProviderPublicKey` (`x/provider/keeper/keeper.go:29`).
+  - `GenerateDomainVerificationToken`, `VerifyProviderDomain` (`x/provider/keeper/keeper.go:35`).
+- MsgServer methods: `CreateProvider`, `UpdateProvider`, `DeleteProvider`, `GenerateDomainVerificationToken`, `VerifyProviderDomain` (`x/provider/handler/server.go:47`).
+
+## Dependencies & Environment
+- Depends on Cosmos SDK modules (`x/market`, `x/veid`, `x/mfa`) via keeper interfaces (`x/provider/module.go:53`).
+- Uses DNS lookups for domain verification (`x/provider/keeper/domain_verification.go:95`); ensure DNS access in integration tests.
+- No package-specific environment variables.
+
+## Testing
+- Unit tests:
+  - `x/provider/handler/handler_test.go`
+  - `x/provider/keeper/*_test.go`
+  - `x/provider/types/daemon/*_test.go`
+- Recommended commands:
+  - `go test ./x/provider/... -count=1`
+  - `go test ./sdk/go/node/provider/v1beta4 -count=1`


### PR DESCRIPTION
## Summary
- add AGENTS guides for x/provider, api/openapi, scripts/codex-monitor, and sdk/ts
- document architecture, core concepts, usage examples, and testing entry points

## Testing
- go test ./x/provider/... -count=1
- go test ./sdk/go/node/provider/v1beta4 -count=1
- go build ./...
- (scripts/codex-monitor) npm test
- (sdk/ts) npm test (fails: jwt-validator.spec.ts token validation, buf generate config parsing on Windows shell quoting, SDL snapshot mismatches)
