### PR TITLE
feat(dex): add fiat conversion settlement pipeline

### DIFF
--- a/pkg/payments/offramp/bridge.go
+++ b/pkg/payments/offramp/bridge.go
@@ -1,0 +1,201 @@
+package offramp
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// bridgeImpl aggregates multiple off-ramp adapters.
+type bridgeImpl struct {
+	adapters   map[string]Adapter
+	adapterMu  sync.RWMutex
+	operations map[string]PayoutResult
+	opMu       sync.RWMutex
+}
+
+// NewBridge creates a new off-ramp bridge.
+func NewBridge() *bridgeImpl {
+	return &bridgeImpl{
+		adapters:   make(map[string]Adapter),
+		operations: make(map[string]PayoutResult),
+	}
+}
+
+// RegisterAdapter registers an adapter with the bridge.
+func (b *bridgeImpl) RegisterAdapter(adapter Adapter) error {
+	if adapter == nil {
+		return ErrAdapterUnavailable
+	}
+	b.adapterMu.Lock()
+	defer b.adapterMu.Unlock()
+	b.adapters[adapter.Name()] = adapter
+	return nil
+}
+
+// GetQuote returns the best quote across adapters.
+func (b *bridgeImpl) GetQuote(ctx context.Context, req QuoteRequest) (Quote, error) {
+	if req.CryptoAmount.IsNil() || !req.CryptoAmount.IsPositive() {
+		return Quote{}, ErrInvalidRequest
+	}
+	if req.FiatCurrency == "" || req.PaymentMethod == "" {
+		return Quote{}, ErrInvalidRequest
+	}
+
+	adapter, err := b.selectBestAdapter(ctx, req)
+	if err != nil {
+		return Quote{}, err
+	}
+
+	quote, err := adapter.GetQuote(ctx, req)
+	if err != nil {
+		return Quote{}, err
+	}
+
+	if quote.ExpiresAt.IsZero() {
+		quote.ExpiresAt = time.Now().UTC().Add(5 * time.Minute)
+	}
+
+	return quote, nil
+}
+
+// InitiatePayout executes a payout via the selected adapter.
+func (b *bridgeImpl) InitiatePayout(ctx context.Context, quote Quote, cryptoTxRef string, destination string, metadata map[string]string) (PayoutResult, error) {
+	if quote.IsExpired(time.Now().UTC()) {
+		return PayoutResult{}, ErrQuoteExpired
+	}
+
+	b.adapterMu.RLock()
+	adapter, ok := b.adapters[quote.Provider]
+	b.adapterMu.RUnlock()
+	if !ok {
+		return PayoutResult{}, ErrAdapterUnavailable
+	}
+
+	result, err := adapter.InitiatePayout(ctx, PayoutRequest{
+		Quote:       quote,
+		CryptoTxRef: cryptoTxRef,
+		Destination: destination,
+		Metadata:    metadata,
+	})
+	if err != nil {
+		return PayoutResult{}, err
+	}
+
+	b.opMu.Lock()
+	b.operations[result.ID] = result
+	b.opMu.Unlock()
+
+	return result, nil
+}
+
+// GetStatus retrieves payout status and refreshes from adapter when available.
+func (b *bridgeImpl) GetStatus(ctx context.Context, payoutID string) (PayoutResult, error) {
+	b.opMu.RLock()
+	result, ok := b.operations[payoutID]
+	b.opMu.RUnlock()
+	if !ok {
+		return PayoutResult{}, fmt.Errorf("payout %s not found", payoutID)
+	}
+
+	if result.Status == StatusPending || result.Status == StatusProcessing {
+		b.adapterMu.RLock()
+		adapter, exists := b.adapters[result.Provider]
+		b.adapterMu.RUnlock()
+		if exists {
+			updated, err := adapter.GetStatus(ctx, payoutID)
+			if err == nil {
+				b.opMu.Lock()
+				b.operations[payoutID] = updated
+				b.opMu.Unlock()
+				return updated, nil
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// Cancel attempts to cancel a payout.
+func (b *bridgeImpl) Cancel(ctx context.Context, payoutID string) error {
+	b.opMu.RLock()
+	result, ok := b.operations[payoutID]
+	b.opMu.RUnlock()
+	if !ok {
+		return fmt.Errorf("payout %s not found", payoutID)
+	}
+
+	b.adapterMu.RLock()
+	adapter, ok := b.adapters[result.Provider]
+	b.adapterMu.RUnlock()
+	if !ok {
+		return ErrAdapterUnavailable
+	}
+
+	if err := adapter.Cancel(ctx, payoutID); err != nil {
+		return err
+	}
+
+	b.opMu.Lock()
+	result.Status = StatusCancelled
+	b.operations[payoutID] = result
+	b.opMu.Unlock()
+	return nil
+}
+
+// ListProviders lists registered adapters.
+func (b *bridgeImpl) ListProviders() []string {
+	b.adapterMu.RLock()
+	defer b.adapterMu.RUnlock()
+
+	providers := make([]string, 0, len(b.adapters))
+	for name := range b.adapters {
+		providers = append(providers, name)
+	}
+	sort.Strings(providers)
+	return providers
+}
+
+func (b *bridgeImpl) selectBestAdapter(ctx context.Context, req QuoteRequest) (Adapter, error) {
+	b.adapterMu.RLock()
+	defer b.adapterMu.RUnlock()
+
+	var best Adapter
+	var bestRate float64
+
+	for _, adapter := range b.adapters {
+		if !adapter.IsHealthy(ctx) {
+			continue
+		}
+		if !adapter.SupportsCurrency(req.FiatCurrency) || !adapter.SupportsMethod(req.PaymentMethod) {
+			continue
+		}
+
+		quote, err := adapter.GetQuote(ctx, req)
+		if err != nil {
+			continue
+		}
+		rate, _ := quote.ExchangeRate.Float64()
+		if best == nil || rate > bestRate {
+			best = adapter
+			bestRate = rate
+		}
+	}
+
+	if best == nil {
+		return nil, ErrAdapterUnavailable
+	}
+	return best, nil
+}
+
+func generateID(prefix string) (string, error) {
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s", prefix, hex.EncodeToString(buf)), nil
+}

--- a/pkg/payments/offramp/doc.go
+++ b/pkg/payments/offramp/doc.go
@@ -1,0 +1,2 @@
+// Package offramp provides fiat off-ramp provider abstractions.
+package offramp

--- a/pkg/payments/offramp/errors.go
+++ b/pkg/payments/offramp/errors.go
@@ -1,0 +1,9 @@
+package offramp
+
+import "errors"
+
+var (
+	ErrAdapterUnavailable = errors.New("offramp adapter unavailable")
+	ErrQuoteExpired       = errors.New("offramp quote expired")
+	ErrInvalidRequest     = errors.New("offramp request invalid")
+)

--- a/pkg/payments/offramp/mock_provider.go
+++ b/pkg/payments/offramp/mock_provider.go
@@ -1,0 +1,125 @@
+package offramp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// MockProvider is a deterministic off-ramp adapter for testing.
+type MockProvider struct {
+	name       string
+	currencies map[string]bool
+	methods    map[string]bool
+	feePercent sdkmath.LegacyDec
+	healthy    bool
+	rateByFiat map[string]sdkmath.LegacyDec
+}
+
+// NewMockProvider creates a mock provider.
+func NewMockProvider(name string, currencies []string, methods []string) *MockProvider {
+	cur := make(map[string]bool)
+	for _, c := range currencies {
+		cur[c] = true
+	}
+	met := make(map[string]bool)
+	for _, m := range methods {
+		met[m] = true
+	}
+
+	return &MockProvider{
+		name:       name,
+		currencies: cur,
+		methods:    met,
+		feePercent: sdkmath.LegacyNewDecWithPrec(15, 3), // 1.5%
+		healthy:    true,
+		rateByFiat: map[string]sdkmath.LegacyDec{
+			"USD": sdkmath.LegacyNewDec(1),
+			"EUR": sdkmath.LegacyNewDecWithPrec(92, 2),
+			"GBP": sdkmath.LegacyNewDecWithPrec(78, 2),
+		},
+	}
+}
+
+func (p *MockProvider) Name() string { return p.name }
+
+func (p *MockProvider) GetQuote(ctx context.Context, req QuoteRequest) (Quote, error) {
+	if !p.SupportsCurrency(req.FiatCurrency) || !p.SupportsMethod(req.PaymentMethod) {
+		return Quote{}, fmt.Errorf("unsupported currency or method")
+	}
+
+	rate, ok := p.rateByFiat[req.FiatCurrency]
+	if !ok {
+		rate = sdkmath.LegacyOneDec()
+	}
+
+	fiatAmount := rate.MulInt(req.CryptoAmount)
+	fee := p.feePercent.MulInt(req.CryptoAmount).TruncateInt()
+
+	id, err := generateID("quote")
+	if err != nil {
+		return Quote{}, err
+	}
+
+	return Quote{
+		ID:           id,
+		Request:      req,
+		FiatAmount:   fiatAmount,
+		ExchangeRate: rate,
+		Fee:          fee,
+		Provider:     p.name,
+		CreatedAt:    time.Now().UTC(),
+		ExpiresAt:    time.Now().UTC().Add(5 * time.Minute),
+	}, nil
+}
+
+func (p *MockProvider) InitiatePayout(ctx context.Context, req PayoutRequest) (PayoutResult, error) {
+	id, err := generateID("payout")
+	if err != nil {
+		return PayoutResult{}, err
+	}
+
+	result := PayoutResult{
+		ID:           id,
+		QuoteID:      req.Quote.ID,
+		Status:       StatusCompleted,
+		Provider:     p.name,
+		FiatAmount:   req.Quote.FiatAmount,
+		CryptoAmount: req.Quote.Request.CryptoAmount,
+		Fee:          req.Quote.Fee,
+		Reference:    fmt.Sprintf("mock-%s", id),
+		InitiatedAt:  time.Now().UTC(),
+	}
+
+	completedAt := time.Now().UTC()
+	result.CompletedAt = &completedAt
+
+	return result, nil
+}
+
+func (p *MockProvider) GetStatus(ctx context.Context, payoutID string) (PayoutResult, error) {
+	return PayoutResult{}, fmt.Errorf("payout %s not found", payoutID)
+}
+
+func (p *MockProvider) Cancel(ctx context.Context, payoutID string) error {
+	return nil
+}
+
+func (p *MockProvider) SupportsCurrency(currency string) bool {
+	return p.currencies[currency]
+}
+
+func (p *MockProvider) SupportsMethod(method string) bool {
+	return p.methods[method]
+}
+
+func (p *MockProvider) IsHealthy(ctx context.Context) bool {
+	return p.healthy
+}
+
+// SetHealthy toggles mock provider health.
+func (p *MockProvider) SetHealthy(healthy bool) {
+	p.healthy = healthy
+}

--- a/pkg/payments/offramp/types.go
+++ b/pkg/payments/offramp/types.go
@@ -1,0 +1,92 @@
+package offramp
+
+import (
+	"context"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+// Status represents the state of an off-ramp payout.
+type Status string
+
+const (
+	StatusPending    Status = "pending"
+	StatusProcessing Status = "processing"
+	StatusCompleted  Status = "completed"
+	StatusFailed     Status = "failed"
+	StatusCancelled  Status = "cancelled"
+)
+
+// QuoteRequest requests a fiat payout quote.
+type QuoteRequest struct {
+	CryptoSymbol  string      `json:"crypto_symbol"`
+	CryptoDenom   string      `json:"crypto_denom"`
+	CryptoAmount  sdkmath.Int `json:"crypto_amount"`
+	FiatCurrency  string      `json:"fiat_currency"`
+	PaymentMethod string      `json:"payment_method"`
+	Sender        string      `json:"sender"`
+	Destination   string      `json:"destination"`
+}
+
+// Quote represents an off-ramp quote.
+type Quote struct {
+	ID           string            `json:"id"`
+	Request      QuoteRequest      `json:"request"`
+	FiatAmount   sdkmath.LegacyDec `json:"fiat_amount"`
+	ExchangeRate sdkmath.LegacyDec `json:"exchange_rate"`
+	Fee          sdkmath.Int       `json:"fee"`
+	Provider     string            `json:"provider"`
+	ExpiresAt    time.Time         `json:"expires_at"`
+	CreatedAt    time.Time         `json:"created_at"`
+}
+
+// IsExpired returns true when the quote is no longer valid.
+func (q Quote) IsExpired(now time.Time) bool {
+	return !q.ExpiresAt.IsZero() && now.After(q.ExpiresAt)
+}
+
+// PayoutRequest executes a fiat payout using an accepted quote.
+type PayoutRequest struct {
+	Quote       Quote             `json:"quote"`
+	CryptoTxRef string            `json:"crypto_tx_ref"`
+	Destination string            `json:"destination"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// PayoutResult is the result of an off-ramp payout.
+type PayoutResult struct {
+	ID            string            `json:"id"`
+	QuoteID       string            `json:"quote_id"`
+	Status        Status            `json:"status"`
+	Provider      string            `json:"provider"`
+	FiatAmount    sdkmath.LegacyDec `json:"fiat_amount"`
+	CryptoAmount  sdkmath.Int       `json:"crypto_amount"`
+	Fee           sdkmath.Int       `json:"fee"`
+	Reference     string            `json:"reference"`
+	InitiatedAt   time.Time         `json:"initiated_at"`
+	CompletedAt   *time.Time        `json:"completed_at,omitempty"`
+	FailureReason string            `json:"failure_reason,omitempty"`
+}
+
+// Adapter defines the off-ramp provider interface.
+type Adapter interface {
+	Name() string
+	GetQuote(ctx context.Context, req QuoteRequest) (Quote, error)
+	InitiatePayout(ctx context.Context, req PayoutRequest) (PayoutResult, error)
+	GetStatus(ctx context.Context, payoutID string) (PayoutResult, error)
+	Cancel(ctx context.Context, payoutID string) error
+	SupportsCurrency(currency string) bool
+	SupportsMethod(method string) bool
+	IsHealthy(ctx context.Context) bool
+}
+
+// Bridge aggregates multiple adapters.
+type Bridge interface {
+	RegisterAdapter(adapter Adapter) error
+	GetQuote(ctx context.Context, req QuoteRequest) (Quote, error)
+	InitiatePayout(ctx context.Context, quote Quote, cryptoTxRef string, destination string, metadata map[string]string) (PayoutResult, error)
+	GetStatus(ctx context.Context, payoutID string) (PayoutResult, error)
+	Cancel(ctx context.Context, payoutID string) error
+	ListProviders() []string
+}

--- a/tests/integration/settlement/dex_offramp_test.go
+++ b/tests/integration/settlement/dex_offramp_test.go
@@ -1,0 +1,273 @@
+//go:build e2e.integration
+
+package settlement_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/virtengine/virtengine/pkg/dex"
+	"github.com/virtengine/virtengine/pkg/payments/offramp"
+	"github.com/virtengine/virtengine/testutil/state"
+	"github.com/virtengine/virtengine/x/settlement/types"
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+type swapExecutor struct {
+	quote  dex.SwapQuote
+	result dex.SwapResult
+}
+
+func (s swapExecutor) GetQuote(ctx context.Context, request dex.SwapRequest) (dex.SwapQuote, error) {
+	return s.quote, nil
+}
+
+func (s swapExecutor) ExecuteSwap(ctx context.Context, quote dex.SwapQuote, signedTx []byte) (dex.SwapResult, error) {
+	return s.result, nil
+}
+
+type pendingOffRamp struct {
+	status offramp.PayoutResult
+}
+
+func (p *pendingOffRamp) Name() string { return "pending-mock" }
+func (p *pendingOffRamp) GetQuote(ctx context.Context, req offramp.QuoteRequest) (offramp.Quote, error) {
+	return offramp.Quote{
+		ID:           "quote-pending",
+		Request:      req,
+		FiatAmount:   sdkmath.LegacyNewDec(100),
+		ExchangeRate: sdkmath.LegacyNewDec(1),
+		Fee:          sdkmath.NewInt(1),
+		Provider:     p.Name(),
+		CreatedAt:    time.Now().UTC(),
+		ExpiresAt:    time.Now().UTC().Add(5 * time.Minute),
+	}, nil
+}
+func (p *pendingOffRamp) InitiatePayout(ctx context.Context, req offramp.PayoutRequest) (offramp.PayoutResult, error) {
+	p.status = offramp.PayoutResult{
+		ID:           "pending-payout",
+		QuoteID:      req.Quote.ID,
+		Status:       offramp.StatusProcessing,
+		Provider:     p.Name(),
+		FiatAmount:   req.Quote.FiatAmount,
+		CryptoAmount: req.Quote.Request.CryptoAmount,
+		Fee:          req.Quote.Fee,
+		Reference:    "pending-ref",
+		InitiatedAt:  time.Now().UTC(),
+	}
+	return p.status, nil
+}
+func (p *pendingOffRamp) GetStatus(ctx context.Context, payoutID string) (offramp.PayoutResult, error) {
+	completedAt := time.Now().UTC()
+	p.status.Status = offramp.StatusCompleted
+	p.status.CompletedAt = &completedAt
+	return p.status, nil
+}
+func (p *pendingOffRamp) Cancel(ctx context.Context, payoutID string) error { return nil }
+func (p *pendingOffRamp) SupportsCurrency(currency string) bool             { return currency == "USD" }
+func (p *pendingOffRamp) SupportsMethod(method string) bool                 { return method == "bank_transfer" }
+func (p *pendingOffRamp) IsHealthy(ctx context.Context) bool                { return true }
+
+func setupConversionDeps(t *testing.T, suite *state.TestSuite) *swapExecutor {
+	ctx := suite.Context()
+	app := suite.App()
+
+	swapQuote := dex.SwapQuote{
+		ID: "quote-int",
+		Route: dex.SwapRoute{
+			Hops: []dex.SwapHop{
+				{AmountOut: sdkmath.NewInt(900)},
+			},
+		},
+		ExpiresAt: ctx.BlockTime().Add(5 * time.Minute),
+	}
+	swapExec := &swapExecutor{
+		quote: swapQuote,
+		result: dex.SwapResult{
+			QuoteID:      swapQuote.ID,
+			TxHash:       "swap-int",
+			InputAmount:  sdkmath.NewInt(1000),
+			OutputAmount: sdkmath.NewInt(900),
+			ExecutedAt:   ctx.BlockTime(),
+		},
+	}
+
+	bridge := offramp.NewBridge()
+	require.NoError(t, bridge.RegisterAdapter(offramp.NewMockProvider("mock", []string{"USD"}, []string{"bank_transfer"})))
+
+	keeper := &app.Keepers.VirtEngine.Settlement
+	keeper.SetDexSwapExecutor(swapExec)
+	keeper.SetOffRampBridge(bridge)
+	keeper.SetComplianceKeeper(app.Keepers.VirtEngine.VEID)
+
+	params := keeper.GetParams(ctx)
+	params.FiatConversionEnabled = true
+	params.FiatConversionMinAmount = "1"
+	params.FiatConversionMaxAmount = "1000000000"
+	params.FiatConversionDailyLimit = "10000000000"
+	params.FiatConversionStableDenom = "uusdc"
+	params.FiatConversionStableSymbol = "USDC"
+	params.FiatConversionStableDecimals = 6
+	params.FiatConversionMaxSlippage = "0.05"
+	params.FiatConversionMinComplianceStatus = "CLEARED"
+	require.NoError(t, keeper.SetParams(ctx, params))
+
+	return swapExec
+}
+
+func seedComplianceRecord(t *testing.T, suite *state.TestSuite, provider sdk.AccAddress) {
+	ctx := suite.Context()
+	veid := suite.App().Keepers.VirtEngine.VEID
+	record := veidtypes.NewComplianceRecord(provider.String(), ctx.BlockTime())
+	record.Status = veidtypes.ComplianceStatusCleared
+	record.RiskScore = 5
+	record.ExpiresAt = ctx.BlockTime().Add(24 * time.Hour).Unix()
+	require.NoError(t, veid.SetComplianceRecord(ctx, record))
+}
+
+func fundAccount(t *testing.T, suite *state.TestSuite, addr sdk.AccAddress, coins sdk.Coins) {
+	ctx := suite.Context()
+	bank := suite.App().Keepers.Cosmos.Bank
+	require.NoError(t, bank.MintCoins(ctx, minttypes.ModuleName, coins))
+	require.NoError(t, bank.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, addr, coins))
+}
+
+func TestFiatConversionPipelineSuccess(t *testing.T) {
+	suite := state.SetupTestSuite(t)
+	ctx := suite.Context()
+	app := suite.App()
+	keeper := &app.Keepers.VirtEngine.Settlement
+
+	setupConversionDeps(t, suite)
+
+	depositor := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	provider := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+
+	seedComplianceRecord(t, suite, provider)
+	fundAccount(t, suite, depositor, sdk.NewCoins(sdk.NewCoin("uve", sdkmath.NewInt(100000))))
+
+	pref := types.FiatPayoutPreference{
+		Provider:          provider.String(),
+		Enabled:           true,
+		FiatCurrency:      "USD",
+		PaymentMethod:     "bank_transfer",
+		DestinationRef:    "acct-token",
+		SlippageTolerance: 0.01,
+		CryptoToken:       types.TokenSpec{Symbol: "UVE", Denom: "uve", Decimals: 6},
+		StableToken:       types.TokenSpec{Symbol: "USDC", Denom: "uusdc", Decimals: 6},
+		CreatedAt:         ctx.BlockTime(),
+		UpdatedAt:         ctx.BlockTime(),
+	}
+	require.NoError(t, keeper.SetFiatPayoutPreference(ctx, pref))
+
+	escrowID, err := keeper.CreateEscrow(ctx, "order-int-1", depositor, sdk.NewCoins(sdk.NewCoin("uve", sdkmath.NewInt(1000))), 24*time.Hour, nil)
+	require.NoError(t, err)
+	require.NoError(t, keeper.ActivateEscrow(ctx, escrowID, "lease-int-1", provider))
+
+	usage := &types.UsageRecord{
+		OrderID:           "order-int-1",
+		LeaseID:           "lease-int-1",
+		Provider:          provider.String(),
+		Customer:          depositor.String(),
+		UsageUnits:        1,
+		UsageType:         "compute",
+		TotalCost:         sdk.NewCoins(sdk.NewCoin("uve", sdkmath.NewInt(1000))),
+		PeriodStart:       ctx.BlockTime().Add(-time.Hour),
+		PeriodEnd:         ctx.BlockTime(),
+		SubmittedAt:       ctx.BlockTime(),
+		ProviderSignature: []byte("sig"),
+	}
+	require.NoError(t, keeper.RecordUsage(ctx, usage))
+
+	settlement, err := keeper.SettleOrder(ctx, "order-int-1", []string{usage.UsageID}, false)
+	require.NoError(t, err)
+
+	payout, found := keeper.GetPayoutBySettlement(ctx, settlement.SettlementID)
+	require.True(t, found)
+	require.Equal(t, types.PayoutStateCompleted, payout.State)
+
+	conversion, found := keeper.GetFiatConversionBySettlement(ctx, settlement.SettlementID)
+	require.True(t, found)
+	require.Equal(t, types.FiatConversionStateCompleted, conversion.State)
+	require.NotEmpty(t, conversion.OffRampID)
+}
+
+func TestFiatConversionReconciliation(t *testing.T) {
+	suite := state.SetupTestSuite(t)
+	ctx := suite.Context()
+	app := suite.App()
+	keeper := &app.Keepers.VirtEngine.Settlement
+
+	swapExec := setupConversionDeps(t, suite)
+
+	// Override bridge with pending adapter
+	bridge := offramp.NewBridge()
+	pending := &pendingOffRamp{}
+	require.NoError(t, bridge.RegisterAdapter(pending))
+	keeper.SetOffRampBridge(bridge)
+	keeper.SetDexSwapExecutor(swapExec)
+	keeper.SetComplianceKeeper(app.Keepers.VirtEngine.VEID)
+
+	depositor := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	provider := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+
+	seedComplianceRecord(t, suite, provider)
+	fundAccount(t, suite, depositor, sdk.NewCoins(sdk.NewCoin("uve", sdkmath.NewInt(100000))))
+
+	pref := types.FiatPayoutPreference{
+		Provider:          provider.String(),
+		Enabled:           true,
+		FiatCurrency:      "USD",
+		PaymentMethod:     "bank_transfer",
+		DestinationRef:    "acct-token",
+		SlippageTolerance: 0.01,
+		CryptoToken:       types.TokenSpec{Symbol: "UVE", Denom: "uve", Decimals: 6},
+		StableToken:       types.TokenSpec{Symbol: "USDC", Denom: "uusdc", Decimals: 6},
+		CreatedAt:         ctx.BlockTime(),
+		UpdatedAt:         ctx.BlockTime(),
+	}
+	require.NoError(t, keeper.SetFiatPayoutPreference(ctx, pref))
+
+	escrowID, err := keeper.CreateEscrow(ctx, "order-int-2", depositor, sdk.NewCoins(sdk.NewCoin("uve", sdkmath.NewInt(1000))), 24*time.Hour, nil)
+	require.NoError(t, err)
+	require.NoError(t, keeper.ActivateEscrow(ctx, escrowID, "lease-int-2", provider))
+
+	usage := &types.UsageRecord{
+		OrderID:           "order-int-2",
+		LeaseID:           "lease-int-2",
+		Provider:          provider.String(),
+		Customer:          depositor.String(),
+		UsageUnits:        1,
+		UsageType:         "compute",
+		TotalCost:         sdk.NewCoins(sdk.NewCoin("uve", sdkmath.NewInt(1000))),
+		PeriodStart:       ctx.BlockTime().Add(-time.Hour),
+		PeriodEnd:         ctx.BlockTime(),
+		SubmittedAt:       ctx.BlockTime(),
+		ProviderSignature: []byte("sig"),
+	}
+	require.NoError(t, keeper.RecordUsage(ctx, usage))
+
+	settlement, err := keeper.SettleOrder(ctx, "order-int-2", []string{usage.UsageID}, false)
+	require.NoError(t, err)
+
+	conversion, found := keeper.GetFiatConversionBySettlement(ctx, settlement.SettlementID)
+	require.True(t, found)
+	require.Equal(t, types.FiatConversionStateOffRampPending, conversion.State)
+
+	reconciled, err := keeper.ReconcileFiatConversion(ctx, conversion.ConversionID)
+	require.NoError(t, err)
+	require.Equal(t, types.FiatConversionStateCompleted, reconciled.State)
+
+	payout, found := keeper.GetPayoutBySettlement(ctx, settlement.SettlementID)
+	require.True(t, found)
+	require.Equal(t, types.PayoutStateCompleted, payout.State)
+	require.Equal(t, fmt.Sprintf("fiat-%s", conversion.ConversionID), payout.TxHash)
+}

--- a/x/settlement/client/cli/query.go
+++ b/x/settlement/client/cli/query.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+
+	"github.com/virtengine/virtengine/x/settlement/types"
+)
+
+// GetQueryCmd returns the root query command for settlement.
+func GetQueryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Settlement query subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		CmdFiatConversion(),
+		CmdFiatPayoutPreference(),
+	)
+
+	return cmd
+}
+
+// CmdFiatConversion queries a fiat conversion by ID.
+func CmdFiatConversion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fiat-conversion [conversion-id]",
+		Short: "Query a fiat conversion record",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			key := types.FiatConversionKey(args[0])
+			bz, _, err := clientCtx.QueryStore(key, types.StoreKey)
+			if err != nil {
+				return err
+			}
+			if len(bz) == 0 {
+				return fmt.Errorf("conversion %s not found", args[0])
+			}
+
+			var conversion types.FiatConversionRecord
+			if err := json.Unmarshal(bz, &conversion); err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(conversion, "", "  ")
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			return err
+		},
+	}
+	return cmd
+}
+
+// CmdFiatPayoutPreference queries fiat payout preference by provider.
+func CmdFiatPayoutPreference() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fiat-preference [provider]",
+		Short: "Query fiat payout preference for a provider",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			key := types.FiatPayoutPreferenceKey(args[0])
+			bz, _, err := clientCtx.QueryStore(key, types.StoreKey)
+			if err != nil {
+				return err
+			}
+			if len(bz) == 0 {
+				return fmt.Errorf("preference for %s not found", args[0])
+			}
+
+			var pref types.FiatPayoutPreference
+			if err := json.Unmarshal(bz, &pref); err != nil {
+				return err
+			}
+			out, err := json.MarshalIndent(pref, "", "  ")
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			return err
+		},
+	}
+	return cmd
+}

--- a/x/settlement/keeper/dex.go
+++ b/x/settlement/keeper/dex.go
@@ -1,0 +1,712 @@
+package keeper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/virtengine/virtengine/pkg/dex"
+	"github.com/virtengine/virtengine/pkg/payments/offramp"
+	"github.com/virtengine/virtengine/x/settlement/types"
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+// DexSwapExecutor is the subset of DEX swap executor used for conversions.
+type DexSwapExecutor interface {
+	GetQuote(ctx context.Context, request dex.SwapRequest) (dex.SwapQuote, error)
+	ExecuteSwap(ctx context.Context, quote dex.SwapQuote, signedTx []byte) (dex.SwapResult, error)
+}
+
+// OffRampBridge is the subset of offramp bridge used for conversions.
+type OffRampBridge interface {
+	GetQuote(ctx context.Context, req offramp.QuoteRequest) (offramp.Quote, error)
+	InitiatePayout(ctx context.Context, quote offramp.Quote, cryptoTxRef string, destination string, metadata map[string]string) (offramp.PayoutResult, error)
+	GetStatus(ctx context.Context, payoutID string) (offramp.PayoutResult, error)
+	Cancel(ctx context.Context, payoutID string) error
+}
+
+// ComplianceKeeper provides compliance records for conversion checks.
+type ComplianceKeeper interface {
+	GetComplianceRecord(ctx sdk.Context, address string) (*veidtypes.ComplianceRecord, bool)
+}
+
+const complianceStatusUnknown = "UNKNOWN"
+
+// ======================================================================
+// Sequence management
+// ======================================================================
+
+func (k Keeper) getNextFiatConversionSequence(ctx sdk.Context) uint64 {
+	return k.getNextSequence(ctx, types.FiatConversionSequenceKey())
+}
+
+func (k Keeper) incrementFiatConversionSequence(ctx sdk.Context) uint64 {
+	seq := k.getNextFiatConversionSequence(ctx)
+	k.setNextSequence(ctx, types.FiatConversionSequenceKey(), seq+1)
+	return seq
+}
+
+// SetNextFiatConversionSequence sets the next fiat conversion sequence.
+func (k Keeper) SetNextFiatConversionSequence(ctx sdk.Context, seq uint64) {
+	k.setNextSequence(ctx, types.FiatConversionSequenceKey(), seq)
+}
+
+// ======================================================================
+// Preference storage
+// ======================================================================
+
+// SetFiatPayoutPreference stores provider fiat payout preferences.
+func (k Keeper) SetFiatPayoutPreference(ctx sdk.Context, pref types.FiatPayoutPreference) error {
+	if err := pref.Validate(); err != nil {
+		return err
+	}
+
+	if pref.DestinationHash == "" && pref.DestinationRef != "" {
+		pref.DestinationHash = types.HashDestination(pref.DestinationRef)
+	}
+
+	store := ctx.KVStore(k.skey)
+	bz, err := json.Marshal(&pref)
+	if err != nil {
+		return err
+	}
+	store.Set(types.FiatPayoutPreferenceKey(pref.Provider), bz)
+	return nil
+}
+
+// GetFiatPayoutPreference retrieves provider fiat payout preferences.
+func (k Keeper) GetFiatPayoutPreference(ctx sdk.Context, provider string) (types.FiatPayoutPreference, bool) {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(types.FiatPayoutPreferenceKey(provider))
+	if bz == nil {
+		return types.FiatPayoutPreference{}, false
+	}
+
+	var pref types.FiatPayoutPreference
+	if err := json.Unmarshal(bz, &pref); err != nil {
+		return types.FiatPayoutPreference{}, false
+	}
+	return pref, true
+}
+
+// DeleteFiatPayoutPreference removes preferences for a provider.
+func (k Keeper) DeleteFiatPayoutPreference(ctx sdk.Context, provider string) error {
+	store := ctx.KVStore(k.skey)
+	store.Delete(types.FiatPayoutPreferenceKey(provider))
+	return nil
+}
+
+// WithFiatPayoutPreferences iterates over all preferences.
+func (k Keeper) WithFiatPayoutPreferences(ctx sdk.Context, fn func(types.FiatPayoutPreference) bool) {
+	store := ctx.KVStore(k.skey)
+	iter := storetypes.KVStorePrefixIterator(store, types.PrefixFiatPayoutPreference)
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		var pref types.FiatPayoutPreference
+		if err := json.Unmarshal(iter.Value(), &pref); err != nil {
+			continue
+		}
+		if fn(pref) {
+			break
+		}
+	}
+}
+
+// ======================================================================
+// Conversion storage
+// ======================================================================
+
+// SetFiatConversion saves a fiat conversion record.
+func (k Keeper) SetFiatConversion(ctx sdk.Context, conversion types.FiatConversionRecord) error {
+	if err := conversion.Validate(); err != nil {
+		return err
+	}
+
+	store := ctx.KVStore(k.skey)
+
+	existing, found := k.GetFiatConversion(ctx, conversion.ConversionID)
+	if found && existing.State != conversion.State {
+		k.updateFiatConversionState(ctx, conversion, existing.State)
+	}
+
+	if conversion.InvoiceID != "" {
+		store.Set(types.FiatConversionByInvoiceKey(conversion.InvoiceID), []byte(conversion.ConversionID))
+	}
+	if conversion.SettlementID != "" {
+		store.Set(types.FiatConversionBySettlementKey(conversion.SettlementID), []byte(conversion.ConversionID))
+	}
+	if conversion.PayoutID != "" {
+		store.Set(types.FiatConversionByPayoutKey(conversion.PayoutID), []byte(conversion.ConversionID))
+	}
+	store.Set(types.FiatConversionByProviderKey(conversion.Provider, conversion.ConversionID), []byte{})
+	store.Set(types.FiatConversionByStateKey(conversion.State, conversion.ConversionID), []byte{})
+
+	bz, err := json.Marshal(&conversion)
+	if err != nil {
+		return err
+	}
+	store.Set(types.FiatConversionKey(conversion.ConversionID), bz)
+	return nil
+}
+
+// GetFiatConversion retrieves a fiat conversion record.
+func (k Keeper) GetFiatConversion(ctx sdk.Context, conversionID string) (types.FiatConversionRecord, bool) {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(types.FiatConversionKey(conversionID))
+	if bz == nil {
+		return types.FiatConversionRecord{}, false
+	}
+	var conversion types.FiatConversionRecord
+	if err := json.Unmarshal(bz, &conversion); err != nil {
+		return types.FiatConversionRecord{}, false
+	}
+	return conversion, true
+}
+
+// GetFiatConversionByInvoice retrieves conversion by invoice.
+func (k Keeper) GetFiatConversionByInvoice(ctx sdk.Context, invoiceID string) (types.FiatConversionRecord, bool) {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(types.FiatConversionByInvoiceKey(invoiceID))
+	if bz == nil {
+		return types.FiatConversionRecord{}, false
+	}
+	return k.GetFiatConversion(ctx, string(bz))
+}
+
+// GetFiatConversionBySettlement retrieves conversion by settlement.
+func (k Keeper) GetFiatConversionBySettlement(ctx sdk.Context, settlementID string) (types.FiatConversionRecord, bool) {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(types.FiatConversionBySettlementKey(settlementID))
+	if bz == nil {
+		return types.FiatConversionRecord{}, false
+	}
+	return k.GetFiatConversion(ctx, string(bz))
+}
+
+// GetFiatConversionByPayout retrieves conversion by payout.
+func (k Keeper) GetFiatConversionByPayout(ctx sdk.Context, payoutID string) (types.FiatConversionRecord, bool) {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(types.FiatConversionByPayoutKey(payoutID))
+	if bz == nil {
+		return types.FiatConversionRecord{}, false
+	}
+	return k.GetFiatConversion(ctx, string(bz))
+}
+
+// WithFiatConversions iterates over conversions.
+func (k Keeper) WithFiatConversions(ctx sdk.Context, fn func(types.FiatConversionRecord) bool) {
+	store := ctx.KVStore(k.skey)
+	iter := storetypes.KVStorePrefixIterator(store, types.PrefixFiatConversion)
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		var conversion types.FiatConversionRecord
+		if err := json.Unmarshal(iter.Value(), &conversion); err != nil {
+			continue
+		}
+		if fn(conversion) {
+			break
+		}
+	}
+}
+
+// WithFiatConversionsByState iterates over conversions by state.
+func (k Keeper) WithFiatConversionsByState(ctx sdk.Context, state types.FiatConversionState, fn func(types.FiatConversionRecord) bool) {
+	store := ctx.KVStore(k.skey)
+	iter := storetypes.KVStorePrefixIterator(store, types.FiatConversionByStatePrefixKey(state))
+	defer iter.Close()
+
+	for ; iter.Valid(); iter.Next() {
+		key := iter.Key()
+		statePrefix := types.FiatConversionByStatePrefixKey(state)
+		if len(key) <= len(statePrefix) {
+			continue
+		}
+		conversionID := string(key[len(statePrefix):])
+		conversion, found := k.GetFiatConversion(ctx, conversionID)
+		if !found {
+			continue
+		}
+		if fn(conversion) {
+			break
+		}
+	}
+}
+
+func (k Keeper) updateFiatConversionState(ctx sdk.Context, conversion types.FiatConversionRecord, oldState types.FiatConversionState) {
+	store := ctx.KVStore(k.skey)
+	store.Delete(types.FiatConversionByStateKey(oldState, conversion.ConversionID))
+	store.Set(types.FiatConversionByStateKey(conversion.State, conversion.ConversionID), []byte{})
+}
+
+// ======================================================================
+// Conversion execution
+// ======================================================================
+
+// RequestFiatConversion creates a conversion record after compliance checks.
+func (k Keeper) RequestFiatConversion(ctx sdk.Context, request types.FiatConversionRequest) (*types.FiatConversionRecord, error) {
+	if err := request.Validate(); err != nil {
+		return nil, err
+	}
+
+	params := k.GetParams(ctx)
+	if !params.FiatConversionEnabled {
+		return nil, types.ErrFiatConversionNotAllowed.Wrap("fiat conversion disabled")
+	}
+
+	if request.InvoiceID != "" {
+		if existing, found := k.GetFiatConversionByInvoice(ctx, request.InvoiceID); found {
+			return &existing, nil
+		}
+	}
+	if request.SettlementID != "" {
+		if existing, found := k.GetFiatConversionBySettlement(ctx, request.SettlementID); found {
+			return &existing, nil
+		}
+	}
+	if request.PayoutID != "" {
+		if existing, found := k.GetFiatConversionByPayout(ctx, request.PayoutID); found {
+			return &existing, nil
+		}
+	}
+
+	if err := k.ensureFiatConversionDependencies(); err != nil {
+		return nil, err
+	}
+
+	complianceStatus, complianceRisk, err := k.validateFiatConversionCompliance(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	seq := k.incrementFiatConversionSequence(ctx)
+	conversionID := generateIDWithTimestamp("conv", seq, ctx.BlockTime().Unix())
+	conversion := types.NewFiatConversionRecord(conversionID, request, request.CryptoAmount, ctx.BlockTime())
+	conversion.ComplianceStatus = complianceStatus
+	conversion.ComplianceRiskScore = complianceRisk
+	conversion.ComplianceCheckedAt = ctx.BlockTime().Unix()
+	conversion.AddAuditEntry("conversion_requested", request.RequestedBy, "", map[string]string{
+		"invoice_id":    request.InvoiceID,
+		"settlement_id": request.SettlementID,
+	}, ctx.BlockTime())
+
+	if err := k.SetFiatConversion(ctx, *conversion); err != nil {
+		return nil, err
+	}
+
+	_ = ctx.EventManager().EmitTypedEvent(&types.EventFiatConversionRequested{
+		ConversionID:  conversionID,
+		InvoiceID:     request.InvoiceID,
+		SettlementID:  request.SettlementID,
+		Provider:      request.Provider,
+		FiatCurrency:  request.FiatCurrency,
+		PaymentMethod: request.PaymentMethod,
+		RequestedAt:   ctx.BlockTime().Unix(),
+	})
+
+	return conversion, nil
+}
+
+// ReconcileFiatConversion refreshes conversion status from the off-ramp.
+func (k Keeper) ReconcileFiatConversion(ctx sdk.Context, conversionID string) (*types.FiatConversionRecord, error) {
+	conversion, found := k.GetFiatConversion(ctx, conversionID)
+	if !found {
+		return nil, types.ErrFiatConversionNotFound.Wrapf("conversion %s not found", conversionID)
+	}
+
+	if conversion.OffRampID == "" || k.offRampBridge == nil {
+		return &conversion, nil
+	}
+
+	status, err := k.offRampBridge.GetStatus(ctx, conversion.OffRampID)
+	if err != nil {
+		return &conversion, err
+	}
+
+	conversion.OffRampStatus = string(status.Status)
+	conversion.OffRampReference = status.Reference
+	conversion.AddAuditEntry("offramp_reconciled", "system", "", map[string]string{
+		"status": string(status.Status),
+	}, ctx.BlockTime())
+
+	switch status.Status {
+	case offramp.StatusCompleted:
+		_ = conversion.MarkCompleted(ctx.BlockTime())
+	case offramp.StatusFailed:
+		_ = conversion.MarkFailed("off-ramp failed", ctx.BlockTime())
+	}
+
+	if err := k.SetFiatConversion(ctx, conversion); err != nil {
+		return nil, err
+	}
+
+	if conversion.PayoutID != "" {
+		payout, found := k.GetPayout(ctx, conversion.PayoutID)
+		if found {
+			if conversion.State == types.FiatConversionStateCompleted && payout.State != types.PayoutStateCompleted {
+				oldState := payout.State
+				_ = payout.MarkCompleted(fmt.Sprintf("fiat-%s", conversion.ConversionID), ctx.BlockTime())
+				k.updatePayoutState(ctx, payout, oldState)
+				_ = k.SetPayout(ctx, payout)
+			} else if conversion.State == types.FiatConversionStateFailed && payout.State != types.PayoutStateFailed {
+				oldState := payout.State
+				_ = payout.MarkFailed("fiat conversion failed", ctx.BlockTime())
+				k.updatePayoutState(ctx, payout, oldState)
+				_ = k.SetPayout(ctx, payout)
+			}
+		}
+	}
+
+	_ = ctx.EventManager().EmitTypedEvent(&types.EventFiatConversionReconciled{
+		ConversionID: conversion.ConversionID,
+		Provider:     conversion.Provider,
+		State:        string(conversion.State),
+		ReconciledAt: ctx.BlockTime().Unix(),
+	})
+
+	return &conversion, nil
+}
+
+// createConversionFromPreference builds a conversion request from preferences.
+func (k Keeper) createConversionFromPreference(ctx sdk.Context, settlement types.SettlementRecord, invoiceID string, pref types.FiatPayoutPreference) (*types.FiatConversionRecord, error) {
+	if !pref.Enabled {
+		return nil, nil
+	}
+
+	netAmount, err := k.calculateNetPayoutAmount(ctx, settlement)
+	if err != nil {
+		return nil, err
+	}
+	if netAmount.Denom != pref.CryptoToken.Denom {
+		return nil, types.ErrInvalidAmount.Wrap("payout denom does not match preference crypto token")
+	}
+
+	request := types.FiatConversionRequest{
+		InvoiceID:         invoiceID,
+		SettlementID:      settlement.SettlementID,
+		Provider:          settlement.Provider,
+		Customer:          settlement.Customer,
+		RequestedBy:       settlement.Provider,
+		CryptoAmount:      netAmount,
+		FiatCurrency:      pref.FiatCurrency,
+		PaymentMethod:     pref.PaymentMethod,
+		Destination:       pref.DestinationRef,
+		DestinationRegion: pref.DestinationRegion,
+		PreferredDEX:      pref.PreferredDEX,
+		PreferredOffRamp:  pref.PreferredOffRamp,
+		SlippageTolerance: pref.SlippageTolerance,
+		CryptoToken:       pref.CryptoToken,
+		StableToken:       pref.StableToken,
+	}
+
+	conversion, err := k.RequestFiatConversion(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	conversion.OrderID = settlement.OrderID
+	conversion.EscrowID = settlement.EscrowID
+	conversion.LeaseID = settlement.LeaseID
+	if err := k.SetFiatConversion(ctx, *conversion); err != nil {
+		return nil, err
+	}
+	return conversion, nil
+}
+
+func (k Keeper) ensureFiatConversionDependencies() error {
+	if k.dexSwap == nil {
+		return types.ErrDexUnavailable.Wrap("dex swap executor missing")
+	}
+	if k.offRampBridge == nil {
+		return types.ErrOffRampUnavailable.Wrap("off-ramp bridge missing")
+	}
+	return nil
+}
+
+func (k Keeper) validateFiatConversionCompliance(ctx sdk.Context, request types.FiatConversionRequest) (string, int32, error) {
+	if k.complianceKeeper == nil {
+		return complianceStatusUnknown, 0, types.ErrComplianceRequired.Wrap("compliance keeper not configured")
+	}
+
+	record, found := k.complianceKeeper.GetComplianceRecord(ctx, request.Provider)
+	if !found || record == nil {
+		return complianceStatusUnknown, 0, types.ErrComplianceRequired.Wrap("compliance record missing")
+	}
+
+	if record.IsExpired(ctx.BlockTime().Unix()) {
+		return record.Status.String(), record.RiskScore, types.ErrComplianceRequired.Wrap("compliance record expired")
+	}
+
+	params := k.GetParams(ctx)
+	if record.RiskScore > params.FiatConversionRiskScoreThreshold {
+		return record.Status.String(), record.RiskScore, types.ErrComplianceRequired.Wrap("risk score exceeds threshold")
+	}
+
+	if request.DestinationRegion != "" {
+		for _, region := range record.RestrictedRegions {
+			if region == request.DestinationRegion {
+				return record.Status.String(), record.RiskScore, types.ErrComplianceRequired.Wrap("destination region restricted")
+			}
+		}
+	}
+
+	minStatus := strings.ToUpper(params.FiatConversionMinComplianceStatus)
+	requiredStatus := veidtypes.ComplianceStatusCleared
+	switch minStatus {
+	case complianceStatusUnknown:
+		requiredStatus = veidtypes.ComplianceStatusUnknown
+	case "PENDING":
+		requiredStatus = veidtypes.ComplianceStatusPending
+	case "CLEARED":
+		requiredStatus = veidtypes.ComplianceStatusCleared
+	case "FLAGGED":
+		requiredStatus = veidtypes.ComplianceStatusFlagged
+	case "BLOCKED":
+		requiredStatus = veidtypes.ComplianceStatusBlocked
+	case "EXPIRED":
+		requiredStatus = veidtypes.ComplianceStatusExpired
+	}
+
+	if record.Status != requiredStatus {
+		return record.Status.String(), record.RiskScore, types.ErrComplianceRequired.Wrap("compliance status not sufficient")
+	}
+
+	return record.Status.String(), record.RiskScore, nil
+}
+
+func (k Keeper) calculateNetPayoutAmount(ctx sdk.Context, settlement types.SettlementRecord) (sdk.Coin, error) {
+	holdback := k.calculateHoldbackAmount(ctx, settlement.TotalAmount)
+	netAmount := settlement.ProviderShare.Sub(holdback...)
+	if len(netAmount) != 1 {
+		return sdk.Coin{}, types.ErrInvalidAmount.Wrap("net payout must be single denom for fiat conversion")
+	}
+	return netAmount[0], nil
+}
+
+func (k Keeper) validateConversionLimits(ctx sdk.Context, provider string, amount sdkmath.Int) error {
+	params := k.GetParams(ctx)
+
+	minAmount, _ := sdkmath.NewIntFromString(params.FiatConversionMinAmount)
+	maxAmount, _ := sdkmath.NewIntFromString(params.FiatConversionMaxAmount)
+	dailyLimit, _ := sdkmath.NewIntFromString(params.FiatConversionDailyLimit)
+
+	if minAmount.IsPositive() && amount.LT(minAmount) {
+		return types.ErrFiatLimitExceeded.Wrap("amount below minimum")
+	}
+	if maxAmount.IsPositive() && amount.GT(maxAmount) {
+		return types.ErrFiatLimitExceeded.Wrap("amount exceeds maximum")
+	}
+
+	if dailyLimit.IsPositive() {
+		day := ctx.BlockTime().UTC().Format("20060102")
+		total := k.getFiatDailyTotal(ctx, provider, day)
+		if total.Add(amount).GT(dailyLimit) {
+			return types.ErrFiatLimitExceeded.Wrap("daily limit exceeded")
+		}
+	}
+	return nil
+}
+
+func (k Keeper) getFiatDailyTotal(ctx sdk.Context, provider string, day string) sdkmath.Int {
+	store := ctx.KVStore(k.skey)
+	bz := store.Get(types.FiatDailyTotalKey(provider, day))
+	if bz == nil {
+		return sdkmath.ZeroInt()
+	}
+	total, ok := sdkmath.NewIntFromString(string(bz))
+	if !ok {
+		return sdkmath.ZeroInt()
+	}
+	return total
+}
+
+func (k Keeper) setFiatDailyTotal(ctx sdk.Context, provider string, day string, total sdkmath.Int) {
+	store := ctx.KVStore(k.skey)
+	store.Set(types.FiatDailyTotalKey(provider, day), []byte(total.String()))
+}
+
+func tokenSpecToDexToken(spec types.TokenSpec) dex.Token {
+	return dex.Token{
+		Symbol:   spec.Symbol,
+		Denom:    spec.Denom,
+		Decimals: spec.Decimals,
+		ChainID:  spec.ChainID,
+	}
+}
+
+func swapQuoteOutputAmount(quote dex.SwapQuote) (sdkmath.Int, error) {
+	if len(quote.Route.Hops) == 0 {
+		return sdkmath.ZeroInt(), fmt.Errorf("swap quote missing route")
+	}
+	lastHop := quote.Route.Hops[len(quote.Route.Hops)-1]
+	return lastHop.AmountOut, nil
+}
+
+func (k Keeper) executeFiatConversion(ctx sdk.Context, payout *types.PayoutRecord, conversion *types.FiatConversionRecord) error {
+	if err := k.ensureFiatConversionDependencies(); err != nil {
+		return err
+	}
+
+	oldState := payout.State
+	if err := payout.MarkProcessing(ctx.BlockTime()); err != nil {
+		return err
+	}
+	k.updatePayoutState(ctx, *payout, oldState)
+	if err := k.SetPayout(ctx, *payout); err != nil {
+		return err
+	}
+	k.savePayoutLedgerEntry(ctx, payout.PayoutID, types.PayoutLedgerEntryProcessing,
+		oldState, types.PayoutStateProcessing, sdk.NewCoins(), "fiat conversion processing", "system")
+
+	if err := conversion.MarkSwapping(ctx.BlockTime()); err != nil {
+		return err
+	}
+	conversion.AddAuditEntry("swap_requested", "system", "", nil, ctx.BlockTime())
+	if err := k.SetFiatConversion(ctx, *conversion); err != nil {
+		return err
+	}
+
+	params := k.GetParams(ctx)
+	slippage := conversion.SlippageTolerance
+	if slippage <= 0 {
+		slippage = 0.01
+	}
+	if params.FiatConversionMaxSlippage != "" {
+		if maxSlippage, err := sdkmath.LegacyNewDecFromStr(params.FiatConversionMaxSlippage); err == nil {
+			if slippageDec, err := sdkmath.LegacyNewDecFromStr(fmt.Sprintf("%f", slippage)); err == nil {
+				if slippageDec.GT(maxSlippage) {
+					slippage, _ = maxSlippage.Float64()
+				}
+			}
+		}
+	}
+
+	swapReq := dex.SwapRequest{
+		FromToken:         tokenSpecToDexToken(conversion.CryptoToken),
+		ToToken:           tokenSpecToDexToken(conversion.StableToken),
+		Amount:            conversion.CryptoAmount.Amount,
+		Type:              dex.SwapTypeExactIn,
+		SlippageTolerance: slippage,
+		Deadline:          ctx.BlockTime().Add(2 * time.Minute),
+		Sender:            payout.Provider,
+		PreferredDEX:      conversion.DexAdapter,
+	}
+
+	swapQuote, err := k.dexSwap.GetQuote(ctx, swapReq)
+	if err != nil {
+		return types.ErrFiatConversionFailed.Wrapf("swap quote failed: %s", err)
+	}
+	expectedOut, err := swapQuoteOutputAmount(swapQuote)
+	if err != nil {
+		return types.ErrFiatConversionFailed.Wrap(err.Error())
+	}
+	if err := k.validateConversionLimits(ctx, conversion.Provider, expectedOut); err != nil {
+		return err
+	}
+
+	swapResult, err := k.dexSwap.ExecuteSwap(ctx, swapQuote, []byte("settlement"))
+	if err != nil {
+		return types.ErrFiatConversionFailed.Wrapf("swap execution failed: %s", err)
+	}
+
+	conversion.SwapQuoteID = swapResult.QuoteID
+	conversion.SwapTxHash = swapResult.TxHash
+	conversion.SwapStatus = "executed"
+	conversion.StableAmount = sdk.NewCoin(conversion.StableToken.Denom, swapResult.OutputAmount)
+	conversion.AddAuditEntry("swap_executed", "system", "", map[string]string{
+		"tx_hash": swapResult.TxHash,
+	}, ctx.BlockTime())
+
+	if err := conversion.MarkOffRampPending(ctx.BlockTime()); err != nil {
+		return err
+	}
+	if err := k.SetFiatConversion(ctx, *conversion); err != nil {
+		return err
+	}
+
+	offQuote, err := k.offRampBridge.GetQuote(ctx, offramp.QuoteRequest{
+		CryptoSymbol:  conversion.StableToken.Symbol,
+		CryptoDenom:   conversion.StableToken.Denom,
+		CryptoAmount:  conversion.StableAmount.Amount,
+		FiatCurrency:  conversion.FiatCurrency,
+		PaymentMethod: conversion.PaymentMethod,
+		Sender:        payout.Provider,
+		Destination:   conversion.DestinationRef,
+	})
+	if err != nil {
+		return types.ErrFiatConversionFailed.Wrapf("off-ramp quote failed: %s", err)
+	}
+
+	offResult, err := k.offRampBridge.InitiatePayout(ctx, offQuote, swapResult.TxHash, conversion.DestinationRef, map[string]string{
+		"conversion_id": conversion.ConversionID,
+	})
+	if err != nil {
+		return types.ErrFiatConversionFailed.Wrapf("off-ramp initiation failed: %s", err)
+	}
+
+	conversion.OffRampProvider = offResult.Provider
+	conversion.OffRampQuoteID = offResult.QuoteID
+	conversion.OffRampID = offResult.ID
+	conversion.OffRampStatus = string(offResult.Status)
+	conversion.OffRampReference = offResult.Reference
+	conversion.FiatAmount = offResult.FiatAmount.String()
+	conversion.AddAuditEntry("offramp_initiated", "system", "", map[string]string{
+		"offramp_id": offResult.ID,
+	}, ctx.BlockTime())
+
+	switch offResult.Status {
+	case offramp.StatusCompleted:
+		_ = conversion.MarkCompleted(ctx.BlockTime())
+		_ = payout.MarkCompleted(fmt.Sprintf("fiat-%s", conversion.ConversionID), ctx.BlockTime())
+		k.updatePayoutState(ctx, *payout, types.PayoutStateProcessing)
+		if err := k.SetPayout(ctx, *payout); err != nil {
+			return err
+		}
+		k.savePayoutLedgerEntry(ctx, payout.PayoutID, types.PayoutLedgerEntryCompleted,
+			types.PayoutStateProcessing, types.PayoutStateCompleted, payout.NetAmount, "fiat conversion completed", "system")
+
+		k.recordTreasuryEntry(ctx, payout, types.TreasuryRecordPlatformFee, payout.PlatformFee)
+		k.recordTreasuryEntry(ctx, payout, types.TreasuryRecordValidatorFee, payout.ValidatorFee)
+		if !payout.HoldbackAmount.IsZero() {
+			k.recordTreasuryEntry(ctx, payout, types.TreasuryRecordHoldback, payout.HoldbackAmount)
+		}
+
+		day := ctx.BlockTime().UTC().Format("20060102")
+		total := k.getFiatDailyTotal(ctx, conversion.Provider, day)
+		k.setFiatDailyTotal(ctx, conversion.Provider, day, total.Add(offResult.CryptoAmount))
+		_ = ctx.EventManager().EmitTypedEvent(&types.EventFiatConversionCompleted{
+			ConversionID: conversion.ConversionID,
+			Provider:     conversion.Provider,
+			FiatCurrency: conversion.FiatCurrency,
+			FiatAmount:   conversion.FiatAmount,
+			CompletedAt:  ctx.BlockTime().Unix(),
+		})
+	case offramp.StatusFailed:
+		_ = conversion.MarkFailed("off-ramp failed", ctx.BlockTime())
+		_ = payout.MarkFailed("fiat conversion failed", ctx.BlockTime())
+		k.updatePayoutState(ctx, *payout, types.PayoutStateProcessing)
+		if err := k.SetPayout(ctx, *payout); err != nil {
+			return err
+		}
+		k.savePayoutLedgerEntry(ctx, payout.PayoutID, types.PayoutLedgerEntryFailed,
+			types.PayoutStateProcessing, types.PayoutStateFailed, sdk.NewCoins(), "fiat conversion failed", "system")
+		_ = ctx.EventManager().EmitTypedEvent(&types.EventFiatConversionFailed{
+			ConversionID: conversion.ConversionID,
+			Provider:     conversion.Provider,
+			Reason:       "off-ramp failed",
+			FailedAt:     ctx.BlockTime().Unix(),
+		})
+	}
+
+	if err := k.SetFiatConversion(ctx, *conversion); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x/settlement/keeper/dex_offramp_test.go
+++ b/x/settlement/keeper/dex_offramp_test.go
@@ -1,0 +1,214 @@
+package keeper_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/virtengine/virtengine/pkg/dex"
+	"github.com/virtengine/virtengine/pkg/payments/offramp"
+	"github.com/virtengine/virtengine/x/settlement/types"
+	veidtypes "github.com/virtengine/virtengine/x/veid/types"
+)
+
+type mockSwapExecutor struct {
+	quote    dex.SwapQuote
+	result   dex.SwapResult
+	quoteErr error
+	execErr  error
+}
+
+func (m *mockSwapExecutor) GetQuote(ctx context.Context, request dex.SwapRequest) (dex.SwapQuote, error) {
+	if m.quoteErr != nil {
+		return dex.SwapQuote{}, m.quoteErr
+	}
+	return m.quote, nil
+}
+
+func (m *mockSwapExecutor) ExecuteSwap(ctx context.Context, quote dex.SwapQuote, signedTx []byte) (dex.SwapResult, error) {
+	if m.execErr != nil {
+		return dex.SwapResult{}, m.execErr
+	}
+	return m.result, nil
+}
+
+type mockComplianceKeeper struct {
+	record *veidtypes.ComplianceRecord
+}
+
+func (m mockComplianceKeeper) GetComplianceRecord(ctx sdk.Context, address string) (*veidtypes.ComplianceRecord, bool) {
+	if m.record == nil {
+		return nil, false
+	}
+	return m.record, true
+}
+
+func (s *KeeperTestSuite) configureFiatConversion(t *testing.T, swapExec *mockSwapExecutor) {
+	params := s.keeper.GetParams(s.ctx)
+	params.FiatConversionEnabled = true
+	params.FiatConversionMinAmount = "1"
+	params.FiatConversionMaxAmount = "1000000000"
+	params.FiatConversionDailyLimit = "10000000000"
+	params.FiatConversionStableDenom = "uusdc"
+	params.FiatConversionStableSymbol = "USDC"
+	params.FiatConversionStableDecimals = 6
+	params.FiatConversionMaxSlippage = "0.05"
+	params.FiatConversionMinComplianceStatus = "CLEARED"
+	require.NoError(t, s.keeper.SetParams(s.ctx, params))
+
+	record := veidtypes.NewComplianceRecord(s.provider.String(), s.ctx.BlockTime())
+	record.Status = veidtypes.ComplianceStatusCleared
+	record.RiskScore = 5
+	record.ExpiresAt = s.ctx.BlockTime().Add(24 * time.Hour).Unix()
+
+	s.keeper.SetDexSwapExecutor(swapExec)
+
+	bridge := offramp.NewBridge()
+	require.NoError(t, bridge.RegisterAdapter(offramp.NewMockProvider("mock", []string{"USD"}, []string{"bank_transfer"})))
+	s.keeper.SetOffRampBridge(bridge)
+	s.keeper.SetComplianceKeeper(mockComplianceKeeper{record: record})
+}
+
+func (s *KeeperTestSuite) buildSettlement(t *testing.T, settlementID string) types.SettlementRecord {
+	amount := sdk.NewCoins(sdk.NewCoin("uve", sdkmath.NewInt(10000)))
+	escrowID, err := s.keeper.CreateEscrow(s.ctx, "order-"+settlementID, s.depositor, amount, 24*time.Hour, nil)
+	require.NoError(t, err)
+	require.NoError(t, s.keeper.ActivateEscrow(s.ctx, escrowID, "lease-"+settlementID, s.provider))
+
+	return *types.NewSettlementRecord(
+		settlementID,
+		escrowID,
+		"order-"+settlementID,
+		"lease-"+settlementID,
+		s.provider.String(),
+		s.depositor.String(),
+		sdk.NewCoins(sdk.NewCoin("uve", sdkmath.NewInt(1000))),
+		sdk.NewCoins(sdk.NewCoin("uve", sdkmath.NewInt(1000))),
+		sdk.NewCoins(),
+		sdk.NewCoins(),
+		nil,
+		0,
+		s.ctx.BlockTime().Add(-time.Hour),
+		s.ctx.BlockTime(),
+		types.SettlementTypeUsageBased,
+		false,
+		s.ctx.BlockTime(),
+		s.ctx.BlockHeight(),
+	)
+}
+
+func (s *KeeperTestSuite) TestFiatConversionPayoutSuccess() {
+	t := s.T()
+
+	swapQuote := dex.SwapQuote{
+		ID: "quote-1",
+		Route: dex.SwapRoute{
+			Hops: []dex.SwapHop{
+				{
+					AmountOut: sdkmath.NewInt(900),
+				},
+			},
+		},
+		ExpiresAt: s.ctx.BlockTime().Add(5 * time.Minute),
+	}
+
+	swapExec := &mockSwapExecutor{
+		quote: swapQuote,
+		result: dex.SwapResult{
+			QuoteID:      swapQuote.ID,
+			TxHash:       "swap-tx",
+			InputAmount:  sdkmath.NewInt(1000),
+			OutputAmount: sdkmath.NewInt(900),
+			ExecutedAt:   s.ctx.BlockTime(),
+		},
+	}
+
+	s.configureFiatConversion(t, swapExec)
+
+	settlement := s.buildSettlement(t, "settle-1")
+	require.NoError(t, s.keeper.SetSettlement(s.ctx, settlement))
+
+	request := types.FiatConversionRequest{
+		InvoiceID:         "inv-1",
+		SettlementID:      settlement.SettlementID,
+		Provider:          settlement.Provider,
+		Customer:          settlement.Customer,
+		RequestedBy:       settlement.Provider,
+		CryptoAmount:      sdk.NewCoin("uve", sdkmath.NewInt(1000)),
+		FiatCurrency:      "USD",
+		PaymentMethod:     "bank_transfer",
+		Destination:       "acct-token",
+		SlippageTolerance: 0.01,
+		CryptoToken:       types.TokenSpec{Symbol: "UVE", Denom: "uve", Decimals: 6},
+		StableToken:       types.TokenSpec{Symbol: "USDC", Denom: "uusdc", Decimals: 6},
+	}
+
+	_, err := s.keeper.RequestFiatConversion(s.ctx, request)
+	require.NoError(t, err)
+
+	payout, err := s.keeper.ExecutePayout(s.ctx, "inv-1", settlement.SettlementID)
+	require.NoError(t, err)
+	require.Equal(t, types.PayoutStateCompleted, payout.State)
+	require.NotEmpty(t, payout.FiatConversionID)
+
+	conversion, found := s.keeper.GetFiatConversionByPayout(s.ctx, payout.PayoutID)
+	require.True(t, found)
+	require.Equal(t, types.FiatConversionStateCompleted, conversion.State)
+	require.NotEmpty(t, conversion.OffRampID)
+	require.NotEmpty(t, conversion.SwapTxHash)
+}
+
+func (s *KeeperTestSuite) TestFiatConversionPayoutSwapFailure() {
+	t := s.T()
+
+	swapExec := &mockSwapExecutor{
+		quote: dex.SwapQuote{
+			ID: "quote-2",
+			Route: dex.SwapRoute{
+				Hops: []dex.SwapHop{
+					{
+						AmountOut: sdkmath.NewInt(900),
+					},
+				},
+			},
+			ExpiresAt: s.ctx.BlockTime().Add(5 * time.Minute),
+		},
+		execErr: errors.New("swap failed"),
+	}
+
+	s.configureFiatConversion(t, swapExec)
+
+	settlement := s.buildSettlement(t, "settle-2")
+	require.NoError(t, s.keeper.SetSettlement(s.ctx, settlement))
+
+	request := types.FiatConversionRequest{
+		InvoiceID:         "inv-2",
+		SettlementID:      settlement.SettlementID,
+		Provider:          settlement.Provider,
+		Customer:          settlement.Customer,
+		RequestedBy:       settlement.Provider,
+		CryptoAmount:      sdk.NewCoin("uve", sdkmath.NewInt(1000)),
+		FiatCurrency:      "USD",
+		PaymentMethod:     "bank_transfer",
+		Destination:       "acct-token",
+		SlippageTolerance: 0.01,
+		CryptoToken:       types.TokenSpec{Symbol: "UVE", Denom: "uve", Decimals: 6},
+		StableToken:       types.TokenSpec{Symbol: "USDC", Denom: "uusdc", Decimals: 6},
+	}
+
+	_, err := s.keeper.RequestFiatConversion(s.ctx, request)
+	require.NoError(t, err)
+
+	payout, err := s.keeper.ExecutePayout(s.ctx, "inv-2", settlement.SettlementID)
+	require.NoError(t, err)
+	require.Equal(t, types.PayoutStateFailed, payout.State)
+
+	conversion, found := s.keeper.GetFiatConversionByInvoice(s.ctx, "inv-2")
+	require.True(t, found)
+	require.Equal(t, types.FiatConversionStateFailed, conversion.State)
+}

--- a/x/settlement/keeper/grpc_query.go
+++ b/x/settlement/keeper/grpc_query.go
@@ -316,3 +316,55 @@ func (q GRPCQuerier) Params(ctx sdk.Context, req *types.QueryParamsRequest) (*ty
 		Params: params,
 	}, nil
 }
+
+// FiatConversion returns a fiat conversion by ID.
+func (q GRPCQuerier) FiatConversion(ctx sdk.Context, req *types.QueryFiatConversionRequest) (*types.QueryFiatConversionResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "empty request")
+	}
+	if req.ConversionID == "" {
+		return nil, status.Error(codes.InvalidArgument, "conversion_id cannot be empty")
+	}
+
+	conversion, found := q.GetFiatConversion(ctx, req.ConversionID)
+	if !found {
+		return &types.QueryFiatConversionResponse{Conversion: nil}, nil
+	}
+	return &types.QueryFiatConversionResponse{Conversion: &conversion}, nil
+}
+
+// FiatConversionsByProvider returns conversions for a provider.
+func (q GRPCQuerier) FiatConversionsByProvider(ctx sdk.Context, req *types.QueryFiatConversionsByProviderRequest) (*types.QueryFiatConversionsByProviderResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "empty request")
+	}
+	if req.Provider == "" {
+		return nil, status.Error(codes.InvalidArgument, "provider cannot be empty")
+	}
+
+	var conversions []types.FiatConversionRecord
+	q.WithFiatConversions(ctx, func(conversion types.FiatConversionRecord) bool {
+		if conversion.Provider == req.Provider {
+			conversions = append(conversions, conversion)
+		}
+		return false
+	})
+
+	return &types.QueryFiatConversionsByProviderResponse{Conversions: conversions}, nil
+}
+
+// FiatPayoutPreference returns payout preference for a provider.
+func (q GRPCQuerier) FiatPayoutPreference(ctx sdk.Context, req *types.QueryFiatPayoutPreferenceRequest) (*types.QueryFiatPayoutPreferenceResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "empty request")
+	}
+	if req.Provider == "" {
+		return nil, status.Error(codes.InvalidArgument, "provider cannot be empty")
+	}
+
+	pref, found := q.GetFiatPayoutPreference(ctx, req.Provider)
+	if !found {
+		return &types.QueryFiatPayoutPreferenceResponse{Preference: nil}, nil
+	}
+	return &types.QueryFiatPayoutPreferenceResponse{Preference: &pref}, nil
+}

--- a/x/settlement/keeper/settlement.go
+++ b/x/settlement/keeper/settlement.go
@@ -225,6 +225,12 @@ func (k Keeper) SettleOrder(ctx sdk.Context, orderID string, usageRecordIDs []st
 			return nil, err
 		}
 
+		if pref, ok := k.GetFiatPayoutPreference(ctx, settlement.Provider); ok && pref.Enabled {
+			if _, err := k.createConversionFromPreference(ctx, *settlement, invoiceID, pref); err != nil {
+				return nil, err
+			}
+		}
+
 		if _, err := k.ExecutePayout(ctx, invoiceID, settlement.SettlementID); err != nil {
 			return nil, err
 		}

--- a/x/settlement/module.go
+++ b/x/settlement/module.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 
 	settlementv1 "github.com/virtengine/virtengine/sdk/go/node/settlement/v1"
+	"github.com/virtengine/virtengine/x/settlement/client/cli"
 	"github.com/virtengine/virtengine/x/settlement/keeper"
 	"github.com/virtengine/virtengine/x/settlement/types"
 )
@@ -86,7 +87,7 @@ func (AppModuleBasic) GetTxCmd() *cobra.Command {
 
 // GetQueryCmd returns the root query command for the settlement module.
 func (AppModuleBasic) GetQueryCmd() *cobra.Command {
-	return nil // CLI commands to be implemented
+	return cli.GetQueryCmd()
 }
 
 // AppModule implements an application module for the settlement module.

--- a/x/settlement/types/codec.go
+++ b/x/settlement/types/codec.go
@@ -223,3 +223,33 @@ type QueryParamsRequest struct{}
 type QueryParamsResponse struct {
 	Params Params `json:"params"`
 }
+
+// QueryFiatConversionRequest is the request for querying a fiat conversion
+type QueryFiatConversionRequest struct {
+	ConversionID string `json:"conversion_id"`
+}
+
+// QueryFiatConversionResponse is the response for querying a fiat conversion
+type QueryFiatConversionResponse struct {
+	Conversion *FiatConversionRecord `json:"conversion"`
+}
+
+// QueryFiatConversionsByProviderRequest is the request for provider conversions
+type QueryFiatConversionsByProviderRequest struct {
+	Provider string `json:"provider"`
+}
+
+// QueryFiatConversionsByProviderResponse is the response for provider conversions
+type QueryFiatConversionsByProviderResponse struct {
+	Conversions []FiatConversionRecord `json:"conversions"`
+}
+
+// QueryFiatPayoutPreferenceRequest is the request for payout preference
+type QueryFiatPayoutPreferenceRequest struct {
+	Provider string `json:"provider"`
+}
+
+// QueryFiatPayoutPreferenceResponse is the response for payout preference
+type QueryFiatPayoutPreferenceResponse struct {
+	Preference *FiatPayoutPreference `json:"preference"`
+}

--- a/x/settlement/types/errors.go
+++ b/x/settlement/types/errors.go
@@ -120,4 +120,25 @@ var (
 
 	// ErrPayoutExecutionFailed is returned when payout execution fails
 	ErrPayoutExecutionFailed = errorsmod.Register(ModuleName, 1537, "payout execution failed")
+
+	// ErrFiatConversionNotFound is returned when conversion record is missing
+	ErrFiatConversionNotFound = errorsmod.Register(ModuleName, 1538, "fiat conversion not found")
+
+	// ErrFiatConversionNotAllowed is returned when conversion is not permitted
+	ErrFiatConversionNotAllowed = errorsmod.Register(ModuleName, 1539, "fiat conversion not allowed")
+
+	// ErrFiatConversionFailed is returned when conversion fails
+	ErrFiatConversionFailed = errorsmod.Register(ModuleName, 1540, "fiat conversion failed")
+
+	// ErrComplianceRequired is returned when compliance requirements are not met
+	ErrComplianceRequired = errorsmod.Register(ModuleName, 1541, "compliance requirements not met")
+
+	// ErrDexUnavailable is returned when DEX integration is missing
+	ErrDexUnavailable = errorsmod.Register(ModuleName, 1542, "dex integration unavailable")
+
+	// ErrOffRampUnavailable is returned when off-ramp integration is missing
+	ErrOffRampUnavailable = errorsmod.Register(ModuleName, 1543, "off-ramp integration unavailable")
+
+	// ErrFiatLimitExceeded is returned when conversion limits are exceeded
+	ErrFiatLimitExceeded = errorsmod.Register(ModuleName, 1544, "fiat conversion limit exceeded")
 )

--- a/x/settlement/types/events.go
+++ b/x/settlement/types/events.go
@@ -24,6 +24,12 @@ const (
 	EventTypeStakingRewardsDistributed      = "staking_rewards_distributed"
 	EventTypeProviderRewardsDistributed     = "provider_rewards_distributed"
 	EventTypeVerificationRewardsDistributed = "verification_rewards_distributed"
+
+	// Fiat conversion events
+	EventTypeFiatConversionRequested  = "fiat_conversion_requested"
+	EventTypeFiatConversionCompleted  = "fiat_conversion_completed"
+	EventTypeFiatConversionFailed     = "fiat_conversion_failed"
+	EventTypeFiatConversionReconciled = "fiat_conversion_reconciled"
 )
 
 // Event attribute keys
@@ -73,6 +79,12 @@ const (
 	AttributeKeySettlementType = "settlement_type"
 	AttributeKeyIsFinal        = "is_final"
 	AttributeKeyBlockHeight    = "block_height"
+
+	// Fiat conversion attributes
+	AttributeKeyConversionID  = "conversion_id"
+	AttributeKeyFiatCurrency  = "fiat_currency"
+	AttributeKeyFiatAmount    = "fiat_amount"
+	AttributeKeyPaymentMethod = "payment_method"
 )
 
 // EventEscrowCreated is emitted when an escrow is created
@@ -157,6 +169,42 @@ type EventUsageRecorded struct {
 	RecordedAt int64  `json:"recorded_at"`
 }
 
+// EventFiatConversionRequested is emitted when a fiat conversion is requested
+type EventFiatConversionRequested struct {
+	ConversionID  string `json:"conversion_id"`
+	InvoiceID     string `json:"invoice_id,omitempty"`
+	SettlementID  string `json:"settlement_id,omitempty"`
+	Provider      string `json:"provider"`
+	FiatCurrency  string `json:"fiat_currency"`
+	PaymentMethod string `json:"payment_method"`
+	RequestedAt   int64  `json:"requested_at"`
+}
+
+// EventFiatConversionCompleted is emitted when conversion completes
+type EventFiatConversionCompleted struct {
+	ConversionID string `json:"conversion_id"`
+	Provider     string `json:"provider"`
+	FiatCurrency string `json:"fiat_currency"`
+	FiatAmount   string `json:"fiat_amount"`
+	CompletedAt  int64  `json:"completed_at"`
+}
+
+// EventFiatConversionFailed is emitted when conversion fails
+type EventFiatConversionFailed struct {
+	ConversionID string `json:"conversion_id"`
+	Provider     string `json:"provider"`
+	Reason       string `json:"reason"`
+	FailedAt     int64  `json:"failed_at"`
+}
+
+// EventFiatConversionReconciled is emitted when conversion status is reconciled
+type EventFiatConversionReconciled struct {
+	ConversionID string `json:"conversion_id"`
+	Provider     string `json:"provider"`
+	State        string `json:"state"`
+	ReconciledAt int64  `json:"reconciled_at"`
+}
+
 // EventRewardsDistributed is emitted when rewards are distributed
 type EventRewardsDistributed struct {
 	DistributionID string `json:"distribution_id"`
@@ -176,28 +224,42 @@ type EventRewardsClaimed struct {
 }
 
 // ProtoMessage stubs for Event types
-func (*EventEscrowCreated) ProtoMessage()      {}
-func (*EventEscrowActivated) ProtoMessage()    {}
-func (*EventEscrowReleased) ProtoMessage()     {}
-func (*EventEscrowRefunded) ProtoMessage()     {}
-func (*EventEscrowDisputed) ProtoMessage()     {}
-func (*EventEscrowExpired) ProtoMessage()      {}
-func (*EventRewardsDistributed) ProtoMessage() {}
-func (*EventRewardsClaimed) ProtoMessage()     {}
-func (*EventOrderSettled) ProtoMessage()       {}
-func (*EventUsageRecorded) ProtoMessage()      {}
+func (*EventEscrowCreated) ProtoMessage()            {}
+func (*EventEscrowActivated) ProtoMessage()          {}
+func (*EventEscrowReleased) ProtoMessage()           {}
+func (*EventEscrowRefunded) ProtoMessage()           {}
+func (*EventEscrowDisputed) ProtoMessage()           {}
+func (*EventEscrowExpired) ProtoMessage()            {}
+func (*EventRewardsDistributed) ProtoMessage()       {}
+func (*EventRewardsClaimed) ProtoMessage()           {}
+func (*EventOrderSettled) ProtoMessage()             {}
+func (*EventUsageRecorded) ProtoMessage()            {}
+func (*EventFiatConversionRequested) ProtoMessage()  {}
+func (*EventFiatConversionCompleted) ProtoMessage()  {}
+func (*EventFiatConversionFailed) ProtoMessage()     {}
+func (*EventFiatConversionReconciled) ProtoMessage() {}
 
 // Reset stubs for Event types
-func (e *EventEscrowCreated) Reset()      { *e = EventEscrowCreated{} }
-func (e *EventEscrowActivated) Reset()    { *e = EventEscrowActivated{} }
-func (e *EventEscrowReleased) Reset()     { *e = EventEscrowReleased{} }
-func (e *EventEscrowRefunded) Reset()     { *e = EventEscrowRefunded{} }
-func (e *EventEscrowDisputed) Reset()     { *e = EventEscrowDisputed{} }
-func (e *EventEscrowExpired) Reset()      { *e = EventEscrowExpired{} }
-func (e *EventRewardsDistributed) Reset() { *e = EventRewardsDistributed{} }
-func (e *EventRewardsClaimed) Reset()     { *e = EventRewardsClaimed{} }
-func (e *EventOrderSettled) Reset()       { *e = EventOrderSettled{} }
-func (e *EventUsageRecorded) Reset()      { *e = EventUsageRecorded{} }
+func (e *EventEscrowCreated) Reset()            { *e = EventEscrowCreated{} }
+func (e *EventEscrowActivated) Reset()          { *e = EventEscrowActivated{} }
+func (e *EventEscrowReleased) Reset()           { *e = EventEscrowReleased{} }
+func (e *EventEscrowRefunded) Reset()           { *e = EventEscrowRefunded{} }
+func (e *EventEscrowDisputed) Reset()           { *e = EventEscrowDisputed{} }
+func (e *EventEscrowExpired) Reset()            { *e = EventEscrowExpired{} }
+func (e *EventRewardsDistributed) Reset()       { *e = EventRewardsDistributed{} }
+func (e *EventRewardsClaimed) Reset()           { *e = EventRewardsClaimed{} }
+func (e *EventOrderSettled) Reset()             { *e = EventOrderSettled{} }
+func (e *EventUsageRecorded) Reset()            { *e = EventUsageRecorded{} }
+func (e *EventFiatConversionRequested) Reset()  { *e = EventFiatConversionRequested{} }
+func (e *EventFiatConversionCompleted) Reset()  { *e = EventFiatConversionCompleted{} }
+func (e *EventFiatConversionFailed) Reset()     { *e = EventFiatConversionFailed{} }
+func (e *EventFiatConversionReconciled) Reset() { *e = EventFiatConversionReconciled{} }
+
+// String stubs for Fiat Conversion Event types
+func (e *EventFiatConversionRequested) String() string  { return fmt.Sprintf("%+v", *e) }
+func (e *EventFiatConversionCompleted) String() string  { return fmt.Sprintf("%+v", *e) }
+func (e *EventFiatConversionFailed) String() string     { return fmt.Sprintf("%+v", *e) }
+func (e *EventFiatConversionReconciled) String() string { return fmt.Sprintf("%+v", *e) }
 
 // String stubs for Event types
 func (e *EventEscrowCreated) String() string      { return fmt.Sprintf("%+v", *e) }

--- a/x/settlement/types/fiat_conversion.go
+++ b/x/settlement/types/fiat_conversion.go
@@ -1,0 +1,318 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// FiatConversionState represents the state of a fiat conversion.
+type FiatConversionState string
+
+const (
+	FiatConversionStateRequested      FiatConversionState = "requested"
+	FiatConversionStateSwapping       FiatConversionState = "swapping"
+	FiatConversionStateOffRampPending FiatConversionState = "off_ramp_pending"
+	FiatConversionStateCompleted      FiatConversionState = "completed"
+	FiatConversionStateFailed         FiatConversionState = "failed"
+	FiatConversionStateCancelled      FiatConversionState = "cancelled"
+)
+
+// IsValid returns true when the state is recognized.
+func (s FiatConversionState) IsValid() bool {
+	switch s {
+	case FiatConversionStateRequested, FiatConversionStateSwapping, FiatConversionStateOffRampPending,
+		FiatConversionStateCompleted, FiatConversionStateFailed, FiatConversionStateCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// TokenSpec captures token metadata for swaps.
+type TokenSpec struct {
+	Symbol   string `json:"symbol"`
+	Denom    string `json:"denom"`
+	Decimals uint8  `json:"decimals"`
+	ChainID  string `json:"chain_id,omitempty"`
+}
+
+// Validate validates the token spec.
+func (t TokenSpec) Validate() error {
+	if t.Symbol == "" || t.Denom == "" {
+		return ErrInvalidParams.Wrap("token spec requires symbol and denom")
+	}
+	return nil
+}
+
+// FiatPayoutPreference configures provider fiat conversion preferences.
+type FiatPayoutPreference struct {
+	Provider          string    `json:"provider"`
+	Enabled           bool      `json:"enabled"`
+	FiatCurrency      string    `json:"fiat_currency"`
+	PaymentMethod     string    `json:"payment_method"`
+	DestinationRef    string    `json:"destination_ref,omitempty"`
+	DestinationHash   string    `json:"destination_hash"`
+	DestinationRegion string    `json:"destination_region,omitempty"`
+	PreferredDEX      string    `json:"preferred_dex,omitempty"`
+	PreferredOffRamp  string    `json:"preferred_off_ramp,omitempty"`
+	SlippageTolerance float64   `json:"slippage_tolerance"`
+	CryptoToken       TokenSpec `json:"crypto_token"`
+	StableToken       TokenSpec `json:"stable_token"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}
+
+// FiatConversionRequest captures a conversion request.
+type FiatConversionRequest struct {
+	InvoiceID         string    `json:"invoice_id,omitempty"`
+	SettlementID      string    `json:"settlement_id,omitempty"`
+	PayoutID          string    `json:"payout_id,omitempty"`
+	Provider          string    `json:"provider"`
+	Customer          string    `json:"customer"`
+	RequestedBy       string    `json:"requested_by"`
+	CryptoAmount      sdk.Coin  `json:"crypto_amount"`
+	FiatCurrency      string    `json:"fiat_currency"`
+	PaymentMethod     string    `json:"payment_method"`
+	Destination       string    `json:"destination"`
+	DestinationRegion string    `json:"destination_region,omitempty"`
+	PreferredDEX      string    `json:"preferred_dex,omitempty"`
+	PreferredOffRamp  string    `json:"preferred_off_ramp,omitempty"`
+	SlippageTolerance float64   `json:"slippage_tolerance"`
+	CryptoToken       TokenSpec `json:"crypto_token"`
+	StableToken       TokenSpec `json:"stable_token"`
+}
+
+// FiatConversionAuditEntry is an audit log entry for conversions.
+type FiatConversionAuditEntry struct {
+	Action    string            `json:"action"`
+	Actor     string            `json:"actor"`
+	Reason    string            `json:"reason,omitempty"`
+	Timestamp int64             `json:"timestamp"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// FiatConversionRecord stores conversion details.
+type FiatConversionRecord struct {
+	ConversionID        string                     `json:"conversion_id"`
+	InvoiceID           string                     `json:"invoice_id,omitempty"`
+	SettlementID        string                     `json:"settlement_id,omitempty"`
+	PayoutID            string                     `json:"payout_id,omitempty"`
+	EscrowID            string                     `json:"escrow_id,omitempty"`
+	OrderID             string                     `json:"order_id,omitempty"`
+	LeaseID             string                     `json:"lease_id,omitempty"`
+	Provider            string                     `json:"provider"`
+	Customer            string                     `json:"customer"`
+	RequestedBy         string                     `json:"requested_by"`
+	RequestedAt         time.Time                  `json:"requested_at"`
+	UpdatedAt           time.Time                  `json:"updated_at"`
+	State               FiatConversionState        `json:"state"`
+	CryptoToken         TokenSpec                  `json:"crypto_token"`
+	StableToken         TokenSpec                  `json:"stable_token"`
+	CryptoAmount        sdk.Coin                   `json:"crypto_amount"`
+	StableAmount        sdk.Coin                   `json:"stable_amount"`
+	FiatCurrency        string                     `json:"fiat_currency"`
+	FiatAmount          string                     `json:"fiat_amount"`
+	PaymentMethod       string                     `json:"payment_method"`
+	DestinationRef      string                     `json:"destination_ref,omitempty"`
+	DestinationHash     string                     `json:"destination_hash"`
+	DestinationRegion   string                     `json:"destination_region,omitempty"`
+	SlippageTolerance   float64                    `json:"slippage_tolerance"`
+	DexAdapter          string                     `json:"dex_adapter,omitempty"`
+	SwapQuoteID         string                     `json:"swap_quote_id,omitempty"`
+	SwapTxHash          string                     `json:"swap_tx_hash,omitempty"`
+	SwapStatus          string                     `json:"swap_status,omitempty"`
+	OffRampProvider     string                     `json:"off_ramp_provider,omitempty"`
+	OffRampQuoteID      string                     `json:"off_ramp_quote_id,omitempty"`
+	OffRampID           string                     `json:"off_ramp_id,omitempty"`
+	OffRampStatus       string                     `json:"off_ramp_status,omitempty"`
+	OffRampReference    string                     `json:"off_ramp_reference,omitempty"`
+	ComplianceStatus    string                     `json:"compliance_status,omitempty"`
+	ComplianceRiskScore int32                      `json:"compliance_risk_score,omitempty"`
+	ComplianceCheckedAt int64                      `json:"compliance_checked_at,omitempty"`
+	FailureReason       string                     `json:"failure_reason,omitempty"`
+	AuditTrail          []FiatConversionAuditEntry `json:"audit_trail,omitempty"`
+}
+
+// Validate validates the conversion record.
+func (r *FiatConversionRecord) Validate() error {
+	if r.ConversionID == "" {
+		return ErrInvalidSettlement.Wrap("conversion_id cannot be empty")
+	}
+	if _, err := sdk.AccAddressFromBech32(r.Provider); err != nil {
+		return ErrInvalidAddress.Wrap("invalid provider address")
+	}
+	if _, err := sdk.AccAddressFromBech32(r.Customer); err != nil {
+		return ErrInvalidAddress.Wrap("invalid customer address")
+	}
+	if !r.State.IsValid() {
+		return ErrInvalidSettlement.Wrapf("invalid conversion state: %s", r.State)
+	}
+	if !r.CryptoAmount.IsValid() || !r.CryptoAmount.IsPositive() {
+		return ErrInvalidAmount.Wrap("crypto_amount must be positive")
+	}
+	if r.CryptoAmount.Denom != "" && r.CryptoToken.Denom != "" && r.CryptoAmount.Denom != r.CryptoToken.Denom {
+		return ErrInvalidAmount.Wrap("crypto_amount denom must match crypto_token")
+	}
+	if r.FiatCurrency == "" {
+		return ErrInvalidParams.Wrap("fiat_currency required")
+	}
+	if r.SlippageTolerance < 0 || r.SlippageTolerance > 1 {
+		return ErrInvalidParams.Wrap("slippage_tolerance must be between 0 and 1")
+	}
+	if err := r.CryptoToken.Validate(); err != nil {
+		return err
+	}
+	if err := r.StableToken.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// HashDestination hashes a destination string to avoid storing raw PII.
+func HashDestination(destination string) string {
+	if destination == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(destination))
+	return hex.EncodeToString(sum[:])
+}
+
+// NewFiatConversionRecord builds a conversion record from a request.
+func NewFiatConversionRecord(id string, request FiatConversionRequest, payout sdk.Coin, now time.Time) *FiatConversionRecord {
+	return &FiatConversionRecord{
+		ConversionID:      id,
+		InvoiceID:         request.InvoiceID,
+		SettlementID:      request.SettlementID,
+		PayoutID:          request.PayoutID,
+		Provider:          request.Provider,
+		Customer:          request.Customer,
+		RequestedBy:       request.RequestedBy,
+		RequestedAt:       now,
+		UpdatedAt:         now,
+		State:             FiatConversionStateRequested,
+		CryptoToken:       request.CryptoToken,
+		StableToken:       request.StableToken,
+		CryptoAmount:      payout,
+		StableAmount:      sdk.NewCoin(request.StableToken.Denom, sdkmath.ZeroInt()),
+		FiatCurrency:      request.FiatCurrency,
+		PaymentMethod:     request.PaymentMethod,
+		DestinationRef:    request.Destination,
+		DestinationHash:   HashDestination(request.Destination),
+		DestinationRegion: request.DestinationRegion,
+		SlippageTolerance: request.SlippageTolerance,
+		DexAdapter:        request.PreferredDEX,
+		OffRampProvider:   request.PreferredOffRamp,
+		AuditTrail:        []FiatConversionAuditEntry{},
+	}
+}
+
+// AddAuditEntry appends an audit entry.
+func (r *FiatConversionRecord) AddAuditEntry(action, actor, reason string, metadata map[string]string, ts time.Time) {
+	r.AuditTrail = append(r.AuditTrail, FiatConversionAuditEntry{
+		Action:    action,
+		Actor:     actor,
+		Reason:    reason,
+		Timestamp: ts.Unix(),
+		Metadata:  metadata,
+	})
+	r.UpdatedAt = ts
+}
+
+// MarkSwapping transitions to swapping state.
+func (r *FiatConversionRecord) MarkSwapping(ts time.Time) error {
+	if !r.State.IsValid() {
+		return ErrInvalidSettlement.Wrap("invalid conversion state")
+	}
+	r.State = FiatConversionStateSwapping
+	r.UpdatedAt = ts
+	return nil
+}
+
+// MarkOffRampPending transitions to off-ramp pending.
+func (r *FiatConversionRecord) MarkOffRampPending(ts time.Time) error {
+	r.State = FiatConversionStateOffRampPending
+	r.UpdatedAt = ts
+	return nil
+}
+
+// MarkCompleted transitions to completed.
+func (r *FiatConversionRecord) MarkCompleted(ts time.Time) error {
+	r.State = FiatConversionStateCompleted
+	r.UpdatedAt = ts
+	return nil
+}
+
+// MarkFailed transitions to failed.
+func (r *FiatConversionRecord) MarkFailed(reason string, ts time.Time) error {
+	r.State = FiatConversionStateFailed
+	r.FailureReason = reason
+	r.UpdatedAt = ts
+	return nil
+}
+
+// ValidatePreference validates payout preference.
+func (p *FiatPayoutPreference) Validate() error {
+	if _, err := sdk.AccAddressFromBech32(p.Provider); err != nil {
+		return ErrInvalidAddress.Wrap("invalid provider address")
+	}
+	if p.Enabled {
+		if p.FiatCurrency == "" || p.PaymentMethod == "" {
+			return ErrInvalidParams.Wrap("fiat_currency and payment_method required")
+		}
+		if p.DestinationRef == "" {
+			return ErrInvalidParams.Wrap("destination_ref required")
+		}
+		if err := p.CryptoToken.Validate(); err != nil {
+			return err
+		}
+		if err := p.StableToken.Validate(); err != nil {
+			return err
+		}
+		if p.SlippageTolerance < 0 || p.SlippageTolerance > 1 {
+			return ErrInvalidParams.Wrap("slippage_tolerance must be between 0 and 1")
+		}
+	}
+	return nil
+}
+
+// ValidateRequest validates a conversion request.
+func (r *FiatConversionRequest) Validate() error {
+	if _, err := sdk.AccAddressFromBech32(r.Provider); err != nil {
+		return ErrInvalidAddress.Wrap("invalid provider address")
+	}
+	if _, err := sdk.AccAddressFromBech32(r.Customer); err != nil {
+		return ErrInvalidAddress.Wrap("invalid customer address")
+	}
+	if r.FiatCurrency == "" || r.PaymentMethod == "" {
+		return ErrInvalidParams.Wrap("fiat_currency and payment_method required")
+	}
+	if r.Destination == "" {
+		return ErrInvalidParams.Wrap("destination required")
+	}
+	if !r.CryptoAmount.IsValid() || !r.CryptoAmount.IsPositive() {
+		return ErrInvalidAmount.Wrap("crypto_amount must be positive")
+	}
+	if r.CryptoAmount.Denom != "" && r.CryptoToken.Denom != "" && r.CryptoAmount.Denom != r.CryptoToken.Denom {
+		return ErrInvalidAmount.Wrap("crypto_amount denom must match crypto_token")
+	}
+	if err := r.CryptoToken.Validate(); err != nil {
+		return err
+	}
+	if err := r.StableToken.Validate(); err != nil {
+		return err
+	}
+	if r.SlippageTolerance < 0 || r.SlippageTolerance > 1 {
+		return ErrInvalidParams.Wrap("slippage_tolerance must be between 0 and 1")
+	}
+	return nil
+}
+
+// FormatComplianceSnapshot formats compliance summary.
+func FormatComplianceSnapshot(status string, riskScore int32) string {
+	return fmt.Sprintf("%s/%d", status, riskScore)
+}

--- a/x/settlement/types/keys.go
+++ b/x/settlement/types/keys.go
@@ -81,6 +81,41 @@ var (
 	// PrefixClaimableRewards is the prefix for claimable rewards by address
 	// Key: PrefixClaimableRewards | address -> ClaimableRewards
 	PrefixClaimableRewards = []byte{0x11}
+
+	// PrefixFiatConversion is the prefix for fiat conversion storage
+	// Key: PrefixFiatConversion | conversion_id -> FiatConversionRecord
+	PrefixFiatConversion = []byte{0x12}
+
+	// PrefixFiatConversionByInvoice is the prefix for conversion lookup by invoice
+	// Key: PrefixFiatConversionByInvoice | invoice_id -> conversion_id
+	PrefixFiatConversionByInvoice = []byte{0x13}
+
+	// PrefixFiatConversionBySettlement is the prefix for conversion lookup by settlement
+	// Key: PrefixFiatConversionBySettlement | settlement_id -> conversion_id
+	PrefixFiatConversionBySettlement = []byte{0x14}
+
+	// PrefixFiatConversionByPayout is the prefix for conversion lookup by payout
+	// Key: PrefixFiatConversionByPayout | payout_id -> conversion_id
+	PrefixFiatConversionByPayout = []byte{0x15}
+
+	// PrefixFiatConversionByProvider is the prefix for conversion lookup by provider
+	// Key: PrefixFiatConversionByProvider | provider | conversion_id -> nil
+	PrefixFiatConversionByProvider = []byte{0x16}
+
+	// PrefixFiatConversionByState is the prefix for conversion lookup by state
+	// Key: PrefixFiatConversionByState | state | conversion_id -> nil
+	PrefixFiatConversionByState = []byte{0x17}
+
+	// PrefixFiatConversionSequence is the prefix for conversion sequence counter
+	PrefixFiatConversionSequence = []byte{0x18}
+
+	// PrefixFiatPayoutPreference stores provider fiat payout preferences
+	// Key: PrefixFiatPayoutPreference | provider -> FiatPayoutPreference
+	PrefixFiatPayoutPreference = []byte{0x19}
+
+	// PrefixFiatDailyTotals stores daily fiat conversion totals
+	// Key: PrefixFiatDailyTotals | provider | yyyymmdd -> sdkmath.Int (bytes)
+	PrefixFiatDailyTotals = []byte{0x1A}
 )
 
 // ParamsKey returns the store key for module parameters
@@ -194,6 +229,101 @@ func ClaimableRewardsKey(address []byte) []byte {
 	key := make([]byte, 0, len(PrefixClaimableRewards)+len(address))
 	key = append(key, PrefixClaimableRewards...)
 	key = append(key, address...)
+	return key
+}
+
+// FiatConversionKey returns the store key for a fiat conversion record
+func FiatConversionKey(conversionID string) []byte {
+	key := make([]byte, 0, len(PrefixFiatConversion)+len(conversionID))
+	key = append(key, PrefixFiatConversion...)
+	key = append(key, []byte(conversionID)...)
+	return key
+}
+
+// FiatConversionByInvoiceKey returns the store key for conversion lookup by invoice
+func FiatConversionByInvoiceKey(invoiceID string) []byte {
+	key := make([]byte, 0, len(PrefixFiatConversionByInvoice)+len(invoiceID))
+	key = append(key, PrefixFiatConversionByInvoice...)
+	key = append(key, []byte(invoiceID)...)
+	return key
+}
+
+// FiatConversionBySettlementKey returns the store key for conversion lookup by settlement
+func FiatConversionBySettlementKey(settlementID string) []byte {
+	key := make([]byte, 0, len(PrefixFiatConversionBySettlement)+len(settlementID))
+	key = append(key, PrefixFiatConversionBySettlement...)
+	key = append(key, []byte(settlementID)...)
+	return key
+}
+
+// FiatConversionByPayoutKey returns the store key for conversion lookup by payout
+func FiatConversionByPayoutKey(payoutID string) []byte {
+	key := make([]byte, 0, len(PrefixFiatConversionByPayout)+len(payoutID))
+	key = append(key, PrefixFiatConversionByPayout...)
+	key = append(key, []byte(payoutID)...)
+	return key
+}
+
+// FiatConversionByProviderKey returns the store key for conversion lookup by provider
+func FiatConversionByProviderKey(provider string, conversionID string) []byte {
+	key := make([]byte, 0, len(PrefixFiatConversionByProvider)+len(provider)+1+len(conversionID))
+	key = append(key, PrefixFiatConversionByProvider...)
+	key = append(key, []byte(provider)...)
+	key = append(key, byte('/'))
+	key = append(key, []byte(conversionID)...)
+	return key
+}
+
+// FiatConversionByProviderPrefixKey returns the prefix for conversion lookup by provider
+func FiatConversionByProviderPrefixKey(provider string) []byte {
+	key := make([]byte, 0, len(PrefixFiatConversionByProvider)+len(provider)+1)
+	key = append(key, PrefixFiatConversionByProvider...)
+	key = append(key, []byte(provider)...)
+	key = append(key, byte('/'))
+	return key
+}
+
+// FiatConversionByStateKey returns the store key for conversion lookup by state
+func FiatConversionByStateKey(state FiatConversionState, conversionID string) []byte {
+	stateBytes := []byte(state)
+	key := make([]byte, 0, len(PrefixFiatConversionByState)+len(stateBytes)+1+len(conversionID))
+	key = append(key, PrefixFiatConversionByState...)
+	key = append(key, stateBytes...)
+	key = append(key, byte('/'))
+	key = append(key, []byte(conversionID)...)
+	return key
+}
+
+// FiatConversionByStatePrefixKey returns the prefix for conversion lookup by state
+func FiatConversionByStatePrefixKey(state FiatConversionState) []byte {
+	stateBytes := []byte(state)
+	key := make([]byte, 0, len(PrefixFiatConversionByState)+len(stateBytes)+1)
+	key = append(key, PrefixFiatConversionByState...)
+	key = append(key, stateBytes...)
+	key = append(key, byte('/'))
+	return key
+}
+
+// FiatConversionSequenceKey returns the store key for conversion sequence
+func FiatConversionSequenceKey() []byte {
+	return PrefixFiatConversionSequence
+}
+
+// FiatPayoutPreferenceKey returns the store key for provider payout preferences
+func FiatPayoutPreferenceKey(provider string) []byte {
+	key := make([]byte, 0, len(PrefixFiatPayoutPreference)+len(provider))
+	key = append(key, PrefixFiatPayoutPreference...)
+	key = append(key, []byte(provider)...)
+	return key
+}
+
+// FiatDailyTotalKey returns the store key for daily totals
+func FiatDailyTotalKey(provider string, day string) []byte {
+	key := make([]byte, 0, len(PrefixFiatDailyTotals)+len(provider)+1+len(day))
+	key = append(key, PrefixFiatDailyTotals...)
+	key = append(key, []byte(provider)...)
+	key = append(key, byte('/'))
+	key = append(key, []byte(day)...)
 	return key
 }
 

--- a/x/settlement/types/payout.go
+++ b/x/settlement/types/payout.go
@@ -66,6 +66,9 @@ type PayoutRecord struct {
 	// PayoutID is the unique identifier for this payout
 	PayoutID string `json:"payout_id"`
 
+	// FiatConversionID links to fiat conversion (optional)
+	FiatConversionID string `json:"fiat_conversion_id,omitempty"`
+
 	// InvoiceID is the linked invoice
 	InvoiceID string `json:"invoice_id"`
 


### PR DESCRIPTION
## Summary
- add fiat conversion records, preferences, and compliance gating in settlement keeper
- integrate DEX swap + off-ramp bridge into payout execution with audit trail
- add off-ramp adapter package + mock provider and CLI queries for conversion status
- add unit and integration tests for swap/off-ramp success + reconciliation

## Testing
- go test ./x/settlement/... ./pkg/payments/offramp/...
- go test -tags=e2e.integration ./tests/integration/settlement (fails in this repo due to pre-existing compile errors in invoice_test.go/usage_pipeline_test.go)
- go build ./...