### PR TITLE
feat(cli): add fraud/review/benchmark cli and invariants

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -210,6 +210,10 @@ func NewApp(
 	modules := appModules(app, encodingConfig)
 
 	app.MM = module.NewManager(modules...)
+	if app.Keepers.Cosmos.Crisis != nil {
+		//nolint:staticcheck // required for crisis invariant registration in this build
+		app.MM.RegisterInvariants(app.Keepers.Cosmos.Crisis)
+	}
 
 	// During begin block slashing happens after distr.BeginBlocker so that
 	// there is nothing left over in the validator fee pool, to keep the

--- a/sdk/go/node/audit/v1/gateway_stub.go
+++ b/sdk/go/node/audit/v1/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/bme/v1/gateway_stub.go
+++ b/sdk/go/node/bme/v1/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/cert/v1/gateway_stub.go
+++ b/sdk/go/node/cert/v1/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/delegation/v1/gateway_stub.go
+++ b/sdk/go/node/delegation/v1/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/deployment/v1beta4/gateway_stub.go
+++ b/sdk/go/node/deployment/v1beta4/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1beta4
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/escrow/v1/gateway_stub.go
+++ b/sdk/go/node/escrow/v1/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/market/v1beta5/gateway_stub.go
+++ b/sdk/go/node/market/v1beta5/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1beta5
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/oracle/v1/gateway_stub.go
+++ b/sdk/go/node/oracle/v1/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/provider/v1beta4/gateway_stub.go
+++ b/sdk/go/node/provider/v1beta4/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1beta4
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/resources/v1/gateway_stub.go
+++ b/sdk/go/node/resources/v1/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/settlement/v1/gateway_stub.go
+++ b/sdk/go/node/settlement/v1/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/sdk/go/node/take/v1/gateway_stub.go
+++ b/sdk/go/node/take/v1/gateway_stub.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+// RegisterQueryHandlerClient registers gRPC gateway routes.
+// NOTE: Gateway handlers are not generated in this build, so this is a no-op.
+func RegisterQueryHandlerClient(_ context.Context, _ *runtime.ServeMux, _ QueryClient) error {
+	return nil
+}

--- a/x/benchmark/client/cli/flags.go
+++ b/x/benchmark/client/cli/flags.go
@@ -1,0 +1,15 @@
+package cli
+
+const (
+	flagProvider      = "provider"
+	flagBenchmarkType = "benchmark-type"
+	flagResults       = "results"
+	flagResultsFile   = "results-file"
+	flagResult        = "result"
+	flagResultFile    = "result-file"
+	flagSignature     = "signature"
+	flagReason        = "reason"
+	flagEvidence      = "evidence"
+	flagResolution    = "resolution"
+	flagIsValid       = "is-valid"
+)

--- a/x/benchmark/client/cli/query.go
+++ b/x/benchmark/client/cli/query.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/version"
+
+	benchmarkv1 "github.com/virtengine/virtengine/sdk/go/node/benchmark/v1"
+	"github.com/virtengine/virtengine/x/benchmark/types"
+)
+
+// GetQueryCmd returns the root query command for benchmark.
+func GetQueryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Benchmark query subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		CmdBenchmark(),
+		CmdBenchmarksByProvider(),
+		CmdParams(),
+	)
+
+	return cmd
+}
+
+// CmdBenchmark queries a benchmark report by ID.
+func CmdBenchmark() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "benchmark [report-id]",
+		Short: "Query a benchmark report by ID",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := benchmarkv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.Benchmark(cmd.Context(), &benchmarkv1.QueryBenchmarkRequest{ReportId: args[0]})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdBenchmarksByProvider queries benchmarks by provider.
+func CmdBenchmarksByProvider() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "benchmarks-by-provider [provider]",
+		Short: "List benchmark reports by provider",
+		Args:  cobra.ExactArgs(1),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query benchmark reports for a provider.
+
+Example:
+$ %s query benchmark benchmarks-by-provider ve1provider
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := benchmarkv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.BenchmarksByProvider(cmd.Context(), &benchmarkv1.QueryBenchmarksByProviderRequest{Provider: args[0]})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdParams queries module parameters.
+func CmdParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "Query benchmark module parameters",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := benchmarkv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.Params(cmd.Context(), &benchmarkv1.QueryParamsRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}

--- a/x/benchmark/client/cli/tx.go
+++ b/x/benchmark/client/cli/tx.go
@@ -1,0 +1,272 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/version"
+
+	"github.com/virtengine/virtengine/x/benchmark/types"
+)
+
+// GetTxCmd returns the root tx command for benchmark.
+func GetTxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Benchmark transaction subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		CmdSubmitBenchmarks(),
+		CmdRequestChallenge(),
+		CmdRespondChallenge(),
+		CmdFlagProvider(),
+		CmdUnflagProvider(),
+		CmdResolveAnomalyFlag(),
+	)
+
+	return cmd
+}
+
+// CmdSubmitBenchmarks submits benchmark results.
+func CmdSubmitBenchmarks() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "submit-benchmarks [cluster-id]",
+		Short: "Submit benchmark results for a cluster",
+		Args:  cobra.ExactArgs(1),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Submit benchmark results as JSON via --%s or --%s, plus a hex signature.
+
+Example:
+$ %s tx benchmark submit-benchmarks cluster-1 --%s @benchmarks.json --%s deadbeef --from provider
+`, flagResults, flagResultsFile, version.AppName, flagResults, flagSignature),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			resultsJSON, _ := cmd.Flags().GetString(flagResults)
+			resultsFile, _ := cmd.Flags().GetString(flagResultsFile)
+			results, err := readBenchmarkResults(resultsJSON, resultsFile)
+			if err != nil {
+				return err
+			}
+
+			signatureHex, _ := cmd.Flags().GetString(flagSignature)
+			signature, err := parseSignatureHex(signatureHex)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgSubmitBenchmarks(
+				clientCtx.GetFromAddress().String(),
+				args[0],
+				results,
+				signature,
+			)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(flagResults, "", "JSON benchmark results payload or @path to JSON file")
+	cmd.Flags().String(flagResultsFile, "", "Path to JSON file with benchmark results array")
+	cmd.Flags().String(flagSignature, "", "Hex-encoded benchmark signature")
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdRequestChallenge requests a benchmark challenge.
+func CmdRequestChallenge() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "request-challenge [provider] [benchmark-type]",
+		Short: "Request a benchmark challenge",
+		Args:  cobra.ExactArgs(2),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Request a benchmark challenge for a provider.
+
+Example:
+$ %s tx benchmark request-challenge ve1provider gpu-v1 --from requester
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgRequestChallenge(
+				clientCtx.GetFromAddress().String(),
+				args[0],
+				args[1],
+			)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdRespondChallenge responds to a benchmark challenge.
+func CmdRespondChallenge() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "respond-challenge [challenge-id]",
+		Short: "Respond to a benchmark challenge",
+		Args:  cobra.ExactArgs(1),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Respond to a benchmark challenge with a benchmark result.
+
+Example:
+$ %s tx benchmark respond-challenge challenge-1 --%s @result.json --%s deadbeef --from provider
+`, version.AppName, flagResult, flagSignature),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			resultJSON, _ := cmd.Flags().GetString(flagResult)
+			resultFile, _ := cmd.Flags().GetString(flagResultFile)
+			result, err := readBenchmarkResult(resultJSON, resultFile)
+			if err != nil {
+				return err
+			}
+
+			signatureHex, _ := cmd.Flags().GetString(flagSignature)
+			signature, err := parseSignatureHex(signatureHex)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgRespondChallenge(
+				clientCtx.GetFromAddress().String(),
+				args[0],
+				result,
+				signature,
+			)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(flagResult, "", "JSON benchmark result payload or @path to JSON file")
+	cmd.Flags().String(flagResultFile, "", "Path to JSON file with a single benchmark result")
+	cmd.Flags().String(flagSignature, "", "Hex-encoded benchmark signature")
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdFlagProvider flags a provider for anomalous benchmarks.
+func CmdFlagProvider() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "flag-provider [provider] [reason] [evidence]",
+		Short: "Flag a provider for anomalous benchmark results",
+		Args:  cobra.ExactArgs(3),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Flag a provider with a reason and evidence reference.
+
+Example:
+$ %s tx benchmark flag-provider ve1provider "Suspicious scores" "ipfs://evidence" --from reporter
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgFlagProvider(
+				clientCtx.GetFromAddress().String(),
+				args[0],
+				args[1],
+				args[2],
+			)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdUnflagProvider unflags a provider.
+func CmdUnflagProvider() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unflag-provider [provider]",
+		Short: "Remove a provider anomaly flag",
+		Args:  cobra.ExactArgs(1),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Remove an anomaly flag from a provider (governance only).
+
+Example:
+$ %s tx benchmark unflag-provider ve1provider --from gov
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgUnflagProvider(clientCtx.GetFromAddress().String(), args[0])
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdResolveAnomalyFlag resolves a benchmark anomaly flag.
+func CmdResolveAnomalyFlag() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resolve-anomaly [provider] [resolution]",
+		Short: "Resolve a benchmark anomaly flag",
+		Args:  cobra.ExactArgs(2),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Resolve an anomaly flag with a resolution note.
+
+Example:
+$ %s tx benchmark resolve-anomaly ve1provider "Manual verification passed" --%s=true --from gov
+`, version.AppName, flagIsValid),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			isValid, err := cmd.Flags().GetBool(flagIsValid)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgResolveAnomalyFlag(
+				clientCtx.GetFromAddress().String(),
+				args[0],
+				args[1],
+				isValid,
+			)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().Bool(flagIsValid, false, "Whether the anomaly flag is valid")
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}

--- a/x/benchmark/client/cli/util.go
+++ b/x/benchmark/client/cli/util.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	benchmarkv1 "github.com/virtengine/virtengine/sdk/go/node/benchmark/v1"
+)
+
+func readBenchmarkResults(resultsJSON string, resultsFile string) ([]benchmarkv1.BenchmarkResult, error) {
+	if strings.HasPrefix(strings.TrimSpace(resultsJSON), "@") {
+		resultsFile = strings.TrimPrefix(strings.TrimSpace(resultsJSON), "@")
+		resultsJSON = ""
+	}
+
+	var results []benchmarkv1.BenchmarkResult
+	if resultsFile != "" {
+		payload, err := os.ReadFile(resultsFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read results file: %w", err)
+		}
+		parsed, err := parseBenchmarkResultsJSON(string(payload))
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, parsed...)
+	}
+
+	if strings.TrimSpace(resultsJSON) != "" {
+		parsed, err := parseBenchmarkResultsJSON(resultsJSON)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, parsed...)
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("benchmark results are required; provide --%s or --%s", flagResults, flagResultsFile)
+	}
+
+	return results, nil
+}
+
+func parseBenchmarkResultsJSON(raw string) ([]benchmarkv1.BenchmarkResult, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, fmt.Errorf("benchmark results payload is empty")
+	}
+
+	var results []benchmarkv1.BenchmarkResult
+	if strings.HasPrefix(trimmed, "{") {
+		var single benchmarkv1.BenchmarkResult
+		if err := json.Unmarshal([]byte(trimmed), &single); err != nil {
+			return nil, fmt.Errorf("invalid benchmark result JSON object: %w", err)
+		}
+		results = append(results, single)
+	} else {
+		if err := json.Unmarshal([]byte(trimmed), &results); err != nil {
+			return nil, fmt.Errorf("invalid benchmark results JSON array: %w", err)
+		}
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("benchmark results payload is empty")
+	}
+
+	return results, nil
+}
+
+func readBenchmarkResult(resultJSON string, resultFile string) (benchmarkv1.BenchmarkResult, error) {
+	results, err := readBenchmarkResults(resultJSON, resultFile)
+	if err != nil {
+		return benchmarkv1.BenchmarkResult{}, err
+	}
+	if len(results) != 1 {
+		return benchmarkv1.BenchmarkResult{}, fmt.Errorf("expected exactly one benchmark result")
+	}
+	return results[0], nil
+}
+
+func parseSignatureHex(signature string) ([]byte, error) {
+	trimmed := strings.TrimSpace(signature)
+	trimmed = strings.TrimPrefix(trimmed, "0x")
+	if trimmed == "" {
+		return nil, fmt.Errorf("signature is required")
+	}
+	decoded, err := hex.DecodeString(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("invalid hex signature: %w", err)
+	}
+	return decoded, nil
+}

--- a/x/benchmark/module.go
+++ b/x/benchmark/module.go
@@ -18,6 +18,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
+	"github.com/virtengine/virtengine/x/benchmark/client/cli"
 	"github.com/virtengine/virtengine/x/benchmark/keeper"
 	"github.com/virtengine/virtengine/x/benchmark/types"
 )
@@ -86,12 +87,12 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *r
 
 // GetTxCmd returns the root tx command for the Benchmark module.
 func (AppModuleBasic) GetTxCmd() *cobra.Command {
-	return nil // CLI commands to be implemented
+	return cli.GetTxCmd()
 }
 
 // GetQueryCmd returns the root query command for the Benchmark module.
 func (AppModuleBasic) GetQueryCmd() *cobra.Command {
-	return nil // CLI commands to be implemented
+	return cli.GetQueryCmd()
 }
 
 // AppModule implements an application module for the Benchmark module.

--- a/x/benchmark/types/codec.go
+++ b/x/benchmark/types/codec.go
@@ -40,7 +40,8 @@ func NewQueryClient(cc grpc.ClientConn) QueryClient {
 
 // RegisterQueryHandlerClient registers the gRPC gateway routes for the query service.
 func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, client QueryClient) error {
-	return benchmarkv1.RegisterQueryHandlerClient(ctx, mux, client)
+	// grpc-gateway handlers are not generated in this build; keep as no-op.
+	return nil
 }
 
 // ModuleCdc is the codec for the benchmark module

--- a/x/fraud/client/cli/flags.go
+++ b/x/fraud/client/cli/flags.go
@@ -1,0 +1,14 @@
+package cli
+
+const (
+	flagCategory        = "category"
+	flagStatus          = "status"
+	flagReporter        = "reporter"
+	flagReportedParty   = "reported-party"
+	flagAssignedTo      = "assigned-to"
+	flagEvidence        = "evidence"
+	flagEvidenceFile    = "evidence-file"
+	flagResolution      = "resolution"
+	flagNotes           = "notes"
+	flagRelatedOrderIDs = "related-order-ids"
+)

--- a/x/fraud/client/cli/query.go
+++ b/x/fraud/client/cli/query.go
@@ -1,0 +1,276 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/version"
+
+	fraudv1 "github.com/virtengine/virtengine/sdk/go/node/fraud/v1"
+	"github.com/virtengine/virtengine/x/fraud/types"
+)
+
+// GetQueryCmd returns the root query command for fraud.
+func GetQueryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Fraud query subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		CmdParams(),
+		CmdFraudReport(),
+		CmdFraudReports(),
+		CmdFraudReportsByReporter(),
+		CmdFraudReportsByReportedParty(),
+		CmdAuditLog(),
+		CmdModeratorQueue(),
+	)
+
+	return cmd
+}
+
+// CmdParams queries module parameters.
+func CmdParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "Query fraud module parameters",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := fraudv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.Params(cmd.Context(), &fraudv1.QueryParamsRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdFraudReport queries a fraud report by ID.
+func CmdFraudReport() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "report [report-id]",
+		Short: "Query a fraud report by ID",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := fraudv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.FraudReport(cmd.Context(), &fraudv1.QueryFraudReportRequest{ReportId: args[0]})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdFraudReports queries fraud reports with optional filters.
+func CmdFraudReports() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reports",
+		Short: "List fraud reports with optional filters",
+		Args:  cobra.NoArgs,
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query fraud reports with optional status/category filters.
+
+Example:
+$ %s query fraud reports --%s submitted
+`, version.AppName, flagStatus),
+		),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			statusValue, _ := cmd.Flags().GetString(flagStatus)
+			categoryValue, _ := cmd.Flags().GetString(flagCategory)
+
+			status := fraudv1.FraudReportStatusUnspecified
+			if strings.TrimSpace(statusValue) != "" {
+				parsed, err := parseFraudStatus(statusValue)
+				if err != nil {
+					return err
+				}
+				status = parsed
+			}
+
+			category := fraudv1.FraudCategoryUnspecified
+			if strings.TrimSpace(categoryValue) != "" {
+				parsed, err := parseFraudCategory(categoryValue)
+				if err != nil {
+					return err
+				}
+				category = parsed
+			}
+
+			queryClient := fraudv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.FraudReports(cmd.Context(), &fraudv1.QueryFraudReportsRequest{
+				Pagination: pageReq,
+				Status:     status,
+				Category:   category,
+			})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	cmd.Flags().String(flagStatus, "", "Filter by status (submitted, reviewing, resolved, rejected, escalated)")
+	cmd.Flags().String(flagCategory, "", "Filter by category (fake_identity, payment_fraud, etc.)")
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdFraudReportsByReporter queries fraud reports by reporter.
+func CmdFraudReportsByReporter() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reports-by-reporter [reporter]",
+		Short: "List fraud reports submitted by a reporter",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := fraudv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.FraudReportsByReporter(cmd.Context(), &fraudv1.QueryFraudReportsByReporterRequest{Reporter: args[0]})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdFraudReportsByReportedParty queries fraud reports by reported party.
+func CmdFraudReportsByReportedParty() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reports-by-reported-party [reported-party]",
+		Short: "List fraud reports against a reported party",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := fraudv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.FraudReportsByReportedParty(cmd.Context(), &fraudv1.QueryFraudReportsByReportedPartyRequest{ReportedParty: args[0]})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdAuditLog queries audit log entries for a report.
+func CmdAuditLog() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "audit-log [report-id]",
+		Short: "Query audit log entries for a fraud report",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := fraudv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.AuditLog(cmd.Context(), &fraudv1.QueryAuditLogRequest{ReportId: args[0]})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdModeratorQueue queries the moderator queue.
+func CmdModeratorQueue() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "moderator-queue",
+		Short: "List moderator queue entries",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			categoryValue, _ := cmd.Flags().GetString(flagCategory)
+			assignedTo, _ := cmd.Flags().GetString(flagAssignedTo)
+
+			category := fraudv1.FraudCategoryUnspecified
+			if strings.TrimSpace(categoryValue) != "" {
+				parsed, err := parseFraudCategory(categoryValue)
+				if err != nil {
+					return err
+				}
+				category = parsed
+			}
+
+			queryClient := fraudv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.ModeratorQueue(cmd.Context(), &fraudv1.QueryModeratorQueueRequest{
+				Category:   category,
+				AssignedTo: assignedTo,
+			})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	cmd.Flags().String(flagCategory, "", "Filter by fraud category")
+	cmd.Flags().String(flagAssignedTo, "", "Filter by assigned moderator address")
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}

--- a/x/fraud/client/cli/tx.go
+++ b/x/fraud/client/cli/tx.go
@@ -1,0 +1,327 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/version"
+
+	fraudv1 "github.com/virtengine/virtengine/sdk/go/node/fraud/v1"
+	"github.com/virtengine/virtengine/x/fraud/types"
+)
+
+// GetTxCmd returns the root tx command for fraud.
+func GetTxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Fraud transaction subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		CmdSubmitFraudReport(),
+		CmdAssignModerator(),
+		CmdUpdateReportStatus(),
+		CmdResolveFraudReport(),
+		CmdRejectFraudReport(),
+		CmdEscalateFraudReport(),
+		CmdUpdateParams(),
+	)
+
+	return cmd
+}
+
+// CmdSubmitFraudReport submits a new fraud report.
+func CmdSubmitFraudReport() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "submit-report [reported-party] [category] [description]",
+		Short: "Submit a new fraud report",
+		Args:  cobra.ExactArgs(3),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Submit a fraud report with encrypted evidence. Evidence must be supplied
+as JSON (array or object) via --%s or --%s.
+
+Example:
+$ %s tx fraud submit-report ve1reportedparty fake_identity "Suspected identity fraud" \\
+  --%s @evidence.json --related-order-ids order-123,order-456 --from provider
+`, flagEvidence, flagEvidenceFile, version.AppName, flagEvidence),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			category, err := parseFraudCategory(args[1])
+			if err != nil {
+				return err
+			}
+
+			evidenceJSON, _ := cmd.Flags().GetString(flagEvidence)
+			evidenceFile, _ := cmd.Flags().GetString(flagEvidenceFile)
+			evidence, err := readEvidenceFromFlags(evidenceJSON, evidenceFile)
+			if err != nil {
+				return err
+			}
+
+			relatedOrderIDs, err := cmd.Flags().GetStringSlice(flagRelatedOrderIDs)
+			if err != nil {
+				return err
+			}
+
+			msg := &types.MsgSubmitFraudReport{
+				Reporter:        clientCtx.GetFromAddress().String(),
+				ReportedParty:   args[0],
+				Category:        category,
+				Description:     args[2],
+				Evidence:        evidence,
+				RelatedOrderIds: relatedOrderIDs,
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(flagEvidence, "", "JSON evidence payload or @path to JSON file")
+	cmd.Flags().String(flagEvidenceFile, "", "Path to JSON file with evidence array")
+	cmd.Flags().StringSlice(flagRelatedOrderIDs, nil, "Comma-separated related order IDs")
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdAssignModerator assigns a moderator to a report.
+func CmdAssignModerator() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "assign-moderator [report-id] [assign-to]",
+		Short: "Assign a moderator to a fraud report",
+		Args:  cobra.ExactArgs(2),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Assign a moderator to a pending fraud report.
+
+Example:
+$ %s tx fraud assign-moderator fraud-report-12 ve1moderator --from admin
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := &types.MsgAssignModerator{
+				Moderator: clientCtx.GetFromAddress().String(),
+				ReportId:  args[0],
+				AssignTo:  args[1],
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdUpdateReportStatus updates the status of a report.
+func CmdUpdateReportStatus() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-status [report-id] [status]",
+		Short: "Update fraud report status",
+		Args:  cobra.ExactArgs(2),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Update the status of a fraud report (submitted, reviewing, resolved, rejected, escalated).
+
+Example:
+$ %s tx fraud update-status fraud-report-12 reviewing --%s "Investigating evidence" --from moderator
+`, version.AppName, flagNotes),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			status, err := parseFraudStatus(args[1])
+			if err != nil {
+				return err
+			}
+
+			notes, _ := cmd.Flags().GetString(flagNotes)
+
+			msg := &types.MsgUpdateReportStatus{
+				Moderator: clientCtx.GetFromAddress().String(),
+				ReportId:  args[0],
+				NewStatus: status,
+				Notes:     notes,
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(flagNotes, "", "Status update notes")
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdResolveFraudReport resolves a report.
+func CmdResolveFraudReport() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resolve-report [report-id] [resolution]",
+		Short: "Resolve a fraud report",
+		Args:  cobra.ExactArgs(2),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Resolve a fraud report with a resolution type (warning, suspension, termination, refund, no_action).
+
+Example:
+$ %s tx fraud resolve-report fraud-report-12 suspension --%s "Account suspended" --from moderator
+`, version.AppName, flagNotes),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			resolution, err := parseResolutionType(args[1])
+			if err != nil {
+				return err
+			}
+
+			notes, _ := cmd.Flags().GetString(flagNotes)
+
+			msg := &types.MsgResolveFraudReport{
+				Moderator:  clientCtx.GetFromAddress().String(),
+				ReportId:   args[0],
+				Resolution: resolution,
+				Notes:      notes,
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(flagNotes, "", "Resolution notes")
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdRejectFraudReport rejects a report.
+func CmdRejectFraudReport() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reject-report [report-id]",
+		Short: "Reject a fraud report",
+		Args:  cobra.ExactArgs(1),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Reject a fraud report with optional notes.
+
+Example:
+$ %s tx fraud reject-report fraud-report-12 --%s "Insufficient evidence" --from moderator
+`, version.AppName, flagNotes),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			notes, _ := cmd.Flags().GetString(flagNotes)
+
+			msg := &types.MsgRejectFraudReport{
+				Moderator: clientCtx.GetFromAddress().String(),
+				ReportId:  args[0],
+				Notes:     notes,
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	cmd.Flags().String(flagNotes, "", "Rejection notes")
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdEscalateFraudReport escalates a report.
+func CmdEscalateFraudReport() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "escalate-report [report-id] [reason]",
+		Short: "Escalate a fraud report to admin",
+		Args:  cobra.ExactArgs(2),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Escalate a fraud report for admin review.
+
+Example:
+$ %s tx fraud escalate-report fraud-report-12 "High severity fraud" --from moderator
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := &types.MsgEscalateFraudReport{
+				Moderator: clientCtx.GetFromAddress().String(),
+				ReportId:  args[0],
+				Reason:    args[1],
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdUpdateParams updates module parameters.
+func CmdUpdateParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-params [params-file]",
+		Short: "Update fraud module parameters (governance only)",
+		Args:  cobra.ExactArgs(1),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Update fraud module parameters from a JSON file.
+
+Example:
+$ %s tx fraud update-params ./fraud-params.json --from gov
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			payload, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to read params file: %w", err)
+			}
+
+			var params fraudv1.Params
+			if err := json.Unmarshal(payload, &params); err != nil {
+				return fmt.Errorf("failed to decode params: %w", err)
+			}
+
+			msg := &types.MsgUpdateParams{
+				Authority: clientCtx.GetFromAddress().String(),
+				Params:    params,
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}

--- a/x/fraud/client/cli/util.go
+++ b/x/fraud/client/cli/util.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	fraudv1 "github.com/virtengine/virtengine/sdk/go/node/fraud/v1"
+	"github.com/virtengine/virtengine/x/fraud/types"
+)
+
+func normalizeEnumInput(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	value = strings.TrimPrefix(value, "fraud_category_")
+	value = strings.TrimPrefix(value, "fraud_report_status_")
+	value = strings.TrimPrefix(value, "resolution_type_")
+	value = strings.ReplaceAll(value, "-", "_")
+	value = strings.ReplaceAll(value, " ", "_")
+	return value
+}
+
+func parseFraudCategory(value string) (fraudv1.FraudCategory, error) {
+	value = normalizeEnumInput(value)
+	if value == "" {
+		return fraudv1.FraudCategoryUnspecified, fmt.Errorf("category is required")
+	}
+	if numeric, err := strconv.ParseInt(value, 10, 32); err == nil {
+		if numeric < 0 || numeric > int64(fraudv1.FraudCategoryOther) {
+			return fraudv1.FraudCategoryUnspecified, fmt.Errorf("invalid fraud category: %s", value)
+		}
+		return fraudv1.FraudCategory(numeric), nil
+	}
+
+	for cat, name := range types.FraudCategoryNames {
+		if value == name {
+			return types.FraudCategoryToProto(cat), nil
+		}
+	}
+
+	return fraudv1.FraudCategoryUnspecified, fmt.Errorf("unknown fraud category: %s", value)
+}
+
+func parseFraudStatus(value string) (fraudv1.FraudReportStatus, error) {
+	value = normalizeEnumInput(value)
+	if value == "" {
+		return fraudv1.FraudReportStatusUnspecified, fmt.Errorf("status is required")
+	}
+	if numeric, err := strconv.ParseInt(value, 10, 32); err == nil {
+		if numeric < 0 || numeric > int64(fraudv1.FraudReportStatusEscalated) {
+			return fraudv1.FraudReportStatusUnspecified, fmt.Errorf("invalid fraud report status: %s", value)
+		}
+		return fraudv1.FraudReportStatus(numeric), nil
+	}
+
+	for status, name := range types.FraudReportStatusNames {
+		if value == name {
+			return types.FraudReportStatusToProto(status), nil
+		}
+	}
+
+	return fraudv1.FraudReportStatusUnspecified, fmt.Errorf("unknown fraud report status: %s", value)
+}
+
+func parseResolutionType(value string) (fraudv1.ResolutionType, error) {
+	value = normalizeEnumInput(value)
+	if value == "" {
+		return fraudv1.ResolutionTypeUnspecified, fmt.Errorf("resolution is required")
+	}
+	if numeric, err := strconv.ParseInt(value, 10, 32); err == nil {
+		if numeric < 0 || numeric > int64(fraudv1.ResolutionTypeNoAction) {
+			return fraudv1.ResolutionTypeUnspecified, fmt.Errorf("invalid resolution type: %s", value)
+		}
+		return fraudv1.ResolutionType(numeric), nil
+	}
+
+	for resolution, name := range types.ResolutionTypeNames {
+		if value == name {
+			return types.ResolutionTypeToProto(resolution), nil
+		}
+	}
+
+	return fraudv1.ResolutionTypeUnspecified, fmt.Errorf("unknown resolution type: %s", value)
+}
+
+func readEvidenceFromFlags(evidenceJSON string, evidenceFile string) ([]fraudv1.EncryptedEvidence, error) {
+	var evidence []fraudv1.EncryptedEvidence
+
+	if strings.HasPrefix(strings.TrimSpace(evidenceJSON), "@") {
+		evidenceFile = strings.TrimPrefix(strings.TrimSpace(evidenceJSON), "@")
+		evidenceJSON = ""
+	}
+
+	if evidenceFile != "" {
+		data, err := os.ReadFile(evidenceFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read evidence file: %w", err)
+		}
+		parsed, err := parseEvidenceJSON(string(data))
+		if err != nil {
+			return nil, err
+		}
+		evidence = append(evidence, parsed...)
+	}
+
+	if strings.TrimSpace(evidenceJSON) != "" {
+		parsed, err := parseEvidenceJSON(evidenceJSON)
+		if err != nil {
+			return nil, err
+		}
+		evidence = append(evidence, parsed...)
+	}
+
+	if len(evidence) == 0 {
+		return nil, fmt.Errorf("evidence is required; provide --%s or --%s", flagEvidence, flagEvidenceFile)
+	}
+
+	for i := range evidence {
+		if err := types.ValidateEncryptedEvidenceValue(evidence[i]); err != nil {
+			return nil, fmt.Errorf("invalid evidence[%d]: %w", i, err)
+		}
+	}
+
+	return evidence, nil
+}
+
+func parseEvidenceJSON(raw string) ([]fraudv1.EncryptedEvidence, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, fmt.Errorf("evidence payload is empty")
+	}
+
+	var evidence []fraudv1.EncryptedEvidence
+	if strings.HasPrefix(trimmed, "{") {
+		var single fraudv1.EncryptedEvidence
+		if err := json.Unmarshal([]byte(trimmed), &single); err != nil {
+			return nil, fmt.Errorf("invalid evidence JSON object: %w", err)
+		}
+		evidence = append(evidence, single)
+	} else {
+		if err := json.Unmarshal([]byte(trimmed), &evidence); err != nil {
+			return nil, fmt.Errorf("invalid evidence JSON array: %w", err)
+		}
+	}
+
+	if len(evidence) == 0 {
+		return nil, fmt.Errorf("evidence payload is empty")
+	}
+
+	return evidence, nil
+}

--- a/x/fraud/keeper/invariants.go
+++ b/x/fraud/keeper/invariants.go
@@ -1,0 +1,188 @@
+package keeper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"cosmossdk.io/store/prefix"
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/virtengine/virtengine/x/fraud/types"
+)
+
+// RegisterInvariants registers fraud module invariants.
+//
+//nolint:staticcheck // sdk.InvariantRegistry is required by the module interface.
+func RegisterInvariants(ir sdk.InvariantRegistry, k IKeeper) {
+	ir.RegisterRoute(types.ModuleName, "report-state-consistency", ReportStateConsistencyInvariant(k))
+	ir.RegisterRoute(types.ModuleName, "blacklist-integrity", BlacklistIntegrityInvariant(k))
+	ir.RegisterRoute(types.ModuleName, "evidence-hash-verification", EvidenceHashVerificationInvariant(k))
+	ir.RegisterRoute(types.ModuleName, "reporter-exists", ReporterExistsInvariant(k))
+}
+
+// ReportStateConsistencyInvariant checks report status with queue consistency.
+//
+//nolint:staticcheck // sdk.Invariant is required by the module interface.
+func ReportStateConsistencyInvariant(k IKeeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		var broken []string
+
+		k.WithFraudReports(ctx, func(report types.FraudReport) bool {
+			if !report.Status.IsValid() {
+				broken = append(broken, fmt.Sprintf("report=%s invalid-status=%s", report.ID, report.Status.String()))
+				return false
+			}
+
+			queueEntry, inQueue := k.GetModeratorQueueEntry(ctx, report.ID)
+			if report.Status.IsPending() {
+				if !inQueue {
+					broken = append(broken, fmt.Sprintf("report=%s pending-without-queue", report.ID))
+				} else if queueEntry.Category != report.Category {
+					broken = append(broken, fmt.Sprintf("report=%s queue-category-mismatch=%s report-category=%s", report.ID, queueEntry.Category.String(), report.Category.String()))
+				}
+				if report.Status == types.FraudReportStatusReviewing && report.AssignedModerator == "" {
+					broken = append(broken, fmt.Sprintf("report=%s reviewing-without-assigned-moderator", report.ID))
+				}
+			} else if inQueue {
+				broken = append(broken, fmt.Sprintf("report=%s terminal-with-queue-entry", report.ID))
+			}
+
+			if report.Status.IsTerminal() && report.ResolvedAt == nil {
+				broken = append(broken, fmt.Sprintf("report=%s terminal-without-resolved-at", report.ID))
+			}
+			if !report.Status.IsTerminal() && report.ResolvedAt != nil {
+				broken = append(broken, fmt.Sprintf("report=%s nonterminal-with-resolved-at", report.ID))
+			}
+
+			return false
+		})
+
+		if len(broken) > 0 {
+			return fmt.Sprintf("report-state-consistency invariant broken: %s", strings.Join(broken, "; ")), true
+		}
+		return "report-state-consistency: ok", false
+	}
+}
+
+// BlacklistIntegrityInvariant validates reported-party index integrity.
+//
+//nolint:staticcheck // sdk.Invariant is required by the module interface.
+func BlacklistIntegrityInvariant(k IKeeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		store := ctx.KVStore(k.StoreKey())
+		indexStore := prefix.NewStore(store, types.ReportedPartyIndexPrefix)
+		iterator := storetypes.KVStorePrefixIterator(indexStore, nil)
+		defer iterator.Close()
+
+		var broken []string
+
+		for ; iterator.Valid(); iterator.Next() {
+			key := string(iterator.Key())
+			parts := strings.SplitN(key, "/", 2)
+			if len(parts) != 2 {
+				broken = append(broken, fmt.Sprintf("reported-party-index-invalid-key=%s", key))
+				continue
+			}
+			reportedParty := parts[0]
+			reportID := parts[1]
+			value := string(iterator.Value())
+			if value != reportID {
+				broken = append(broken, fmt.Sprintf("reported-party-index-value-mismatch key=%s value=%s", reportID, value))
+				continue
+			}
+			report, found := k.GetFraudReport(ctx, reportID)
+			if !found {
+				broken = append(broken, fmt.Sprintf("reported-party-index-missing-report=%s", reportID))
+				continue
+			}
+			if report.ReportedParty != reportedParty {
+				broken = append(broken, fmt.Sprintf("reported-party-index-report-mismatch report=%s expected=%s got=%s", report.ID, reportedParty, report.ReportedParty))
+			}
+		}
+
+		if len(broken) > 0 {
+			return fmt.Sprintf("blacklist-integrity invariant broken: %s", strings.Join(broken, "; ")), true
+		}
+		return "blacklist-integrity: ok", false
+	}
+}
+
+// EvidenceHashVerificationInvariant verifies report content and evidence hashes.
+//
+//nolint:staticcheck // sdk.Invariant is required by the module interface.
+func EvidenceHashVerificationInvariant(k IKeeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		var broken []string
+
+		k.WithFraudReports(ctx, func(report types.FraudReport) bool {
+			expectedContentHash := report.ComputeContentHash()
+			if report.ContentHash == "" || report.ContentHash != expectedContentHash {
+				broken = append(broken, fmt.Sprintf("report=%s content-hash-mismatch", report.ID))
+			}
+
+			for idx, evidence := range report.Evidence {
+				if evidence.EvidenceHash == "" {
+					broken = append(broken, fmt.Sprintf("report=%s evidence[%d]-missing-hash", report.ID, idx))
+					continue
+				}
+				normalized, ok := normalizeEvidenceHash(evidence.EvidenceHash)
+				if !ok {
+					continue
+				}
+				computed := sha256.Sum256(evidence.Ciphertext)
+				computedHex := hex.EncodeToString(computed[:])
+				if computedHex != normalized {
+					broken = append(broken, fmt.Sprintf("report=%s evidence[%d]-hash-mismatch", report.ID, idx))
+				}
+			}
+
+			return false
+		})
+
+		if len(broken) > 0 {
+			return fmt.Sprintf("evidence-hash-verification invariant broken: %s", strings.Join(broken, "; ")), true
+		}
+		return "evidence-hash-verification: ok", false
+	}
+}
+
+// ReporterExistsInvariant ensures reporters are valid provider addresses.
+//
+//nolint:staticcheck // sdk.Invariant is required by the module interface.
+func ReporterExistsInvariant(k IKeeper) sdk.Invariant {
+	return func(ctx sdk.Context) (string, bool) {
+		var broken []string
+
+		k.WithFraudReports(ctx, func(report types.FraudReport) bool {
+			addr, err := sdk.AccAddressFromBech32(report.Reporter)
+			if err != nil {
+				broken = append(broken, fmt.Sprintf("report=%s invalid-reporter=%s", report.ID, report.Reporter))
+				return false
+			}
+			if !k.IsProvider(ctx, addr) {
+				broken = append(broken, fmt.Sprintf("report=%s reporter-not-provider=%s", report.ID, report.Reporter))
+			}
+			return false
+		})
+
+		if len(broken) > 0 {
+			return fmt.Sprintf("reporter-exists invariant broken: %s", strings.Join(broken, "; ")), true
+		}
+		return "reporter-exists: ok", false
+	}
+}
+
+func normalizeEvidenceHash(hash string) (string, bool) {
+	trimmed := strings.TrimSpace(strings.ToLower(hash))
+	trimmed = strings.TrimPrefix(trimmed, "sha256:")
+	if len(trimmed) != 64 {
+		return "", false
+	}
+	if _, err := hex.DecodeString(trimmed); err != nil {
+		return "", false
+	}
+	return trimmed, true
+}

--- a/x/fraud/keeper/invariants_test.go
+++ b/x/fraud/keeper/invariants_test.go
@@ -1,0 +1,161 @@
+package keeper
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/virtengine/virtengine/x/fraud/types"
+)
+
+func TestReportStateConsistencyInvariantOK(t *testing.T) {
+	k, ctx, _, mockProvider := setupKeeper(t)
+
+	reporter := sdk.AccAddress("cosmos1reporter_____")
+	reported := sdk.AccAddress("cosmos1reported_____")
+	mockProvider.SetProvider(reporter.String())
+
+	report := types.NewFraudReport(
+		"",
+		reporter.String(),
+		reported.String(),
+		types.FraudCategoryFakeIdentity,
+		testFraudDescription,
+		createValidEvidence(),
+		ctx.BlockHeight(),
+		ctx.BlockTime(),
+	)
+
+	require.NoError(t, k.SubmitFraudReport(ctx, report))
+
+	invariant := ReportStateConsistencyInvariant(k)
+	msg, broken := invariant(ctx)
+	require.False(t, broken, msg)
+}
+
+func TestReportStateConsistencyInvariantDetectsQueueMismatch(t *testing.T) {
+	k, ctx, _, mockProvider := setupKeeper(t)
+
+	reporter := sdk.AccAddress("cosmos1reporter_____")
+	reported := sdk.AccAddress("cosmos1reported_____")
+	mockProvider.SetProvider(reporter.String())
+
+	report := types.NewFraudReport(
+		"",
+		reporter.String(),
+		reported.String(),
+		types.FraudCategoryFakeIdentity,
+		testFraudDescription,
+		createValidEvidence(),
+		ctx.BlockHeight(),
+		ctx.BlockTime(),
+	)
+
+	require.NoError(t, k.SubmitFraudReport(ctx, report))
+	require.NoError(t, k.RemoveFromModeratorQueue(ctx, report.ID))
+
+	invariant := ReportStateConsistencyInvariant(k)
+	_, broken := invariant(ctx)
+	require.True(t, broken)
+}
+
+func TestEvidenceHashVerificationInvariantDetectsMismatch(t *testing.T) {
+	k, ctx, _, mockProvider := setupKeeper(t)
+
+	reporter := sdk.AccAddress("cosmos1reporter_____")
+	reported := sdk.AccAddress("cosmos1reported_____")
+	mockProvider.SetProvider(reporter.String())
+
+	ciphertext := []byte("encrypted_payload")
+	hash := sha256.Sum256(ciphertext)
+	validEvidence := []types.EncryptedEvidence{
+		{
+			AlgorithmID:     "X25519-XSALSA20-POLY1305",
+			RecipientKeyIDs: []string{"moderator-key-1"},
+			Nonce:           []byte("unique_nonce_123"),
+			Ciphertext:      ciphertext,
+			SenderPubKey:    []byte("sender_public_key"),
+			EvidenceHash:    hex.EncodeToString(hash[:]),
+		},
+	}
+
+	report := types.NewFraudReport(
+		"",
+		reporter.String(),
+		reported.String(),
+		types.FraudCategoryFakeIdentity,
+		testFraudDescription,
+		validEvidence,
+		ctx.BlockHeight(),
+		ctx.BlockTime(),
+	)
+
+	require.NoError(t, k.SubmitFraudReport(ctx, report))
+
+	stored, found := k.GetFraudReport(ctx, report.ID)
+	require.True(t, found)
+	stored.ContentHash = "mismatched"
+	require.NoError(t, k.SetFraudReport(ctx, stored))
+
+	invariant := EvidenceHashVerificationInvariant(k)
+	_, broken := invariant(ctx)
+	require.True(t, broken)
+}
+
+func TestReporterExistsInvariantDetectsNonProvider(t *testing.T) {
+	k, ctx, _, _ := setupKeeper(t)
+
+	reporter := sdk.AccAddress("cosmos1reporter_____")
+	reported := sdk.AccAddress("cosmos1reported_____")
+
+	report := types.NewFraudReport(
+		"fraud-report-99",
+		reporter.String(),
+		reported.String(),
+		types.FraudCategoryFakeIdentity,
+		testFraudDescription,
+		createValidEvidence(),
+		ctx.BlockHeight(),
+		ctx.BlockTime(),
+	)
+
+	require.NoError(t, k.SetFraudReport(ctx, *report))
+
+	invariant := ReporterExistsInvariant(k)
+	_, broken := invariant(ctx)
+	require.True(t, broken)
+}
+
+func TestBlacklistIntegrityInvariantDetectsMissingReport(t *testing.T) {
+	k, ctx, _, mockProvider := setupKeeper(t)
+
+	reporter := sdk.AccAddress("cosmos1reporter_____")
+	reported := sdk.AccAddress("cosmos1reported_____")
+	mockProvider.SetProvider(reporter.String())
+
+	report := types.NewFraudReport(
+		"",
+		reporter.String(),
+		reported.String(),
+		types.FraudCategoryFakeIdentity,
+		testFraudDescription,
+		createValidEvidence(),
+		ctx.BlockHeight(),
+		ctx.BlockTime(),
+	)
+
+	require.NoError(t, k.SubmitFraudReport(ctx, report))
+
+	store := ctx.KVStore(k.StoreKey())
+	badKey := append(append([]byte{}, types.ReportedPartyIndexPrefix...), []byte(reported.String())...)
+	badKey = append(badKey, []byte("/missing-report")...)
+	store.Set(badKey, []byte("missing-report"))
+
+	invariant := BlacklistIntegrityInvariant(k)
+	_, broken := invariant(ctx)
+	require.True(t, broken)
+}

--- a/x/fraud/module.go
+++ b/x/fraud/module.go
@@ -21,6 +21,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
+	"github.com/virtengine/virtengine/x/fraud/client/cli"
 	"github.com/virtengine/virtengine/x/fraud/keeper"
 	"github.com/virtengine/virtengine/x/fraud/types"
 )
@@ -83,12 +84,12 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *r
 
 // GetTxCmd returns the root tx command for the Fraud module.
 func (AppModuleBasic) GetTxCmd() *cobra.Command {
-	return nil // CLI commands to be implemented
+	return cli.GetTxCmd()
 }
 
 // GetQueryCmd returns the root query command for the Fraud module.
 func (AppModuleBasic) GetQueryCmd() *cobra.Command {
-	return nil // CLI commands to be implemented
+	return cli.GetQueryCmd()
 }
 
 // AppModule implements an application module for the Fraud module.
@@ -123,7 +124,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 //
 //nolint:staticcheck // sdk.InvariantRegistry is deprecated in upstream SDK
 func (am AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
-	// Invariants to be implemented
+	keeper.RegisterInvariants(ir, am.keeper)
 }
 
 // InitGenesis performs genesis initialization

--- a/x/review/client/cli/query.go
+++ b/x/review/client/cli/query.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/version"
+
+	reviewv1 "github.com/virtengine/virtengine/sdk/go/node/review/v1"
+	"github.com/virtengine/virtengine/x/review/types"
+)
+
+// GetQueryCmd returns the root query command for review.
+func GetQueryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Review query subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		CmdReview(),
+		CmdReviewsByUser(),
+		CmdParams(),
+	)
+
+	return cmd
+}
+
+// CmdReview queries a review by ID.
+func CmdReview() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "review [review-id]",
+		Short: "Query a review by ID",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := reviewv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.Review(cmd.Context(), &reviewv1.QueryReviewRequest{ReviewId: args[0]})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdReviewsByUser queries reviews by reviewer address.
+func CmdReviewsByUser() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reviews-by-user [reviewer]",
+		Short: "List reviews submitted by a reviewer",
+		Args:  cobra.ExactArgs(1),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query reviews by reviewer address.
+
+Example:
+$ %s query review reviews-by-user ve1reviewer
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := reviewv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.ReviewsByUser(cmd.Context(), &reviewv1.QueryReviewsByUserRequest{Reviewer: args[0]})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdParams queries module parameters.
+func CmdParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "Query review module parameters",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := reviewv1.NewQueryClient(clientCtx)
+			resp, err := queryClient.Params(cmd.Context(), &reviewv1.QueryParamsRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(resp)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}

--- a/x/review/client/cli/tx.go
+++ b/x/review/client/cli/tx.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/version"
+
+	reviewv1 "github.com/virtengine/virtengine/sdk/go/node/review/v1"
+	"github.com/virtengine/virtengine/x/review/types"
+)
+
+// GetTxCmd returns the root tx command for review.
+func GetTxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Review transaction subcommands",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(
+		CmdSubmitReview(),
+		CmdDeleteReview(),
+		CmdUpdateParams(),
+	)
+
+	return cmd
+}
+
+// CmdSubmitReview submits a review.
+func CmdSubmitReview() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "submit-review [order-id] [provider] [rating] [comment]",
+		Short: "Submit a provider review",
+		Args:  cobra.ExactArgs(4),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Submit a review for a completed order.
+
+Example:
+$ %s tx review submit-review order-123 ve1provider 5 "Excellent service" --from customer
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			rating, err := strconv.ParseUint(args[2], 10, 32)
+			if err != nil {
+				return fmt.Errorf("invalid rating: %w", err)
+			}
+
+			msg := types.NewMsgSubmitReview(
+				clientCtx.GetFromAddress().String(),
+				args[0],
+				args[1],
+				uint32(rating),
+				args[3],
+			)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdDeleteReview deletes a review.
+func CmdDeleteReview() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete-review [review-id] [reason]",
+		Short: "Delete a review (governance only)",
+		Args:  cobra.ExactArgs(2),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Delete a review using a governance-authorized account.
+
+Example:
+$ %s tx review delete-review review-123 "Policy violation" --from gov
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgDeleteReview(
+				clientCtx.GetFromAddress().String(),
+				args[0],
+				args[1],
+			)
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}
+
+// CmdUpdateParams updates review module parameters.
+func CmdUpdateParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-params [params-file]",
+		Short: "Update review module parameters (governance only)",
+		Args:  cobra.ExactArgs(1),
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Update review module parameters from a JSON file.
+
+Example:
+$ %s tx review update-params ./review-params.json --from gov
+`, version.AppName),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			payload, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to read params file: %w", err)
+			}
+
+			var params reviewv1.Params
+			if err := json.Unmarshal(payload, &params); err != nil {
+				return fmt.Errorf("failed to decode params: %w", err)
+			}
+
+			msg := types.NewMsgUpdateParams(clientCtx.GetFromAddress().String(), params)
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
+}

--- a/x/review/module.go
+++ b/x/review/module.go
@@ -21,6 +21,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
+	"github.com/virtengine/virtengine/x/review/client/cli"
 	"github.com/virtengine/virtengine/x/review/keeper"
 	"github.com/virtengine/virtengine/x/review/types"
 )
@@ -88,12 +89,12 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *r
 
 // GetTxCmd returns the root tx command for the Review module.
 func (AppModuleBasic) GetTxCmd() *cobra.Command {
-	return nil // CLI commands to be implemented
+	return cli.GetTxCmd()
 }
 
 // GetQueryCmd returns the root query command for the Review module.
 func (AppModuleBasic) GetQueryCmd() *cobra.Command {
-	return nil // CLI commands to be implemented
+	return cli.GetQueryCmd()
 }
 
 // AppModule implements an application module for the Review module.

--- a/x/review/types/codec.go
+++ b/x/review/types/codec.go
@@ -69,5 +69,6 @@ func NewQueryClient(cc grpc.ClientConn) QueryClient {
 
 // RegisterQueryHandlerClient registers the gRPC gateway routes for the query service.
 func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, client QueryClient) error {
-	return reviewv1.RegisterQueryHandlerClient(ctx, mux, client)
+	// grpc-gateway handlers are not generated in this build; keep as no-op.
+	return nil
 }

--- a/x/settlement/ibc/rate_limit.go
+++ b/x/settlement/ibc/rate_limit.go
@@ -18,16 +18,16 @@ const (
 
 // RateLimitConfig defines per-block packet limits.
 type RateLimitConfig struct {
-	Enabled                     bool   `json:"enabled"`
-	MaxPacketsPerBlock          uint64 `json:"max_packets_per_block"`
+	Enabled                      bool   `json:"enabled"`
+	MaxPacketsPerBlock           uint64 `json:"max_packets_per_block"`
 	MaxPacketsPerRelayerPerBlock uint64 `json:"max_packets_per_relayer_per_block"`
 }
 
 // DefaultRateLimitConfig returns the default IBC rate limit config.
 func DefaultRateLimitConfig() RateLimitConfig {
 	return RateLimitConfig{
-		Enabled:                     true,
-		MaxPacketsPerBlock:          200,
+		Enabled:                      true,
+		MaxPacketsPerBlock:           200,
 		MaxPacketsPerRelayerPerBlock: 50,
 	}
 }
@@ -81,7 +81,7 @@ func (k IBCKeeper) CheckRateLimit(ctx sdk.Context, relayer sdk.AccAddress, packe
 		return nil
 	}
 
-	height := uint64(ctx.BlockHeight())
+	height := uint64(ctx.BlockHeight()) //nolint:gosec // block height is non-negative
 	store := ctx.KVStore(k.storeKey)
 
 	totalKey := RateLimitKey(height, packetType)
@@ -122,7 +122,7 @@ func (k IBCKeeper) CleanupRateLimitData(ctx sdk.Context) {
 				continue
 			}
 
-			height := int64(readUint64(key[len(prefix) : len(prefix)+8]))
+			height := int64(readUint64(key[len(prefix) : len(prefix)+8])) //nolint:gosec // stored heights fit in int64
 			if height <= cutoff {
 				store.Delete(key)
 			}


### PR DESCRIPTION
## Summary
- add CLI commands for fraud/review/benchmark modules
- add fraud invariants + tests and register with crisis
- add grpc-gateway stubs + update settlement IBC port binding compatibility

## Testing
- go build ./x/fraud/... ./x/review/... ./x/benchmark/...
- go test ./x/fraud/... ./x/review/... ./x/benchmark/... -count=1
- go vet ./x/fraud/... ./x/review/... ./x/benchmark/...
- golangci-lint run ./x/fraud/... ./x/review/... ./x/benchmark/...
- go build ./cmd/...
- go test -short -count=1 (pre-push hook, changed packages)
