### PR TITLE
fix(app): harden TLS and HTTP client defaults

### DIFF
--- a/cmd/hpc-node-agent/agent.go
+++ b/cmd/hpc-node-agent/agent.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // AgentConfig contains configuration for the node agent
@@ -56,10 +58,8 @@ func NewAgent(config AgentConfig) *Agent {
 	agent := &Agent{
 		config:           config,
 		metricsCollector: NewMetricsCollector(),
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		stopCh: make(chan struct{}),
+		httpClient:       security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
+		stopCh:           make(chan struct{}),
 	}
 	agent.messageHandler = NewMessageHandler(agent)
 	return agent

--- a/cmd/provider-daemon/main.go
+++ b/cmd/provider-daemon/main.go
@@ -28,10 +28,11 @@ import (
 	rolesv1 "github.com/virtengine/virtengine/sdk/go/node/roles/v1"
 	veidv1 "github.com/virtengine/virtengine/sdk/go/node/veid/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/virtengine/virtengine/pkg/observability"
 	provider_daemon "github.com/virtengine/virtengine/pkg/provider_daemon"
+	"github.com/virtengine/virtengine/pkg/security"
 	"github.com/virtengine/virtengine/pkg/servicedesk"
 	"github.com/virtengine/virtengine/pkg/waldur"
 )
@@ -955,7 +956,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if grpcEndpoint := viper.GetString(FlagWaldurChainGRPC); grpcEndpoint != "" {
 		conn, err := grpc.NewClient(
 			grpcEndpoint,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithTransportCredentials(credentials.NewTLS(security.SecureTLSConfig())),
 			grpc.WithStatsHandler(observability.GRPCClientStatsHandler()),
 		)
 		if err != nil {

--- a/cmd/virtengine/cmd/access/lifecycle.go
+++ b/cmd/virtengine/cmd/access/lifecycle.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 type lifecycleRequest struct {
@@ -178,7 +179,7 @@ func doHMACRequest(reqURL, principal, secret string, body []byte) (*http.Respons
 	req.Header.Set("X-VE-Timestamp", timestamp)
 	req.Header.Set("X-VE-Signature", signature)
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second))
 	return client.Do(req)
 }
 

--- a/pkg/dex/osmosis_adapter.go
+++ b/pkg/dex/osmosis_adapter.go
@@ -18,7 +18,7 @@ import (
 	sdkmath "cosmossdk.io/math"
 	"github.com/virtengine/virtengine/pkg/security"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 // ============================================================================
@@ -243,9 +243,8 @@ func (a *RealOsmosisAdapter) Connect(ctx context.Context) error {
 	endpoint := a.config.GetGRPCEndpoint()
 
 	// Create gRPC connection
-	// Note: In production, use proper TLS credentials
 	conn, err := grpc.NewClient(endpoint,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(credentials.NewTLS(security.SecureTLSConfig())),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to connect to Osmosis gRPC: %w", err)

--- a/pkg/enclave_runtime/crypto_sev.go
+++ b/pkg/enclave_runtime/crypto_sev.go
@@ -44,6 +44,8 @@ import (
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // =============================================================================
@@ -437,10 +439,8 @@ type VCEKCertificateFetcher struct {
 // NewVCEKCertificateFetcher creates a new VCEK certificate fetcher.
 func NewVCEKCertificateFetcher() *VCEKCertificateFetcher {
 	return &VCEKCertificateFetcher{
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		cache: NewCertificateCache(1000, 7*24*time.Hour), // Cache for 7 days
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
+		cache:      NewCertificateCache(1000, 7*24*time.Hour), // Cache for 7 days
 	}
 }
 

--- a/pkg/enclave_runtime/sev_production.go
+++ b/pkg/enclave_runtime/sev_production.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // =============================================================================
@@ -108,9 +110,7 @@ func NewProductionSEVBackend(config SEVProductionConfig) *ProductionSEVBackend {
 		config:     config,
 		kdsBaseURL: config.KDSBaseURL,
 		kdsTimeout: config.KDSTimeout,
-		httpClient: &http.Client{
-			Timeout: config.KDSTimeout,
-		},
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(config.KDSTimeout)),
 	}
 }
 

--- a/pkg/inference/tensorflow_runtime.go
+++ b/pkg/inference/tensorflow_runtime.go
@@ -33,6 +33,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ============================================================================
@@ -236,9 +238,7 @@ func (r *TensorFlowRuntime) Initialize() error {
 	if timeout == 0 {
 		timeout = 10 * time.Second
 	}
-	r.httpClient = &http.Client{
-		Timeout: timeout,
-	}
+	r.httpClient = security.NewSecureHTTPClient(security.WithTimeout(timeout))
 
 	// Verify sidecar is healthy
 	if err := r.checkSidecarHealth(); err != nil {

--- a/pkg/observability/tracing_http.go
+++ b/pkg/observability/tracing_http.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // HTTPTracingHandler wraps an HTTP handler with OpenTelemetry instrumentation.
@@ -19,7 +21,7 @@ func HTTPTracingHandler(handler http.Handler, name string) http.Handler {
 
 // TracedHTTPClient returns an HTTP client instrumented with OpenTelemetry.
 func TracedHTTPClient() *http.Client {
-	return &http.Client{
-		Transport: otelhttp.NewTransport(http.DefaultTransport),
-	}
+	client := security.NewSecureHTTPClient()
+	client.Transport = otelhttp.NewTransport(client.Transport)
+	return client
 }

--- a/pkg/ood_adapter/auth.go
+++ b/pkg/ood_adapter/auth.go
@@ -15,6 +15,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // Error messages
@@ -44,9 +46,7 @@ func NewVEIDAuthClient(issuer, clientID, clientSecret string) *VEIDAuthClient {
 		issuer:       issuer,
 		clientID:     clientID,
 		clientSecret: clientSecret,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		httpClient:   security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
 	}
 }
 

--- a/pkg/ood_adapter/oauth2.go
+++ b/pkg/ood_adapter/oauth2.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // OAuth2Config contains OAuth2/OIDC configuration.
@@ -85,10 +87,8 @@ type ManagedToken struct {
 // NewOAuth2TokenManager creates a new OAuth2 token manager.
 func NewOAuth2TokenManager(config *OAuth2Config) *OAuth2TokenManager {
 	return &OAuth2TokenManager{
-		config: config,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		config:     config,
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
 		tokens:     make(map[string]*ManagedToken),
 		refreshing: make(map[string]bool),
 		stopCh:     make(chan struct{}),

--- a/pkg/payment/adapters.go
+++ b/pkg/payment/adapters.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // environmentLive is the Adyen live environment identifier
@@ -67,7 +69,7 @@ func NewStripeStubAdapter(config StripeConfig) (Gateway, error) {
 
 	return &stripeStubAdapter{
 		config:     config,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
 		baseURL:    baseURL,
 	}, nil
 }
@@ -409,7 +411,7 @@ func NewAdyenStubAdapter(config AdyenConfig) (Gateway, error) {
 
 	return &adyenStubAdapter{
 		config:     config,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
 		baseURL:    baseURL,
 	}, nil
 }

--- a/pkg/payment/offramp/ach_adapter.go
+++ b/pkg/payment/offramp/ach_adapter.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ============================================================================
@@ -42,11 +44,9 @@ func NewACHAdapter(config ACHConfig) (*ACHAdapter, error) {
 	}
 
 	return &ACHAdapter{
-		config: config,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
-		baseURL: baseURL,
+		config:     config,
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
+		baseURL:    baseURL,
 	}, nil
 }
 
@@ -503,7 +503,7 @@ type DirectACHAdapter struct {
 func NewDirectACHAdapter(config ACHConfig) (*DirectACHAdapter, error) {
 	return &DirectACHAdapter{
 		config:     config,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
 	}, nil
 }
 

--- a/pkg/payment/offramp/paypal_adapter.go
+++ b/pkg/payment/offramp/paypal_adapter.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ============================================================================
@@ -41,10 +43,8 @@ func NewPayPalAdapter(config PayPalConfig) (*PayPalAdapter, error) {
 	}
 
 	return &PayPalAdapter{
-		config: config,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		config:     config,
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
 	}, nil
 }
 

--- a/pkg/pricefeed/coingecko.go
+++ b/pkg/pricefeed/coingecko.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ============================================================================
@@ -83,11 +85,9 @@ func NewCoinGeckoProvider(name string, cfg CoinGeckoConfig, retryCfg RetryConfig
 	}
 
 	provider := &CoinGeckoProvider{
-		name:   name,
-		config: cfg,
-		client: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		name:        name,
+		config:      cfg,
+		client:      security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
 		rateLimiter: newRateLimiter(cfg.RateLimitPerMinute),
 		health: SourceHealth{
 			Source:    name,

--- a/pkg/pricefeed/pyth.go
+++ b/pkg/pricefeed/pyth.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ============================================================================
@@ -39,9 +41,7 @@ func NewPythProvider(name string, cfg PythConfig, retryCfg RetryConfig) (*PythPr
 	provider := &PythProvider{
 		name:   name,
 		config: cfg,
-		client: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		client: security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second)),
 		health: SourceHealth{
 			Source:    name,
 			Type:      SourceTypePyth,

--- a/pkg/provider_daemon/chain_callback_sink.go
+++ b/pkg/provider_daemon/chain_callback_sink.go
@@ -11,13 +11,14 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
+	"github.com/virtengine/virtengine/pkg/security"
 	"github.com/virtengine/virtengine/sdk/go/node/client/types"
 	clientv1beta3 "github.com/virtengine/virtengine/sdk/go/node/client/v1beta3"
 	"github.com/virtengine/virtengine/sdk/go/sdkutil"
@@ -106,7 +107,11 @@ func NewChainCallbackSink(ctx context.Context, cfg ChainCallbackSinkConfig) (*Ch
 	defer cancel()
 
 	//nolint:staticcheck // grpc.DialContext kept for compatibility with existing connection flow.
-	grpcConn, err := grpc.DialContext(dialCtx, cfg.GRPCEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	grpcConn, err := grpc.DialContext(
+		dialCtx,
+		cfg.GRPCEndpoint,
+		grpc.WithTransportCredentials(credentials.NewTLS(security.SecureTLSConfig())),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("dial grpc: %w", err)
 	}

--- a/pkg/provider_daemon/chain_client.go
+++ b/pkg/provider_daemon/chain_client.go
@@ -8,11 +8,12 @@ import (
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/virtengine/virtengine/pkg/observability"
+	"github.com/virtengine/virtengine/pkg/security"
 	hpcv1 "github.com/virtengine/virtengine/sdk/go/node/hpc/v1"
 	resourcesv1 "github.com/virtengine/virtengine/sdk/go/node/resources/v1"
 	hpctypes "github.com/virtengine/virtengine/x/hpc/types"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 const (
@@ -49,7 +50,7 @@ func newRPCChainClient(config RPCChainClientConfig) (*rpcChainClient, error) {
 	if config.GRPCEndpoint != "" {
 		conn, err := grpc.NewClient(
 			config.GRPCEndpoint,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithTransportCredentials(credentials.NewTLS(security.SecureTLSConfig())),
 			grpc.WithStatsHandler(observability.GRPCClientStatsHandler()),
 		)
 		if err != nil {

--- a/pkg/provider_daemon/support.go
+++ b/pkg/provider_daemon/support.go
@@ -8,8 +8,9 @@ import (
 
 	"cosmossdk.io/log"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 
+	"github.com/virtengine/virtengine/pkg/security"
 	"github.com/virtengine/virtengine/pkg/servicedesk"
 )
 
@@ -107,7 +108,10 @@ func NewSupportService(cfg SupportServiceConfig, keyManager *KeyManager, logger 
 
 	var grpcConn *grpc.ClientConn
 	if cfg.GRPCEndpoint != "" {
-		conn, err := grpc.NewClient(cfg.GRPCEndpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.NewClient(
+			cfg.GRPCEndpoint,
+			grpc.WithTransportCredentials(credentials.NewTLS(security.SecureTLSConfig())),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("connect support grpc: %w", err)
 		}

--- a/pkg/security/httpclient.go
+++ b/pkg/security/httpclient.go
@@ -157,9 +157,14 @@ func NewSecureHTTPClient(opts ...HTTPClientOption) *http.Client {
 
 // NewHTTPClientFromConfig creates an HTTP client from a configuration struct.
 func NewHTTPClientFromConfig(config HTTPClientConfig) *http.Client {
+	minTLSVersion := config.MinTLSVersion
+	if minTLSVersion < tls.VersionTLS12 {
+		minTLSVersion = tls.VersionTLS12
+	}
+
 	// Create TLS config with secure defaults
 	tlsConfig := &tls.Config{
-		MinVersion:         config.MinTLSVersion,
+		MinVersion:         minTLSVersion,
 		InsecureSkipVerify: config.InsecureSkipVerify, //nolint:gosec // G402: Configurable for dev/test
 	}
 

--- a/pkg/security/httpclient_test.go
+++ b/pkg/security/httpclient_test.go
@@ -64,6 +64,21 @@ func TestNewSecureHTTPClientWithOptions(t *testing.T) {
 	}
 }
 
+func TestHTTPClientMinTLSVersionClamp(t *testing.T) {
+	config := DefaultHTTPClientConfig()
+	config.MinTLSVersion = tls.VersionTLS10
+
+	client := NewHTTPClientFromConfig(config)
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+
+	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("expected MinTLSVersion TLS 1.2, got %v", transport.TLSClientConfig.MinVersion)
+	}
+}
+
 func TestNewSecureHTTPClientTLS13(t *testing.T) {
 	client := NewSecureHTTPClientTLS13()
 

--- a/pkg/verification/oidc/jwks.go
+++ b/pkg/verification/oidc/jwks.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ============================================================================
@@ -102,12 +103,10 @@ func NewJWKSManager(config *JWKSManagerConfig, logger zerolog.Logger) *JWKSManag
 	}
 
 	return &JWKSManager{
-		httpClient: &http.Client{
-			Timeout: config.HTTPTimeout,
-		},
-		logger: logger.With().Str("component", "jwks_manager").Logger(),
-		caches: make(map[string]*jwksCache),
-		config: config,
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(config.HTTPTimeout)),
+		logger:     logger.With().Str("component", "jwks_manager").Logger(),
+		caches:     make(map[string]*jwksCache),
+		config:     config,
 	}
 }
 

--- a/pkg/verification/oidc/verifier.go
+++ b/pkg/verification/oidc/verifier.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/virtengine/virtengine/pkg/security"
 
 	"github.com/virtengine/virtengine/pkg/verification/audit"
 	veidtypes "github.com/virtengine/virtengine/x/veid/types"
@@ -74,7 +75,7 @@ func NewDefaultVerifier(
 	v := &DefaultVerifier{
 		config:         config,
 		jwksManager:    NewJWKSManager(jwksConfig, logger),
-		httpClient:     &http.Client{Timeout: time.Duration(config.HTTPClientTimeoutSeconds) * time.Second},
+		httpClient:     security.NewSecureHTTPClient(security.WithTimeout(time.Duration(config.HTTPClientTimeoutSeconds) * time.Second)),
 		auditor:        auditor,
 		logger:         logger.With().Str("component", "oidc_verifier").Logger(),
 		discoveryCache: make(map[string]*OIDCDiscoveryDocument),

--- a/pkg/verification/sms/gateway.go
+++ b/pkg/verification/sms/gateway.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/virtengine/virtengine/pkg/errors"
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ============================================================================
@@ -107,11 +108,9 @@ func NewTwilioGateway(config ProviderConfig, logger zerolog.Logger) (*TwilioGate
 	}
 
 	gateway := &TwilioGateway{
-		config: config,
-		logger: logger.With().Str("provider", "twilio").Logger(),
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
+		config:           config,
+		logger:           logger.With().Str("provider", "twilio").Logger(),
+		httpClient:       security.NewSecureHTTPClient(security.WithTimeout(timeout)),
 		lastRequestReset: time.Now(),
 		rateLimit:        100, // Default 100 req/sec
 		rateLimitBurst:   150,
@@ -608,11 +607,9 @@ func NewVonageGateway(config ProviderConfig, logger zerolog.Logger) (*VonageGate
 	}
 
 	return &VonageGateway{
-		config: config,
-		logger: logger.With().Str("provider", "vonage").Logger(),
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
+		config:           config,
+		logger:           logger.With().Str("provider", "vonage").Logger(),
+		httpClient:       security.NewSecureHTTPClient(security.WithTimeout(timeout)),
 		lastRequestReset: time.Now(),
 		rateLimit:        30, // Default 30 req/sec
 		rateLimitBurst:   50,

--- a/pkg/verification/sms/voip_detector.go
+++ b/pkg/verification/sms/voip_detector.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/virtengine/virtengine/pkg/errors"
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ============================================================================
@@ -629,12 +630,10 @@ func NewNumVerifyDetector(apiKey string, logger zerolog.Logger) (*NumVerifyDetec
 	}
 
 	return &NumVerifyDetector{
-		apiKey: apiKey,
-		httpClient: &http.Client{
-			Timeout: 15 * time.Second,
-		},
-		logger: logger.With().Str("component", "numverify_detector").Logger(),
-		cache:  newVoIPCache(24 * time.Hour),
+		apiKey:     apiKey,
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(15 * time.Second)),
+		logger:     logger.With().Str("component", "numverify_detector").Logger(),
+		cache:      newVoIPCache(24 * time.Hour),
 	}, nil
 }
 

--- a/pkg/waldur/client.go
+++ b/pkg/waldur/client.go
@@ -16,6 +16,8 @@ import (
 
 	client "github.com/waldur/go-client"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // Waldur-specific errors
@@ -195,10 +197,8 @@ func NewClient(cfg Config) (*Client, error) {
 	}
 
 	// Create HTTP client with timeout
-	httpClient := &http.Client{
-		Timeout:   cfg.Timeout,
-		Transport: otelhttp.NewTransport(http.DefaultTransport),
-	}
+	httpClient := security.NewSecureHTTPClient(security.WithTimeout(cfg.Timeout))
+	httpClient.Transport = otelhttp.NewTransport(httpClient.Transport)
 
 	// Create Waldur API client
 	api, err := client.NewClientWithResponses(

--- a/sdk/go/cli/genesis_init.go
+++ b/sdk/go/cli/genesis_init.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/virtengine/virtengine/pkg/security"
+
 	cmtcfg "github.com/cometbft/cometbft/config"
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 	cmtypes "github.com/cometbft/cometbft/types"
@@ -217,9 +219,7 @@ func downloadGenesis(config *cmtcfg.Config, chainID string) error {
 	genFilePath := config.GenesisFile()
 
 	// Create a new HTTP client with a 30-second timeout
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
+	client := security.NewSecureHTTPClient(security.WithTimeout(30 * time.Second))
 
 	// Create a new GET request
 	req, err := http.NewRequest("GET", genesisURL, nil)

--- a/sdk/go/node/client/http.go
+++ b/sdk/go/node/client/http.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 func makeHTTPDialer(remoteAddr string) (func(context.Context, string, string) (net.Conn, error), error) {
@@ -58,6 +60,7 @@ func NewHTTPClient(ctx context.Context, remoteAddr string) (*http.Client, error)
 			// Set to true to prevent GZIP-bomb DoS attacks
 			DisableCompression: true,
 			DialContext:        dialFn,
+			TLSClientConfig:    security.SecureTLSConfig(),
 
 			// Force HTTP/1.1 to ensure better connection pooling behavior
 			// Some RPC nodes may not handle HTTP/2 connection pooling optimally

--- a/x/mfa/types/revocation.go
+++ b/x/mfa/types/revocation.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ocsp"
+
+	"github.com/virtengine/virtengine/pkg/security"
 )
 
 // ============================================================================
@@ -106,11 +108,9 @@ type OCSPCacheEntry struct {
 // NewRevocationChecker creates a new revocation checker
 func NewRevocationChecker(timeout time.Duration) *RevocationChecker {
 	return &RevocationChecker{
-		httpClient: &http.Client{
-			Timeout: timeout,
-		},
-		crlCache:  make(map[string]*CRLCacheEntry),
-		ocspCache: make(map[string]*OCSPCacheEntry),
+		httpClient: security.NewSecureHTTPClient(security.WithTimeout(timeout)),
+		crlCache:   make(map[string]*CRLCacheEntry),
+		ocspCache:  make(map[string]*OCSPCacheEntry),
 	}
 }
 


### PR DESCRIPTION
## Summary
- adopt secure HTTP client defaults across packages and tracing/http utilities
- enforce TLS minimums in client configs and tighten gRPC dial credentials
- add TLS version clamp test for secure HTTP client configuration

## Testing
- go test ./pkg/security/... -count=1
- go test ./pkg/pricefeed/... -count=1
- go test ./pkg/govdata/... -count=1
- go vet ./pkg/... ./cmd/... ./sdk/... ./util/... ./x/...
- golangci-lint run --new-from-rev=HEAD~1
- go build ./cmd/...